### PR TITLE
Refactored most of the codebase to use Strong Path instead of Path.

### DIFF
--- a/waspc/app/Main.hs
+++ b/waspc/app/Main.hs
@@ -3,32 +3,32 @@ module Main where
 import System.Environment
 import System.Directory
 import qualified System.FilePath as FilePath
-import Path ((</>), reldir)
-import qualified Path
-import qualified Path.Aliases as Path
+import qualified Path as P
 
 import CompileOptions (CompileOptions (..))
+import StrongPath (Path, Abs, Dir)
+import qualified StrongPath as SP
 import Lib (compile)
 
 
 main :: IO ()
 main = do
-  absCwdPath <- getCurrentDirectory >>= Path.parseAbsDir
+  absCwdPath <- getCurrentDirectory >>= SP.parseAbsDir
   args <- getArgs
   case args of
     [waspFilePath, outDirPath] -> do
-        absWaspFilePath <- Path.parseAbsFile (ensurePathIsAbs absCwdPath waspFilePath)
-        absOutDirPath <- Path.parseAbsDir (ensurePathIsAbs absCwdPath outDirPath)
+        absWaspFilePath <- SP.parseAbsFile (ensurePathIsAbs absCwdPath waspFilePath)
+        absOutDirPath <- SP.parseAbsDir (ensurePathIsAbs absCwdPath outDirPath)
         -- TODO(martin): Take compile options as arguments to the command, right now I hardcoded the value.
         let options = CompileOptions
-                { externalCodeDirPath = (Path.parent absWaspFilePath) </> [reldir|ext|]
+                { externalCodeDirPath = (SP.parent absWaspFilePath) SP.</> SP.fromPathRelDir [P.reldir|ext|]
                 }
         result <- compile absWaspFilePath absOutDirPath options
         either putStrLn (\_ -> print ("Success!" :: String)) result
     _ -> print ("Usage: ./waspc <wasp_file_path> <out_dir>" :: String)
   where
     -- | If path is not absolute, it is prefixed with given absolute directory.
-    ensurePathIsAbs :: Path.AbsDir -> FilePath -> FilePath
+    ensurePathIsAbs :: Path Abs (Dir a) -> FilePath -> FilePath
     ensurePathIsAbs absDirPath path = if FilePath.isAbsolute path
                                       then path
-                                      else (Path.toFilePath absDirPath) FilePath.</> path
+                                      else (SP.toFilePath absDirPath) FilePath.</> path

--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -52,6 +52,7 @@ library:
     - path
     - regex-compat
     - time
+    - exceptions
 
 executables:
   waspc-cli:

--- a/waspc/src/CompileOptions.hs
+++ b/waspc/src/CompileOptions.hs
@@ -2,11 +2,13 @@ module CompileOptions
     ( CompileOptions(..)
     ) where
 
-import qualified Path.Aliases as Path
+import StrongPath (Path, Abs, Dir)
+import ExternalCode(SourceExternalCodeDir)
+
 
 -- TODO(martin): Should these be merged with Wasp data? Is it really a separate thing or not?
 --   It would be easier to pass around if it is part of Wasp data. But is it semantically correct?
 --   Maybe it is, even more than this!
 data CompileOptions = CompileOptions
-    { externalCodeDirPath :: !Path.AbsDir
+    { externalCodeDirPath :: !(Path Abs (Dir SourceExternalCodeDir))
     }

--- a/waspc/src/ExternalCode.hs
+++ b/waspc/src/ExternalCode.hs
@@ -4,20 +4,23 @@ module ExternalCode
     , fileAbsPath
     , fileText
     , readFiles
+    , SourceExternalCodeDir
     ) where
 
 import qualified Data.Text.Lazy as TextL
 import qualified Data.Text.Lazy.IO as TextL.IO
 import Data.Text (Text)
-import qualified Path
-import qualified Path.Aliases as Path
 
 import qualified Util.IO
+import StrongPath (Path, Abs, Rel, Dir, (</>))
+import qualified StrongPath as SP
 
+-- | External code directory in Wasp source, from which external code files are read.
+data SourceExternalCodeDir
 
 data File = File
-    { _pathInExtCodeDir :: !Path.RelFile  -- ^ Path relative to external code directory.
-    , _extCodeDirPath :: !Path.AbsDir  -- ^ Absolute path of external code directory.
+    { _pathInExtCodeDir :: !(Path (Rel SourceExternalCodeDir) SP.File)
+    , _extCodeDirPath :: !(Path Abs (Dir SourceExternalCodeDir))
     , _text :: TextL.Text  -- ^ File content. It will throw error when evaluated if file is not textual file.
     }
 
@@ -28,7 +31,7 @@ instance Eq File where
     f1 == f2 = (_pathInExtCodeDir f1) == (_pathInExtCodeDir f2)
 
 -- | Returns path relative to the external code directory.
-filePathInExtCodeDir :: File -> Path.RelFile
+filePathInExtCodeDir :: File -> Path (Rel SourceExternalCodeDir) SP.File
 filePathInExtCodeDir = _pathInExtCodeDir
 
 -- | Unsafe method: throws error if text could not be read (if file is not a textual file)!
@@ -36,15 +39,14 @@ fileText :: File -> Text
 fileText = TextL.toStrict . _text
 
 -- | Returns absolute path of the external code file.
-fileAbsPath :: ExternalCode.File -> Path.AbsFile
-fileAbsPath file = _extCodeDirPath file Path.</> _pathInExtCodeDir file
+fileAbsPath :: ExternalCode.File -> Path Abs SP.File
+fileAbsPath file = _extCodeDirPath file </> _pathInExtCodeDir file
 
 -- | Returns all files contained in the specified external code dir, recursively.
--- File paths are relative to the specified external code dir path.
-readFiles :: Path.AbsDir -> IO [File]
+readFiles :: Path Abs (Dir SourceExternalCodeDir) -> IO [File]
 readFiles extCodeDirPath = do
-    relFilePaths <- Util.IO.listDirectoryDeep extCodeDirPath
-    let absFilePaths = map (extCodeDirPath Path.</>) relFilePaths
+    relFilePaths <- Util.IO.listDirectoryDeep (SP.toPathAbsDir extCodeDirPath) >>= return . (map SP.fromPathRelFile)
+    let absFilePaths = map (extCodeDirPath </>) relFilePaths
     -- NOTE: We read text from all the files, regardless if they are text files or not, because
     --   we don't know if they are a text file or not.
     --   Since we do lazy reading (Text.Lazy), this is not a problem as long as we don't try to use
@@ -58,7 +60,7 @@ readFiles extCodeDirPath = do
     --     or create new file draft that will support that.
     --     In generator, when creating TextFileDraft, give it function/logic for text transformation,
     --     and it will be taken care of when draft will be written to the disk.
-    fileTexts <- mapM (TextL.IO.readFile . Path.toFilePath) absFilePaths
+    fileTexts <- mapM (TextL.IO.readFile . SP.toFilePath) absFilePaths
     let files = map (\(path, text) -> File path extCodeDirPath text) (zip relFilePaths fileTexts)
     return files
 

--- a/waspc/src/Generator/Common.hs
+++ b/waspc/src/Generator/Common.hs
@@ -1,0 +1,5 @@
+module Generator.Common
+    ( ProjectRootDir
+    ) where
+
+data ProjectRootDir -- ^ Directory where the whole web app project (client, server, ...) is generated.

--- a/waspc/src/Generator/ExternalCodeGenerator.hs
+++ b/waspc/src/Generator/ExternalCodeGenerator.hs
@@ -3,8 +3,9 @@ module Generator.ExternalCodeGenerator
        ) where
 
 import qualified System.FilePath as FP
-import qualified Path
 
+import StrongPath (Path, Rel, File, (</>))
+import qualified StrongPath as SP
 import Wasp (Wasp)
 import qualified Wasp
 import qualified ExternalCode as EC
@@ -24,11 +25,15 @@ generateExternalCodeDir strategy wasp =
 generateFile :: C.ExternalCodeGeneratorStrategy -> EC.File -> FD.FileDraft
 generateFile strategy file
     | extension `elem` [".js", ".jsx"] = generateJsFile strategy file
-    | otherwise = let relDstPath = (C._extCodeDirInProjectRootDir strategy) Path.</> EC.filePathInExtCodeDir file
+    | otherwise = let relDstPath = (C._extCodeDirInProjectRootDir strategy)
+                                   </> dstPathInGenExtCodeDir
                       absSrcPath = EC.fileAbsPath file
                   in FD.createCopyFileDraft relDstPath absSrcPath
   where
-    extension = FP.takeExtension $ Path.toFilePath $ EC.filePathInExtCodeDir file
+    dstPathInGenExtCodeDir :: Path (Rel C.GeneratedExternalCodeDir) File
+    dstPathInGenExtCodeDir = C.castRelPathFromSrcToGenExtCodeDir $ EC.filePathInExtCodeDir file
+
+    extension = FP.takeExtension $ SP.toFilePath $ EC.filePathInExtCodeDir file
 
 
 

--- a/waspc/src/Generator/ExternalCodeGenerator/Common.hs
+++ b/waspc/src/Generator/ExternalCodeGenerator/Common.hs
@@ -1,19 +1,31 @@
 module Generator.ExternalCodeGenerator.Common
     ( ExternalCodeGeneratorStrategy(..)
+    , GeneratedExternalCodeDir
+    , castRelPathFromSrcToGenExtCodeDir
+    , asGenExtFile
     ) where
 
 import Data.Text (Text)
-import qualified Path.Aliases as Path
+import qualified Path as P
 
+import StrongPath (Path, Rel, File, Dir)
+import qualified StrongPath as SP
+import Generator.Common (ProjectRootDir)
+import ExternalCode (SourceExternalCodeDir)
+
+
+data GeneratedExternalCodeDir -- ^ Path to the directory where ext code will be generated.
+
+asGenExtFile :: P.Path P.Rel P.File -> (Path (Rel GeneratedExternalCodeDir) File)
+asGenExtFile = SP.fromPathRelFile
+
+castRelPathFromSrcToGenExtCodeDir :: Path (Rel SourceExternalCodeDir) a -> Path (Rel GeneratedExternalCodeDir) a
+castRelPathFromSrcToGenExtCodeDir = SP.castRel
 
 data ExternalCodeGeneratorStrategy = ExternalCodeGeneratorStrategy
-    { -- | Takes a file path where the external code js file will be generated (relative to the generated external code dir).
+    { -- | Takes a path where the external code js file will be generated.
       -- Also takes text of the file. Returns text where special @wasp imports have been replaced with
       -- imports that will work.
-      _resolveJsFileWaspImports :: Path.RelFile -> Text -> Text
-      -- | Path to directory where ext code will be generated. Relative to the generated project root.
-    , _extCodeDirInProjectRootDir :: Path.RelDir
+      _resolveJsFileWaspImports :: Path (Rel GeneratedExternalCodeDir) File -> Text -> Text
+    , _extCodeDirInProjectRootDir :: Path (Rel ProjectRootDir) (Dir GeneratedExternalCodeDir)
     }
-
-
-

--- a/waspc/src/Generator/ExternalCodeGenerator/Js.hs
+++ b/waspc/src/Generator/ExternalCodeGenerator/Js.hs
@@ -2,15 +2,21 @@ module Generator.ExternalCodeGenerator.Js
        ( generateJsFile
        ) where
 
-import qualified Path
+import StrongPath (Path, Rel, File, (</>))
 import qualified Generator.FileDraft as FD
 import qualified ExternalCode as EC
 import qualified Generator.ExternalCodeGenerator.Common as C
 
+
 generateJsFile :: C.ExternalCodeGeneratorStrategy -> EC.File -> FD.FileDraft
 generateJsFile strategy file = FD.createTextFileDraft dstPath text'
   where
+    filePathInSrcExtCodeDir = EC.filePathInExtCodeDir file
+
+    filePathInGenExtCodeDir :: Path (Rel C.GeneratedExternalCodeDir) File
+    filePathInGenExtCodeDir = (C.castRelPathFromSrcToGenExtCodeDir filePathInSrcExtCodeDir)
+
     text = EC.fileText file
-    text' = (C._resolveJsFileWaspImports strategy) (EC.filePathInExtCodeDir file) text
-    dstPath = (C._extCodeDirInProjectRootDir strategy) Path.</> EC.filePathInExtCodeDir file
+    text' = (C._resolveJsFileWaspImports strategy) filePathInGenExtCodeDir text
+    dstPath = (C._extCodeDirInProjectRootDir strategy) </> filePathInGenExtCodeDir
 

--- a/waspc/src/Generator/FileDraft.hs
+++ b/waspc/src/Generator/FileDraft.hs
@@ -8,17 +8,13 @@ module Generator.FileDraft
 
 import qualified Data.Aeson as Aeson
 import Data.Text (Text)
-import qualified Path.Aliases as Path
 
+import StrongPath (Path, Abs, Rel, File)
+import Generator.Templates (TemplatesDir)
+import Generator.Common (ProjectRootDir)
 import Generator.FileDraft.Writeable
-
-import Generator.FileDraft.TemplateFileDraft (TemplateFileDraft)
 import qualified Generator.FileDraft.TemplateFileDraft as TmplFD
-
-import Generator.FileDraft.CopyFileDraft (CopyFileDraft)
 import qualified Generator.FileDraft.CopyFileDraft as CopyFD
-
-import Generator.FileDraft.TextFileDraft (TextFileDraft)
 import qualified Generator.FileDraft.TextFileDraft as TextFD
 
 
@@ -26,9 +22,9 @@ import qualified Generator.FileDraft.TextFileDraft as TextFD
 --   so that in the rest of the system they can be passed around as heterogeneous
 --   collection when needed.
 data FileDraft
-    = FileDraftTemplateFd TemplateFileDraft
-    | FileDraftCopyFd CopyFileDraft
-    | FileDraftTextFd TextFileDraft
+    = FileDraftTemplateFd TmplFD.TemplateFileDraft
+    | FileDraftCopyFd CopyFD.CopyFileDraft
+    | FileDraftTextFd TextFD.TextFileDraft
     deriving (Show, Eq)
 
 instance Writeable FileDraft where
@@ -37,17 +33,20 @@ instance Writeable FileDraft where
     write dstDir (FileDraftTextFd draft) = write dstDir draft
 
 
-createTemplateFileDraft :: Path.RelFile -> Path.RelFile -> Maybe Aeson.Value -> FileDraft
+createTemplateFileDraft :: Path (Rel ProjectRootDir) File
+                        -> Path (Rel TemplatesDir) File
+                        -> Maybe Aeson.Value
+                        -> FileDraft
 createTemplateFileDraft dstPath tmplSrcPath tmplData =
     FileDraftTemplateFd $ TmplFD.TemplateFileDraft { TmplFD._dstPath = dstPath
                                                    , TmplFD._srcPathInTmplDir = tmplSrcPath
                                                    , TmplFD._tmplData = tmplData
                                                    }
 
-createCopyFileDraft :: Path.RelFile -> Path.AbsFile -> FileDraft
+createCopyFileDraft :: Path (Rel ProjectRootDir) File -> Path Abs File -> FileDraft
 createCopyFileDraft dstPath srcPath =
     FileDraftCopyFd $ CopyFD.CopyFileDraft { CopyFD._dstPath = dstPath, CopyFD._srcPath = srcPath}
 
-createTextFileDraft :: Path.RelFile -> Text -> FileDraft
+createTextFileDraft :: Path (Rel ProjectRootDir) File -> Text -> FileDraft
 createTextFileDraft dstPath content =
     FileDraftTextFd $ TextFD.TextFileDraft { TextFD._dstPath = dstPath, TextFD._content = content}

--- a/waspc/src/Generator/FileDraft/CopyFileDraft.hs
+++ b/waspc/src/Generator/FileDraft/CopyFileDraft.hs
@@ -2,23 +2,23 @@ module Generator.FileDraft.CopyFileDraft
        ( CopyFileDraft(..)
        ) where
 
-import qualified Path
-import qualified Path.Aliases as Path
-
+import StrongPath (Path, Abs, Rel, File, (</>))
+import qualified StrongPath as SP
+import Generator.Common (ProjectRootDir)
 import Generator.FileDraft.Writeable
 import Generator.FileDraft.WriteableMonad
 
 
 -- | File draft based purely on another file, that is just copied.
 data CopyFileDraft = CopyFileDraft
-    { _dstPath :: !Path.RelFile -- ^ Path of file to be written, relative to some root dir.
-    , _srcPath :: !Path.AbsFile -- ^ Absolute path of source file to copy.
+    { _dstPath :: !(Path (Rel ProjectRootDir) File)-- ^ Path where the file will be copied to.
+    , _srcPath :: !(Path Abs File) -- ^ Absolute path of source file to copy.
     }
     deriving (Show, Eq)
 
 instance Writeable CopyFileDraft where
     write absDstDirPath draft = do
-        createDirectoryIfMissing True (Path.toFilePath $ Path.parent absDraftDstPath)
-        copyFile (Path.toFilePath $ _srcPath draft) (Path.toFilePath $ absDraftDstPath)
+        createDirectoryIfMissing True (SP.toFilePath $ SP.parent absDraftDstPath)
+        copyFile (SP.toFilePath $ _srcPath draft) (SP.toFilePath $ absDraftDstPath)
       where
-          absDraftDstPath = absDstDirPath Path.</> (_dstPath draft)
+          absDraftDstPath = absDstDirPath </> (_dstPath draft)

--- a/waspc/src/Generator/FileDraft/TemplateFileDraft.hs
+++ b/waspc/src/Generator/FileDraft/TemplateFileDraft.hs
@@ -3,31 +3,32 @@ module Generator.FileDraft.TemplateFileDraft
        ) where
 
 import qualified Data.Aeson as Aeson
-import qualified Path
-import qualified Path.Aliases as Path
 
+import StrongPath (Path, Abs, Rel, File, (</>))
+import qualified StrongPath as SP
+import Generator.Common (ProjectRootDir)
 import Generator.FileDraft.Writeable
 import Generator.FileDraft.WriteableMonad
-
+import Generator.Templates (TemplatesDir)
 
 -- | File draft based on template file that gets combined with data.
 data TemplateFileDraft = TemplateFileDraft
-    { _dstPath :: !Path.RelFile -- ^ Path of file to be written, relative to some dst root dir.
-    , _srcPathInTmplDir :: !Path.RelFile -- ^ Path of template source file, relative to templates root dir.
+    { _dstPath :: !(Path (Rel ProjectRootDir) File) -- ^ Path where file will be generated.
+    , _srcPathInTmplDir :: !(Path (Rel TemplatesDir) File) -- ^ Path of template source file.
     , _tmplData :: Maybe Aeson.Value -- ^ Data to be fed to the template while rendering it.
     }
     deriving (Show, Eq)
 
 instance Writeable TemplateFileDraft where
     write absDstDirPath draft = do
-        createDirectoryIfMissing True (Path.toFilePath $ Path.parent absDraftDstPath)
+        createDirectoryIfMissing True (SP.toFilePath $ SP.parent absDraftDstPath)
         case _tmplData draft of
             Nothing -> do
                 absDraftSrcPath <- getTemplateFileAbsPath (_srcPathInTmplDir draft)
-                copyFile (Path.toFilePath absDraftSrcPath) (Path.toFilePath absDraftDstPath)
+                copyFile (SP.toFilePath absDraftSrcPath) (SP.toFilePath absDraftDstPath)
             Just tmplData -> do
                 content <- compileAndRenderTemplate (_srcPathInTmplDir draft) tmplData
-                writeFileFromText (Path.toFilePath absDraftDstPath) content
+                writeFileFromText (SP.toFilePath absDraftDstPath) content
       where
-        absDraftDstPath :: Path.AbsFile
-        absDraftDstPath = absDstDirPath Path.</> (_dstPath draft)
+        absDraftDstPath :: Path Abs File
+        absDraftDstPath = absDstDirPath </> (_dstPath draft)

--- a/waspc/src/Generator/FileDraft/TextFileDraft.hs
+++ b/waspc/src/Generator/FileDraft/TextFileDraft.hs
@@ -2,25 +2,25 @@ module Generator.FileDraft.TextFileDraft
        ( TextFileDraft(..)
        ) where
 
-import qualified Path
-import qualified Path.Aliases as Path
+import Data.Text (Text)
 
+import StrongPath (Path, Rel, File, (</>))
+import qualified StrongPath as SP
+import Generator.Common (ProjectRootDir)
 import Generator.FileDraft.Writeable
 import Generator.FileDraft.WriteableMonad
-
-import Data.Text (Text)
 
 
 -- | File draft based on text, that is to be written to file when time comes.
 data TextFileDraft = TextFileDraft
-    { _dstPath :: !Path.RelFile -- ^ Path of file to be written, relative to some root dir.
+    { _dstPath :: !(Path (Rel ProjectRootDir) File) -- ^ Path where file will be generated.
     , _content :: Text
     }
     deriving (Show, Eq)
 
 instance Writeable TextFileDraft where
     write dstDir draft = do
-        createDirectoryIfMissing True (Path.toFilePath $ Path.parent absDraftDstPath)
-        writeFileFromText (Path.toFilePath absDraftDstPath) (_content draft)
+        createDirectoryIfMissing True (SP.toFilePath $ SP.parent absDraftDstPath)
+        writeFileFromText (SP.toFilePath absDraftDstPath) (_content draft)
       where
-          absDraftDstPath = dstDir Path.</> (_dstPath draft)
+          absDraftDstPath = dstDir </> (_dstPath draft)

--- a/waspc/src/Generator/FileDraft/Writeable.hs
+++ b/waspc/src/Generator/FileDraft/Writeable.hs
@@ -2,13 +2,14 @@ module Generator.FileDraft.Writeable
        ( Writeable(..)
        ) where
 
-import qualified Path.Aliases as Path
-
+import StrongPath (Path, Abs, Dir)
+import Generator.Common (ProjectRootDir)
 import Generator.FileDraft.WriteableMonad
 
+
 class Writeable w where
-    -- | Write file somewhere in the provided dst directory.
+    -- | Write file somewhere in the provided project root directory.
     write :: (WriteableMonad m)
-          => Path.AbsDir  -- ^ Absolute path of dst directory.
+          => Path Abs (Dir ProjectRootDir)
           -> w
           -> m ()

--- a/waspc/src/Generator/FileDraft/WriteableMonad.hs
+++ b/waspc/src/Generator/FileDraft/WriteableMonad.hs
@@ -7,9 +7,9 @@ import qualified System.Directory
 import qualified Data.Text.IO
 import Data.Aeson as Aeson
 import Data.Text (Text)
-import qualified Path.Aliases as Path
 
-import qualified Generator.Templates
+import StrongPath (Path, Abs, Rel, File, Dir)
+import qualified Generator.Templates as Templates
 
 
 -- TODO: Should we use DI via data instead of typeclasses?
@@ -36,14 +36,13 @@ class (Monad m) => WriteableMonad m where
     writeFileFromText :: FilePath -> Text -> m ()
 
     getTemplateFileAbsPath
-        :: Path.RelFile  -- ^ Template file path, relative to templates root directory.
-        -> m Path.AbsFile
+        :: Path (Rel Templates.TemplatesDir) File  -- ^ Template file path.
+        -> m (Path Abs File)
 
-    -- | Returns absolute path of templates root directory.
-    getTemplatesDirAbsPath :: m Path.AbsDir
+    getTemplatesDirAbsPath :: m (Path Abs (Dir Templates.TemplatesDir))
 
     compileAndRenderTemplate
-        :: Path.RelFile  -- ^ Path to the template file, relative to template root dir.
+        :: Path (Rel Templates.TemplatesDir) File  -- ^ Template file path.
         -> Aeson.Value  -- ^ JSON to be provided as template data.
         -> m Text
 
@@ -51,6 +50,6 @@ instance WriteableMonad IO where
     createDirectoryIfMissing = System.Directory.createDirectoryIfMissing
     copyFile = System.Directory.copyFile
     writeFileFromText = Data.Text.IO.writeFile
-    getTemplateFileAbsPath = Generator.Templates.getTemplateFileAbsPath
-    getTemplatesDirAbsPath = Generator.Templates.getTemplatesDirAbsPath
-    compileAndRenderTemplate = Generator.Templates.compileAndRenderTemplate
+    getTemplateFileAbsPath = Templates.getTemplateFileAbsPath
+    getTemplatesDirAbsPath = Templates.getTemplatesDirAbsPath
+    compileAndRenderTemplate = Templates.compileAndRenderTemplate

--- a/waspc/src/Generator/ServerGenerator.hs
+++ b/waspc/src/Generator/ServerGenerator.hs
@@ -2,13 +2,15 @@ module Generator.ServerGenerator
     ( genServer
     ) where
 
-import Path ((</>), relfile, reldir)
-import qualified Path.Aliases as Path
+import qualified Path as P
 
+import StrongPath (Path, Rel, File)
+import qualified StrongPath as SP
 import Wasp (Wasp)
 import CompileOptions (CompileOptions)
 import Generator.FileDraft (FileDraft)
-import Generator.ServerGenerator.Common as C
+import Generator.ServerGenerator.Common (asTmplFile, asServerFile)
+import qualified Generator.ServerGenerator.Common as C
 
 
 genServer :: Wasp -> CompileOptions -> [FileDraft]
@@ -22,24 +24,33 @@ genServer wasp _ = concat
     ]
 
 genReadme :: Wasp -> FileDraft
-genReadme _ = C.copyTmplAsIs [relfile|README.md|]
+genReadme _ = C.copyTmplAsIs (asTmplFile [P.relfile|README.md|])
 
 genPackageJson :: Wasp -> FileDraft
-genPackageJson _ = C.copyTmplAsIs [relfile|package.json|]
+genPackageJson _ = C.copyTmplAsIs (asTmplFile [P.relfile|package.json|])
 
 genNpmrc :: Wasp -> FileDraft
-genNpmrc _ = C.makeTemplateFD [relfile|npmrc|] [relfile|.npmrc|] Nothing
+genNpmrc _ = C.makeTemplateFD (asTmplFile [P.relfile|npmrc|])
+                              (asServerFile [P.relfile|.npmrc|])
+                              Nothing
 
 genNvmrc :: Wasp -> FileDraft
-genNvmrc _ = C.makeTemplateFD [relfile|nvmrc|] [relfile|.nvmrc|] Nothing
+genNvmrc _ = C.makeTemplateFD (asTmplFile [P.relfile|nvmrc|])
+                              (asServerFile [P.relfile|.nvmrc|])
+                              Nothing
 
 genGitignore :: Wasp -> FileDraft
-genGitignore _ = C.makeTemplateFD [relfile|gitignore|] [relfile|.gitignore|] Nothing
+genGitignore _ = C.makeTemplateFD (asTmplFile [P.relfile|gitignore|])
+                                  (asServerFile [P.relfile|.gitignore|])
+                                  Nothing
+
+asTmplSrcFile :: P.Path P.Rel P.File -> Path (Rel C.ServerTemplatesSrcDir) File
+asTmplSrcFile = SP.fromPathRelFile
 
 genSrcDir :: Wasp -> [FileDraft]
 genSrcDir wasp = concat
-    [ [copySrcTmpl [relfile|app.js|]]
-    , [copySrcTmpl [relfile|server.js|]]
+    [ [C.copySrcTmplAsIs $ asTmplSrcFile [P.relfile|app.js|]]
+    , [C.copySrcTmplAsIs $ asTmplSrcFile [P.relfile|server.js|]]
     , genRoutesDir wasp
     ]
 
@@ -47,10 +58,9 @@ genRoutesDir :: Wasp -> [FileDraft]
 genRoutesDir _ =
     -- TODO(martin): We will probably want to extract "routes" path here same as we did with "src", to avoid hardcoding,
     -- but I did not bother with it yet since it is used only here for now.
-    [ copySrcTmpl [relfile|routes/index.js|]
+    [ C.copySrcTmplAsIs $ asTmplSrcFile [P.relfile|routes/index.js|]
     ]
 
-copySrcTmpl :: Path.RelFile -> FileDraft
-copySrcTmpl pathInTemplatesSrcDir = C.makeTemplateFD srcPath dstPath Nothing
-  where srcPath = [reldir|src|] </> pathInTemplatesSrcDir
-        dstPath = C.serverSrcDirInServerRootDir </> pathInTemplatesSrcDir
+
+
+

--- a/waspc/src/Generator/ServerGenerator/Common.hs
+++ b/waspc/src/Generator/ServerGenerator/Common.hs
@@ -5,43 +5,83 @@ module Generator.ServerGenerator.Common
     , copyTmplAsIs
     , makeSimpleTemplateFD
     , makeTemplateFD
+    , copySrcTmplAsIs
+    , srcDirInServerTemplatesDir
+    , asTmplFile
+    , asServerFile
+    , ServerRootDir
+    , ServerSrcDir
+    , ServerTemplatesDir
+    , ServerTemplatesSrcDir
     ) where
 
 import qualified Data.Aeson as Aeson
-import Path ((</>), reldir)
-import qualified Path.Aliases as Path
+import qualified Path as P
+
+import StrongPath (Path, Rel, File, Dir, (</>))
+import qualified StrongPath as SP
 import Wasp (Wasp)
 import Generator.FileDraft (FileDraft, createTemplateFileDraft)
+import Generator.Common (ProjectRootDir)
+import Generator.Templates (TemplatesDir)
+
+
+data ServerRootDir
+data ServerSrcDir
+data ServerTemplatesDir
+data ServerTemplatesSrcDir
+
+
+asTmplFile :: P.Path P.Rel P.File -> Path (Rel ServerTemplatesDir) File
+asTmplFile = SP.fromPathRelFile
+
+asServerFile :: P.Path P.Rel P.File -> Path (Rel ServerRootDir) File
+asServerFile = SP.fromPathRelFile
 
 
 -- * Paths
 
--- | Path where server root dir is generated, relative to the root directory of the whole generated project.
-serverRootDirInProjectRootDir :: Path.RelDir
-serverRootDirInProjectRootDir = [reldir|server|]
+-- | Path where server root dir is generated.
+serverRootDirInProjectRootDir :: Path (Rel ProjectRootDir) (Dir ServerRootDir)
+serverRootDirInProjectRootDir = SP.fromPathRelDir [P.reldir|server|]
 
--- | Path to generated server src/ directory, relative to the root directory of generated server.
-serverSrcDirInServerRootDir :: Path.RelDir
-serverSrcDirInServerRootDir = [reldir|src|]
+-- | Path to generated server src/ directory.
+serverSrcDirInServerRootDir :: Path (Rel ServerRootDir) (Dir ServerSrcDir)
+serverSrcDirInServerRootDir = SP.fromPathRelDir [P.reldir|src|]
 
-serverSrcDirInProjectRootDir :: Path.RelDir
+serverSrcDirInProjectRootDir :: Path (Rel ProjectRootDir) (Dir ServerSrcDir)
 serverSrcDirInProjectRootDir = serverRootDirInProjectRootDir </> serverSrcDirInServerRootDir
+
 
 -- * Templates
 
-copyTmplAsIs :: Path.RelFile -> FileDraft
-copyTmplAsIs path = makeTemplateFD path path Nothing
+copyTmplAsIs :: Path (Rel ServerTemplatesDir) File -> FileDraft
+copyTmplAsIs srcPath = makeTemplateFD srcPath dstPath Nothing
+    where dstPath = (SP.castRel srcPath) :: Path (Rel ServerRootDir) File
 
-makeSimpleTemplateFD :: Path.RelFile -> Wasp -> FileDraft
-makeSimpleTemplateFD path wasp = makeTemplateFD path path (Just $ Aeson.toJSON wasp)
+makeSimpleTemplateFD :: Path (Rel ServerTemplatesDir) File -> Wasp -> FileDraft
+makeSimpleTemplateFD srcPath wasp = makeTemplateFD srcPath dstPath (Just $ Aeson.toJSON wasp)
+    where dstPath = (SP.castRel srcPath) :: Path (Rel ServerRootDir) File
 
-makeTemplateFD :: Path.RelFile -> Path.RelFile -> Maybe Aeson.Value -> FileDraft
+makeTemplateFD :: Path (Rel ServerTemplatesDir) File
+               -> Path (Rel ServerRootDir) File
+               -> Maybe Aeson.Value
+               -> FileDraft
 makeTemplateFD relSrcPath relDstPath tmplData =
     createTemplateFileDraft
         (serverRootDirInProjectRootDir </> relDstPath)
         (serverTemplatesDirInTemplatesDir </> relSrcPath)
         tmplData
 
--- | Path in templates directory where server app templates reside.
-serverTemplatesDirInTemplatesDir :: Path.RelDir
-serverTemplatesDirInTemplatesDir = [reldir|server|]
+copySrcTmplAsIs :: Path (Rel ServerTemplatesSrcDir) File -> FileDraft
+copySrcTmplAsIs pathInTemplatesSrcDir = makeTemplateFD srcPath dstPath Nothing
+  where srcPath = srcDirInServerTemplatesDir </> pathInTemplatesSrcDir
+        dstPath = serverSrcDirInServerRootDir
+                  </> ((SP.castRel pathInTemplatesSrcDir) :: Path (Rel ServerSrcDir) File)
+
+-- | Path where server app templates reside.
+serverTemplatesDirInTemplatesDir :: Path (Rel TemplatesDir) (Dir ServerTemplatesDir)
+serverTemplatesDirInTemplatesDir = SP.fromPathRelDir [P.reldir|server|]
+
+srcDirInServerTemplatesDir :: Path (Rel ServerTemplatesDir) (Dir ServerTemplatesSrcDir)
+srcDirInServerTemplatesDir = SP.fromPathRelDir [P.reldir|src|]

--- a/waspc/src/Generator/WebAppGenerator/Common.hs
+++ b/waspc/src/Generator/WebAppGenerator/Common.hs
@@ -6,43 +6,69 @@ module Generator.WebAppGenerator.Common
     , makeTemplateFD
     , webAppSrcDirInProjectRootDir
     , webAppTemplatesDirInTemplatesDir
+    , asTmplFile
+    , asWebAppFile
+    , asWebAppSrcFile
+    , WebAppRootDir
+    , WebAppSrcDir
+    , WebAppTemplatesDir
     ) where
 
 import qualified Data.Aeson as Aeson
-import Path ((</>), reldir)
-import qualified Path.Aliases as Path
+import qualified Path as P
+
+import StrongPath (Path, Rel, Dir, File, (</>))
+import qualified StrongPath as SP
 import Wasp (Wasp)
+import Generator.Common (ProjectRootDir)
 import Generator.FileDraft (FileDraft, createTemplateFileDraft)
+import Generator.Templates (TemplatesDir)
+
+
+data WebAppRootDir
+data WebAppSrcDir
+data WebAppTemplatesDir
+
+
+asTmplFile :: P.Path P.Rel P.File -> Path (Rel WebAppTemplatesDir) File
+asTmplFile = SP.fromPathRelFile
+
+asWebAppFile :: P.Path P.Rel P.File -> Path (Rel WebAppRootDir) File
+asWebAppFile = SP.fromPathRelFile
+
+asWebAppSrcFile :: P.Path P.Rel P.File -> Path (Rel WebAppSrcDir) File
+asWebAppSrcFile = SP.fromPathRelFile
 
 
 -- * Paths
 
 -- | Path where web app root dir is generated, relative to the root directory of the whole generated project.
-webAppRootDirInProjectRootDir :: Path.RelDir
-webAppRootDirInProjectRootDir = [reldir|web-app|]
+webAppRootDirInProjectRootDir :: Path (Rel ProjectRootDir) (Dir WebAppRootDir)
+webAppRootDirInProjectRootDir = SP.fromPathRelDir [P.reldir|web-app|]
 
 -- | Path to generated web app src/ directory, relative to the root directory of generated web app.
-webAppSrcDirInWebAppRootDir :: Path.RelDir
-webAppSrcDirInWebAppRootDir = [reldir|src|]
+webAppSrcDirInWebAppRootDir :: Path (Rel WebAppRootDir) (Dir WebAppSrcDir)
+webAppSrcDirInWebAppRootDir = SP.fromPathRelDir [P.reldir|src|]
 
-webAppSrcDirInProjectRootDir :: Path.RelDir
+webAppSrcDirInProjectRootDir :: Path (Rel ProjectRootDir) (Dir WebAppSrcDir)
 webAppSrcDirInProjectRootDir = webAppRootDirInProjectRootDir </> webAppSrcDirInWebAppRootDir
+
 
 -- * Templates
 
-copyTmplAsIs :: Path.RelFile -> FileDraft
-copyTmplAsIs path = makeTemplateFD path path Nothing
+-- | Path in templates directory where web app templates reside.
+webAppTemplatesDirInTemplatesDir :: Path (Rel TemplatesDir) (Dir WebAppTemplatesDir)
+webAppTemplatesDirInTemplatesDir = SP.fromPathRelDir [P.reldir|react-app|]
 
-makeSimpleTemplateFD :: Path.RelFile -> Wasp -> FileDraft
-makeSimpleTemplateFD path wasp = makeTemplateFD path path (Just $ Aeson.toJSON wasp)
+copyTmplAsIs :: Path (Rel WebAppTemplatesDir) File -> FileDraft
+copyTmplAsIs path = makeTemplateFD path (SP.castRel path) Nothing
 
-makeTemplateFD :: Path.RelFile -> Path.RelFile -> Maybe Aeson.Value -> FileDraft
+makeSimpleTemplateFD :: Path (Rel WebAppTemplatesDir) File -> Wasp -> FileDraft
+makeSimpleTemplateFD path wasp = makeTemplateFD path (SP.castRel path) (Just $ Aeson.toJSON wasp)
+
+makeTemplateFD :: Path (Rel WebAppTemplatesDir) File -> Path (Rel WebAppRootDir) File -> Maybe Aeson.Value -> FileDraft
 makeTemplateFD srcPathInWebAppTemplatesDir dstPathInWebAppRootDir tmplData =
     createTemplateFileDraft
         (webAppRootDirInProjectRootDir </> dstPathInWebAppRootDir)
         (webAppTemplatesDirInTemplatesDir </> srcPathInWebAppTemplatesDir)
         tmplData
-
--- | Path in templates directory where web app templates reside.
-webAppTemplatesDirInTemplatesDir :: Path.RelDir
-webAppTemplatesDirInTemplatesDir = [reldir|react-app|]

--- a/waspc/src/Generator/WebAppGenerator/EntityGenerator/Common.hs
+++ b/waspc/src/Generator/WebAppGenerator/EntityGenerator/Common.hs
@@ -7,32 +7,50 @@ module Generator.WebAppGenerator.EntityGenerator.Common
     , addEntityFieldTypeToJsonAsKeyWithValueTrue
     , getEntityLowerName
     , getEntityClassName
+    , asEntityTmplFile 
+    , EntityDir
+    , EntityComponentsDir
+    , EntityTemplatesDir
     ) where
 
 import Data.Maybe (fromJust)
 import Data.Aeson ((.=), object)
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
-import Path ((</>), reldir)
-import qualified Path
+import qualified Path as P
 
-import qualified Path.Aliases as Path
+import StrongPath (Path, Rel, Dir, File, (</>))
+import qualified StrongPath as SP
 import qualified Util
 import Wasp
-import Generator.WebAppGenerator.Common (webAppTemplatesDirInTemplatesDir)
+import Generator.WebAppGenerator.Common (webAppTemplatesDirInTemplatesDir, WebAppSrcDir)
+import Generator.Templates (TemplatesDir)
 
--- | Path of the entity-related generated code, relative to src/ directory.
-entityDirPathInSrc :: Entity -> Path.RelDir
-entityDirPathInSrc entity = [reldir|entities|] </>
-                            (fromJust $ Path.parseRelDir $ Util.camelToKebabCase (entityName entity))
 
--- | Path of the code generated for entity components, relative to src/ directory.
-entityComponentsDirPathInSrc :: Entity -> Path.RelDir
-entityComponentsDirPathInSrc entity = (entityDirPathInSrc entity) </> [reldir|components|]
+
+data EntityDir
+
+-- | Path of the entity-related generated code.
+entityDirPathInSrc :: Entity -> Path (Rel WebAppSrcDir) (Dir EntityDir)
+entityDirPathInSrc entity = SP.fromPathRelDir [P.reldir|entities|] </> entityDirInEntitiesDir
+  where entityDirInEntitiesDir = (fromJust $ SP.parseRelDir $ Util.camelToKebabCase (entityName entity))
+
+data EntityComponentsDir
+
+-- | Path of the code generated for entity components.
+entityComponentsDirPathInSrc :: Entity -> Path (Rel WebAppSrcDir) (Dir EntityComponentsDir)
+entityComponentsDirPathInSrc entity = (entityDirPathInSrc entity) </> SP.fromPathRelDir [P.reldir|components|]
+
+data EntityTemplatesDir
 
 -- | Location in templates where entity related templates reside.
-entityTemplatesDirPath :: Path.RelDir
-entityTemplatesDirPath = webAppTemplatesDirInTemplatesDir </> [reldir|src/entities/_entity|]
+entityTemplatesDirPath :: Path (Rel TemplatesDir) (Dir EntityTemplatesDir)
+entityTemplatesDirPath = webAppTemplatesDirInTemplatesDir </> SP.fromPathRelDir [P.reldir|src/entities/_entity|]
+
+
+asEntityTmplFile :: P.Path P.Rel P.File -> Path (Rel EntityTemplatesDir) File
+asEntityTmplFile = SP.fromPathRelFile
+
 
 -- | Default generic data for entity templates.
 entityTemplateData :: Wasp -> Entity -> Aeson.Value

--- a/waspc/src/Generator/WebAppGenerator/EntityGenerator/EntityListGenerator.hs
+++ b/waspc/src/Generator/WebAppGenerator/EntityGenerator/EntityListGenerator.hs
@@ -7,9 +7,10 @@ import Control.Exception (assert)
 import Data.Aeson ((.=), object, ToJSON(..), toJSON)
 import qualified Data.Aeson as Aeson
 import Data.Maybe (fromJust)
-import Path ((</>), reldir, relfile, parseRelFile)
-import qualified Path.Aliases as Path
+import qualified Path as P
 
+import StrongPath (Path, Rel, File, (</>))
+import qualified StrongPath as SP
 import qualified Util as U
 import qualified Wasp
 import Wasp (Wasp)
@@ -180,14 +181,14 @@ generateEntityList wasp entityList =
         id
         (Wasp.getEntityByName wasp (WEL._entityName entityList))
 
-    templateSrcPath = EC.entityTemplatesDirPath </> [reldir|components|] </> [relfile|List.js|]
+    templateSrcPath = EC.entityTemplatesDirPath </> SP.fromPathRelFile [P.relfile|components/List.js|]
 
     dstPath = Common.webAppSrcDirInProjectRootDir </> (entityListPathInSrc entity entityList)
 
     templateData = toJSON $ createEntityListTemplateData entity entityList
 
 -- | Path in the generated src dir where the given entity list will be located.
-entityListPathInSrc :: Wasp.Entity -> WEL.EntityList -> Path.RelFile
+entityListPathInSrc :: Wasp.Entity -> WEL.EntityList -> Path (Rel Common.WebAppSrcDir) File
 entityListPathInSrc entity entityList =
     EC.entityComponentsDirPathInSrc entity </>
-    (fromJust $ parseRelFile $ (WEL._name entityList) ++ ".js")
+    (fromJust $ SP.parseRelFile $ (WEL._name entityList) ++ ".js")

--- a/waspc/src/Lib.hs
+++ b/waspc/src/Lib.hs
@@ -1,22 +1,24 @@
 module Lib
     ( compile
+    , ProjectRootDir
     ) where
 
+import StrongPath (Path, Abs, File, Dir)
+import qualified StrongPath as SP
 import CompileOptions (CompileOptions)
 import qualified CompileOptions
 import qualified ExternalCode
 import qualified Parser
 import qualified Generator
 import Wasp (setExternalCodeFiles)
-import qualified Path
-import qualified Path.Aliases as Path
+import Generator.Common (ProjectRootDir)
 
 
 type CompileError = String
 
-compile :: Path.AbsFile -> Path.AbsDir -> CompileOptions -> IO (Either CompileError ())
+compile :: Path Abs File -> Path Abs (Dir ProjectRootDir)-> CompileOptions -> IO (Either CompileError ())
 compile waspFile outDir options = do
-    waspStr <- readFile (Path.toFilePath waspFile)
+    waspStr <- readFile (SP.toFilePath waspFile)
 
     case Parser.parseWasp waspStr of
         Left err -> return $ Left (show err)

--- a/waspc/src/Parser/Common.hs
+++ b/waspc/src/Parser/Common.hs
@@ -7,8 +7,7 @@ module Parser.Common where
 import Text.Parsec (ParseError, parse, anyChar, manyTill, try, unexpected)
 import Text.Parsec.String (Parser)
 import qualified Data.Text as T
-import qualified Path
-import qualified Path.Aliases as Path
+import qualified Path as P
 
 import qualified Lexer as L
 
@@ -134,9 +133,9 @@ strip :: String -> String
 strip = T.unpack . T.strip . T.pack
 
 -- | Parses relative file path, e.g. "my/file.txt".
-relFilePathString :: Parser Path.RelFile
+relFilePathString :: Parser (P.Path P.Rel P.File)
 relFilePathString = do
     path <- L.stringLiteral
     maybe (unexpected $ "string \"" ++ path ++ "\": Expected relative file path.")
           return
-          (Path.parseRelFile path)
+          (P.parseRelFile path)

--- a/waspc/src/Parser/ExternalCode.hs
+++ b/waspc/src/Parser/ExternalCode.hs
@@ -4,18 +4,20 @@ module Parser.ExternalCode
 
 import Text.Parsec (unexpected)
 import Text.Parsec.String (Parser)
-import Path (reldir)
-import qualified Path
-import qualified Path.Aliases as Path
+import qualified Path as P
 
+import StrongPath (Path, Rel, File)
+import qualified StrongPath as SP
+import ExternalCode (SourceExternalCodeDir)
 import qualified Parser.Common
+
 
 -- Parses string literal that is file path to file in external code dir.
 -- Returns file path relative to the external code dir.
 -- Example of input: "@ext/some/file.txt". Output would be: "some/file.txt".
-extCodeFilePathString :: Parser Path.RelFile
+extCodeFilePathString :: Parser (Path (Rel SourceExternalCodeDir) File)
 extCodeFilePathString = do
     path <- Parser.Common.relFilePathString
     maybe (unexpected $ "string \"" ++ (show path) ++ "\": External code file path should start with \"@ext/\".")
-          return
-          (Path.stripProperPrefix [reldir|@ext|] path)
+          (return . SP.fromPathRelFile)
+          (P.stripProperPrefix [P.reldir|@ext|] path)

--- a/waspc/src/Path/Aliases.hs
+++ b/waspc/src/Path/Aliases.hs
@@ -1,9 +1,0 @@
-module Path.Aliases where
-
-import Path (Path, Abs, Rel, Dir, File)
-
-
-type RelFile = Path Rel File
-type AbsFile = Path Abs File
-type RelDir  = Path Rel Dir
-type AbsDir  = Path Abs Dir

--- a/waspc/src/StrongPath.hs
+++ b/waspc/src/StrongPath.hs
@@ -1,60 +1,104 @@
 module StrongPath
     ( Path
-    , Abs, File, Dir
+    , Abs, Rel, Dir, File
+    , parseRelDir, parseRelFile, parseAbsDir, parseAbsFile
+    , toFilePath
     , (</>)
-    , fromRelDir, fromRelFile, fromAbsDir, fromAbsFile
-    , toRelDir, toRelFile, toAbsDir, toAbsFile
+    , castRel
+    , parent
+    , fromPathRelDir, fromPathRelFile, fromPathAbsDir, fromPathAbsFile
+    , toPathRelDir, toPathRelFile, toPathAbsDir, toPathAbsFile
     ) where
 
 import qualified Path as P
+import Control.Monad.Catch (MonadThrow)
 
 
-data Path from to = RelDir  (P.Path P.Rel P.Dir)
-                  | RelFile (P.Path P.Rel P.File)
-                  | AbsDir  (P.Path P.Abs P.Dir)
-                  | AbsFile (P.Path P.Abs P.File)
+data Path b t = RelDir  (P.Path P.Rel P.Dir)
+              | RelFile (P.Path P.Rel P.File)
+              | AbsDir  (P.Path P.Abs P.Dir)
+              | AbsFile (P.Path P.Abs P.File)
+    deriving (Show, Eq)
 
 data Abs
-data Dir name
+data Rel dir
+data Dir dir
 data File
 
+-- TODO: We still depend on Path for creating hardcoded paths via generics. Any way to go around that?
+--   Maybe implement our own mechanism for that, so that people don't have to know about / use Path?
+--   This means we would implement our own [reldir|foobar|] stuff.
 
-fromRelDir :: P.Path P.Rel P.Dir -> Path (Dir a) (Dir b)
-fromRelDir p = RelDir p
+fromPathRelDir :: P.Path P.Rel P.Dir -> Path (Rel a) (Dir b)
+fromPathRelDir p = RelDir p
 
-fromRelFile :: P.Path P.Rel P.File -> Path (Dir a) File
-fromRelFile p = RelFile p
+fromPathRelFile :: P.Path P.Rel P.File -> Path (Rel a) File
+fromPathRelFile p = RelFile p
 
-fromAbsDir :: P.Path P.Abs P.Dir -> Path Abs (Dir a)
-fromAbsDir p = AbsDir p
+fromPathAbsDir :: P.Path P.Abs P.Dir -> Path Abs (Dir a)
+fromPathAbsDir p = AbsDir p
 
-fromAbsFile :: P.Path P.Abs P.File -> Path Abs File
-fromAbsFile p = AbsFile p
-
-
-toRelDir :: Path (Dir a) (Dir b) -> P.Path P.Rel P.Dir
-toRelDir (RelDir p) = p
-toRelDir _ = impossible
-
-toRelFile :: Path (Dir a) File -> P.Path P.Rel P.File
-toRelFile (RelFile p) = p
-toRelFile _ = impossible
-
-toAbsDir :: Path Abs (Dir a) -> P.Path P.Abs P.Dir
-toAbsDir (AbsDir p) = p
-toAbsDir _ = impossible
-
-toAbsFile :: Path Abs File -> P.Path P.Abs P.File
-toAbsFile (AbsFile p) = p
-toAbsFile _ = impossible
+fromPathAbsFile :: P.Path P.Abs P.File -> Path Abs File
+fromPathAbsFile p = AbsFile p
 
 
-(</>) :: Path a b -> Path b c -> Path a c
+toPathRelDir :: Path (Rel a) (Dir b) -> P.Path P.Rel P.Dir
+toPathRelDir (RelDir p) = p
+toPathRelDir _ = impossible
+
+toPathRelFile :: Path (Rel a) File -> P.Path P.Rel P.File
+toPathRelFile (RelFile p) = p
+toPathRelFile _ = impossible
+
+toPathAbsDir :: Path Abs (Dir a) -> P.Path P.Abs P.Dir
+toPathAbsDir (AbsDir p) = p
+toPathAbsDir _ = impossible
+
+toPathAbsFile :: Path Abs File -> P.Path P.Abs P.File
+toPathAbsFile (AbsFile p) = p
+toPathAbsFile _ = impossible
+
+
+parseRelDir :: MonadThrow m => FilePath -> m (Path (Rel d1) (Dir d2))
+parseRelDir fp = P.parseRelDir fp >>= return . fromPathRelDir
+
+parseRelFile :: MonadThrow m => FilePath -> m (Path (Rel d) File)
+parseRelFile fp = P.parseRelFile fp >>= return . fromPathRelFile
+
+parseAbsDir :: MonadThrow m => FilePath -> m (Path Abs (Dir d))
+parseAbsDir fp = P.parseAbsDir fp >>= return . fromPathAbsDir
+
+parseAbsFile :: MonadThrow m => FilePath -> m (Path Abs File)
+parseAbsFile fp = P.parseAbsFile fp >>= return . fromPathAbsFile
+
+
+toFilePath :: Path b t -> FilePath
+toFilePath (RelDir p) = P.toFilePath p
+toFilePath (RelFile p) = P.toFilePath p
+toFilePath (AbsDir p) = P.toFilePath p
+toFilePath (AbsFile p) = P.toFilePath p
+
+
+parent :: Path b t -> Path b (Dir d)
+parent (RelDir p) = RelDir $ P.parent p
+parent (RelFile p) = RelDir $ P.parent p
+parent (AbsDir p) = AbsDir $ P.parent p
+parent (AbsFile p) = AbsDir $ P.parent p
+
+
+(</>) :: Path a (Dir d) -> Path (Rel d) c -> Path a c
 (RelDir p1) </> (RelFile p2) = RelFile $ p1 P.</> p2
 (RelDir p1) </> (RelDir p2) = RelDir $ p1 P.</> p2
 (AbsDir p1) </> (RelFile p2) = AbsFile $ p1 P.</> p2
 (AbsDir p1) </> (RelDir p2) = AbsDir $ p1 P.</> p2
 _ </> _ = impossible
+
+
+castRel :: Path (Rel d1) a -> Path (Rel d2) a
+castRel (RelDir p) = RelDir p
+castRel (RelFile p) = RelFile p
+castRel _ = impossible
+
 
 impossible :: a
 impossible = error "This should be impossible."

--- a/waspc/src/Util/IO.hs
+++ b/waspc/src/Util/IO.hs
@@ -7,38 +7,36 @@ import qualified System.FilePath as FilePath
 import System.IO.Error (isDoesNotExistError)
 import Control.Exception (catch, throw)
 import Control.Monad (filterM, mapM)
-import qualified Path
-
-import qualified Path.Aliases as Path
+import qualified Path as P
 
 
 -- TODO: write tests.
 -- | Lists all files in the directory recursively.
 -- All paths are relative to the directory we are listing.
 -- If directory does not exist, returns empty list.
--- 
+--
 -- Example: Imagine we have directory foo that contains test.txt and bar/test2.txt.
 -- If we call
 -- >>> listDirectoryDeep "foo/"
 -- we should get
 -- >>> ["test.txt", "bar/text2.txt"]
-listDirectoryDeep :: Path.AbsDir -> IO [Path.RelFile]
+listDirectoryDeep :: (P.Path P.Abs P.Dir) -> IO [(P.Path P.Rel P.File)]
 listDirectoryDeep absDirPath = do
     (relFilePaths, relSubDirPaths) <- (listDirectory absDirPath)
         `catch` \e -> if isDoesNotExistError e then return ([], []) else throw e
-    relSubDirFilesPaths <- mapM (listSubDirDeep . (absDirPath Path.</>)) relSubDirPaths
+    relSubDirFilesPaths <- mapM (listSubDirDeep . (absDirPath P.</>)) relSubDirPaths
     return $ relFilePaths ++ (concat relSubDirFilesPaths)
   where
       -- | NOTE: Here, returned paths are relative to the main dir whose sub dir we are listing,
       --   which is one level above what you might intuitively expect.
-      listSubDirDeep :: Path.AbsDir -> IO [Path.RelFile]
+      listSubDirDeep :: (P.Path P.Abs P.Dir) -> IO [(P.Path P.Rel P.File)]
       listSubDirDeep subDirPath = do
           files <- listDirectoryDeep subDirPath
-          return $ map ((Path.dirname subDirPath) Path.</>) files
+          return $ map ((P.dirname subDirPath) P.</>) files
 
 -- TODO: write tests.
 -- | Lists files and directories at top lvl of the directory.
-listDirectory :: Path.AbsDir -> IO ([Path.RelFile], [Path.RelDir])
+listDirectory :: (P.Path P.Abs P.Dir) -> IO ([(P.Path P.Rel P.File)], [P.Path P.Rel P.Dir])
 listDirectory absDirPath = do
     fpRelItemPaths <- Dir.listDirectory fpAbsDirPath
     relFilePaths <- filterFiles fpAbsDirPath fpRelItemPaths
@@ -46,12 +44,12 @@ listDirectory absDirPath = do
     return (relFilePaths, relDirPaths)
   where
       fpAbsDirPath :: FilePath
-      fpAbsDirPath = Path.toFilePath absDirPath
+      fpAbsDirPath = P.toFilePath absDirPath
 
-      filterFiles :: FilePath -> [FilePath] -> IO [Path.RelFile]
+      filterFiles :: FilePath -> [FilePath] -> IO [(P.Path P.Rel P.File)]
       filterFiles absDir relItems = filterM (Dir.doesFileExist . (absDir FilePath.</>)) relItems
-                                    >>= mapM Path.parseRelFile
+                                    >>= mapM P.parseRelFile
 
-      filterDirs :: FilePath -> [FilePath] -> IO [Path.RelDir]
+      filterDirs :: FilePath -> [FilePath] -> IO [P.Path P.Rel P.Dir]
       filterDirs absDir relItems = filterM (Dir.doesDirectoryExist . (absDir FilePath.</>)) relItems
-                                   >>= mapM Path.parseRelDir
+                                   >>= mapM P.parseRelDir

--- a/waspc/src/Wasp/JsImport.hs
+++ b/waspc/src/Wasp/JsImport.hs
@@ -3,21 +3,20 @@ module Wasp.JsImport
     ) where
 
 import Data.Aeson ((.=), object, ToJSON(..))
-import qualified Path.Aliases as Path
+
+import StrongPath (Path, Rel, File)
+import qualified StrongPath as SP
+import ExternalCode (SourceExternalCodeDir)
 
 
 -- | Represents javascript import -> "import <what> from <from>".
 data JsImport = JsImport
     { jsImportWhat :: !String
-    -- | Path of file to import, relative to external code directory.
-    --   So for example if jsImportFrom is "test.js", we expect file
-    --   to exist at <external_code_dir>/test.js.
-    --   TODO: Make this more explicit in the code (both here and in wasp lang)? Also, support importing npm packages?
-    , jsImportFrom :: !Path.RelFile
+    , jsImportFrom :: !(Path (Rel SourceExternalCodeDir) File)
     } deriving (Show, Eq)
 
 instance ToJSON JsImport where
     toJSON jsImport = object
         [ "what" .= jsImportWhat jsImport
-        , "from" .= jsImportFrom jsImport
+        , "from" .= (SP.toFilePath $ jsImportFrom jsImport)
         ]

--- a/waspc/src/Wasp/Style.hs
+++ b/waspc/src/Wasp/Style.hs
@@ -4,13 +4,16 @@ module Wasp.Style
 
 import Data.Aeson (ToJSON(..))
 import Data.Text (Text)
-import qualified Path.Aliases as Path
+
+import StrongPath (Path, Rel, File)
+import qualified StrongPath as SP
+import ExternalCode (SourceExternalCodeDir)
 
 
-data Style = ExtCodeCssFile !Path.RelFile
+data Style = ExtCodeCssFile !(Path (Rel SourceExternalCodeDir) File)
            | CssCode !Text
     deriving (Show, Eq)
 
 instance ToJSON Style where
-    toJSON (ExtCodeCssFile path) = toJSON path
+    toJSON (ExtCodeCssFile path) = toJSON $ SP.toFilePath path
     toJSON (CssCode code) = toJSON code

--- a/waspc/test/Generator/EntityTest.hs
+++ b/waspc/test/Generator/EntityTest.hs
@@ -2,8 +2,9 @@ module Generator.EntityTest where
 
 import Test.Tasty.Hspec
 
-import Path ((</>), relfile)
+import qualified Path as P
 
+import qualified StrongPath as SP
 import Wasp
 import Generator.FileDraft
 import Generator.FileDraft.TemplateFileDraft
@@ -18,19 +19,19 @@ spec_EntityGenerator = do
 
     describe "generateEntityClass" $ do
         testGeneratorUsesCorrectSrcPath
-            testWasp generateEntityClass (entityTemplatesDirPath </> [relfile|_Entity.js|])
+            testWasp generateEntityClass (entityTemplatesDirPath SP.</> SP.fromPathRelFile [P.relfile|_Entity.js|])
 
     describe "generateEntityActions" $ do
         testGeneratorUsesCorrectSrcPath
-            testWasp generateEntityActions (entityTemplatesDirPath </> [relfile|actions.js|])
+            testWasp generateEntityActions (entityTemplatesDirPath SP.</> SP.fromPathRelFile [P.relfile|actions.js|])
 
     describe "generateEntityActionTypes" $ do
         testGeneratorUsesCorrectSrcPath
-            testWasp generateEntityActionTypes (entityTemplatesDirPath </> [relfile|actionTypes.js|])
+            testWasp generateEntityActionTypes (entityTemplatesDirPath SP.</> SP.fromPathRelFile [P.relfile|actionTypes.js|])
 
     describe "generateEntityState" $ do
         testGeneratorUsesCorrectSrcPath
-            testWasp generateEntityState (entityTemplatesDirPath </> [relfile|state.js|])
+            testWasp generateEntityState (entityTemplatesDirPath SP.</> SP.fromPathRelFile [P.relfile|state.js|])
 
   where
       testGeneratorUsesCorrectSrcPath testWasp generator expectedSrcPath = it

--- a/waspc/test/Generator/FileDraft/CopyFileDraftTest.hs
+++ b/waspc/test/Generator/FileDraft/CopyFileDraftTest.hs
@@ -2,9 +2,9 @@ module Generator.FileDraft.CopyFileDraftTest where
 
 import Test.Tasty.Hspec
 
-import qualified Path
-import Path ((</>), absdir, relfile, absfile)
+import qualified Path as P
 
+import qualified StrongPath as SP
 import Generator.FileDraft
 
 import qualified Generator.MockWriteableMonad as Mock
@@ -17,11 +17,15 @@ spec_CopyFileDraft = do
             let mock = write dstDir fileDraft
             let mockLogs = Mock.getMockLogs mock Mock.defaultMockConfig
             Mock.createDirectoryIfMissing_calls mockLogs
-                `shouldBe` [(True, Path.toFilePath $ Path.parent expectedDstPath)]
+                `shouldBe` [(True, SP.toFilePath $ SP.parent expectedDstPath)]
             Mock.copyFile_calls mockLogs
-                `shouldBe` [(Path.toFilePath expectedSrcPath, Path.toFilePath expectedDstPath)]
+                `shouldBe` [(SP.toFilePath expectedSrcPath, SP.toFilePath expectedDstPath)]
               where
-                (dstDir, dstPath, srcPath) = ([absdir|/a/b|], [relfile|c/d/dst.txt|], [absfile|/e/src.txt|])
+                (dstDir, dstPath, srcPath) =
+                    ( SP.fromPathAbsDir [P.absdir|/a/b|]
+                    , SP.fromPathRelFile [P.relfile|c/d/dst.txt|]
+                    , SP.fromPathAbsFile [P.absfile|/e/src.txt|]
+                    )
                 fileDraft = createCopyFileDraft dstPath srcPath
                 expectedSrcPath = srcPath
-                expectedDstPath = dstDir </> dstPath
+                expectedDstPath = dstDir SP.</> dstPath

--- a/waspc/test/Generator/WebAppGenerator/EntityGenerator/EntityFormGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGenerator/EntityGenerator/EntityFormGeneratorTest.hs
@@ -2,8 +2,7 @@ module Generator.WebAppGenerator.EntityGenerator.EntityFormGeneratorTest where
 
 import Test.Tasty.Hspec
 
-import Path ((</>))
-
+import StrongPath ((</>))
 import Wasp
 import Generator.FileDraft
 import qualified Generator.FileDraft.TemplateFileDraft as TmplFD

--- a/waspc/test/Generator/WebAppGenerator/ExternalCodeGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGenerator/ExternalCodeGeneratorTest.hs
@@ -1,18 +1,20 @@
 module Generator.WebAppGenerator.ExternalCodeGeneratorTest where
 
 import Test.Tasty.Hspec
+import qualified Path as P
 
-import Path (relfile)
-
+import qualified StrongPath as SP
 import Generator.WebAppGenerator.ExternalCodeGenerator as G
+import Generator.ExternalCodeGenerator.Common (asGenExtFile)
 
 spec_resolveJsFileWaspImports :: Spec
 spec_resolveJsFileWaspImports = do
-    ([relfile|extFile.js|], "import foo from 'bar'") ~> "import foo from 'bar'"
-    ([relfile|extFile.js|], "import foo from '@wasp/bar'") ~> "import foo from '../bar'"
-    ([relfile|a/extFile.js|], "import foo from  \"@wasp/bar/foo\"") ~>
+    (asGenExtFile [P.relfile|extFile.js|], "import foo from 'bar'") ~> "import foo from 'bar'"
+    (asGenExtFile [P.relfile|extFile.js|], "import foo from '@wasp/bar'") ~> "import foo from '../bar'"
+    (asGenExtFile [P.relfile|a/extFile.js|], "import foo from  \"@wasp/bar/foo\"") ~>
         "import foo from  \"../../bar/foo\""
   where
     (path, text) ~> expectedText =
-        it ((show path) ++ " " ++ (show text) ++ " -> " ++ (show expectedText)) $ do
+        it ((SP.toFilePath path) ++ " " ++ (show text) ++ " -> " ++ (show expectedText)) $ do
         G.resolveJsFileWaspImports path text `shouldBe` expectedText
+

--- a/waspc/test/Generator/WebAppGenerator/PageGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGenerator/PageGeneratorTest.hs
@@ -2,8 +2,9 @@ module Generator.WebAppGenerator.PageGeneratorTest where
 
 import Test.Tasty.Hspec
 
-import Path (relfile)
+import qualified Path as P
 
+import qualified StrongPath as SP
 import Wasp
 import Generator.FileDraft
 import Generator.FileDraft.TemplateFileDraft
@@ -20,4 +21,4 @@ spec_PageGenerator = do
         it "Given a simple Wasp, creates template file draft from _Page.js" $ do
             let (FileDraftTemplateFd (TemplateFileDraft _ srcPath _))
                     = generatePageComponent testWasp (head $ getPages testWasp)
-            srcPath `shouldBe` [relfile|react-app/src/_Page.js|]
+            srcPath `shouldBe` SP.fromPathRelFile [P.relfile|react-app/src/_Page.js|]

--- a/waspc/test/Generator/WebAppGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGeneratorTest.hs
@@ -3,9 +3,9 @@ module Generator.WebAppGeneratorTest where
 import Test.Tasty.Hspec
 
 import System.FilePath ((</>), (<.>))
-import Path (absdir)
-import qualified Path
+import qualified Path as P
 
+import qualified StrongPath as SP
 import Util
 import qualified CompileOptions
 import Generator.WebAppGenerator
@@ -26,7 +26,7 @@ spec_WebAppGenerator = do
     let testEntity = (Entity "TestEntity" [EntityField "testField" EftString])
     let testWasp = (fromApp testApp) `addPage` testPage `addEntity` testEntity
     let testCompileOptions = CompileOptions.CompileOptions
-            { CompileOptions.externalCodeDirPath = [absdir|/test/src|]
+            { CompileOptions.externalCodeDirPath = SP.fromPathAbsDir [P.absdir|/test/src|]
             }
 
     describe "generateWebApp" $ do
@@ -37,7 +37,7 @@ spec_WebAppGenerator = do
             let fileDrafts = generateWebApp testWasp testCompileOptions
             let testEntityDstDirInSrc
                     = "entities" </> (Util.camelToKebabCase (entityName testEntity))
-            let expectedFileDraftDstPaths = map ((Path.toFilePath Common.webAppRootDirInProjectRootDir) </>) $ concat $
+            let expectedFileDraftDstPaths = map ((SP.toFilePath Common.webAppRootDirInProjectRootDir) </>) $ concat $
                     [ [ "README.md"
                       , "package.json"
                       , ".gitignore"
@@ -47,7 +47,7 @@ spec_WebAppGenerator = do
                       , "index.html"
                       , "manifest.json"
                       ]
-                    , map ((Path.toFilePath Common.webAppSrcDirInWebAppRootDir) </>)
+                    , map ((SP.toFilePath Common.webAppSrcDirInWebAppRootDir) </>)
                       [ "logo.png"
                       , "index.css"
                       , "index.js"
@@ -78,6 +78,6 @@ existsFdWithDst fds dstPath = any ((== dstPath) . getFileDraftDstPath) fds
 -- TODO(martin): This should really become part of the Writeable typeclass,
 --   since it is smth we want to do for all file drafts.
 getFileDraftDstPath :: FileDraft -> FilePath
-getFileDraftDstPath (FileDraftTemplateFd fd) = Path.toFilePath $ TmplFD._dstPath fd
-getFileDraftDstPath (FileDraftCopyFd fd) = Path.toFilePath $ CopyFD._dstPath fd
-getFileDraftDstPath (FileDraftTextFd fd) = Path.toFilePath $ TextFD._dstPath fd
+getFileDraftDstPath (FileDraftTemplateFd fd) = SP.toFilePath $ TmplFD._dstPath fd
+getFileDraftDstPath (FileDraftCopyFd fd) = SP.toFilePath $ CopyFD._dstPath fd
+getFileDraftDstPath (FileDraftTextFd fd) = SP.toFilePath $ TextFD._dstPath fd

--- a/waspc/test/Parser/ExternalCodeTest.hs
+++ b/waspc/test/Parser/ExternalCodeTest.hs
@@ -3,8 +3,9 @@ module Parser.ExternalCodeTest where
 import Test.Tasty.Hspec
 
 import Data.Either (isLeft)
-import Path (relfile)
+import qualified Path as P
 
+import qualified StrongPath as SP
 import Parser.ExternalCode (extCodeFilePathString)
 import Parser.Common (runWaspParser)
 
@@ -14,7 +15,7 @@ spec_ParserExternalCode = do
     describe "Parsing external code file path string" $ do
         it "Correctly parses external code path in double quotes" $ do
             runWaspParser extCodeFilePathString "\"@ext/foo/bar.txt\""
-                `shouldBe` Right [relfile|foo/bar.txt|]
+                `shouldBe` Right (SP.fromPathRelFile [P.relfile|foo/bar.txt|])
 
         it "When path does not start with @ext/, returns Left" $ do
             isLeft (runWaspParser extCodeFilePathString "\"@ext2/foo/bar.txt\"") `shouldBe` True

--- a/waspc/test/Parser/JsImportTest.hs
+++ b/waspc/test/Parser/JsImportTest.hs
@@ -3,8 +3,9 @@ module Parser.JsImportTest where
 import Test.Tasty.Hspec
 
 import Data.Either (isLeft)
-import Path (relfile)
+import qualified Path as P
 
+import qualified StrongPath as SP
 import Parser.Common (runWaspParser)
 import Parser.JsImport (jsImport)
 import qualified Wasp
@@ -14,15 +15,15 @@ spec_parseJsImport :: Spec
 spec_parseJsImport = do
     it "Parses external code js import correctly" $ do
         runWaspParser jsImport "import something from \"@ext/some/file.js\""
-            `shouldBe` Right (Wasp.JsImport "something" [relfile|some/file.js|])
+            `shouldBe` Right (Wasp.JsImport "something" (SP.fromPathRelFile [P.relfile|some/file.js|]))
 
     it "Parses correctly when there is whitespace up front" $ do
         runWaspParser jsImport " import something from \"@ext/some/file.js\""
-            `shouldBe` Right (Wasp.JsImport "something" [relfile|some/file.js|])
+            `shouldBe` Right (Wasp.JsImport "something" (SP.fromPathRelFile [P.relfile|some/file.js|]))
 
     it "Parses correctly when 'from' is part of WHAT part" $ do
         runWaspParser jsImport "import somethingfrom from \"@ext/some/file.js\""
-            `shouldBe` Right (Wasp.JsImport "somethingfrom" [relfile|some/file.js|])
+            `shouldBe` Right (Wasp.JsImport "somethingfrom" (SP.fromPathRelFile [P.relfile|some/file.js|]))
 
     it "Throws error if there is no whitespace after import" $ do
         isLeft (runWaspParser jsImport "importsomething from \"@ext/some/file.js\"")

--- a/waspc/test/Parser/ParserTest.hs
+++ b/waspc/test/Parser/ParserTest.hs
@@ -2,8 +2,9 @@ module Parser.ParserTest where
 
 import Test.Tasty.Hspec
 import Data.Either
-import Path (relfile)
+import qualified Path as P
 
+import qualified StrongPath as SP
 import Parser
 import Wasp
 import qualified Wasp.EntityForm as EF
@@ -55,7 +56,7 @@ spec_parseWasp =
                         { pageName = "TestPage"
                         , pageRoute = "/test"
                         , pageContent = "<div>This is a test page!</div>"
-                        , pageStyle = Just $ Wasp.Style.ExtCodeCssFile [relfile|test.css|]
+                        , pageStyle = Just $ Wasp.Style.ExtCodeCssFile $ SP.fromPathRelFile [P.relfile|test.css|]
                         }
                     , WaspElementEntity $ Entity
                         { entityName = "Task"
@@ -112,5 +113,5 @@ spec_parseWasp =
                             ]
                         }
                     ]
-                    `setJsImports` [ JsImport "something" [relfile|some/file|] ]
+                    `setJsImports` [ JsImport "something" (SP.fromPathRelFile [P.relfile|some/file|]) ]
                 )

--- a/waspc/test/Parser/StyleTest.hs
+++ b/waspc/test/Parser/StyleTest.hs
@@ -3,8 +3,9 @@ module Parser.StyleTest where
 import Test.Tasty.Hspec
 
 import Data.Either (isLeft)
-import Path (relfile)
+import qualified Path as P
 
+import qualified StrongPath as SP
 import Parser.Common (runWaspParser)
 import Parser.Style (style)
 import qualified Wasp.Style
@@ -14,7 +15,7 @@ spec_parseStyle :: Spec
 spec_parseStyle = do
     it "Parses external code file path correctly" $ do
         runWaspParser style "\"@ext/some/file.js\""
-            `shouldBe` Right (Wasp.Style.ExtCodeCssFile [relfile|some/file.js|])
+            `shouldBe` Right (Wasp.Style.ExtCodeCssFile $ SP.fromPathRelFile [P.relfile|some/file.js|])
 
     it "Parses css closure correctly" $ do
         runWaspParser style "{=css Some css code css=}"

--- a/waspc/test/StrongPathTest.hs
+++ b/waspc/test/StrongPathTest.hs
@@ -3,11 +3,8 @@ module StrongPathTest where
 import Test.Tasty.Hspec
 
 import qualified Path as P
-import StrongPath
-    ( Path, Abs, Dir, File, (</>)
-    , fromRelFile, fromRelDir, fromAbsFile, fromAbsDir
-    , toAbsFile, toAbsDir, toRelFile, toRelDir
-    )
+import StrongPath (Path, Abs, Rel, Dir, File, (</>))
+import qualified StrongPath as SP
 
 
 data Bar
@@ -16,18 +13,18 @@ data Fizz
 spec_StrongPath :: Spec
 spec_StrongPath = do
     describe "Example with Foo file and Bar, Fizz and Kokolo dirs" $ do
-        let fooFileInBarDir = (fromRelFile [P.relfile|foo.txt|]) :: Path (Dir Bar) File
-        let barDirInFizzDir = (fromRelDir [P.reldir|kokolo/bar|]) :: Path (Dir Fizz) (Dir Bar)
-        let fizzDir = (fromAbsDir [P.absdir|/fizz|]) :: Path Abs (Dir Fizz)
+        let fooFileInBarDir = (SP.fromPathRelFile [P.relfile|foo.txt|]) :: Path (Rel Bar) File
+        let barDirInFizzDir = (SP.fromPathRelDir [P.reldir|kokolo/bar|]) :: Path (Rel Fizz) (Dir Bar)
+        let fizzDir = (SP.fromPathAbsDir [P.absdir|/fizz|]) :: Path Abs (Dir Fizz)
         let fooFile = (fizzDir </> barDirInFizzDir </> fooFileInBarDir) :: Path Abs File
-        let fooFileInFizzDir = (barDirInFizzDir </> fooFileInBarDir) :: Path (Dir Fizz) File
+        let fooFileInFizzDir = (barDirInFizzDir </> fooFileInBarDir) :: Path (Rel Fizz) File
 
         it "Paths are correctly concatenated" $ do
-            (P.toFilePath $ toAbsFile fooFile) `shouldBe` "/fizz/kokolo/bar/foo.txt"
-            (P.toFilePath $ toRelFile fooFileInFizzDir) `shouldBe` "kokolo/bar/foo.txt"
+            (P.toFilePath $ SP.toPathAbsFile fooFile) `shouldBe` "/fizz/kokolo/bar/foo.txt"
+            (P.toFilePath $ SP.toPathRelFile fooFileInFizzDir) `shouldBe` "kokolo/bar/foo.txt"
 
     it "Paths are unchanged when packed and unpacked" $ do
-        (P.toFilePath $ toRelFile $ fromRelFile [P.relfile|some/file.txt|]) `shouldBe` "some/file.txt"
-        (P.toFilePath $ toRelDir $ fromRelDir [P.reldir|some/dir/|]) `shouldBe` "some/dir/"
-        (P.toFilePath $ toAbsFile $ fromAbsFile [P.absfile|/some/file.txt|]) `shouldBe` "/some/file.txt"
-        (P.toFilePath $ toAbsDir $ fromAbsDir [P.absdir|/some/dir/|]) `shouldBe` "/some/dir/"
+        (P.toFilePath $ SP.toPathRelFile $ SP.fromPathRelFile [P.relfile|some/file.txt|]) `shouldBe` "some/file.txt"
+        (P.toFilePath $ SP.toPathRelDir $ SP.fromPathRelDir [P.reldir|some/dir/|]) `shouldBe` "some/dir/"
+        (P.toFilePath $ SP.toPathAbsFile $ SP.fromPathAbsFile [P.absfile|/some/file.txt|]) `shouldBe` "/some/file.txt"
+        (P.toFilePath $ SP.toPathAbsDir $ SP.fromPathAbsDir [P.absdir|/some/dir/|]) `shouldBe` "/some/dir/"


### PR DESCRIPTION
Most of the codebase now uses StrongPath!

The main idea is that now, when declaring a relative path somewhere, you can purposefully name what it is relative to, to avoid possible errors later. This still does not make everything error-free, since you have to "name" the paths yourself and if you "name" them wrong you will have a problem, but that is something that we can't really solve, it is up to you to say what you want.

There is also castRel method that lets you change what is path relative to, because sometimes taht makes sense -> you have path relative to dir A, but now you want to concat it with dir B because you are copying it from A to B (we have that situation with source vs generated external code dir), and then you can use castRel to say -> ok, now I declare it relative to B, not A anymore.

I tried to stick to following way of imports:
```haskell
import qualified Path as P
import StrongPath (Path, Abs, Rel, Dir, File, (</>))
import qualified StrongPath as SP
```
And I think it works quite ok.

The main thing missing, that could certainly improve the code, is support for `[reldir|foo/bar|]` directly in StrongPath, which would make code shorter and people would not have to think about Path almost at all. I will look into adding that down the road (fun, generics!).