### PR TITLE
Implemented Query parser.

### DIFF
--- a/waspc/src/Generator/WebAppGenerator/PageGenerator.hs
+++ b/waspc/src/Generator/WebAppGenerator/PageGenerator.hs
@@ -93,11 +93,11 @@ generatePageComponent wasp page = Common.makeTemplateFD tmplPath dstPath (Just t
 
     toJsImportData :: WJsImport.JsImport -> Aeson.Value
     toJsImportData jsImport = object
-        [ "what" .= fromMaybe (error "Expected default JS import.") (WJsImport.jsImportDefaultImport jsImport)
+        [ "what" .= fromMaybe (error "Expected default JS import.") (WJsImport._defaultImport jsImport)
         -- NOTE: Here we assume that "from" is relative to external code dir path.
         --   If this part will be reused, consider externalizing this assumption, so we don't have it on multiple places.
         , "from" .= buildImportPathFromPathInSrc
-            (extCodeDirInWebAppSrcDir </> castRelPathFromSrcToGenExtCodeDir (WJsImport.jsImportFrom jsImport))
+            (extCodeDirInWebAppSrcDir </> castRelPathFromSrcToGenExtCodeDir (WJsImport._from jsImport))
         ]
 
 data PageDir

--- a/waspc/src/Generator/WebAppGenerator/PageGenerator.hs
+++ b/waspc/src/Generator/WebAppGenerator/PageGenerator.hs
@@ -7,7 +7,7 @@ module Generator.WebAppGenerator.PageGenerator
        , generatePageStyle
        ) where
 
-import Data.Maybe (fromJust)
+import Data.Maybe (fromJust, fromMaybe)
 import Data.Aeson ((.=), object)
 import qualified Data.Aeson as Aeson
 import qualified System.FilePath as FP
@@ -44,7 +44,7 @@ generatePage wasp page =
 generatePageComponent :: Wasp -> WP.Page -> FileDraft
 generatePageComponent wasp page = Common.makeTemplateFD tmplPath dstPath (Just templateData)
   where
-    tmplPath = (SP.fromPathRelFile [P.relfile|src/_Page.js|]) :: Path (Rel Common.WebAppTemplatesDir) File
+    tmplPath = SP.fromPathRelFile [P.relfile|src/_Page.js|] :: Path (Rel Common.WebAppTemplatesDir) File
     dstPath = Common.webAppSrcDirInWebAppRootDir </> pageDirPathInSrc
               </> (fromJust $ SP.parseRelFile $ (WP.pageName page) ++ ".js")
     templateData = object $
@@ -93,11 +93,11 @@ generatePageComponent wasp page = Common.makeTemplateFD tmplPath dstPath (Just t
 
     toJsImportData :: WJsImport.JsImport -> Aeson.Value
     toJsImportData jsImport = object
-        [ "what" .= WJsImport.jsImportWhat jsImport
+        [ "what" .= fromMaybe (error "Expected default JS import.") (WJsImport.jsImportDefaultImport jsImport)
         -- NOTE: Here we assume that "from" is relative to external code dir path.
         --   If this part will be reused, consider externalizing this assumption, so we don't have it on multiple places.
-        , "from" .= (buildImportPathFromPathInSrc $ extCodeDirInWebAppSrcDir
-                     </> (castRelPathFromSrcToGenExtCodeDir $ WJsImport.jsImportFrom jsImport))
+        , "from" .= buildImportPathFromPathInSrc
+            (extCodeDirInWebAppSrcDir </> castRelPathFromSrcToGenExtCodeDir (WJsImport.jsImportFrom jsImport))
         ]
 
 data PageDir

--- a/waspc/src/Lexer.hs
+++ b/waspc/src/Lexer.hs
@@ -37,6 +37,9 @@ reservedNameEntityForm = "entity-form"
 reservedNameEntityList :: String
 reservedNameEntityList = "entity-list"
 
+reservedNameQuery :: String
+reservedNameQuery = "query"
+
 -- * Data types.
 
 reservedNameString :: String

--- a/waspc/src/Parser.hs
+++ b/waspc/src/Parser.hs
@@ -19,6 +19,7 @@ import Parser.JsImport (jsImport)
 import Parser.Button (button)
 import Parser.Action (action)
 import Parser.Common (runWaspParser)
+import qualified Parser.Query
 
 
 waspElement :: Parser Wasp.WaspElement
@@ -31,6 +32,7 @@ waspElement
     <|> waspElementEntityList
     <|> waspElementButton
     <|> waspElementAction
+    <|> waspElementQuery
 
 waspElementApp :: Parser Wasp.WaspElement
 waspElementApp = Wasp.WaspElementApp <$> app
@@ -56,6 +58,9 @@ waspElementEntityForm = Wasp.WaspElementEntityForm <$> entityForm
 waspElementEntityList :: Parser Wasp.WaspElement
 waspElementEntityList = Wasp.WaspElementEntityList <$> entityList
 
+waspElementQuery :: Parser Wasp.WaspElement
+waspElementQuery = Wasp.WaspElementQuery <$> Parser.Query.query
+
 -- | Top level parser, produces Wasp.
 waspParser :: Parser Wasp.Wasp
 waspParser = do
@@ -74,8 +79,8 @@ waspParser = do
     -- e.g. check there is only 1 title - if not, throw a meaningful error.
     -- Also, check there is at least one Page defined.
 
-    return $ (Wasp.fromWaspElems waspElems) `Wasp.setJsImports` jsImports
+    return $ Wasp.fromWaspElems waspElems `Wasp.setJsImports` jsImports
 
 -- | Top level parser executor.
 parseWasp :: String -> Either ParseError Wasp.Wasp
-parseWasp input = runWaspParser waspParser input
+parseWasp = runWaspParser waspParser

--- a/waspc/src/Parser/JsImport.hs
+++ b/waspc/src/Parser/JsImport.hs
@@ -17,9 +17,15 @@ jsImport :: Parser Wasp.JsImport.JsImport
 jsImport = do
     L.whiteSpace
     _ <- L.reserved L.reservedNameImport
-    what <- L.identifier <|> L.braces L.identifier
+    -- For now we support only default import or one named import.
+    (defaultImport, namedImports) <- ((\i -> (Just i, [])) <$> L.identifier)
+                                     <|> ((\i -> (Nothing, [i])) <$> L.braces L.identifier)
     _ <- L.reserved L.reservedNameFrom
     -- TODO: For now we only support double quotes here, we should also support single quotes.
     --   We would need to write this from scratch, with single quote escaping enabled.
     from <- Parser.ExternalCode.extCodeFilePathString
-    return Wasp.JsImport.JsImport { Wasp.JsImport.jsImportWhat = what, Wasp.JsImport.jsImportFrom = from }
+    return Wasp.JsImport.JsImport
+        { Wasp.JsImport.jsImportDefaultImport = defaultImport
+        , Wasp.JsImport.jsImportNamedImports = namedImports
+        , Wasp.JsImport.jsImportFrom = from
+        }

--- a/waspc/src/Parser/JsImport.hs
+++ b/waspc/src/Parser/JsImport.hs
@@ -25,7 +25,7 @@ jsImport = do
     --   We would need to write this from scratch, with single quote escaping enabled.
     from <- Parser.ExternalCode.extCodeFilePathString
     return Wasp.JsImport.JsImport
-        { Wasp.JsImport.jsImportDefaultImport = defaultImport
-        , Wasp.JsImport.jsImportNamedImports = namedImports
-        , Wasp.JsImport.jsImportFrom = from
+        { Wasp.JsImport._defaultImport = defaultImport
+        , Wasp.JsImport._namedImports = namedImports
+        , Wasp.JsImport._from = from
         }

--- a/waspc/src/Parser/Query.hs
+++ b/waspc/src/Parser/Query.hs
@@ -1,0 +1,38 @@
+module Parser.Query
+    ( query
+    ) where
+
+import Text.Parsec.String (Parser)
+import Data.Maybe (listToMaybe, fromMaybe)
+
+import qualified Wasp.Query
+import qualified Wasp.JsImport
+
+import qualified Parser.JsImport
+import qualified Parser.Common as C
+import qualified Lexer as L
+
+
+-- | Parses query looking like this:
+-- query myQuery {
+--   fn: import { myQueryInJs } from "..."
+-- }
+query :: Parser Wasp.Query.Query
+query = do
+    (queryName, queryProps) <- C.waspElementNameAndClosure L.reservedNameQuery queryProperties
+    return Wasp.Query.Query
+        { Wasp.Query._name = queryName
+        , Wasp.Query._jsFunction = fromMaybe (error "Query js function is missing.") (getQueryJsFunction queryProps)
+        }
+
+data QueryProperty = JsFunction !Wasp.JsImport.JsImport
+    deriving (Show, Eq)
+
+queryProperties :: Parser [QueryProperty]
+queryProperties = L.commaSep1 queryPropertyJsFunction
+
+queryPropertyJsFunction :: Parser QueryProperty
+queryPropertyJsFunction = JsFunction <$> C.waspProperty "fn" Parser.JsImport.jsImport
+
+getQueryJsFunction :: [QueryProperty] -> Maybe Wasp.JsImport.JsImport
+getQueryJsFunction ps = listToMaybe [f | JsFunction f <- ps]

--- a/waspc/src/Wasp.hs
+++ b/waspc/src/Wasp.hs
@@ -31,7 +31,11 @@ module Wasp
     , module Wasp.Page
     , getPages
     , addPage
-    
+
+    , getQueries
+    , addQuery
+    , getQueryByName
+
     , setExternalCodeFiles
     , getExternalCodeFiles
     ) where
@@ -49,6 +53,7 @@ import Wasp.Route
 import Wasp.Button
 import Wasp.Action (Action)
 import qualified Wasp.Action
+import qualified Wasp.Query
 
 import qualified Util as U
 
@@ -69,6 +74,7 @@ data WaspElement
     | WaspElementEntityList !EL.EntityList
     | WaspElementButton !Button
     | WaspElementAction !Action
+    | WaspElementQuery !Wasp.Query.Query
     deriving (Show, Eq)
 
 fromWaspElems :: [WaspElement] -> Wasp
@@ -154,6 +160,19 @@ getActionsForEntity :: Wasp -> Entity -> [Action]
 getActionsForEntity wasp entity = filter isActionOfGivenEntity (getActions wasp)
     where
         isActionOfGivenEntity action = entityName entity == Wasp.Action._entityName action
+
+-- * Query
+
+getQueries :: Wasp -> [Wasp.Query.Query]
+getQueries wasp = [query | (WaspElementQuery query) <- waspElements wasp]
+
+addQuery :: Wasp -> Wasp.Query.Query -> Wasp
+addQuery wasp query = wasp { waspElements = (WaspElementQuery query):(waspElements wasp) }
+
+-- | Gets query with a specified name from wasp, if such an action exists.
+-- We assume here that there are no two queries with same name.
+getQueryByName :: Wasp -> String -> Maybe Wasp.Query.Query
+getQueryByName wasp name = U.headSafe $ filter (\a -> Wasp.Query._name a == name) (getQueries wasp)
 
 -- * Entities
 

--- a/waspc/src/Wasp/JsImport.hs
+++ b/waspc/src/Wasp/JsImport.hs
@@ -11,14 +11,14 @@ import ExternalCode (SourceExternalCodeDir)
 
 -- | Represents javascript import -> "import <what> from <from>".
 data JsImport = JsImport
-    { jsImportDefaultImport :: !(Maybe String)
-    , jsImportNamedImports :: ![String]
-    , jsImportFrom :: !(Path (Rel SourceExternalCodeDir) File)
+    { _defaultImport :: !(Maybe String)
+    , _namedImports :: ![String]
+    , _from :: !(Path (Rel SourceExternalCodeDir) File)
     } deriving (Show, Eq)
 
 instance ToJSON JsImport where
     toJSON jsImport = object
-        [ "defaultImport" .= jsImportDefaultImport jsImport
-        , "namedImports" .= jsImportNamedImports jsImport
-        , "from" .= SP.toFilePath (jsImportFrom jsImport)
+        [ "defaultImport" .= _defaultImport jsImport
+        , "namedImports" .= _namedImports jsImport
+        , "from" .= SP.toFilePath (_from jsImport)
         ]

--- a/waspc/src/Wasp/JsImport.hs
+++ b/waspc/src/Wasp/JsImport.hs
@@ -11,13 +11,14 @@ import ExternalCode (SourceExternalCodeDir)
 
 -- | Represents javascript import -> "import <what> from <from>".
 data JsImport = JsImport
-    { -- ^ Currently this will always be an identifier, coming either from default or single named import.
-      jsImportWhat :: !String
+    { jsImportDefaultImport :: !(Maybe String)
+    , jsImportNamedImports :: ![String]
     , jsImportFrom :: !(Path (Rel SourceExternalCodeDir) File)
     } deriving (Show, Eq)
 
 instance ToJSON JsImport where
     toJSON jsImport = object
-        [ "what" .= jsImportWhat jsImport
-        , "from" .= (SP.toFilePath $ jsImportFrom jsImport)
+        [ "defaultImport" .= jsImportDefaultImport jsImport
+        , "namedImports" .= jsImportNamedImports jsImport
+        , "from" .= SP.toFilePath (jsImportFrom jsImport)
         ]

--- a/waspc/src/Wasp/Query.hs
+++ b/waspc/src/Wasp/Query.hs
@@ -1,0 +1,17 @@
+module Wasp.Query
+    ( Query(..)
+    ) where
+
+import Data.Aeson ((.=), object, ToJSON(..))
+import Wasp.JsImport (JsImport)
+
+data Query = Query
+    { _name :: !String
+    , _jsFunction :: !JsImport
+    } deriving (Show, Eq)
+
+instance ToJSON Query where
+    toJSON query = object
+        [ "name" .= _name query
+        , "jsFunction" .= _jsFunction query
+        ]

--- a/waspc/test/Parser/JsImportTest.hs
+++ b/waspc/test/Parser/JsImportTest.hs
@@ -15,19 +15,19 @@ spec_parseJsImport :: Spec
 spec_parseJsImport = do
     it "Parses external code js import with default import correctly" $ do
         runWaspParser jsImport "import something from \"@ext/some/file.js\""
-            `shouldBe` Right (Wasp.JsImport "something" (SP.fromPathRelFile [P.relfile|some/file.js|]))
+            `shouldBe` Right (Wasp.JsImport (Just "something") [] (SP.fromPathRelFile [P.relfile|some/file.js|]))
 
     it "Parses correctly when there is whitespace up front" $ do
         runWaspParser jsImport " import something from \"@ext/some/file.js\""
-            `shouldBe` Right (Wasp.JsImport "something" (SP.fromPathRelFile [P.relfile|some/file.js|]))
+            `shouldBe` Right (Wasp.JsImport (Just "something") [] (SP.fromPathRelFile [P.relfile|some/file.js|]))
 
     it "Parses correctly when 'from' is part of WHAT part" $ do
         runWaspParser jsImport "import somethingfrom from \"@ext/some/file.js\""
-            `shouldBe` Right (Wasp.JsImport "somethingfrom" (SP.fromPathRelFile [P.relfile|some/file.js|]))
+            `shouldBe` Right (Wasp.JsImport (Just "somethingfrom") [] (SP.fromPathRelFile [P.relfile|some/file.js|]))
 
     it "Parses correctly when 'what' is a single named export" $ do
         runWaspParser jsImport "import { something } from \"@ext/some/file.js\""
-            `shouldBe` Right (Wasp.JsImport "something" (SP.fromPathRelFile [P.relfile|some/file.js|]))
+            `shouldBe` Right (Wasp.JsImport Nothing ["something"] (SP.fromPathRelFile [P.relfile|some/file.js|]))
 
     it "For now we don't support multiple named exports in WHAT part" $ do
         isLeft (runWaspParser jsImport "import { foo, bar } from \"@ext/some/file.js\"")

--- a/waspc/test/Parser/ParserTest.hs
+++ b/waspc/test/Parser/ParserTest.hs
@@ -12,6 +12,8 @@ import qualified Wasp.EntityList as EL
 import qualified Wasp.Route as R
 import qualified Wasp.Style
 import qualified Wasp.JsCode
+import qualified Wasp.Query
+import qualified Wasp.JsImport
 
 
 spec_parseWasp :: Spec
@@ -102,7 +104,7 @@ spec_parseWasp =
                         , EL._entityName = "Task"
                         , EL._showHeader = Just False
                         , EL._fields =
-                            [ EL.Field 
+                            [ EL.Field
                                 { EL._fieldName = "description"
                                 , EL._fieldRender = Just $ Wasp.JsCode.JsCode "task => task.description"
                                 }
@@ -117,6 +119,14 @@ spec_parseWasp =
                                 , EL._filterPredicate = Wasp.JsCode.JsCode "task => !task.isDone"
                                 }
                             ]
+                        }
+                    , WaspElementQuery $  Wasp.Query.Query
+                        { Wasp.Query._name = "myQuery"
+                        , Wasp.Query._jsFunction = Wasp.JsImport.JsImport
+                            { Wasp.JsImport.jsImportDefaultImport = Nothing
+                            , Wasp.JsImport.jsImportNamedImports = [ "myJsQuery" ]
+                            , Wasp.JsImport.jsImportFrom = SP.fromPathRelFile [P.relfile|some/path|]
+                            }
                         }
                     ]
                     `setJsImports` [ JsImport (Just "something") [] (SP.fromPathRelFile [P.relfile|some/file|]) ]

--- a/waspc/test/Parser/ParserTest.hs
+++ b/waspc/test/Parser/ParserTest.hs
@@ -21,8 +21,7 @@ spec_parseWasp =
             isLeft (parseWasp "hoho") `shouldBe` True
 
         before (readFile "test/Parser/valid.wasp") $ do
-            it "When given a valid wasp source, should return correct\
-                \ Wasp" $ \wasp -> do
+            it "When given a valid wasp source, should return correct Wasp" $ \wasp -> do
                 parseWasp wasp
                 `shouldBe`
                 Right (fromWaspElems
@@ -120,5 +119,5 @@ spec_parseWasp =
                             ]
                         }
                     ]
-                    `setJsImports` [ JsImport "something" (SP.fromPathRelFile [P.relfile|some/file|]) ]
+                    `setJsImports` [ JsImport (Just "something") [] (SP.fromPathRelFile [P.relfile|some/file|]) ]
                 )

--- a/waspc/test/Parser/ParserTest.hs
+++ b/waspc/test/Parser/ParserTest.hs
@@ -123,9 +123,9 @@ spec_parseWasp =
                     , WaspElementQuery $  Wasp.Query.Query
                         { Wasp.Query._name = "myQuery"
                         , Wasp.Query._jsFunction = Wasp.JsImport.JsImport
-                            { Wasp.JsImport.jsImportDefaultImport = Nothing
-                            , Wasp.JsImport.jsImportNamedImports = [ "myJsQuery" ]
-                            , Wasp.JsImport.jsImportFrom = SP.fromPathRelFile [P.relfile|some/path|]
+                            { Wasp.JsImport._defaultImport = Nothing
+                            , Wasp.JsImport._namedImports = [ "myJsQuery" ]
+                            , Wasp.JsImport._from = SP.fromPathRelFile [P.relfile|some/path|]
                             }
                         }
                     ]

--- a/waspc/test/Parser/QueryTest.hs
+++ b/waspc/test/Parser/QueryTest.hs
@@ -23,9 +23,9 @@ spec_parseQuery =
             let testQuery = Wasp.Query.Query
                     { Wasp.Query._name = testQueryName
                     , Wasp.Query._jsFunction = Wasp.JsImport.JsImport
-                        { Wasp.JsImport.jsImportDefaultImport = Nothing
-                        , Wasp.JsImport.jsImportNamedImports = [ testQueryJsFunctionName ]
-                        , Wasp.JsImport.jsImportFrom = testQueryJsFunctionFrom
+                        { Wasp.JsImport._defaultImport = Nothing
+                        , Wasp.JsImport._namedImports = [ testQueryJsFunctionName ]
+                        , Wasp.JsImport._from = testQueryJsFunctionFrom
                         }
                     }
             parseQuery ( "query " ++ testQueryName ++ " {\n" ++

--- a/waspc/test/Parser/QueryTest.hs
+++ b/waspc/test/Parser/QueryTest.hs
@@ -1,0 +1,36 @@
+module Parser.QueryTest where
+
+import Test.Tasty.Hspec
+
+import Data.Either (isLeft)
+import Path (relfile)
+
+import qualified StrongPath as SP
+import Parser.Common (runWaspParser)
+import Parser.Query (query)
+import qualified Wasp.Query
+import qualified Wasp.JsImport
+
+spec_parseQuery :: Spec
+spec_parseQuery =
+    describe "Parsing query declaration" $ do
+        let parseQuery = runWaspParser query
+
+        it "When given a valid query declaration, returns correct AST" $ do
+            let testQueryName = "myQuery"
+                testQueryJsFunctionName = "myJsQuery"
+                testQueryJsFunctionFrom = SP.fromPathRelFile [relfile|some/path|]
+            let testQuery = Wasp.Query.Query
+                    { Wasp.Query._name = testQueryName
+                    , Wasp.Query._jsFunction = Wasp.JsImport.JsImport
+                        { Wasp.JsImport.jsImportDefaultImport = Nothing
+                        , Wasp.JsImport.jsImportNamedImports = [ testQueryJsFunctionName ]
+                        , Wasp.JsImport.jsImportFrom = testQueryJsFunctionFrom
+                        }
+                    }
+            parseQuery ( "query " ++ testQueryName ++ " {\n" ++
+                         "  fn: import { " ++ testQueryJsFunctionName ++ " } from \"@ext/some/path\"\n" ++
+                         "}"
+                       ) `shouldBe` Right testQuery
+        it "When given query wasp declaration without 'fn' property, should return Left" $ do
+            isLeft (parseQuery "query myQuery { }") `shouldBe` True

--- a/waspc/test/Parser/valid.wasp
+++ b/waspc/test/Parser/valid.wasp
@@ -83,3 +83,7 @@ entity-list<Task> TaskList {
         active: {=js task => !task.isDone js=}
     }
 }
+
+query myQuery {
+  fn: import { myJsQuery } from "@ext/some/path"
+}


### PR DESCRIPTION
This is first PR that implements operations!
I first fixed JsImport to remember what kind of import it parsed (default or named) and then I implemented Query parser + AST.

I was considering also implementing Action parser right now, but then concluded that it is mostly going to be boring copy/paste and while part could be reused, part will probably not be reused and will be boilerplatish. I don't think we would learn anything new by adding Action now and it would only slow us down (more refactoring if we change stuff) so I decided to just focus on Query for now and implement it end to end, and then later we can do the same thing for Action.