### PR TITLE
Added Travis CI: dynamic binaries are built and if tagged then also released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+os:
+  - linux
+  - osx
+
+# Do not choose a language; we provide our own build tools.
+language: generic
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+    - $HOME/.ghc
+    - $HOME/.cabal
+    # Where GHC and Stackage packages (per specific resolver/snapshot) get installed.
+    # Caching this avoids stack downloading GHC and building all the packages each time.
+    - $HOME/.stack
+    # Where stack produces build artifacts while building our project.
+    # Caching this avoids stack having to re-build our whole project every time.
+    - $TRAVIS_BUILD_DIR/waspc/.stack-work
+
+# Ensure necessary system libraries are present.
+addons:
+  apt:
+    packages:
+      - libgmp-dev
+
+before_install:
+  - mkdir -p ~/.local/bin && export PATH=$HOME/.local/bin:$PATH
+  # Download and install stack executable.
+  # NOTE: While it might seem redundant to do this on every build, it only takes about a second to download it.
+  - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]
+    then
+      travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    else
+      travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+    fi
+  - stack --numeric-version
+
+install:
+  - cd $TRAVIS_BUILD_DIR/waspc
+  # Build dependencies.
+  # --no-terminal because Stack does some fancy stuff with Terminal which Travis does not support (is this still true?).
+  # --install-ghc just tells stack to install ghc if it is missing (normally we would do it manually with stack setup).
+  # --only-dependencies means only wasp dependencies will be built, no wasp source code will be built at this moment.
+  - stack --no-terminal --install-ghc test --only-dependencies
+
+script:
+  # Build the wasp source code and its tests. Dependencies were already built before.
+  - stack --no-terminal test
+
+after_success:
+  # Prepare releases to be deployed.
+  - mkdir travis-releases/
+  - mv "$(stack path --local-install-root)/bin/wasp" "travis-releases/wasp-${TRAVIS_OS_NAME}"
+
+deploy:
+  provider: releases
+  api_key:
+    # Encrypted github access key.
+    secure: BvTKj98pSOsYcU0V8cDo8XrGRCb/VOhlN5aRO+LvvvX8JFIfWrUmnIqD1wlCm0PkOIQm8Wm/vJUZTAxJn57PRK4puPZlZ6zWJR2Oys/Xb5TOiOPXCqRmyyaMUwWyORVm/xI4/zmQVRshrPWlfOhGGBs98cxSgxvmW4BJZ/Zcs0+zvYjikUKUkh2BZmXVxn7t9ZQrf0IYLmRoVf0vReYGplzCLZs8PKZ130kjsGmP1TIakWSmpXzCfZIEcC9n4/jdm6vsYxUbYSi0PRNp99FJoIKRwinFnpyp2hXkohZM5MbP1cQ8kxRsA9hczJ5NWqkS14I58dta64IP/NnA2Xl0q2Ie3PEmwaJMrRm6paIg3AASCy2jt7sVG2/vigon8p6wQk2+PbOaDqd147bDJ+Ms+vgTsDdhGl2zYTHCM82jjEDnYRr51DAMfJPV+4eXA8PKdh0q1A/wTRLDCtArPIi+DVCOYH62VnBpbtKabh5Lqo6nQ3cEod2Ux8pYtxAcDgN2txbUrXEpf+Ivs+HSWD8bTNF8OOSsihurU6DV3qH1HQSxg7upQHyaJ9ScHlLK0EgUXWtCyb8zN3NWKo4LAT0V6YBWBRFC8lFqy35PQn70wWGAR7RyTUdXD4PkER+2lAHjZ/WovNeQtlMpG0Yc+9BDfE/o8XiMa28wF/+QyRiQzX4=
+  file: "travis-releases/wasp-${TRAVIS_OS_NAME}"
+  skip_cleanup: true
+  on:
+    # Whenever we push a tagged commit, binary will be deployed to releases.
+    tags: true

--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -37,6 +37,7 @@ dependencies:
 
 ghc-options:
   - -Wall
+  - -optP-Wno-nonportable-include-path # To avoid warning caused by .../autogen/cabal_macros.h. on OSX.
 
 library:
   source-dirs: src


### PR DESCRIPTION
Although I am not 100% sure that last deployment part is working, it is important to get something into master right now, because that will allow Travis to reuse most of the cached stuff from builds on master for builds on other branches (because if you create new branch/tag, it will use cache from the default branch, which is master), which means build times will go from 10 minutes to about 2 minutes. So let's get something merged into master and then I will iterate more on it.