### PR TITLE
Created a simple windows binary package.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,19 +41,23 @@ test_script:
   - cmd: stack build --test # Run tests
 
 after_test:
-  - ps: mkdir appveyor-releases/
-  - ps: mv "$(stack path --local-install-root)/bin/wasp.exe" "appveyor-releases/wasp-windows.exe"
+  - ps: mkdir binary-package
+  - ps: mv "$(stack path --local-install-root)/bin/wasp.exe" binary-package/wasp-x86_64.exe
+  - ps: mv "$(stack path --project-root)/data" binary-package/data
+  - ps: mv tools/run_wasp.ps1 binary-package/wasp.ps1
 
 artifacts:
-  - path: waspc/appveyor-releases/wasp-windows.exe
-    name: wasp-windows.exe
+  # Since waspc\binary-package is a directory, AppVeyor will zip it for us and
+  # name it by the name of the artifact + .zip.
+  - path: waspc\binary-package
+    name: wasp-win-x86_64
 
 deploy:
   provider: GitHub
   auth_token:
     secure: kyc1YtELeuOSAvRQtg6ppmMWYkbsP16z3eBRu09YozknJEXySteOJTHUUyaMocjC
   description: "Automatic release"
-  artifact: wasp-windows.exe
+  artifact: wasp-win-x86_64
   force_update: true # Adds files to release even if it already exists.
   on:
     APPVEYOR_REPO_TAG: true # Deploy on tag push only.

--- a/waspc/tools/run_wasp.ps1
+++ b/waspc/tools/run_wasp.ps1
@@ -1,0 +1,2 @@
+$env:waspc_datadir="$PSScriptRoot\data"
+& "$PSScriptRoot\wasp-x86_64.exe" $args


### PR DESCRIPTION
It almost works!
So, the idea is that you unpack created zip on Windows, and then you just run wasp.ps1 script via powershell and there you have it!
`wasp new myapp` works, but `wasp start` fails when it tries to run `npm start`, saying it can't find `npm`. But that is weird because it can find `node`, and I had both `node` and `npm` installed in the path.
Maybe some dynamic libraires are missing and this is how it is manifesting? Maybe StreamingProcess does not work but just Process works in Haskell on Windows?
Best would be to actually install stack on windows and compile and try out stuff, see if it works like that, what does or does not work and so on.