### PR TITLE
Wasper can now specify npm dependencies.

### DIFF
--- a/waspc/data/Generator/templates/react-app/package.json
+++ b/waspc/data/Generator/templates/react-app/package.json
@@ -1,22 +1,9 @@
 {{={= =}=}}
 {
-  "name": "{= app.name =}",
+  "name": "{= wasp.app.name =}",
   "version": "0.0.0",
   "private": true,
-  "dependencies": {
-    "@material-ui/core": "^4.9.1",
-    "@reduxjs/toolkit": "^1.2.3",
-    "axios": "^0.20.0",
-    "lodash": "^4.17.15",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "react-query": "^2.14.1",
-    "react-redux": "^7.1.3",
-    "react-router-dom": "^5.1.2",
-    "react-scripts": "3.4.0",
-    "redux": "^4.0.5",
-    "uuid": "^3.4.0"
-  },
+  {=& depsChunk =},
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/waspc/data/Generator/templates/server/package.json
+++ b/waspc/data/Generator/templates/server/package.json
@@ -12,14 +12,7 @@
   "engines": {
     "node": ">={= nodeVersion =}"
   },
-  "dependencies": {
-    "cookie-parser": "~1.4.4",
-    "cors": "^2.8.5",
-    "debug": "~2.6.9",
-    "express": "~4.16.1",
-    "morgan": "~1.9.1",
-    "@prisma/client": "2.x"
-  },
+  {=& depsChunk =},
   "devDependencies": {
     "nodemon": "^2.0.4",
     "standard": "^14.3.4",

--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -59,6 +59,7 @@ library:
     - async
     - bytestring
     - regex-tdfa
+    - utf8-string
 
 executables:
   wasp:
@@ -114,3 +115,4 @@ tests:
       - parsec
       - deepseq
       - path
+      - unordered-containers

--- a/waspc/src/Generator/PackageJsonGenerator.hs
+++ b/waspc/src/Generator/PackageJsonGenerator.hs
@@ -1,0 +1,58 @@
+module Generator.PackageJsonGenerator
+    ( resolveNpmDeps
+    , toPackageJsonDependenciesString
+    ) where
+
+import           Data.List     (find, intercalate)
+import           Data.Maybe    (fromJust, isJust)
+
+import qualified NpmDependency as ND
+
+
+type NpmDependenciesConflictError = String
+
+-- | Takes wasp npm dependencies and user npm dependencies and figures out how to
+--   combine them together, returning (Right) a list of npm dependencies to be used on
+--   behalf of wasp and then also a list of npm dependencies to be used on behalf
+--   of user. These lists might be the same as the initial ones, but might also
+--   be different.
+--   On error (Left), returns list of conflicting user deps together with the error message
+--   explaining what the error is.
+resolveNpmDeps
+    :: [ND.NpmDependency]
+    -> [ND.NpmDependency]
+    -> Either [(ND.NpmDependency, NpmDependenciesConflictError)]
+              ([ND.NpmDependency], [ND.NpmDependency])
+resolveNpmDeps waspDeps userDeps = if null conflictingUserDeps
+    then Right (waspDeps, userDepsNotInWaspDeps)
+    else Left conflictingUserDeps
+  where
+    conflictingUserDeps :: [(ND.NpmDependency, NpmDependenciesConflictError)]
+    conflictingUserDeps = map (\(dep, err) -> (dep, fromJust err))
+                      $ filter (isJust . snd)
+                      $ map (\dep -> (dep, checkIfConflictingUserDep dep)) userDeps
+
+    checkIfConflictingUserDep :: ND.NpmDependency -> Maybe NpmDependenciesConflictError
+    checkIfConflictingUserDep userDep =
+        let attachErrorMessage dep = "Error: Dependency conflict for user npm dependency ("
+                ++ ND._name dep ++ ", " ++ ND._version dep ++ "): "
+                ++ "Version must be set to the exactly the same version as"
+                ++ " the one wasp is using: "
+                ++ ND._version dep
+        in attachErrorMessage <$> find (areTwoDepsInConflict userDep) waspDeps
+
+    areTwoDepsInConflict :: ND.NpmDependency -> ND.NpmDependency -> Bool
+    areTwoDepsInConflict d1 d2 = ND._name d1 == ND._name d2
+                                 && ND._version d1 /= ND._version d2
+
+    userDepsNotInWaspDeps :: [ND.NpmDependency]
+    userDepsNotInWaspDeps = filter (not . isDepWithNameInWaspDeps . ND._name) userDeps
+
+    isDepWithNameInWaspDeps :: String -> Bool
+    isDepWithNameInWaspDeps name = any ((name ==). ND._name) waspDeps
+
+toPackageJsonDependenciesString :: [ND.NpmDependency] -> String
+toPackageJsonDependenciesString deps =
+    "\"dependencies\": {"
+    ++ intercalate ",\n  " (map (\dep -> "\"" ++ ND._name dep ++ "\": \"" ++ ND._version dep ++ "\"") deps)
+    ++ "\n}"

--- a/waspc/src/Lexer.hs
+++ b/waspc/src/Lexer.hs
@@ -43,6 +43,9 @@ reservedNameQuery = "query"
 reservedNameAction :: String
 reservedNameAction = "action"
 
+reservedNameDependencies :: String
+reservedNameDependencies = "dependencies"
+
 -- * Data types.
 
 reservedNameString :: String
@@ -63,6 +66,7 @@ reservedNames =
     , reservedNameFrom
     -- * Wasp element types
     , reservedNameApp
+    , reservedNameDependencies
     , reservedNamePage
     , reservedNameRoute
     , reservedNameEntityPSL

--- a/waspc/src/NpmDependency.hs
+++ b/waspc/src/NpmDependency.hs
@@ -1,0 +1,21 @@
+module NpmDependency
+    ( NpmDependency (..)
+    , fromList
+    ) where
+
+import           Data.Aeson (ToJSON (..), object, (.=))
+
+
+data NpmDependency = NpmDependency
+    { _name    :: !String
+    , _version :: !String }
+  deriving (Show, Eq)
+
+fromList :: [(String, String)] -> [NpmDependency]
+fromList = map (\(name, version) -> NpmDependency { _name = name, _version = version })
+
+instance ToJSON NpmDependency where
+    toJSON npmDep = object
+        [ "name" .= _name npmDep
+        , "version" .= _version npmDep
+        ]

--- a/waspc/src/Parser.hs
+++ b/waspc/src/Parser.hs
@@ -23,6 +23,7 @@ import Parser.JsImport (jsImport)
 import Parser.Common (runWaspParser)
 import qualified Parser.Query
 import qualified Parser.Action
+import qualified Parser.NpmDependencies
 
 waspElement :: Parser Wasp.WaspElement
 waspElement
@@ -37,6 +38,7 @@ waspElement
     <|> waspElementEntity
     <|> waspElementEntityForm
     <|> waspElementEntityList
+    <|> waspElementNpmDependencies
 
 waspElementApp :: Parser Wasp.WaspElement
 waspElementApp = Wasp.WaspElementApp <$> app
@@ -67,6 +69,10 @@ waspElementQuery = Wasp.WaspElementQuery <$> Parser.Query.query
 
 waspElementAction :: Parser Wasp.WaspElement
 waspElementAction = Wasp.WaspElementAction <$> Parser.Action.action
+
+waspElementNpmDependencies :: Parser Wasp.WaspElement
+waspElementNpmDependencies = Wasp.WaspElementNpmDependencies <$> Parser.NpmDependencies.npmDependencies
+
 
 -- | Top level parser, produces Wasp.
 waspParser :: Parser Wasp.Wasp

--- a/waspc/src/Parser/Common.hs
+++ b/waspc/src/Parser/Common.hs
@@ -36,7 +36,7 @@ waspElementNameAndClosure
     :: String -- ^ Element type
     -> Parser a -- ^ Closure parser (needs to parse braces as well, not just the content)
     -> Parser (String, a) -- ^ Name of the element and parsed closure content.
-waspElementNameAndClosure elementType closure = 
+waspElementNameAndClosure elementType closure =
     -- NOTE(matija): It is important to have `try` here because we don't want to consume the
     -- content intended for other parsers.
     -- E.g. if we tried to parse "entity-form" this parser would have been tried first for
@@ -54,7 +54,7 @@ waspElementNameAndClosure elementType closure =
     elementName <- L.identifier
     closureContent <- closure
 
-    return (elementName, closureContent) 
+    return (elementName, closureContent)
 
 -- | Parses declaration of a wasp element linked to an entity.
 -- E.g. "entity-form<Task> ..." or "action<Task> ..."

--- a/waspc/src/Parser/NpmDependencies.hs
+++ b/waspc/src/Parser/NpmDependencies.hs
@@ -1,0 +1,31 @@
+module Parser.NpmDependencies
+    ( npmDependencies
+    ) where
+
+import qualified Data.Aeson                as Aeson
+import qualified Data.ByteString.Lazy.UTF8 as BLU
+import qualified Data.HashMap.Strict       as M
+import           Text.Parsec               (try)
+import           Text.Parsec.String        (Parser)
+
+import qualified Lexer                     as L
+import qualified NpmDependency             as ND
+import qualified Parser.Common             as P
+import           Wasp.NpmDependencies      (NpmDependencies)
+import qualified Wasp.NpmDependencies      as NpmDependencies
+
+
+npmDependencies :: Parser NpmDependencies
+npmDependencies = try $ do
+    L.reserved L.reservedNameDependencies
+    closureContent <- P.waspNamedClosure "json"
+    let jsonBytestring = BLU.fromString $ "{ " ++ closureContent ++ " }"
+    npmDeps <- case Aeson.eitherDecode' jsonBytestring :: Either String (M.HashMap String String) of
+        Left errorMessage -> fail $ "Failed to parse dependencies JSON: " ++ errorMessage
+        Right rawDeps     -> return $ map rawDepToNpmDep (M.toList rawDeps)
+    return NpmDependencies.NpmDependencies
+        { NpmDependencies._dependencies = npmDeps
+        }
+  where
+    rawDepToNpmDep :: (String, String) -> ND.NpmDependency
+    rawDepToNpmDep (name, version) = ND.NpmDependency { ND._name = name, ND._version = version }

--- a/waspc/src/Wasp/NpmDependencies.hs
+++ b/waspc/src/Wasp/NpmDependencies.hs
@@ -1,0 +1,20 @@
+module Wasp.NpmDependencies
+    ( NpmDependencies(..)
+    , empty
+    ) where
+
+import           Data.Aeson    (ToJSON (..), object, (.=))
+import           NpmDependency
+
+
+data NpmDependencies = NpmDependencies
+    { _dependencies :: ![NpmDependency]
+    } deriving (Show, Eq)
+
+empty :: NpmDependencies
+empty = NpmDependencies { _dependencies = [] }
+
+instance ToJSON NpmDependencies where
+    toJSON deps = object
+        [ "dependencies" .= _dependencies deps
+        ]

--- a/waspc/test/Generator/PackageJsonGeneratorTest.hs
+++ b/waspc/test/Generator/PackageJsonGeneratorTest.hs
@@ -1,0 +1,34 @@
+module Generator.PackageJsonGeneratorTest where
+
+import           Test.Tasty.Hspec
+
+import           Generator.PackageJsonGenerator (resolveNpmDeps)
+import qualified NpmDependency                                  as ND
+
+
+spec_resolveNpmDeps :: Spec
+spec_resolveNpmDeps = do
+    let waspDeps = [ ("axios", "^0.20.0")
+                   , ("lodash", "^4.17.15")
+                   ]
+
+    it "Concatenates two distincts lists of deps." $ do
+        let userDeps = [ ("foo", "bar")
+                       , ("foo2", "bar2")
+                       ]
+        resolveNpmDeps (ND.fromList waspDeps) (ND.fromList userDeps)
+            `shouldBe` Right (ND.fromList waspDeps, ND.fromList userDeps)
+
+    it "Does not repeat dep if it is both user and wasp dep." $ do
+        let userDeps = [ ("axios", "^0.20.0")
+                       , ("foo", "bar")
+                       ]
+        resolveNpmDeps (ND.fromList waspDeps) (ND.fromList userDeps)
+            `shouldBe` Right (ND.fromList waspDeps, ND.fromList [("foo", "bar")])
+
+    it "Reports error if user dep version does not match wasp dep version." $ do
+        let userDeps = [ ("axios", "^1.20.0")
+                       , ("foo", "bar")
+                       ]
+        let Left conflicts = resolveNpmDeps (ND.fromList waspDeps) (ND.fromList userDeps)
+        (map fst conflicts) `shouldBe` ND.fromList [("axios", "^1.20.0")]

--- a/waspc/test/Parser/NpmDependenciesTest.hs
+++ b/waspc/test/Parser/NpmDependenciesTest.hs
@@ -1,0 +1,28 @@
+module Parser.NpmDependenciesTest where
+
+import           Test.Tasty.Hspec
+
+import           Data.Aeson             ((.=))
+import           Data.Either            (isLeft)
+import           Data.HashMap.Strict    (fromList)
+
+import qualified NpmDependency          as ND
+import           Parser.Common          (runWaspParser)
+import           Parser.NpmDependencies (npmDependencies)
+import           Wasp.NpmDependencies
+
+
+spec_parseNpmDependencies :: Spec
+spec_parseNpmDependencies = do
+    describe "Parsing npm dependencies" $ do
+        it "When given a valid declaration with valid json, parses it correctly" $ do
+            runWaspParser npmDependencies "dependencies {=json \"foo\": \"test1\", \"bar\": \"test2\" json=}"
+                `shouldBe` Right NpmDependencies
+                               { _dependencies =
+                                       [ ND.NpmDependency { ND._name = "foo", ND._version = "test1" }
+                                       , ND.NpmDependency { ND._name = "bar", ND._version = "test2" }
+                                       ]
+                               }
+        it "When given invalid json, reports error" $ do
+            isLeft (runWaspParser npmDependencies "dependencies {=json foo: 42 json=}")
+                `shouldBe` True

--- a/waspc/test/Parser/ParserTest.hs
+++ b/waspc/test/Parser/ParserTest.hs
@@ -1,22 +1,24 @@
 module Parser.ParserTest where
 
 import           Data.Either
-import qualified Path.Posix       as PPosix
+import qualified Path.Posix           as PPosix
 import           Test.Tasty.Hspec
 
+import           NpmDependency        as ND
 import           Parser
-import qualified StrongPath       as SP
+import qualified StrongPath           as SP
 import           Wasp
 import qualified Wasp.EntityPSL
 import qualified Wasp.JsCode
 import qualified Wasp.JsImport
+import qualified Wasp.NpmDependencies
 import qualified Wasp.Page
 import qualified Wasp.Query
-import qualified Wasp.Route       as R
+import qualified Wasp.Route           as R
 
 -- TODO(matija): old Entity stuff, to be removed.
-import qualified Wasp.EntityForm  as EF
-import qualified Wasp.EntityList  as EL
+import qualified Wasp.EntityForm      as EF
+import qualified Wasp.EntityList      as EL
 
 
 spec_parseWasp :: Spec
@@ -126,6 +128,14 @@ spec_parseWasp =
                             , Wasp.JsImport._namedImports = [ "myJsQuery" ]
                             , Wasp.JsImport._from = SP.fromPathRelFileP [PPosix.relfile|some/path|]
                             }
+                        }
+                     , WaspElementNpmDependencies $  Wasp.NpmDependencies.NpmDependencies
+                        { Wasp.NpmDependencies._dependencies =
+                          [ ND.NpmDependency
+                            { ND._name = "lodash"
+                            , ND._version = "^4.17.15"
+                            }
+                          ]
                         }
                     ]
                     `setJsImports` [ JsImport (Just "something") [] (SP.fromPathRelFileP [PPosix.relfile|some/file|]) ]

--- a/waspc/test/Parser/valid.wasp
+++ b/waspc/test/Parser/valid.wasp
@@ -69,8 +69,10 @@ entity-list<Task> TaskList {
     }
 }
 
-
-
 query myQuery {
   fn: import { myJsQuery } from "@ext/some/path"
 }
+
+dependencies {=json
+  "lodash": "^4.17.15"
+json=}


### PR DESCRIPTION
Implements #11 .

Right now, if user specifies npm package that user is already using, they will get a message explaining that they have to use the very same version as wasp is using, and they will be informed about that version, and everything will crash.

I also need to add documentation for this but that happens in another repo!