### PR TITLE
Queries are now auto-invalidated based on entities they use.

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/actions/_action.js
+++ b/waspc/data/Generator/templates/react-app/src/actions/_action.js
@@ -1,8 +1,15 @@
 {{={= =}=}}
 import { callOperation } from '../operations'
+import * as resources from '../operations/resources'
 
 const {= actionFnName =} = async (args) => {
-  return await callOperation('{= actionRoute =}', args)
+  const actionResult = await callOperation('{= actionRoute =}', args)
+  resources.invalidateQueriesUsing(entitiesUsed)
+  return actionResult
 }
 
+export const entitiesUsed = {=& entitiesArray =}
+
 export default {= actionFnName =}
+
+

--- a/waspc/data/Generator/templates/react-app/src/index.js
+++ b/waspc/data/Generator/templates/react-app/src/index.js
@@ -2,9 +2,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
+import { ReactQueryCacheProvider } from 'react-query'
 
 import router from './router'
 import { configureStore } from './store'
+import queryCache from './queryCache'
 import { rootReducer } from './reducers'
 import * as serviceWorker from './serviceWorker'
 
@@ -14,9 +16,11 @@ import './index.css'
 const store = configureStore(rootReducer)
 
 ReactDOM.render(
-  <Provider store={store}>
-    { router }
-  </Provider>,
+  <ReactQueryCacheProvider queryCache={queryCache}>
+    <Provider store={store}>
+      { router }
+    </Provider>
+  </ReactQueryCacheProvider>,
   document.getElementById('root')
 )
 

--- a/waspc/data/Generator/templates/react-app/src/operations/resources.js
+++ b/waspc/data/Generator/templates/react-app/src/operations/resources.js
@@ -1,0 +1,47 @@
+{{= {= =} =}}
+import queryCache from '../queryCache'
+
+
+// Map where key is resource name and value is Set
+// containing query ids of all the queries that use
+// that resource.
+const resourceToQueryCacheKeys = new Map()
+
+/**
+ * Remembers that specified query is using specified resources.
+ * If called multiple times for same query, resources are added, not reset.
+ * @param {string} queryCacheKey - Unique key under used to identify query in the cache.
+ * @param {string[]} resources - Names of resources that query is using.
+ */
+export const addResourcesUsedByQuery = (queryCacheKey, resources) => {
+  for (const resource of resources) {
+    let cacheKeys = resourceToQueryCacheKeys.get(resource)
+    if (!cacheKeys) {
+      cacheKeys = new Set()
+      resourceToQueryCacheKeys.set(resource, cacheKeys)
+    }
+    cacheKeys.add(queryCacheKey)
+  }
+}
+
+/**
+ * @param {string} resource - Resource name.
+ * @returns {string[]} Array of "query cache keys" of queries that use specified resource.
+ */
+export const getQueriesUsingResource = (resource) => {
+  return Array.from(resourceToQueryCacheKeys.get(resource) || [])
+}
+
+/**
+ * Invalidates all queries that are using specified resources.
+ * @param {string[]} resources - Names of resources.
+ */
+export const invalidateQueriesUsing = (resources) => {
+  const queryCacheKeysToInvalidate = new Set()
+  for (const resource of resources) {
+    getQueriesUsingResource(resource).forEach(key => queryCacheKeysToInvalidate.add(key))
+  }
+  for (const queryCacheKey of queryCacheKeysToInvalidate) {
+    queryCache.invalidateQueries(queryCacheKey)
+  }
+}

--- a/waspc/data/Generator/templates/react-app/src/queries/_query.js
+++ b/waspc/data/Generator/templates/react-app/src/queries/_query.js
@@ -1,11 +1,16 @@
 {{={= =}=}}
 import { callOperation } from '../operations'
+import * as resources from '../operations/resources'
 
 const {= queryFnName =} = async (args) => {
   return await callOperation('{= queryRoute =}', args)
 }
 
-{= queryFnName =}.useQueryKey = '{= queryRoute =}'
+const queryCacheKey = '{= queryRoute =}'
+{= queryFnName =}.queryCacheKey = queryCacheKey
+
+export const entitiesUsed = {=& entitiesArray =}
+resources.addResourcesUsedByQuery(queryCacheKey, entitiesUsed)
 
 export default {= queryFnName =}
 

--- a/waspc/data/Generator/templates/react-app/src/queries/index.js
+++ b/waspc/data/Generator/templates/react-app/src/queries/index.js
@@ -4,12 +4,12 @@ export const useQuery = (queryFn, queryFnArgs, config) => {
   if (typeof queryFn !== 'function') {
     throw new Error('useQuery requires queryFn to be a function.')
   }
-  if (!queryFn.useQueryKey) {
-    throw new Error('queryFn needs to have useQueryKey property defined.')
+  if (!queryFn.queryCacheKey) {
+    throw new Error('queryFn needs to have queryCacheKey property defined.')
   }
 
   const rqResult = rqUseQuery({
-    queryKey: [queryFn.useQueryKey, queryFnArgs],
+    queryKey: [queryFn.queryCacheKey, queryFnArgs],
     queryFn: (_key, args) => queryFn(args),
     config
   })

--- a/waspc/data/Generator/templates/react-app/src/queryCache.js
+++ b/waspc/data/Generator/templates/react-app/src/queryCache.js
@@ -1,0 +1,3 @@
+import { QueryCache } from 'react-query'
+
+export default new QueryCache()

--- a/waspc/examples/todoApp/ext/Todo.js
+++ b/waspc/examples/todoApp/ext/Todo.js
@@ -13,7 +13,7 @@ const Todo = (props) => {
 
   const [newTaskDescription, setNewTaskDescription] = useState(defaultNewTaskDescription)
 
-  const { data: tasks, refetch, isFetching, isError, error: tasksError } = useQuery(getTasks)
+  const { data: tasks, isError, error: tasksError } = useQuery(getTasks)
 
   const isAnyTaskCompleted = () => tasks?.some(t => t.isDone)
 
@@ -22,7 +22,6 @@ const Todo = (props) => {
   const createNewTask = async (description) => {
     const task = { isDone: false, description }
     await createTask(task)
-    refetch()
   }
 
   const handleNewTaskSubmit = async (event) => {
@@ -52,7 +51,6 @@ const Todo = (props) => {
 
     try {
       await updateTaskIsDone({ taskId, newIsDoneVal })
-      refetch()
     } catch (err) {
       console.log(err)
       window.alert('Error:' + err.message)
@@ -74,7 +72,6 @@ const Todo = (props) => {
   const handleDeleteCompletedTasks = async () => {
     try {
       await deleteCompletedTasks()
-      refetch()
     } catch (err) {
       console.log(err)
       window.alert('Error:' + err.message)
@@ -84,7 +81,6 @@ const Todo = (props) => {
   const handleToggleAllTasks = async () => {
     try {
       await toggleAllTasks()
-      refetch()
     } catch (err) {
       console.log(err)
       window.alert('Error:' + err.message)
@@ -113,7 +109,6 @@ const Todo = (props) => {
           </form>
         </div>
 
-        { isFetching && 'Fetching tasks...'}
 
         { isError && <TasksError/> }
 

--- a/waspc/src/Generator/WebAppGenerator.hs
+++ b/waspc/src/Generator/WebAppGenerator.hs
@@ -105,6 +105,7 @@ generateSrcDir wasp
         , [P.relfile|store/index.js|]
         , [P.relfile|store/middleware/logger.js|]
         , [P.relfile|config.js|]
+        , [P.relfile|queryCache.js|]
         ]
     ++ EntityGenerator.generateEntities wasp
     ++ [generateReducersJs wasp]

--- a/waspc/src/Generator/WebAppGenerator/OperationsGenerator/ResourcesG.hs
+++ b/waspc/src/Generator/WebAppGenerator/OperationsGenerator/ResourcesG.hs
@@ -1,0 +1,18 @@
+module Generator.WebAppGenerator.OperationsGenerator.ResourcesG
+    ( genResources
+    ) where
+
+import           Data.Aeson                                  (object)
+import qualified Path                                        as P
+
+import           Generator.FileDraft                         (FileDraft)
+import qualified Generator.WebAppGenerator.Common            as C
+import           Wasp                                        (Wasp)
+
+
+genResources :: Wasp -> [FileDraft]
+genResources _ = [C.makeTemplateFD tmplFile dstFile (Just tmplData)]
+  where
+    tmplFile = C.asTmplFile [P.relfile|src/operations/resources.js|]
+    dstFile = C.asWebAppFile $ [P.relfile|src/operations/resources.js|] -- TODO: Un-hardcode this by combining path to operations dir with path to resources file in it.
+    tmplData = object []


### PR DESCRIPTION
Implements last part of #64 -> entities are now used as resources for automatic query invalidation.

Notice how Todo.js has no `refetch()` statements any more.
