### PR TITLE
Deployment (backend and frontend)

### DIFF
--- a/waspc/data/Generator/templates/Dockerfile
+++ b/waspc/data/Generator/templates/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:14-alpine AS node
+
+
+FROM node AS base
+RUN apk --no-cache -U upgrade # To ensure any potential security patches are applied.
+
+
+FROM base AS server-builder
+# Install packages needed to build native npm packages.
+RUN apk add --no-cache build-base libtool autoconf automake python
+WORKDIR /app
+# Install npm packages, resulting in node_modules/.
+COPY server/package*.json ./server/
+RUN cd server && npm install
+COPY db/schema.prisma ./db/
+RUN cd server && npx prisma generate --schema=../db/schema.prisma
+
+
+# TODO: Use pm2?
+# TODO: Use non-root user (node).
+FROM base AS server-production
+ENV NODE_ENV production
+WORKDIR /app
+COPY --from=server-builder /app/server/node_modules ./server/node_modules
+COPY server/ ./server/
+COPY db/ ./db/
+EXPOSE ${PORT}
+WORKDIR /app/server
+ENTRYPOINT ["npm", "run", "start-production"]

--- a/waspc/data/Generator/templates/dockerignore
+++ b/waspc/data/Generator/templates/dockerignore
@@ -1,0 +1,2 @@
+**/node_modules/
+**/.git

--- a/waspc/data/Generator/templates/react-app/netlify.toml
+++ b/waspc/data/Generator/templates/react-app/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  publish = "build/"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+  force = false

--- a/waspc/data/Generator/templates/react-app/src/config.js
+++ b/waspc/data/Generator/templates/react-app/src/config.js
@@ -1,6 +1,6 @@
 
 const config = {
-  apiUrl: 'http://localhost:3001'
+  apiUrl: process.env.REACT_APP_API_URL || 'http://localhost:3001'
 }
 
 export default config

--- a/waspc/data/Generator/templates/server/package.json
+++ b/waspc/data/Generator/templates/server/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "start": "nodemon ./src/server.js",
     "debug": "DEBUG=server:* npm start",
+    "db-migrate-save": "prisma --experimental migrate save --schema=../db/schema.prisma",
+    "db-migrate": "prisma --experimental migrate up --schema=../db/schema.prisma",
+    "start-production": "{=& startProductionScript =}",
     "standard": "standard"
   },
   "nodemonConfig": {

--- a/waspc/data/Generator/templates/server/src/config.js
+++ b/waspc/data/Generator/templates/server/src/config.js
@@ -1,0 +1,38 @@
+{{={= =}=}}
+import _ from 'lodash'
+
+const env = process.env.NODE_ENV || 'development'
+
+// TODO:
+//   - Use dotenv library to consume env vars from a file.
+//   - Use convict library to define schema and validate env vars.
+//  https://codingsans.com/blog/node-config-best-practices
+
+const config = {
+  all: {
+    env,
+    port: parseInt(process.env.PORT) || 3001,
+    {=# isAuthEnabled =}
+    auth: {
+      jwtSecret: undefined
+    }
+    {=/ isAuthEnabled =}
+  },
+  development: {
+    {=# isAuthEnabled =}
+    auth: {
+      jwtSecret: 'DEVJWTSECRET'
+    }
+    {=/ isAuthEnabled =}
+  },
+  production: {
+    {=# isAuthEnabled =}
+    auth: {
+      jwtSecret: process.env.JWT_SECRET
+    }
+    {=/ isAuthEnabled =}
+  }
+}
+
+const resolvedConfig = _.merge(config.all, config[env])
+export default resolvedConfig

--- a/waspc/data/Generator/templates/server/src/server.js
+++ b/waspc/data/Generator/templates/server/src/server.js
@@ -2,10 +2,11 @@ import debug from 'debug'
 import http from 'http'
 
 import app from './app.js'
+import config from './config.js'
 
 const debugLog = debug('server:server')
 
-const port = normalizePort(process.env.PORT || '3001')
+const port = normalizePort(config.port)
 app.set('port', port)
 
 const server = http.createServer(app)

--- a/waspc/src/Generator.hs
+++ b/waspc/src/Generator.hs
@@ -16,6 +16,7 @@ import           Generator.Common          (ProjectRootDir)
 import           Generator.DbGenerator     (genDb)
 import           Generator.FileDraft       (FileDraft, write)
 import           Generator.ServerGenerator (genServer)
+import           Generator.DockerGenerator (genDockerFiles)
 import qualified Generator.Setup
 import qualified Generator.Start
 import           Generator.WebAppGenerator (generateWebApp)
@@ -34,6 +35,7 @@ writeWebAppCode wasp dstDir compileOptions = do
     writeFileDrafts dstDir (generateWebApp wasp compileOptions)
     writeFileDrafts dstDir (genServer wasp compileOptions)
     writeFileDrafts dstDir (genDb wasp compileOptions)
+    writeFileDrafts dstDir (genDockerFiles wasp compileOptions)
     writeDotWaspInfo dstDir
 
 -- | Writes file drafts while using given destination dir as root dir.

--- a/waspc/src/Generator/DockerGenerator.hs
+++ b/waspc/src/Generator/DockerGenerator.hs
@@ -1,0 +1,33 @@
+module Generator.DockerGenerator
+    ( genDockerFiles
+    ) where
+
+import           Data.Aeson          (object, (.=))
+import qualified Path                as P
+import           StrongPath          (File, Path, Rel)
+import qualified StrongPath          as SP
+
+import           CompileOptions      (CompileOptions)
+import           Generator.Common    (ProjectRootDir)
+import           Generator.FileDraft (FileDraft, createTemplateFileDraft)
+import           Generator.Templates (TemplatesDir)
+import           Wasp                (Wasp)
+
+genDockerFiles :: Wasp -> CompileOptions -> [FileDraft]
+genDockerFiles wasp _ = concat
+    [ [genDockerfile wasp]
+    , [genDockerignore wasp]
+    ]
+
+-- TODO: Inject paths to server and db files/dirs, right now they are hardcoded in the templates.
+genDockerfile :: Wasp -> FileDraft
+genDockerfile wasp = createTemplateFileDraft
+    (SP.fromPathRelFile [P.relfile|Dockerfile|] :: Path (Rel ProjectRootDir) File)
+    (SP.fromPathRelFile [P.relfile|Dockerfile|] :: Path (Rel TemplatesDir) File)
+    (Just $ object [])
+
+genDockerignore :: Wasp -> FileDraft
+genDockerignore _ = createTemplateFileDraft
+    (SP.fromPathRelFile [P.relfile|.dockerignore|] :: Path (Rel ProjectRootDir) File)
+    (SP.fromPathRelFile [P.relfile|dockerignore|] :: Path (Rel TemplatesDir) File)
+    Nothing

--- a/waspc/src/Generator/ServerGenerator.hs
+++ b/waspc/src/Generator/ServerGenerator.hs
@@ -55,7 +55,7 @@ genPackageJson wasp waspDeps = C.makeTemplateFD
      , "nodeVersion" .= nodeVersionAsText
      , "startProductionScript" .= concat
          [ if not (null $ Wasp.getPSLEntities wasp) then "npm run db-migrate && " else ""
-         , "node ./src/server.js"
+         , "NODE_ENV=production node ./src/server.js"
          ]
      ])
   where

--- a/waspc/src/Generator/ServerGenerator.hs
+++ b/waspc/src/Generator/ServerGenerator.hs
@@ -4,8 +4,9 @@ module Generator.ServerGenerator
     ) where
 
 import           Data.Aeson                                      (object, (.=))
-import           Data.Maybe                                      (isJust, fromJust)
 import           Data.List                                       (intercalate)
+import           Data.Maybe                                      (fromJust,
+                                                                  isJust)
 import qualified Path                                            as P
 import           StrongPath                                      ((</>))
 
@@ -15,13 +16,14 @@ import           Generator.ExternalCodeGenerator                 (generateExtern
 import           Generator.FileDraft                             (FileDraft)
 import           Generator.PackageJsonGenerator                  (resolveNpmDeps,
                                                                   toPackageJsonDependenciesString)
+import           Generator.ServerGenerator.AuthG                 (genAuth)
 import           Generator.ServerGenerator.Common                (asServerFile,
                                                                   asTmplFile)
 import qualified Generator.ServerGenerator.Common                as C
+import           Generator.ServerGenerator.ConfigG               (genConfigFile)
 import qualified Generator.ServerGenerator.ExternalCodeGenerator as ServerExternalCodeGenerator
 import           Generator.ServerGenerator.OperationsG           (genOperations)
 import           Generator.ServerGenerator.OperationsRoutesG     (genOperationsRoutes)
-import           Generator.ServerGenerator.AuthG                 (genAuth)
 import qualified NpmDependency                                   as ND
 import           Wasp                                            (Wasp, getAuth)
 import qualified Wasp
@@ -51,6 +53,10 @@ genPackageJson wasp waspDeps = C.makeTemplateFD
      [ "wasp" .= wasp
      , "depsChunk" .= toPackageJsonDependenciesString (resolvedWaspDeps ++ resolvedUserDeps)
      , "nodeVersion" .= nodeVersionAsText
+     , "startProductionScript" .= concat
+         [ if not (null $ Wasp.getPSLEntities wasp) then "npm run db-migrate && " else ""
+         , "node ./src/server.js"
+         ]
      ])
   where
     (resolvedWaspDeps, resolvedUserDeps) =
@@ -97,6 +103,7 @@ genSrcDir wasp = concat
     , [C.copySrcTmplAsIs $ C.asTmplSrcFile [P.relfile|utils.js|]]
     , [C.copySrcTmplAsIs $ C.asTmplSrcFile [P.relfile|core/HttpError.js|]]
     , [genDbClient wasp]
+    , [genConfigFile wasp]
     , genRoutesDir wasp
     , genOperationsRoutes wasp
     , genOperations wasp
@@ -110,13 +117,13 @@ genDbClient wasp = C.makeTemplateFD tmplFile dstFile (Just tmplData)
 
         dbClientRelToSrcP = [P.relfile|dbClient.js|]
         tmplFile = C.asTmplFile $ [P.reldir|src|] P.</> dbClientRelToSrcP
-        dstFile = C.serverSrcDirInServerRootDir </> (C.asServerSrcFile dbClientRelToSrcP)
+        dstFile = C.serverSrcDirInServerRootDir </> C.asServerSrcFile dbClientRelToSrcP
 
         tmplData =
-            if (isJust maybeAuth)
+            if isJust maybeAuth
                 then object
                     [ "isAuthEnabled" .= True
-                    , "userEntityUpper" .= (Wasp.Auth._userEntity $ fromJust maybeAuth)
+                    , "userEntityUpper" .= Wasp.Auth._userEntity (fromJust maybeAuth)
                     ]
                 else object []
 
@@ -127,9 +134,9 @@ genRoutesDir wasp =
     [ C.makeTemplateFD
         (asTmplFile [P.relfile|src/routes/index.js|])
         (asServerFile [P.relfile|src/routes/index.js|])
-        (Just $ object 
-            [ "operationsRouteInRootRouter" .= operationsRouteInRootRouter 
-            , "isAuthEnabled" .= (isJust $ getAuth wasp)
+        (Just $ object
+            [ "operationsRouteInRootRouter" .= operationsRouteInRootRouter
+            , "isAuthEnabled" .= isJust (getAuth wasp)
             ]
         )
     ]

--- a/waspc/src/Generator/ServerGenerator/ConfigG.hs
+++ b/waspc/src/Generator/ServerGenerator/ConfigG.hs
@@ -1,0 +1,27 @@
+module Generator.ServerGenerator.ConfigG
+    ( genConfigFile
+    , configFileInSrcDir
+    ) where
+
+import           Data.Aeson                       (object, (.=))
+import           Data.Maybe                       (isJust)
+import qualified Path                             as P
+import           StrongPath                       (File, Path, Rel, (</>))
+import qualified StrongPath                       as SP
+
+import           Generator.FileDraft              (FileDraft)
+import qualified Generator.ServerGenerator.Common as C
+import           Wasp                             (Wasp, getAuth)
+
+
+genConfigFile :: Wasp -> FileDraft
+genConfigFile wasp = C.makeTemplateFD tmplFile dstFile (Just tmplData)
+  where
+    tmplFile = C.srcDirInServerTemplatesDir </> SP.castRel configFileInSrcDir
+    dstFile = C.serverSrcDirInServerRootDir </> configFileInSrcDir
+    tmplData = object
+        [ "isAuthEnabled" .= isJust (getAuth wasp)
+        ]
+
+configFileInSrcDir :: Path (Rel C.ServerSrcDir) File
+configFileInSrcDir = SP.fromPathRelFile [P.relfile|config.js|]

--- a/waspc/src/Generator/WebAppGenerator.hs
+++ b/waspc/src/Generator/WebAppGenerator.hs
@@ -35,6 +35,7 @@ generateWebApp wasp _ = concat
     , generatePublicDir wasp
     , generateSrcDir wasp
     , generateExternalCodeDir WebAppExternalCodeGenerator.generatorStrategy wasp
+    , [C.makeSimpleTemplateFD (asTmplFile [P.relfile|netlify.toml|]) wasp]
     ]
 
 generateReadme :: Wasp -> FileDraft


### PR DESCRIPTION
For backend/server, we now generate Dockerfile (+ .dockerignore file) that enables you to build image that can be deployed to production. I also ensured that ENV vars are properly used: PORT, DATABASE_URL, and JWT_SECRET.

For frontend, we now generate netlify.toml file that contains instructions on how to deploy to Netlify, and I made sure that API_URL is now controller via an env var.

Many things are not perfect, but you can deploy the app!

The most "rough" thing right now is that you have to manually specify, when building frontend, what is the API_URL. Also, you have to tell Netlify if you want to create new deployment or use existing one -> and if existing one, you have to type the name yourself.
Same goes for backend, you have to type the app name (on Heroku) all the time if you are going with Heroku.
In the future, we could add declarative code to Wasp where we describe deployment, and then there we can provide more info so it doesn't have to be inputted manually. Ideally, you would just call `wasp deploy <deployment name>` and it would take care of everything, based on the declarative description of deployment. It might store some data (like the name of the created app, or its url, or id of deployment (netlify) to an additional file, which would be commited to git, so it can reuse it later).

Anyway, this is the first step for now, and I am off to write documentation for it -> instructions on how to deploy to Netlify + Heroku.