### PR TITLE
Handle case when JWT token verification fails

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/api.js
+++ b/waspc/data/Generator/templates/react-app/src/api.js
@@ -38,6 +38,13 @@ api.interceptors.request.use(request => {
   return request
 })
 
+api.interceptors.response.use(response => {
+  if(response.status === 401) {
+    clearAuthToken()
+  }
+  return response
+})
+
 /**
  * Takes an error returned by the app's API (as returned by axios), and transforms into a more
  * standard format to be further used by the client. It is also assumed that given API

--- a/waspc/data/Generator/templates/react-app/src/api.js
+++ b/waspc/data/Generator/templates/react-app/src/api.js
@@ -38,11 +38,11 @@ api.interceptors.request.use(request => {
   return request
 })
 
-api.interceptors.response.use(response => {
-  if(response.status === 401) {
+api.interceptors.response.use(undefined, error => {
+  if (error.response?.status === 401) {
     clearAuthToken()
   }
-  return response
+  return Promise.reject(error)
 })
 
 /**

--- a/waspc/data/Generator/templates/server/src/core/auth.js
+++ b/waspc/data/Generator/templates/server/src/core/auth.js
@@ -30,11 +30,11 @@ const auth = handleRejection(async (req, res, next) => {
     try {
       var userIdFromToken = (await verify(token)).id
     } catch (error) {
-      if (error.name.match(/^(TokenExpiredError|JsonWebTokenError|NotBeforeError)$/)) {
+      if (['TokenExpiredError', 'JsonWebTokenError', 'NotBeforeError'].includes(error.name)) {
         return res.status(401).send()
       }
       else {
-        console.error(error)
+        throw error
       }
     }
 

--- a/waspc/data/Generator/templates/server/src/core/auth.js
+++ b/waspc/data/Generator/templates/server/src/core/auth.js
@@ -26,9 +26,12 @@ const auth = handleRejection(async (req, res, next) => {
 
   if (authHeader.startsWith('Bearer ')) {
     const token = authHeader.substring(7, authHeader.length)
-    // TODO: If token verification fails, this will throw error that will end up
-    //   being propagated as 500 error. Should we handle it better, turn it into 403 error?
-    const userIdFromToken = (await verify(token)).id
+
+    try {
+      var userIdFromToken = (await verify(token)).id
+    } catch (error) {
+      return res.status(401).send()
+    }
 
     const user = await prisma.{= userEntityLower =}.findUnique({ where: { id: userIdFromToken } })
     if (!user) {

--- a/waspc/data/Generator/templates/server/src/core/auth.js
+++ b/waspc/data/Generator/templates/server/src/core/auth.js
@@ -27,13 +27,13 @@ const auth = handleRejection(async (req, res, next) => {
   if (authHeader.startsWith('Bearer ')) {
     const token = authHeader.substring(7, authHeader.length)
 
+    let userIdFromToken
     try {
-      var userIdFromToken = (await verify(token)).id
+      userIdFromToken = (await verify(token)).id
     } catch (error) {
       if (['TokenExpiredError', 'JsonWebTokenError', 'NotBeforeError'].includes(error.name)) {
         return res.status(401).send()
-      }
-      else {
+      } else {
         throw error
       }
     }

--- a/waspc/data/Generator/templates/server/src/core/auth.js
+++ b/waspc/data/Generator/templates/server/src/core/auth.js
@@ -30,7 +30,12 @@ const auth = handleRejection(async (req, res, next) => {
     try {
       var userIdFromToken = (await verify(token)).id
     } catch (error) {
-      return res.status(401).send()
+      if (error.name.match(/^(TokenExpiredError|JsonWebTokenError|NotBeforeError)$/)) {
+        return res.status(401).send()
+      }
+      else {
+        console.error(error)
+      }
     }
 
     const user = await prisma.{= userEntityLower =}.findUnique({ where: { id: userIdFromToken } })


### PR DESCRIPTION
# Description

Handles the case when JWT token verification fails by sending a 401 instead of a 500 and deleting the JWT token from local storage.

Fixes # [(168)](https://github.com/wasp-lang/wasp/issues/168)

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update