### PR TITLE
added documentation for bypassing stack build errors on macOS Big Sur

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -34,6 +34,19 @@ It can then also run that web app for you, deploy it (not yet but that is coming
 ### Setup
 We use [Stack](https://docs.haskellstack.org/en/stable/README/) for building the project, so you will need to install `stack` on your machine.
 
+### Repo
+Fork this repo and clone the fork to your machine (or clone this repo directly if you don't plan to contribute but just want to try it out).
+
+Position yourself in this directory (`waspc/`) and make sure that you are on the `master` branch.
+
+### Build
+```
+stack build
+```
+to build the library and `wasp` executable.
+
+This might take a longer time (10 mins) if you are doing it for the very first time, since `stack` will need to download the external dependencies.
+
 `NOTE:` For macOS Big Sur users there is a bug in older GHC versions (<= 8.10.3) causing system frameworks to load improperly and will fail when building the project. This can be fixed with the following steps:
 
 <details>
@@ -55,19 +68,6 @@ We use [Stack](https://docs.haskellstack.org/en/stable/README/) for building the
 </details>
 
 <br/>
-
-### Repo
-Fork this repo and clone the fork to your machine (or clone this repo directly if you don't plan to contribute but just want to try it out).
-
-Position yourself in this directory (`waspc/`) and make sure that you are on the `master` branch.
-
-### Build
-```
-stack build
-```
-to build the library and `wasp` executable.
-
-This might take a longer time (10 mins) if you are doing it for the very first time, since `stack` will need to download the external dependencies.
 
 ### Test
 ```

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -34,6 +34,28 @@ It can then also run that web app for you, deploy it (not yet but that is coming
 ### Setup
 We use [Stack](https://docs.haskellstack.org/en/stable/README/) for building the project, so you will need to install `stack` on your machine.
 
+`NOTE:` For macOS Big Sur users there is a bug in older GHC versions (<= 8.10.3) causing system frameworks to load improperly and will fail when building the project. This can be fixed with the following steps:
+
+<details>
+   <summary>Show details</summary>
+
+   1. Clean up stack cache which could have been carried over from previous OS versions using below command.
+
+      ```
+      rm -Rf ~/.stack/setup-exe-cache/x86_64-osx
+      ```
+
+   2. Run `stack build` until it fails with error `can't load framework: Cocoa (not found)`.
+   3. Checkout and build this [workaround](https://github.com/yairchu/macos11-haskell-workaround).
+   4. Re-run stack build with workaround using below command and it should build without errors.
+
+      ```
+      DYLD_INSERT_LIBRARIES=~/macos11-haskell-workaround/macos11ghcwa.dylib stack build
+      ```
+</details>
+
+<br/>
+
 ### Repo
 Fork this repo and clone the fork to your machine (or clone this repo directly if you don't plan to contribute but just want to try it out).
 


### PR DESCRIPTION
# Description

Adds documentation to the readme for addressing a bug found when building the project on macOS Big Sur.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update