### PR TITLE
remove createNewUser, use a direct call to prisma

### DIFF
--- a/waspc/data/Generator/templates/server/src/core/auth.js
+++ b/waspc/data/Generator/templates/server/src/core/auth.js
@@ -53,15 +53,6 @@ const auth = handleRejection(async (req, res, next) => {
   next()
 })
 
-// TODO(matija): since this function is not doing much anymore, we can remove it.
-// Make sure to replace its invocations with direct calls to prisma client's create().
-// Github issue: https://github.com/wasp-lang/wasp/issues/150
-export const createNewUser = async (userFields) => {
-  const newUser = await prisma.{= userEntityLower =}.create({ data: userFields })
-
-  return newUser
-}
-
 const SP = new SecurePassword()
 
 export const hashPassword = async (password) => {

--- a/waspc/data/Generator/templates/server/src/routes/auth/signup.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/signup.js
@@ -1,10 +1,10 @@
-import { createNewUser } from '../../core/auth.js'
+import prisma from '../../dbClient.js'
 import { handleRejection } from '../../utils.js'
 
 export default handleRejection(async (req, res) => {
   const userFields = req.body || {}
 
-  await createNewUser(userFields)
+  await prisma.{= userEntityLower =}.create({ data: userFields })
 
   res.send()
 })

--- a/waspc/data/Generator/templates/server/src/routes/auth/signup.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/signup.js
@@ -1,3 +1,4 @@
+{{={= =}=}}
 import prisma from '../../dbClient.js'
 import { handleRejection } from '../../utils.js'
 

--- a/waspc/src/Generator/ServerGenerator/AuthG.hs
+++ b/waspc/src/Generator/ServerGenerator/AuthG.hs
@@ -18,7 +18,7 @@ genAuth wasp = case maybeAuth of
                    -- Auth routes
                  , genAuthRoutesIndex
                  , genLoginRoute auth
-                 , genSignupRoute
+                 , genSignupRoute auth
                  , genMeRoute auth
                  ]
     Nothing   -> []
@@ -53,8 +53,16 @@ genLoginRoute auth = C.makeTemplateFD tmplFile dstFile (Just tmplData)
             , "userEntityLower" .= Util.toLowerFirst userEntity
             ]
 
-genSignupRoute :: FileDraft
-genSignupRoute = C.copySrcTmplAsIs (C.asTmplSrcFile [P.relfile|routes/auth/signup.js|])
+genSignupRoute :: Wasp.Auth.Auth -> FileDraft
+genSignupRoute auth = C.makeTemplateFD tmplFile dstFile (Just tmplData)
+    where
+        signupRouteRelToSrc = [P.relfile|routes/auth/signup.js|]
+        tmplFile = C.asTmplFile $ [P.reldir|src|] P.</> signupRouteRelToSrc
+        dstFile = C.serverSrcDirInServerRootDir </> (C.asServerSrcFile signupRouteRelToSrc)
+
+        tmplData = object
+            [ "userEntityLower" .= Util.toLowerFirst (Wasp.Auth._userEntity auth)
+            ]
 
 genMeRoute :: Wasp.Auth.Auth -> FileDraft
 genMeRoute auth = C.makeTemplateFD tmplFile dstFile (Just tmplData)


### PR DESCRIPTION
# Description

 Remove `createNewUser` as the function is no longer used and it is replaced with a direct call to prisma.

Fixes #150

## Type of change

Please select the option(s) that is more relevant.

- [ x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update