### PR TITLE
feat: Validate projectName when creating new project

### DIFF
--- a/waspc/cli/Command/Common.hs
+++ b/waspc/cli/Command/Common.hs
@@ -1,50 +1,60 @@
 module Command.Common
-    ( findWaspProjectRootDirFromCwd
-    , findWaspProjectRoot
-    , waspSaysC
-    , alphaWarningMessage
-    ) where
+  ( findWaspProjectRootDirFromCwd,
+    findWaspProjectRoot,
+    waspSaysC,
+    alphaWarningMessage,
+  )
+where
 
-import           Control.Monad          (unless, when)
-import           Control.Monad.Except   (throwError)
-import           Control.Monad.IO.Class (liftIO)
-import           Data.Maybe             (fromJust)
-import           System.Directory       (doesFileExist, doesPathExist,
-                                         getCurrentDirectory)
-import qualified System.FilePath        as FP
-
-import           Cli.Common             (dotWaspRootFileInWaspProjectDir,
-                                         waspSays)
-import           Command                (Command, CommandError (..))
-import           Common                 (WaspProjectDir)
-import           StrongPath             (Abs, Dir, Path)
-import qualified StrongPath             as SP
-
+import Cli.Common
+  ( dotWaspRootFileInWaspProjectDir,
+    waspSays,
+  )
+import Command (Command, CommandError (..))
+import Common (WaspProjectDir)
+import Control.Monad (unless, when)
+import Control.Monad.Except (throwError)
+import Control.Monad.IO.Class (liftIO)
+import Data.Maybe (fromJust)
+import StrongPath (Abs, Dir, Path)
+import qualified StrongPath as SP
+import System.Directory
+  ( doesFileExist,
+    doesPathExist,
+    getCurrentDirectory,
+  )
+import qualified System.FilePath as FP
 
 findWaspProjectRoot :: Path Abs (Dir ()) -> Command (Path Abs (Dir WaspProjectDir))
 findWaspProjectRoot currentDir = do
-    let absCurrentDirFp = SP.toFilePath currentDir
-    doesCurrentDirExist <- liftIO $ doesPathExist absCurrentDirFp
-    unless doesCurrentDirExist (throwError notFoundError)
-    let dotWaspRootFilePath = absCurrentDirFp FP.</> SP.toFilePath dotWaspRootFileInWaspProjectDir
-    isCurrentDirRoot <- liftIO $ doesFileExist dotWaspRootFilePath
-    if isCurrentDirRoot
-        then return $ SP.castDir currentDir
-        else do let parentDir = SP.parent currentDir
-                when (parentDir == currentDir) (throwError notFoundError)
-                findWaspProjectRoot parentDir
+  let absCurrentDirFp = SP.toFilePath currentDir
+  doesCurrentDirExist <- liftIO $ doesPathExist absCurrentDirFp
+  unless doesCurrentDirExist (throwError notFoundError)
+  let dotWaspRootFilePath = absCurrentDirFp FP.</> SP.toFilePath dotWaspRootFileInWaspProjectDir
+  isCurrentDirRoot <- liftIO $ doesFileExist dotWaspRootFilePath
+  if isCurrentDirRoot
+    then return $ SP.castDir currentDir
+    else do
+      let parentDir = SP.parent currentDir
+      when (parentDir == currentDir) (throwError notFoundError)
+      findWaspProjectRoot parentDir
   where
-      notFoundError = CommandError ("Couldn't find wasp project root - make sure"
-                                    ++ " you are running this command from Wasp project.")
+    notFoundError =
+      CommandError
+        ( "Couldn't find wasp project root - make sure"
+            ++ " you are running this command from Wasp project."
+        )
 
 findWaspProjectRootDirFromCwd :: Command (Path Abs (Dir WaspProjectDir))
 findWaspProjectRootDirFromCwd = do
-    absCurrentDir <- liftIO getCurrentDirectory
-    findWaspProjectRoot (fromJust $ SP.parseAbsDir absCurrentDir)
+  absCurrentDir <- liftIO getCurrentDirectory
+  findWaspProjectRoot (fromJust $ SP.parseAbsDir absCurrentDir)
 
 waspSaysC :: String -> Command ()
 waspSaysC = liftIO . waspSays
 
 alphaWarningMessage :: String
-alphaWarningMessage = ("NOTE: Wasp is still in Alpha, therefore not yet production ready "
-                       ++ "and might change significantly in the future versions.")
+alphaWarningMessage =
+  ( "NOTE: Wasp is still in Alpha, therefore not yet production ready "
+      ++ "and might change significantly in the future versions."
+  )


### PR DESCRIPTION
# Description

This PR adds a validation step to `createNewProject` . My motivation to solve this was due to my experiencing this error when I tried to create a new wasp project.

Fixes #119

The validation process is as follows - 

The `checkProjectName :: String -> Either String ()` function in `Command\Common.hs` takes in the project name as an argument and checks if it contains any non-letter characters and if so assigns an error message to the `Left` constructor. The `Right` constructor is assigned `()` since the "correct" value is already preserved in `projectName`.

The first action in the `createNewProject` do block processes the value of `checkProjectName` and if it is the `Left` constructor, throws an error warning users to use CamelCase for their project name. The `Right` constructor returns a no-op (`()`).

Example output - 

```
$ stack exec wasp new test-project
Error: Please use CamelCase for project name
```

## Additional Steps

* Add more restrictive validation - the project name must be in `CamelCase`
* Modify the code to be more idiomatic

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

This is my first PR in Haskell so I'm not sure if I've done it the right way. I would appreciate any feedback!