### PR TITLE
cli: update telemetry command to show data about last telemetry message

### DIFF
--- a/waspc/cli/Command/Telemetry.hs
+++ b/waspc/cli/Command/Telemetry.hs
@@ -3,10 +3,11 @@ module Command.Telemetry
     , telemetry
     ) where
 
-import           Control.Monad             (when)
+import           Control.Monad             (when, unless)
 import           Control.Monad.Except      (catchError, throwError)
 import           Control.Monad.IO.Class    (liftIO)
 import           Data.Maybe                (isJust)
+import           Data.Foldable             (for_)
 import qualified System.Environment        as ENV
 
 import           Command                   (Command, CommandError (..))
@@ -15,16 +16,32 @@ import qualified Command.Call
 import           Command.Telemetry.Common  (ensureTelemetryCacheDirExists)
 import qualified Command.Telemetry.Project as TlmProject
 import qualified Command.Telemetry.User    as TlmUser
+import qualified StrongPath                as SP
 
 isTelemetryDisabled :: IO Bool
 isTelemetryDisabled = isJust <$> ENV.lookupEnv "WASP_TELEMETRY_DISABLE"
 
+-- | Prints basic information about the stauts of telemetry.
 telemetry :: Command ()
 telemetry = do
     telemetryDisabled <- liftIO isTelemetryDisabled
     waspSaysC $ "Telemetry is currently: " <> (if telemetryDisabled
         then "DISABLED"
-        else "ENABLED") 
+        else "ENABLED")
+
+    unless telemetryDisabled $ do
+        telemetryCacheDirPath <- liftIO ensureTelemetryCacheDirExists
+        waspSaysC $ "Telemetry cache directory: " ++ SP.toFilePath telemetryCacheDirPath
+
+        maybeProjectHash <- (Just <$> TlmProject.getWaspProjectPathHash) `catchError` const (return Nothing)
+        for_ maybeProjectHash $ \projectHash -> do
+            maybeProjectCache <- liftIO $ TlmProject.readProjectTelemetryFile telemetryCacheDirPath projectHash
+            for_ maybeProjectCache $ \projectCache -> do
+                let maybeTimeOfLastSending = TlmProject.getTimeOfLastTelemetryDataSent projectCache
+                for_ maybeTimeOfLastSending $ \timeOfLastSending -> do
+                    waspSaysC $ "Last time telemetry data was sent for this project: " ++ show timeOfLastSending
+
+    waspSaysC "Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details."
 
 -- | Sends telemetry data about the current Wasp project, if conditions are met.
 -- If we are not in the Wasp project at the moment, nothing happens.
@@ -40,6 +57,5 @@ considerSendingData cmdCall = (`catchError` const (return ())) $ do
     userSignature <- liftIO $ TlmUser.readOrCreateUserSignatureFile telemetryCacheDirPath
 
     maybeProjectHash <- (Just <$> TlmProject.getWaspProjectPathHash) `catchError` const (return Nothing)
-    case maybeProjectHash of
-        Nothing -> return ()
-        Just projectHash -> liftIO $ TlmProject.considerSendingData telemetryCacheDirPath userSignature projectHash cmdCall
+    for_ maybeProjectHash $ \projectHash -> do
+        liftIO $ TlmProject.considerSendingData telemetryCacheDirPath userSignature projectHash cmdCall

--- a/waspc/cli/Command/Telemetry/Common.hs
+++ b/waspc/cli/Command/Telemetry/Common.hs
@@ -1,6 +1,7 @@
 module Command.Telemetry.Common
     ( TelemetryCacheDir
     , ensureTelemetryCacheDirExists
+    , getTelemetryCacheDirPath
     ) where
 
 import           Path                      (reldir)


### PR DESCRIPTION
# Description

This PR hopes to show the last time when the telemetry data was sent to Wasp.

Some more ideas for the telemetry command (just listing them, not sure of their impact on end users):

- Now that we're reading the project cache, we might as well show the content. (Solely in the spirit of transparency)
- Display the location of the project cache?
- Lay down the ground work for #163? (this should probably go in separately)

Fixes #164

## Type of change

Please select the option(s) that is more relevant.

- [x] New feature (non-breaking change which adds functionality)
- [-] This change requires a documentation update (maybe, if necessary)