### PR TITLE
Implemented PSL model parser, used it for Entity.

### DIFF
--- a/waspc/data/Generator/templates/db/schema.prisma
+++ b/waspc/data/Generator/templates/db/schema.prisma
@@ -11,9 +11,6 @@ generator client {
   output = "../server/node_modules/.prisma/client"
 }
 
-{=# entities =}
-model {= name =} {
-    {=& pslModelSchema =}
-}
-
-{=/ entities =}
+{=# modelSchemas =}
+{=& . =}
+{=/ modelSchemas =}

--- a/waspc/src/Parser/Common.hs
+++ b/waspc/src/Parser/Common.hs
@@ -132,7 +132,7 @@ waspCssClosure = waspNamedClosure "css"
 waspNamedClosure :: String -> Parser String
 waspNamedClosure name = do
     _ <- closureStart
-    strip <$> (manyTill anyChar (try closureEnd))
+    strip <$> manyTill anyChar (try closureEnd)
   where
       closureStart = L.symbol ("{=" ++ name)
       closureEnd = L.symbol (name ++ "=}")

--- a/waspc/src/Parser/Entity.hs
+++ b/waspc/src/Parser/Entity.hs
@@ -2,19 +2,58 @@ module Parser.Entity
     ( entity
     ) where
 
-import Text.Parsec.String (Parser)
-import qualified Data.Text as Text
+import           Text.Parsec.String (Parser)
 
-import qualified Wasp.Entity
-import qualified Parser.Common as P
-import qualified Lexer as L
+import qualified Lexer              as L
+import qualified Psl.Ast.Model      as PslModel
+import qualified Psl.Parser.Model
+import qualified Wasp.Entity        as Entity
 
-entity :: Parser Wasp.Entity.Entity
+entity :: Parser Entity.Entity
 entity = do
-    (name, pslModelSchema) <- P.waspElementNameAndClosure L.reservedNameEntity
-                                                          (P.waspNamedClosure "psl")
+    _ <- L.reserved L.reservedNameEntity
+    name <- L.identifier
+    _ <- L.symbol "{=psl"
+    pslModelBody <- Psl.Parser.Model.body
+    _ <- L.symbol "psl=}"
 
-    return Wasp.Entity.Entity
-        { Wasp.Entity._name = name
-        , Wasp.Entity._pslModelSchema = Text.pack $ pslModelSchema
+    return Entity.Entity
+        { Entity._name = name
+        , Entity._fields = getEntityFields pslModelBody
+        , Entity._pslModelBody = pslModelBody
         }
+
+getEntityFields :: PslModel.Body -> [Entity.Field]
+getEntityFields (PslModel.Body pslElements) = map pslFieldToEntityField pslFields
+  where
+    pslFields = [field | (PslModel.ElementField field) <- pslElements]
+
+    pslFieldToEntityField :: PslModel.Field -> Entity.Field
+    pslFieldToEntityField pslField = Entity.Field
+        { Entity._fieldName = PslModel._name pslField
+        , Entity._fieldType = pslFieldTypeToEntityFieldType
+                    (PslModel._type pslField)
+                    (PslModel._typeModifiers pslField)
+        }
+
+    pslFieldTypeToEntityFieldType
+        :: PslModel.FieldType
+        -> [PslModel.FieldTypeModifier]
+        -> Entity.FieldType
+    pslFieldTypeToEntityFieldType fType fTypeModifiers =
+        let scalar = pslFieldTypeToScalar fType
+        in case fTypeModifiers of
+               []               -> Entity.FieldTypeScalar scalar
+               [PslModel.List]     -> Entity.FieldTypeComposite $ Entity.List scalar
+               [PslModel.Optional] -> Entity.FieldTypeComposite $ Entity.Optional scalar
+               _                -> error "Not a valid list of modifiers."
+
+    pslFieldTypeToScalar :: PslModel.FieldType -> Entity.Scalar
+    pslFieldTypeToScalar fType = case fType of
+        PslModel.String        -> Entity.String
+        PslModel.Boolean       -> Entity.Boolean
+        PslModel.Int           -> Entity.Int
+        PslModel.Float         -> Entity.Float
+        PslModel.DateTime      -> Entity.DateTime
+        PslModel.Json          -> Entity.Json
+        PslModel.UserType name -> Entity.UserType name

--- a/waspc/src/Psl/Ast/Model.hs
+++ b/waspc/src/Psl/Ast/Model.hs
@@ -1,0 +1,47 @@
+module Psl.Ast.Model where
+
+data Model = Model
+    String -- ^ Name of the model
+    Body
+    deriving (Show, Eq)
+
+newtype Body = Body [Element]
+    deriving (Show, Eq)
+
+data Element = ElementField Field | ElementBlockAttribute Attribute
+    deriving (Show, Eq)
+
+-- TODO: To support attributes before the field,
+--   we could just have `attrsBefore :: [[Attr]]`,
+--   which represents lines, each one with list of attributes.
+data Field = Field
+    { _name :: String
+    , _type :: FieldType
+    , _typeModifiers :: [FieldTypeModifier]
+    , _attrs :: [Attribute]
+    }
+    deriving (Show, Eq)
+
+data FieldType = String | Boolean | Int | Float | DateTime | Json | UserType String
+    deriving (Show, Eq)
+
+data FieldTypeModifier = List | Optional
+    deriving (Show, Eq)
+
+data Attribute = Attribute
+    { _attrName :: String
+    , _attrArgs :: [AttributeArg]
+    }
+    deriving (Show, Eq)
+
+data AttributeArg = AttrArgNamed String AttrArgValue | AttrArgUnnamed AttrArgValue
+    deriving (Show, Eq)
+
+data AttrArgValue
+    = AttrArgString String
+    | AttrArgIdentifier String
+    | AttrArgFunc String
+    | AttrArgFieldRefList [String]
+    | AttrArgNumber String
+    | AttrArgUnknown String
+    deriving (Show, Eq)

--- a/waspc/src/Psl/Generator/Model.hs
+++ b/waspc/src/Psl/Generator/Model.hs
@@ -1,0 +1,61 @@
+module Psl.Generator.Model
+    ( generateModel
+    ) where
+
+import           Data.List     (intercalate)
+
+import qualified Psl.Ast.Model as Ast
+
+
+generateModel :: Ast.Model -> String
+generateModel (Ast.Model name body) = "model " ++ name ++ " {\n" ++ generateBody body ++ "\n}"
+
+generateBody :: Ast.Body -> String
+generateBody (Ast.Body elements) = unlines $ map (("  " ++) . generateElement) elements
+
+generateElement :: Ast.Element -> String
+generateElement (Ast.ElementField field) =
+    Ast._name field ++ " "
+    ++ generateFieldType (Ast._type field) ++ concatMap generateFieldTypeModifier (Ast._typeModifiers field)
+    ++ concatMap ((" " ++) . generateAttribute) (Ast._attrs field)
+generateElement (Ast.ElementBlockAttribute attribute) =
+    "@" ++ generateAttribute attribute
+
+generateFieldType :: Ast.FieldType -> String
+generateFieldType fieldType = case fieldType of
+    Ast.String         -> "String"
+    Ast.Boolean        -> "Boolean"
+    Ast.Int            -> "Int"
+    Ast.Float          -> "Float"
+    Ast.DateTime       -> "DateTime"
+    Ast.Json           -> "Json"
+    Ast.UserType label -> label
+
+generateFieldTypeModifier :: Ast.FieldTypeModifier -> String
+generateFieldTypeModifier typeModifier = case typeModifier of
+    Ast.List     -> "[]"
+    Ast.Optional -> "?"
+
+generateAttribute :: Ast.Attribute -> String
+generateAttribute attribute =
+    "@" ++ Ast._attrName attribute
+    ++ if null (Ast._attrArgs attribute)
+       then ""
+       else "(" ++ intercalate ", " (map generateAttributeArg (Ast._attrArgs attribute)) ++ ")"
+
+generateAttributeArg :: Ast.AttributeArg -> String
+generateAttributeArg (Ast.AttrArgNamed name value) = name ++ ": " ++ generateAttrArgValue value
+generateAttributeArg (Ast.AttrArgUnnamed value) = generateAttrArgValue value
+
+generateAttrArgValue :: Ast.AttrArgValue -> String
+generateAttrArgValue value = case value of
+    Ast.AttrArgString strValue -> show strValue
+    Ast.AttrArgIdentifier identifier -> identifier
+    Ast.AttrArgFunc funcName -> funcName ++ "()"
+    Ast.AttrArgFieldRefList refs -> "[" ++ intercalate ", " refs ++ "]"
+    Ast.AttrArgNumber numberStr -> numberStr
+    Ast.AttrArgUnknown unknownStr -> unknownStr
+
+-- TODO: I should make sure to skip attributes that are not known in prisma.
+--   Or maybe it would be better if that was done in previous step, where
+--   we basically edit the AST by kicking out those attributes.

--- a/waspc/src/Psl/Parser/Model.hs
+++ b/waspc/src/Psl/Parser/Model.hs
@@ -1,0 +1,166 @@
+module Psl.Parser.Model
+    ( model
+    , body
+    -- NOTE: Only for testing:
+    , attrArgument
+    ) where
+
+import           Data.Maybe           (fromMaybe, maybeToList)
+import           Text.Parsec          (alphaNum, char, choice, letter,
+                                       lookAhead, many, many1, noneOf, oneOf,
+                                       optionMaybe, try, (<|>))
+import           Text.Parsec.Language (emptyDef)
+import           Text.Parsec.String   (Parser)
+import qualified Text.Parsec.Token    as T
+
+import qualified Psl.Ast.Model        as Model
+
+-- | Parses PSL (Prisma Schema Language model).
+-- Example of PSL model:
+--   model User {
+--     id Int @id
+--     name String
+--     @@index([name])
+--   }
+model :: Parser Model.Model
+model = do
+    T.whiteSpace lexer
+    _ <- T.symbol lexer "model"
+    modelName <- T.identifier lexer
+    Model.Model modelName <$> T.braces lexer body
+
+-- | Parses body of the PSL (Prisma Schema Language) model,
+-- which is everything besides model keyword, name and braces:
+--   `model User { <body> }`.
+body :: Parser Model.Body
+body = do
+    T.whiteSpace lexer
+    Model.Body <$> many1 element
+
+element :: Parser Model.Element
+element = try (Model.ElementField <$> field) <|>
+          try (Model.ElementBlockAttribute <$> blockAttribute)
+
+field :: Parser Model.Field
+field = do
+    name <- T.identifier lexer
+    type' <- fieldType
+    maybeTypeModifier <- fieldTypeModifier
+    attrs <- many (try attribute)
+    return $ Model.Field
+        { Model._name = name
+        , Model._type = type'
+        , Model._typeModifiers = maybeToList maybeTypeModifier
+        , Model._attrs = attrs
+        }
+  where
+    fieldType :: Parser Model.FieldType
+    fieldType =
+        (foldl1 (<|>) $
+         map (\(s, t) -> try (T.symbol lexer s) >> return t)
+         [ ("String",   Model.String)
+         , ("Boolean",  Model.Boolean)
+         , ("Int",      Model.Int)
+         , ("Float",    Model.Float)
+         , ("DateTime", Model.DateTime)
+         , ("Json",     Model.Json)
+         ]
+        )
+        <|> Model.UserType <$> T.identifier lexer
+
+    -- NOTE: As is Prisma currently implemented, there can be only one type modifier at one time: [] or ?.
+    fieldTypeModifier :: Parser (Maybe Model.FieldTypeModifier)
+    fieldTypeModifier = optionMaybe
+        ( (try (T.brackets lexer (T.whiteSpace lexer)) >> return Model.List) <|>
+          (try (T.symbol lexer "?") >> return Model.Optional)
+        )
+
+attribute :: Parser Model.Attribute
+attribute = do
+    _ <- char '@'
+    name <- T.identifier lexer
+    maybeArgs <- optionMaybe (T.parens lexer (T.commaSep1 lexer (try attrArgument)))
+    return $ Model.Attribute
+        { Model._attrName = name
+        , Model._attrArgs = fromMaybe [] maybeArgs
+        }
+
+-- Parses attribute argument that ends with delimiter: , or ).
+-- Doesn't parse the delimiter.
+attrArgument :: Parser Model.AttributeArg
+attrArgument = do
+    arg <- try namedArg <|> try unnamedArg
+    _ <- try $ lookAhead $ oneOf argDelimiters
+    return arg
+  where
+    namedArg :: Parser Model.AttributeArg
+    namedArg = do
+        name <- T.identifier lexer
+        _ <- T.colon lexer
+        Model.AttrArgNamed name <$> argValue
+
+    unnamedArg :: Parser Model.AttributeArg
+    unnamedArg = Model.AttrArgUnnamed <$> argValue
+
+    argValue :: Parser Model.AttrArgValue
+    argValue = choice $ map (try . delimitedArgValue)
+        [ argValueString
+        , argValueFunc
+        , argValueFieldReferenceList
+        , argValueNumberFloat
+        , argValueNumberInt
+        , argValueIdentifier
+        , argValueUnknown
+        ]
+
+    argValueString :: Parser Model.AttrArgValue
+    argValueString = Model.AttrArgString <$> T.stringLiteral lexer
+
+    argValueFunc :: Parser Model.AttrArgValue
+    argValueFunc = do -- TODO: Could I implement this with applicative?
+        name <- T.identifier lexer
+        T.parens lexer $ T.whiteSpace lexer
+        return $ Model.AttrArgFunc name
+
+    argValueFieldReferenceList :: Parser Model.AttrArgValue
+    argValueFieldReferenceList = Model.AttrArgFieldRefList <$>
+        (T.brackets lexer $ T.commaSep1 lexer $ T.identifier lexer)
+
+    -- NOTE: For now we are not supporting negative numbers.
+    --   I couldn't figure out from Prisma docs if there could be the case
+    --   where these numbers could be negative.
+    --   Same goes for argValueNumberInt below.
+    --   TODO: Probably we should take care of that case.
+    argValueNumberFloat :: Parser Model.AttrArgValue
+    argValueNumberFloat = Model.AttrArgNumber . show <$> T.float lexer
+
+    -- NOTE/TODO: Check comment on argValueNumberFloat.
+    argValueNumberInt :: Parser Model.AttrArgValue
+    argValueNumberInt = Model.AttrArgNumber . show <$> T.integer lexer
+
+    argValueIdentifier :: Parser Model.AttrArgValue
+    argValueIdentifier = Model.AttrArgIdentifier <$> T.identifier lexer
+
+    -- | Our "wildcard" -> tries to capture anything.
+    argValueUnknown :: Parser Model.AttrArgValue
+    argValueUnknown = Model.AttrArgUnknown <$>
+        (many1 $ try $ noneOf argDelimiters)
+
+    delimitedArgValue :: Parser Model.AttrArgValue -> Parser Model.AttrArgValue
+    delimitedArgValue argValueP = do
+        value <- argValueP
+        _ <- lookAhead $ oneOf argDelimiters
+        return value
+
+    argDelimiters = [',', ')']
+
+blockAttribute :: Parser Model.Attribute
+blockAttribute = char '@' >> attribute
+
+lexer :: T.TokenParser ()
+lexer = T.makeTokenParser emptyDef
+    { T.commentLine = "//"
+    , T.caseSensitive = True
+    , T.identStart = letter
+    , T.identLetter = alphaNum <|> char '_'
+    }

--- a/waspc/src/Psl/Parser/Model.hs
+++ b/waspc/src/Psl/Parser/Model.hs
@@ -90,7 +90,6 @@ attribute = do
 attrArgument :: Parser Model.AttributeArg
 attrArgument = do
     arg <- try namedArg <|> try unnamedArg
-    _ <- try $ lookAhead $ oneOf argDelimiters
     return arg
   where
     namedArg :: Parser Model.AttributeArg

--- a/waspc/src/Wasp/Entity.hs
+++ b/waspc/src/Wasp/Entity.hs
@@ -1,19 +1,51 @@
--- TODO(matija): remove PSL suffix, added it to avoid clashes with the existing Entity module.
--- Once the old Entity module is removed, rename to "Entity".
 module Wasp.Entity
     ( Entity (..)
+    , Field (..)
+    , FieldType (..)
+    , Scalar (..)
+    , Composite (..)
     ) where
 
-import Data.Text (Text)
 import Data.Aeson (ToJSON(..), (.=), object)
+
+import qualified Psl.Ast.Model
+
 
 data Entity = Entity
     { _name :: !String
-    , _pslModelSchema :: !Text -- ^ PSL stands for Prisma Schema Language.
-    } deriving (Show, Eq)
+    , _fields :: ![Field]
+    , _pslModelBody :: !Psl.Ast.Model.Body
+    }
+    deriving (Show, Eq)
+
+data Field = Field
+    { _fieldName :: !String
+    , _fieldType :: !FieldType
+    }
+    deriving (Show, Eq)
+
+data FieldType = FieldTypeScalar Scalar | FieldTypeComposite Composite
+    deriving (Show, Eq)
+
+data Composite = Optional Scalar | List Scalar
+    deriving (Show, Eq)
+
+data Scalar
+    = String
+    | Boolean
+    | Int
+    | Float
+    | DateTime
+    | Json
+    -- | Name of the user-defined type.
+    -- This could be another entity, or maybe an enum,
+    -- we don't know here yet.
+    | UserType String
+    deriving (Show, Eq)
 
 instance ToJSON Entity where
     toJSON entity = object
         [ "name" .= _name entity
-        , "pslModelSchema" .= _pslModelSchema entity
+        , "fields" .= show (_fields entity)
+        , "pslModelBody" .= show (_pslModelBody entity)
         ]

--- a/waspc/test/Parser/ParserTest.hs
+++ b/waspc/test/Parser/ParserTest.hs
@@ -6,10 +6,12 @@ import           Test.Tasty.Hspec
 
 import           NpmDependency        as ND
 import           Parser
+import           Parser.Common        (runWaspParser)
+import qualified Psl.Parser.Model
 import qualified StrongPath           as SP
 import           Wasp
-import qualified Wasp.Entity
 import qualified Wasp.Auth
+import qualified Wasp.Entity
 import qualified Wasp.JsImport
 import qualified Wasp.NpmDependencies
 import qualified Wasp.Page
@@ -65,10 +67,25 @@ spec_parseWasp =
                         }
                     , WaspElementEntity $ Wasp.Entity.Entity
                         { Wasp.Entity._name = "Task"
-                        , Wasp.Entity._pslModelSchema = "\
-                                \id          Int     @id @default(autoincrement())\n\
-                            \    description String\n\
-                            \    isDone      Boolean @default(false)"
+                        , Wasp.Entity._fields =
+                          [ Wasp.Entity.Field
+                            { Wasp.Entity._fieldName = "id"
+                            , Wasp.Entity._fieldType = Wasp.Entity.FieldTypeScalar Wasp.Entity.Int
+                            }
+                          , Wasp.Entity.Field
+                            { Wasp.Entity._fieldName = "description"
+                            , Wasp.Entity._fieldType = Wasp.Entity.FieldTypeScalar Wasp.Entity.String
+                            }
+                          , Wasp.Entity.Field
+                            { Wasp.Entity._fieldName = "isDone"
+                            , Wasp.Entity._fieldType = Wasp.Entity.FieldTypeScalar Wasp.Entity.Boolean
+                            }
+                          ]
+                        , Wasp.Entity._pslModelBody = fromRight (error "failed to parse") $
+                            runWaspParser Psl.Parser.Model.body "\
+                              \    id          Int     @id @default(autoincrement())\n\
+                              \    description String\n\
+                              \    isDone      Boolean @default(false)"
                         }
                     , WaspElementQuery $  Wasp.Query.Query
                         { Wasp.Query._name = "myQuery"

--- a/waspc/test/Psl/Common/ModelTest.hs
+++ b/waspc/test/Psl/Common/ModelTest.hs
@@ -1,0 +1,78 @@
+module Psl.Common.ModelTest where
+
+import qualified Psl.Ast.Model    as AST
+
+
+-- | Corresponds to sampleBodyAst below.
+sampleBodySchema :: String
+sampleBodySchema =
+  unlines
+  [ "  id Int @id @default(value: autoincrement())"
+  , "  email String?"
+  , "  posts Post[] @relation(\"UserPosts\", references: [id]) @customattr"
+  , ""
+  , "  @@someattr([id, email], 2 + 4, [posts])"
+  ]
+
+-- | Corresponds to sampleBodySchema above.
+sampleBodyAst :: AST.Body
+sampleBodyAst =
+  AST.Body
+  [ AST.ElementField
+      ( AST.Field
+          { AST._name = "id"
+          , AST._type = AST.Int
+          , AST._typeModifiers = []
+          , AST._attrs =
+            [ AST.Attribute
+                { AST._attrName = "id"
+                , AST._attrArgs = []
+                }
+            , AST.Attribute
+                { AST._attrName = "default"
+                , AST._attrArgs =
+                  [ AST.AttrArgNamed "value" (AST.AttrArgFunc "autoincrement")
+                  ]
+                }
+            ]
+          }
+      )
+  , AST.ElementField
+      ( AST.Field
+          { AST._name = "email"
+          , AST._type = AST.String
+          , AST._typeModifiers = [AST.Optional]
+          , AST._attrs = []
+          }
+      )
+  , AST.ElementField
+      ( AST.Field
+          { AST._name = "posts"
+          , AST._type = AST.UserType "Post"
+          , AST._typeModifiers = [AST.List]
+          , AST._attrs =
+            [ AST.Attribute
+                { AST._attrName = "relation"
+                , AST._attrArgs =
+                  [ AST.AttrArgUnnamed (AST.AttrArgString "UserPosts")
+                  , AST.AttrArgNamed "references" (AST.AttrArgFieldRefList ["id"])
+                  ]
+                }
+            , AST.Attribute
+                { AST._attrName = "customattr"
+                , AST._attrArgs = []
+                }
+            ]
+          }
+      )
+  , AST.ElementBlockAttribute
+      ( AST.Attribute
+          { AST._attrName = "someattr"
+          , AST._attrArgs =
+            [ AST.AttrArgUnnamed (AST.AttrArgFieldRefList ["id", "email"])
+            , AST.AttrArgUnnamed (AST.AttrArgUnknown "2 + 4")
+            , AST.AttrArgUnnamed (AST.AttrArgFieldRefList ["posts"])
+            ]
+          }
+      )
+  ]

--- a/waspc/test/Psl/Generator/ModelTest.hs
+++ b/waspc/test/Psl/Generator/ModelTest.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Psl.Generator.ModelTest where
+
+import           Test.Tasty.Hspec
+import           Test.Tasty.QuickCheck
+
+import           Parser.Common         (runWaspParser)
+import qualified Psl.Ast.Model         as AST
+import           Psl.Common.ModelTest  (sampleBodyAst)
+import           Psl.Generator.Model   (generateModel)
+import qualified Psl.Parser.Model
+
+
+spec_generatePslModel :: Spec
+spec_generatePslModel = do
+    describe "Complex example" $ do
+        let pslModelAst = AST.Model "User" sampleBodyAst
+
+        it "parse(generate(sampleBodyAst)) == sampleBodyAst" $ do
+            runWaspParser Psl.Parser.Model.model (generateModel pslModelAst) `shouldBe` Right pslModelAst
+
+prop_generatePslModel :: Property
+prop_generatePslModel = mapSize (const 100) $ \modelAst -> within 1000000 $
+    runWaspParser Psl.Parser.Model.model (generateModel modelAst) `shouldBe` Right modelAst
+
+-- TODO: Figure out what to do with these orphand Arbitrary instances.
+--   Should they go into src/Psl/Ast/Model.hs?
+
+instance Arbitrary AST.Model where
+    arbitrary = AST.Model <$> arbitraryIdentifier <*> arbitrary
+
+instance Arbitrary AST.Body where
+    arbitrary = do
+        fieldElement <- AST.ElementField <$> arbitrary
+        elementsBefore <- scale (const 5) arbitrary
+        elementsAfter <- scale (const 5) arbitrary
+        return $ AST.Body $ elementsBefore ++ [fieldElement] ++ elementsAfter
+
+instance Arbitrary AST.Element where
+    arbitrary = oneof [ AST.ElementField <$> arbitrary
+                      , AST.ElementBlockAttribute <$> arbitrary
+                      ]
+
+instance Arbitrary AST.Field where
+    arbitrary = do
+        name <- arbitraryIdentifier
+        fieldType <- arbitrary
+        modifiers <- oneof [ (:[]) <$> arbitrary, return [] ]
+        attrs <- scale (const 5) arbitrary
+        return $ AST.Field { AST._name = name
+                           , AST._type = fieldType
+                           , AST._typeModifiers = modifiers
+                           , AST._attrs = attrs
+                           }
+
+instance Arbitrary AST.FieldType where
+    arbitrary = oneof
+        [ return AST.String
+        , return AST.Boolean
+        , return AST.Int
+        , return AST.Float
+        , return AST.DateTime
+        , return AST.Json
+        , AST.UserType <$> arbitraryIdentifier ]
+
+instance Arbitrary AST.FieldTypeModifier where
+    arbitrary = oneof [ return AST.List, return AST.Optional ]
+
+instance Arbitrary AST.Attribute where
+    arbitrary = do
+        name <- arbitraryIdentifier
+        args <- scale (const 5) arbitrary
+        return $ AST.Attribute { AST._attrName = name, AST._attrArgs = args }
+
+instance Arbitrary AST.AttributeArg where
+    arbitrary = oneof [ AST.AttrArgNamed <$> arbitraryIdentifier <*> arbitrary
+                      , AST.AttrArgUnnamed <$> arbitrary ]
+
+instance Arbitrary AST.AttrArgValue where
+    arbitrary = oneof
+        [ AST.AttrArgString <$> arbitraryNonEmptyPrintableString
+        , AST.AttrArgIdentifier <$> arbitraryIdentifier
+        , AST.AttrArgFunc <$> arbitraryIdentifier
+        , AST.AttrArgFieldRefList <$> scale (const 5) (listOf1 arbitraryIdentifier)
+        -- NOTE: For now we are not supporting negative numbers.
+        --   I couldn't figure out from Prisma docs if there could be the case
+        --   where these numbers could be negative. Probably we should take care of that case.
+        , AST.AttrArgNumber <$> oneof
+            [ show <$> (arbitrary :: Gen Int) `suchThat` (>= 0)
+            , show <$> (arbitrary :: Gen Float) `suchThat` (>= 0) ]
+        -- NOTE: Unknown is commented out because unknown should contain only values
+        --   that are not recognized as any other type of attribute argument,
+        --   and defining how those are generated is not so simple, so I skipped it for now.
+        -- , AST.AttrArgUnknown <$> arbitraryNonEmptyPrintableString
+        ]
+
+arbitraryNonEmptyPrintableString :: Gen String
+arbitraryNonEmptyPrintableString = listOf1 arbitraryPrintableChar
+
+arbitraryAlpha :: Gen Char
+arbitraryAlpha = elements $ ['a'..'z'] ++ ['A'..'Z']
+
+arbitraryAlphaNum :: Gen Char
+arbitraryAlphaNum = elements $ ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9']
+
+arbitraryIdentifier :: Gen String
+arbitraryIdentifier = (:) <$> arbitraryAlpha <*> listOf arbitraryAlphaNum

--- a/waspc/test/Psl/Parser/ModelTest.hs
+++ b/waspc/test/Psl/Parser/ModelTest.hs
@@ -1,0 +1,57 @@
+module Psl.Parser.ModelTest where
+
+import           Test.Tasty.Hspec
+
+import           Data.Either          (isLeft)
+import           Parser.Common        (runWaspParser)
+import qualified Psl.Ast.Model        as AST
+import           Psl.Common.ModelTest (sampleBodyAst, sampleBodySchema)
+import           Psl.Parser.Model     (attrArgument, body, model)
+
+
+spec_parsePslModel :: Spec
+spec_parsePslModel = do
+    describe "Complex example" $ do
+        let pslModel = "model User {\n" ++ sampleBodySchema ++ "\n}"
+            expectedModelAst = AST.Model "User" sampleBodyAst
+
+        it "Body parser correctly parses" $ do
+          runWaspParser body sampleBodySchema `shouldBe` Right sampleBodyAst
+
+        it "Model parser correctly parses" $ do
+          runWaspParser model pslModel `shouldBe` Right expectedModelAst
+
+    describe "Body parser" $ do
+      describe "Fails if input is not valid PSL" $ do
+          let runTest psl = it psl $ isLeft (runWaspParser body psl) `shouldBe` True
+          mapM_ runTest
+              [ "  noType"
+              , "  @startsWithAttribute"
+              , "  @@@tooManyMonkeys"
+              ]
+
+    describe "Attribute argument parser" $ do
+        let tests =
+                [ ( "[foo, bar],"
+                  , AST.AttrArgUnnamed (AST.AttrArgFieldRefList ["foo", "bar"])
+                  )
+                , ( "\"test\")"
+                  , AST.AttrArgUnnamed (AST.AttrArgString "test")
+                  )
+                , ( "foo: bar(),"
+                  , AST.AttrArgNamed "foo" (AST.AttrArgFunc "bar")
+                  )
+                , ( "Bob,"
+                  , AST.AttrArgUnnamed (AST.AttrArgIdentifier "Bob")
+                  )
+                , ( "42.3)"
+                  , AST.AttrArgUnnamed (AST.AttrArgNumber "42.3")
+                  )
+                , ( "2 + 3,"
+                  , AST.AttrArgUnnamed (AST.AttrArgUnknown "2 + 3")
+                  )
+
+                ]
+        let runTest (psl, expected) =
+                it ("correctly parses " ++ psl) $ runWaspParser attrArgument psl `shouldBe` Right expected
+        mapM_ runTest tests


### PR DESCRIPTION
So far, when parsing an entity definition, for example
```
entity User {=psl
    id          Int     @id @default(autoincrement())
    email       String  @unique
    password    String
    tasks       Task[]
psl=}
```
we would take contents of `{=psl psl=}` as a black box and transfer them to the generated schema.prisma file.

Now, we are smarter! I have implemented a PSL parser, which parses the `{=psl psl=}` block into PSL Model AST, then we use that to create Wasp Entity AST, and finally when generating code, we again create schema from the PSL Model AST which we preserved.

This doesn't really change anything at the moment, but what we have now is understanding of the entity in Wasp. Which means we can now reason about it and implement features like automatic generation of CRUD, or some kind of relatively smart ACL, and who knows what not -> we certainly need that kind of understanding since entities are one of the central concepts in Wasp!

I used QuickCheck properly for the first time ever and that was interesting. Had some problems with it creating too big random PSL Model ASTs and never finishing executing, which I fixed by adding `scale (const 5)` on many places, therefore restricting size of arrays to 5, which then made the whole AST reasonable shaped/sized and that worked. Quickcheck helped catch a couple of problems we had, so I am glad I used it!

Some possible TODOs:
- We have orphaned instances now: Arbitrary instances of PSL Model AST. I am not sure where to put them though, I read people are also not sure what to do with Arbitrary instances. Easiest is to put them in Psl.Ast.Model.hs so maybe I should do that. Other solutions are overly complicated (separate packages, flags, ...). Or maybe we can leave them l like this but now we get compiler warnings. I should probably move it.
- We currently don't parse negative numbers, so if they will be used as PSL Model attribute arguments, that will not parse. I am not sure if that is reasonable to expect, let's see, if that becomes a problem we can implement support for it.
- I added support for custom attributes -> I just let them through. I think that is ok for now, Prisma will complain if they are redundant. In the future we might want to use them for Wasp, and in that case we will capture them in Wasp and then not let them through to schema.prisma, but that is best left to the future.