### PR TITLE
Implemented support for dotenv file.

### DIFF
--- a/waspc/cli/Cli/Common.hs
+++ b/waspc/cli/Cli/Common.hs
@@ -1,4 +1,4 @@
-module Common
+module Cli.Common
     ( WaspProjectDir
     , DotWaspDir
     , CliTemplatesDir
@@ -10,16 +10,16 @@ module Common
     , waspSays
     ) where
 
-import qualified Path as P
+import qualified Path             as P
 
-import StrongPath (Path, Rel, Dir, File)
-import qualified StrongPath as SP
-import ExternalCode (SourceExternalCodeDir)
+import           Common           (WaspProjectDir)
+import           ExternalCode     (SourceExternalCodeDir)
 import qualified Generator.Common
-import qualified Util.Terminal as Term
+import           StrongPath       (Dir, File, Path, Rel)
+import qualified StrongPath       as SP
+import qualified Util.Terminal    as Term
 
 
-data WaspProjectDir -- Root dir of Wasp project, containing source files.
 data DotWaspDir -- Here we put everything that wasp generates.
 data CliTemplatesDir
 

--- a/waspc/cli/Command/Build.hs
+++ b/waspc/cli/Command/Build.hs
@@ -5,11 +5,11 @@ module Command.Build
 import           Control.Monad.Except   (throwError)
 import           Control.Monad.IO.Class (liftIO)
 
+import qualified Cli.Common             as Common
 import           Command                (Command, CommandError (..))
 import           Command.Common         (alphaWarningMessage,
                                          findWaspProjectRootDirFromCwd)
 import           Command.Compile        (compileIOWithOptions)
-import qualified Common
 import           CompileOptions         (CompileOptions (..))
 import qualified Lib
 import           StrongPath             (Abs, Dir, Path, (</>))

--- a/waspc/cli/Command/Clean.hs
+++ b/waspc/cli/Command/Clean.hs
@@ -2,14 +2,15 @@ module Command.Clean
     ( clean
     ) where
 
-import System.Directory (doesDirectoryExist, removeDirectoryRecursive)
-import System.IO (hFlush, stdout)
-import Control.Monad.IO.Class (liftIO)
+import           Control.Monad.IO.Class (liftIO)
+import           System.Directory       (doesDirectoryExist,
+                                         removeDirectoryRecursive)
+import           System.IO              (hFlush, stdout)
 
-import qualified StrongPath as SP
-import Command (Command)
-import Command.Common (findWaspProjectRootDirFromCwd)
-import qualified Common
+import qualified Cli.Common             as Common
+import           Command                (Command)
+import           Command.Common         (findWaspProjectRootDirFromCwd)
+import qualified StrongPath             as SP
 
 clean :: Command ()
 clean = do

--- a/waspc/cli/Command/Common.hs
+++ b/waspc/cli/Command/Common.hs
@@ -1,7 +1,6 @@
 module Command.Common
     ( findWaspProjectRootDirFromCwd
     , findWaspProjectRoot
-    , findWaspFile
     , waspSaysC
     , alphaWarningMessage
     ) where
@@ -10,29 +9,17 @@ import           Control.Monad          (unless, when)
 import           Control.Monad.Except   (throwError)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.Maybe             (fromJust)
-import           Data.List              (find, isSuffixOf)
 import           System.Directory       (doesFileExist, doesPathExist,
                                          getCurrentDirectory)
-import qualified Path                   as P
 import qualified System.FilePath        as FP
 
-import           Command                (Command, CommandError (..))
-import           Common                 (WaspProjectDir,
-                                         dotWaspRootFileInWaspProjectDir,
+import           Cli.Common             (dotWaspRootFileInWaspProjectDir,
                                          waspSays)
+import           Command                (Command, CommandError (..))
+import           Common                 (WaspProjectDir)
 import           StrongPath             (Abs, Dir, Path)
 import qualified StrongPath             as SP
-import qualified Util.IO
 
-    
-findWaspFile :: Path Abs (Dir d) -> IO (Maybe (Path Abs SP.File))
-findWaspFile dir = do
-    (files, _) <- liftIO $ Util.IO.listDirectory (SP.toPathAbsDir dir)
-    return $ (dir SP.</>) . SP.fromPathRelFile <$> find isWaspFile files
-
-isWaspFile :: P.Path P.Rel P.File -> Bool
-isWaspFile path = ".wasp" `isSuffixOf` P.toFilePath path
-                  && (length (P.toFilePath path) > length (".wasp" :: String))
 
 findWaspProjectRoot :: Path Abs (Dir ()) -> Command (Path Abs (Dir WaspProjectDir))
 findWaspProjectRoot currentDir = do

--- a/waspc/cli/Command/CreateNewProject.hs
+++ b/waspc/cli/Command/CreateNewProject.hs
@@ -10,9 +10,9 @@ import qualified System.Directory
 import qualified System.FilePath        as FP
 import           Text.Printf            (printf)
 
+import qualified Cli.Common             as Common
 import           Command                (Command, CommandError (..))
 import qualified Command.Common
-import qualified Common
 import qualified Data
 import           ExternalCode           (SourceExternalCodeDir)
 import           StrongPath             (Abs, Dir, File, Path, Rel, (</>))
@@ -97,7 +97,7 @@ createNewProject projectName = do
       gitignoreFileContent = unlines
           [ "/.wasp/"
           ]
-        
+
       waspignoreFileInExtCodeDir :: Path (Rel SourceExternalCodeDir) File
       waspignoreFileInExtCodeDir = SP.fromPathRelFile [P.relfile|.waspignore|]
 

--- a/waspc/cli/Command/CreateNewProject.hs
+++ b/waspc/cli/Command/CreateNewProject.hs
@@ -96,6 +96,7 @@ createNewProject projectName = do
 
       gitignoreFileContent = unlines
           [ "/.wasp/"
+          , "/.env"
           ]
 
       waspignoreFileInExtCodeDir :: Path (Rel SourceExternalCodeDir) File

--- a/waspc/cli/Command/Db.hs
+++ b/waspc/cli/Command/Db.hs
@@ -16,7 +16,7 @@ import Generator.Job.IO (readJobMessagesAndPrintThemPrefixed)
 import Command (Command, CommandError(..), runCommand)
 import Command.Compile (compile)
 import Command.Common (findWaspProjectRootDirFromCwd, waspSaysC)
-import qualified Common
+import qualified Cli.Common as Common
 
 runDbCommand :: Command a -> IO ()
 runDbCommand = runCommand . makeDbCommand

--- a/waspc/cli/Command/Db/Migrate.hs
+++ b/waspc/cli/Command/Db/Migrate.hs
@@ -15,7 +15,7 @@ import StrongPath ((</>), Abs, Dir, Path)
 import qualified StrongPath as SP
 import Command (Command, CommandError(..))
 import Command.Common (findWaspProjectRootDirFromCwd, waspSaysC)
-import qualified Common
+import qualified Cli.Common
 import Common (WaspProjectDir)
 
 -- Wasp generator interface.
@@ -27,8 +27,8 @@ import Generator.Common (ProjectRootDir)
 migrateSave :: String -> Command ()
 migrateSave migrationName = do
     waspProjectDir <- findWaspProjectRootDirFromCwd
-    let genProjectRootDir = waspProjectDir </> Common.dotWaspDirInWaspProjectDir
-                            </> Common.generatedCodeDirInDotWaspDir
+    let genProjectRootDir = waspProjectDir </> Cli.Common.dotWaspDirInWaspProjectDir
+                            </> Cli.Common.generatedCodeDirInDotWaspDir
 
     -- TODO(matija): It might make sense that this (copying migrations folder from source to
     -- the generated proejct) is responsibility of the generator. Since migrations can also be
@@ -67,8 +67,8 @@ migrateSave migrationName = do
 migrateUp :: Command ()
 migrateUp = do
     waspProjectDir <- findWaspProjectRootDirFromCwd
-    let genProjectRootDir = waspProjectDir </> Common.dotWaspDirInWaspProjectDir
-                            </> Common.generatedCodeDirInDotWaspDir
+    let genProjectRootDir = waspProjectDir </> Cli.Common.dotWaspDirInWaspProjectDir
+                            </> Cli.Common.generatedCodeDirInDotWaspDir
 
     waspSaysC "Copying migrations folder from Wasp to Prisma project..."
     copyDbMigDirResult <- liftIO $ copyDbMigrationsDir CopyMigDirDown waspProjectDir

--- a/waspc/cli/Command/Start.hs
+++ b/waspc/cli/Command/Start.hs
@@ -6,12 +6,12 @@ import           Control.Concurrent.Async (race)
 import           Control.Monad.Except     (throwError)
 import           Control.Monad.IO.Class   (liftIO)
 
+import qualified Cli.Common               as Common
 import           Command                  (Command, CommandError (..))
 import           Command.Common           (findWaspProjectRootDirFromCwd,
                                            waspSaysC)
 import           Command.Compile          (compileIO)
 import           Command.Watch            (watch)
-import qualified Common
 import qualified Lib
 import           StrongPath               ((</>))
 

--- a/waspc/cli/Command/Watch.hs
+++ b/waspc/cli/Command/Watch.hs
@@ -8,9 +8,9 @@ import           Data.Time.Clock         (UTCTime, getCurrentTime)
 import qualified System.FilePath         as FP
 import qualified System.FSNotify         as FSN
 
+import           Cli.Common              (waspSays)
+import qualified Cli.Common              as Common
 import           Command.Compile         (compileIO)
-import           Common                  (waspSays)
-import qualified Common
 import qualified Lib
 import           StrongPath              (Abs, Dir, Path, (</>))
 import qualified StrongPath              as SP

--- a/waspc/data/Generator/templates/server/gitignore
+++ b/waspc/data/Generator/templates/server/gitignore
@@ -2,3 +2,5 @@ node_modules
 
 npm-debug.log
 *.log
+
+.env

--- a/waspc/data/Generator/templates/server/package.json
+++ b/waspc/data/Generator/templates/server/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "nodemon ./src/server.js",
+    "start": "nodemon -r dotenv/config ./src/server.js",
     "debug": "DEBUG=server:* npm start",
     "db-migrate-save": "prisma --experimental migrate save --schema=../db/schema.prisma",
     "db-migrate": "prisma --experimental migrate up --schema=../db/schema.prisma",

--- a/waspc/examples/todoApp/.env
+++ b/waspc/examples/todoApp/.env
@@ -1,0 +1,1 @@
+TEST_ENV_VAR="I am test"

--- a/waspc/examples/todoApp/ext/queries.js
+++ b/waspc/examples/todoApp/ext/queries.js
@@ -5,6 +5,7 @@ export const getTasks = async (args, context) => {
     throw new HttpError(403)
   }
   console.log('user who made the query: ', context.user)
+  console.log('TEST_ENV_VAR', process.env.TEST_ENV_VAR)
 
   const Task = context.entities.Task
   const tasks = await Task.findMany(

--- a/waspc/src/Common.hs
+++ b/waspc/src/Common.hs
@@ -1,0 +1,5 @@
+module Common
+    ( WaspProjectDir
+    ) where
+
+data WaspProjectDir -- Root dir of Wasp project, containing source files.

--- a/waspc/src/Generator.hs
+++ b/waspc/src/Generator.hs
@@ -16,6 +16,7 @@ import           Generator.Common          (ProjectRootDir)
 import           Generator.DbGenerator     (genDb)
 import           Generator.FileDraft       (FileDraft, write)
 import           Generator.ServerGenerator (genServer)
+import qualified Generator.ServerGenerator as ServerGenerator
 import           Generator.DockerGenerator (genDockerFiles)
 import qualified Generator.Setup
 import qualified Generator.Start
@@ -33,6 +34,7 @@ import           Wasp                      (Wasp)
 writeWebAppCode :: Wasp -> Path Abs (Dir ProjectRootDir) -> CompileOptions -> IO ()
 writeWebAppCode wasp dstDir compileOptions = do
     writeFileDrafts dstDir (generateWebApp wasp compileOptions)
+    ServerGenerator.preCleanup wasp dstDir compileOptions
     writeFileDrafts dstDir (genServer wasp compileOptions)
     writeFileDrafts dstDir (genDb wasp compileOptions)
     writeFileDrafts dstDir (genDockerFiles wasp compileOptions)

--- a/waspc/src/Generator/FileDraft.hs
+++ b/waspc/src/Generator/FileDraft.hs
@@ -3,6 +3,7 @@ module Generator.FileDraft
        , Writeable(..)
        , createTemplateFileDraft
        , createCopyFileDraft
+       , createCopyFileDraftIfExists
        , createTextFileDraft
        ) where
 
@@ -45,7 +46,19 @@ createTemplateFileDraft dstPath tmplSrcPath tmplData =
 
 createCopyFileDraft :: Path (Rel ProjectRootDir) File -> Path Abs File -> FileDraft
 createCopyFileDraft dstPath srcPath =
-    FileDraftCopyFd $ CopyFD.CopyFileDraft { CopyFD._dstPath = dstPath, CopyFD._srcPath = srcPath}
+    FileDraftCopyFd $ CopyFD.CopyFileDraft
+    { CopyFD._dstPath = dstPath
+    , CopyFD._srcPath = srcPath
+    , CopyFD._failIfSrcDoesNotExist = True
+    }
+
+createCopyFileDraftIfExists :: Path (Rel ProjectRootDir) File -> Path Abs File -> FileDraft
+createCopyFileDraftIfExists dstPath srcPath =
+    FileDraftCopyFd $ CopyFD.CopyFileDraft
+    { CopyFD._dstPath = dstPath
+    , CopyFD._srcPath = srcPath
+    , CopyFD._failIfSrcDoesNotExist = False
+    }
 
 createTextFileDraft :: Path (Rel ProjectRootDir) File -> Text -> FileDraft
 createTextFileDraft dstPath content =

--- a/waspc/src/Generator/FileDraft/CopyFileDraft.hs
+++ b/waspc/src/Generator/FileDraft/CopyFileDraft.hs
@@ -2,23 +2,43 @@ module Generator.FileDraft.CopyFileDraft
        ( CopyFileDraft(..)
        ) where
 
-import StrongPath (Path, Abs, Rel, File, (</>))
-import qualified StrongPath as SP
-import Generator.Common (ProjectRootDir)
-import Generator.FileDraft.Writeable
-import Generator.FileDraft.WriteableMonad
+import           Control.Monad                      (when)
+import           System.IO.Error                    (doesNotExistErrorType, mkIOError)
+
+import           Generator.Common                   (ProjectRootDir)
+import           Generator.FileDraft.Writeable
+import           Generator.FileDraft.WriteableMonad
+import           StrongPath                         (Abs, File, Path, Rel,
+                                                     (</>))
+import qualified StrongPath                         as SP
 
 
 -- | File draft based purely on another file, that is just copied.
 data CopyFileDraft = CopyFileDraft
-    { _dstPath :: !(Path (Rel ProjectRootDir) File)-- ^ Path where the file will be copied to.
-    , _srcPath :: !(Path Abs File) -- ^ Absolute path of source file to copy.
+    -- | Path where the file will be copied to.
+    { _dstPath               :: !(Path (Rel ProjectRootDir) File)
+    -- | Absolute path of source file to copy.
+    , _srcPath               :: !(Path Abs File)
+    , _failIfSrcDoesNotExist :: Bool
     }
     deriving (Show, Eq)
 
 instance Writeable CopyFileDraft where
     write absDstDirPath draft = do
-        createDirectoryIfMissing True (SP.toFilePath $ SP.parent absDraftDstPath)
-        copyFile (SP.toFilePath $ _srcPath draft) (SP.toFilePath $ absDraftDstPath)
+        srcFileExists <- doesFileExist srcFilePath
+        if srcFileExists
+            then do
+                createDirectoryIfMissing True (SP.toFilePath $ SP.parent absDraftDstPath)
+                copyFile srcFilePath (SP.toFilePath $ absDraftDstPath)
+            else
+                when
+                (_failIfSrcDoesNotExist draft)
+                (throwIO $ mkIOError
+                    doesNotExistErrorType
+                    "Source file of CopyFileDraft does not exist."
+                    Nothing
+                    (Just srcFilePath)
+                )
       where
-          absDraftDstPath = absDstDirPath </> (_dstPath draft)
+          srcFilePath = SP.toFilePath $ _srcPath draft
+          absDraftDstPath = absDstDirPath </> _dstPath draft

--- a/waspc/src/Lib.hs
+++ b/waspc/src/Lib.hs
@@ -5,33 +5,68 @@ module Lib
     , ProjectRootDir
     ) where
 
-import StrongPath (Path, Abs, File, Dir)
-import qualified StrongPath as SP
-import CompileOptions (CompileOptions)
+import qualified Path                   as P
+import           System.Directory       (doesFileExist)
+
+import           Common                 (WaspProjectDir)
+import           CompileOptions         (CompileOptions)
 import qualified CompileOptions
+import           Control.Monad.IO.Class (liftIO)
+import           Data.List              (find, isSuffixOf)
 import qualified ExternalCode
-import qualified Parser
 import qualified Generator
-import Wasp (setExternalCodeFiles, setIsBuild, Wasp)
-import Generator.Common (ProjectRootDir)
+import           Generator.Common       (ProjectRootDir)
+import qualified Parser
+import           StrongPath             (Abs, Dir, Path)
+import qualified StrongPath             as SP
+import qualified Util.IO
+import           Wasp                   (Wasp)
+import qualified Wasp
 
 
 type CompileError = String
 
-compile :: Path Abs File -> Path Abs (Dir ProjectRootDir) -> CompileOptions -> IO (Either CompileError ())
-compile waspFile outDir options = do
-    waspStr <- readFile (SP.toFilePath waspFile)
+compile :: Path Abs (Dir WaspProjectDir)
+        -> Path Abs (Dir ProjectRootDir)
+        -> CompileOptions
+        -> IO (Either CompileError ())
+compile waspDir outDir options = do
+    maybeWaspFile <- findWaspFile waspDir
+    case maybeWaspFile of
+        Nothing -> return $ Left "Couldn't find a single *.wasp file."
+        Just waspFile -> do
+            waspStr <- readFile (SP.toFilePath waspFile)
 
-    case Parser.parseWasp waspStr of
-        Left err -> return $ Left (show err)
-        Right wasp -> (enrichWaspASTBasedOnCompileOptions wasp options >>= generateCode)
+            case Parser.parseWasp waspStr of
+                Left err -> return $ Left (show err)
+                Right wasp -> do
+                    maybeDotEnvFile <- findDotEnvFile waspDir
+                    (wasp
+                     `Wasp.setDotEnvFile` maybeDotEnvFile
+                     `enrichWaspASTBasedOnCompileOptions` options
+                        ) >>= generateCode
   where
     generateCode wasp = Generator.writeWebAppCode wasp outDir options >> return (Right ())
-    
+
 enrichWaspASTBasedOnCompileOptions :: Wasp -> CompileOptions -> IO Wasp
 enrichWaspASTBasedOnCompileOptions wasp options = do
     externalCodeFiles <- ExternalCode.readFiles (CompileOptions.externalCodeDirPath options)
     return (wasp
-           `setExternalCodeFiles` externalCodeFiles 
-           `setIsBuild` CompileOptions.isBuild options
+            `Wasp.setExternalCodeFiles` externalCodeFiles
+            `Wasp.setIsBuild` CompileOptions.isBuild options
            )
+
+findWaspFile :: Path Abs (Dir WaspProjectDir) -> IO (Maybe (Path Abs SP.File))
+findWaspFile waspDir = do
+    (files, _) <- liftIO $ Util.IO.listDirectory (SP.toPathAbsDir waspDir)
+    return $ (waspDir SP.</>) . SP.fromPathRelFile <$> find isWaspFile files
+  where
+      isWaspFile :: P.Path P.Rel P.File -> Bool
+      isWaspFile path = ".wasp" `isSuffixOf` P.toFilePath path
+                        && (length (P.toFilePath path) > length (".wasp" :: String))
+
+findDotEnvFile :: Path Abs (Dir WaspProjectDir) -> IO (Maybe (Path Abs SP.File))
+findDotEnvFile waspDir = do
+    let dotEnvAbsPath = waspDir SP.</> SP.fromPathRelFile [P.relfile|.env|]
+    dotEnvExists <- doesFileExist (SP.toFilePath dotEnvAbsPath)
+    return $ if dotEnvExists then Just dotEnvAbsPath else Nothing

--- a/waspc/src/Wasp.hs
+++ b/waspc/src/Wasp.hs
@@ -31,6 +31,9 @@ module Wasp
     , setExternalCodeFiles
     , getExternalCodeFiles
 
+    , setDotEnvFile
+    , getDotEnvFile
+
     , setIsBuild
     , getIsBuild
 
@@ -39,6 +42,7 @@ module Wasp
     ) where
 
 import           Data.Aeson           (ToJSON (..), object, (.=))
+import           StrongPath           (Path, Abs, File)
 
 import qualified ExternalCode
 import qualified Util                 as U
@@ -60,6 +64,7 @@ data Wasp = Wasp
     { waspElements      :: [WaspElement]
     , waspJsImports     :: [JsImport]
     , externalCodeFiles :: [ExternalCode.File]
+    , dotEnvFile        :: Maybe (Path Abs File)
     , isBuild           :: Bool
     } deriving (Show, Eq)
 
@@ -79,6 +84,7 @@ fromWaspElems elems = Wasp
     { waspElements = elems
     , waspJsImports = []
     , externalCodeFiles = []
+    , dotEnvFile = Nothing
     , isBuild = False
     }
 
@@ -97,6 +103,14 @@ getExternalCodeFiles = externalCodeFiles
 
 setExternalCodeFiles :: Wasp -> [ExternalCode.File] -> Wasp
 setExternalCodeFiles wasp files = wasp { externalCodeFiles = files }
+
+-- * Dot env files
+
+getDotEnvFile :: Wasp -> Maybe (Path Abs File)
+getDotEnvFile = dotEnvFile
+
+setDotEnvFile :: Wasp -> Maybe (Path Abs File) -> Wasp
+setDotEnvFile wasp file = wasp { dotEnvFile = file }
 
 -- * Js imports
 

--- a/waspc/test/Generator/FileDraft/CopyFileDraftTest.hs
+++ b/waspc/test/Generator/FileDraft/CopyFileDraftTest.hs
@@ -1,14 +1,14 @@
 module Generator.FileDraft.CopyFileDraftTest where
 
-import Test.Tasty.Hspec
+import           Test.Tasty.Hspec
 
-import qualified Path as P
+import qualified Path                         as P
 
-import qualified StrongPath as SP
-import Generator.FileDraft
+import           Generator.FileDraft
+import qualified StrongPath                   as SP
 
+import           Fixtures                     (systemPathRoot)
 import qualified Generator.MockWriteableMonad as Mock
-import Fixtures (systemPathRoot)
 
 
 spec_CopyFileDraft :: Spec
@@ -21,12 +21,12 @@ spec_CopyFileDraft = do
                 `shouldBe` [(True, SP.toFilePath $ SP.parent expectedDstPath)]
             Mock.copyFile_calls mockLogs
                 `shouldBe` [(SP.toFilePath expectedSrcPath, SP.toFilePath expectedDstPath)]
-              where
-                (dstDir, dstPath, srcPath) =
-                    ( SP.fromPathAbsDir $ systemPathRoot P.</> [P.reldir|a/b|]
-                    , SP.fromPathRelFile [P.relfile|c/d/dst.txt|]
-                    , SP.fromPathAbsFile $ systemPathRoot P.</> [P.relfile|e/src.txt|]
-                    )
-                fileDraft = createCopyFileDraft dstPath srcPath
-                expectedSrcPath = srcPath
-                expectedDstPath = dstDir SP.</> dstPath
+  where
+      (dstDir, dstPath, srcPath) =
+          ( SP.fromPathAbsDir $ systemPathRoot P.</> [P.reldir|a/b|]
+          , SP.fromPathRelFile [P.relfile|c/d/dst.txt|]
+          , SP.fromPathAbsFile $ systemPathRoot P.</> [P.relfile|e/src.txt|]
+          )
+      fileDraft = createCopyFileDraft dstPath srcPath
+      expectedSrcPath = srcPath
+      expectedDstPath = dstDir SP.</> dstPath


### PR DESCRIPTION
Now, if you provide .env file next to the root of the wasp project, it will be used on the server (actions, queries) during development.
This file is not committed to git.

TODO: write separate PR, on web repo, with documentation about this.