### PR TITLE
Add Helmet to node server dependencies

### DIFF
--- a/waspc/data/Generator/templates/server/src/app.js
+++ b/waspc/data/Generator/templates/server/src/app.js
@@ -2,6 +2,7 @@ import express from 'express'
 import cookieParser from 'cookie-parser'
 import logger from 'morgan'
 import cors from 'cors'
+import helmet from 'helmet'
 
 import HttpError from './core/HttpError.js'
 import indexRouter from './routes/index.js'
@@ -11,6 +12,7 @@ import indexRouter from './routes/index.js'
 
 const app = express()
 
+app.use(helmet())
 app.use(cors()) // TODO: Consider configuring CORS to be more restrictive, right now it allows all CORS requests.
 app.use(logger('dev'))
 app.use(express.json())

--- a/waspc/src/Generator/ServerGenerator.hs
+++ b/waspc/src/Generator/ServerGenerator.hs
@@ -122,7 +122,8 @@ waspNpmDeps =
       ("@prisma/client", "2.22.1"),
       ("jsonwebtoken", "^8.5.1"),
       ("secure-password", "^4.0.0"),
-      ("dotenv", "8.2.0")
+      ("dotenv", "8.2.0"),
+      ("helmet", "^4.6.0")
     ]
 
 -- TODO: Also extract devDependencies like we did dependencies (waspNpmDeps).


### PR DESCRIPTION
# Description

Added Helmet 4.6.0 (latest) to the list of node dependencies. The default config options are used, and more info on which response headers are set by default can be seen [here](https://github.com/wasp-lang/wasp/issues/22#issuecomment-814216737).

Here are the response headers when using Helmet on a new Wasp app:

![Screenshot from 2021-05-18 17-12-10](https://user-images.githubusercontent.com/61392361/118724372-85d67c80-b7fc-11eb-8425-f8ef0d6314d5.png)

And here are the response headers without Helmet on a new Wasp app:

![Screenshot from 2021-05-18 17-32-29](https://user-images.githubusercontent.com/61392361/118726365-334a8f80-b7ff-11eb-9396-3d96338a7a4f.png)


Fixes #22 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update