### PR TITLE
Extract server npm dev dependencies

### DIFF
--- a/waspc/data/Generator/templates/server/package.json
+++ b/waspc/data/Generator/templates/server/package.json
@@ -19,9 +19,5 @@
     "node": ">={= nodeVersion =}"
   },
   {=& depsChunk =},
-  "devDependencies": {
-    "nodemon": "^2.0.4",
-    "standard": "^14.3.4",
-    "prisma": "2.22.1"
-  }
+  {=& devDepsChunk =}
 }

--- a/waspc/src/Generator/PackageJsonGenerator.hs
+++ b/waspc/src/Generator/PackageJsonGenerator.hs
@@ -1,7 +1,7 @@
 module Generator.PackageJsonGenerator
   ( resolveNpmDeps,
-    toPackageJsonDependenciesString,
-    toPackageJsonDevDependenciesString,
+    npmDepsToPackageJsonEntry,
+    npmDevDepsToPackageJsonEntry,
   )
 where
 
@@ -59,16 +59,16 @@ resolveNpmDeps waspDeps userDeps =
     isDepWithNameInWaspDeps :: String -> Bool
     isDepWithNameInWaspDeps name = any ((name ==) . ND._name) waspDeps
 
-dependencyToString :: [ND.NpmDependency] -> String -> String
-dependencyToString deps depType =
+npmDepsToPackageJsonEntryWithKey :: [ND.NpmDependency] -> String -> String
+npmDepsToPackageJsonEntryWithKey deps key =
   "\""
-    ++ depType
+    ++ key
     ++ "\": {"
     ++ intercalate ",\n  " (map (\dep -> "\"" ++ ND._name dep ++ "\": \"" ++ ND._version dep ++ "\"") deps)
     ++ "\n}"
 
-toPackageJsonDependenciesString :: [ND.NpmDependency] -> String
-toPackageJsonDependenciesString deps = dependencyToString deps "dependencies"
+npmDepsToPackageJsonEntry :: [ND.NpmDependency] -> String
+npmDepsToPackageJsonEntry deps = npmDepsToPackageJsonEntryWithKey deps "dependencies"
 
-toPackageJsonDevDependenciesString :: [ND.NpmDependency] -> String
-toPackageJsonDevDependenciesString deps = dependencyToString deps "devDependencies"
+npmDevDepsToPackageJsonEntry :: [ND.NpmDependency] -> String
+npmDevDepsToPackageJsonEntry deps = npmDepsToPackageJsonEntryWithKey deps "devDependencies"

--- a/waspc/src/Generator/PackageJsonGenerator.hs
+++ b/waspc/src/Generator/PackageJsonGenerator.hs
@@ -1,6 +1,7 @@
 module Generator.PackageJsonGenerator
   ( resolveNpmDeps,
     toPackageJsonDependenciesString,
+    toPackageJsonDevDependenciesString,
   )
 where
 
@@ -61,5 +62,11 @@ resolveNpmDeps waspDeps userDeps =
 toPackageJsonDependenciesString :: [ND.NpmDependency] -> String
 toPackageJsonDependenciesString deps =
   "\"dependencies\": {"
+    ++ intercalate ",\n  " (map (\dep -> "\"" ++ ND._name dep ++ "\": \"" ++ ND._version dep ++ "\"") deps)
+    ++ "\n}"
+
+toPackageJsonDevDependenciesString :: [ND.NpmDependency] -> String
+toPackageJsonDevDependenciesString deps =
+  "\"devDependencies\": {"
     ++ intercalate ",\n  " (map (\dep -> "\"" ++ ND._name dep ++ "\": \"" ++ ND._version dep ++ "\"") deps)
     ++ "\n}"

--- a/waspc/src/Generator/PackageJsonGenerator.hs
+++ b/waspc/src/Generator/PackageJsonGenerator.hs
@@ -59,14 +59,16 @@ resolveNpmDeps waspDeps userDeps =
     isDepWithNameInWaspDeps :: String -> Bool
     isDepWithNameInWaspDeps name = any ((name ==) . ND._name) waspDeps
 
-toPackageJsonDependenciesString :: [ND.NpmDependency] -> String
-toPackageJsonDependenciesString deps =
-  "\"dependencies\": {"
+dependencyToString :: [ND.NpmDependency] -> String -> String
+dependencyToString deps depType =
+  "\""
+    ++ depType
+    ++ "\": {"
     ++ intercalate ",\n  " (map (\dep -> "\"" ++ ND._name dep ++ "\": \"" ++ ND._version dep ++ "\"") deps)
     ++ "\n}"
 
+toPackageJsonDependenciesString :: [ND.NpmDependency] -> String
+toPackageJsonDependenciesString deps = dependencyToString deps "dependencies"
+
 toPackageJsonDevDependenciesString :: [ND.NpmDependency] -> String
-toPackageJsonDevDependenciesString deps =
-  "\"devDependencies\": {"
-    ++ intercalate ",\n  " (map (\dep -> "\"" ++ ND._name dep ++ "\": \"" ++ ND._version dep ++ "\"") deps)
-    ++ "\n}"
+toPackageJsonDevDependenciesString deps = dependencyToString deps "devDependencies"

--- a/waspc/src/Generator/ServerGenerator.hs
+++ b/waspc/src/Generator/ServerGenerator.hs
@@ -123,7 +123,7 @@ waspNpmDeps =
       ("debug", "~2.6.9"),
       ("express", "~4.16.1"),
       ("morgan", "~1.9.1"),
-      ("@prisma/client", "2.21.0"),
+      ("@prisma/client", "2.22.1"),
       ("jsonwebtoken", "^8.5.1"),
       ("secure-password", "^4.0.0"),
       ("dotenv", "8.2.0"),
@@ -135,7 +135,7 @@ waspNpmDevDeps =
   ND.fromList
     [ ("nodemon", "^2.0.4"),
       ("standard", "^14.3.4"),
-      ("prisma", "2.21.0")
+      ("prisma", "2.22.1")
     ]
 
 genNpmrc :: Wasp -> FileDraft

--- a/waspc/src/Generator/ServerGenerator.hs
+++ b/waspc/src/Generator/ServerGenerator.hs
@@ -126,7 +126,8 @@ waspNpmDeps =
       ("@prisma/client", "2.21.0"),
       ("jsonwebtoken", "^8.5.1"),
       ("secure-password", "^4.0.0"),
-      ("dotenv", "8.2.0")
+      ("dotenv", "8.2.0"),
+      ("helmet", "^4.6.0")
     ]
 
 waspNpmDevDeps :: [ND.NpmDependency]

--- a/waspc/src/Generator/ServerGenerator.hs
+++ b/waspc/src/Generator/ServerGenerator.hs
@@ -19,9 +19,9 @@ import Generator.Common (ProjectRootDir, nodeVersionAsText)
 import Generator.ExternalCodeGenerator (generateExternalCodeDir)
 import Generator.FileDraft (FileDraft, createCopyFileDraft)
 import Generator.PackageJsonGenerator
-  ( resolveNpmDeps,
-    toPackageJsonDependenciesString,
-    toPackageJsonDevDependenciesString,
+  ( npmDepsToPackageJsonEntry,
+    npmDevDepsToPackageJsonEntry,
+    resolveNpmDeps,
   )
 import Generator.ServerGenerator.AuthG (genAuth)
 import Generator.ServerGenerator.Common
@@ -96,8 +96,8 @@ genPackageJson wasp waspDeps waspDevDeps =
     ( Just $
         object
           [ "wasp" .= wasp,
-            "depsChunk" .= toPackageJsonDependenciesString (resolvedWaspDeps ++ resolvedUserDeps),
-            "devDepsChunk" .= toPackageJsonDevDependenciesString waspDevDeps,
+            "depsChunk" .= npmDepsToPackageJsonEntry (resolvedWaspDeps ++ resolvedUserDeps),
+            "devDepsChunk" .= npmDevDepsToPackageJsonEntry waspDevDeps,
             "nodeVersion" .= nodeVersionAsText,
             "startProductionScript"
               .= concat

--- a/waspc/src/Generator/WebAppGenerator.hs
+++ b/waspc/src/Generator/WebAppGenerator.hs
@@ -14,8 +14,8 @@ import Data.List (intercalate)
 import Generator.ExternalCodeGenerator (generateExternalCodeDir)
 import Generator.FileDraft
 import Generator.PackageJsonGenerator
-  ( resolveNpmDeps,
-    toPackageJsonDependenciesString,
+  ( npmDepsToPackageJsonEntry,
+    resolveNpmDeps,
   )
 import qualified Generator.WebAppGenerator.AuthG as AuthG
 import Generator.WebAppGenerator.Common
@@ -63,7 +63,7 @@ genPackageJson wasp waspDeps =
     ( Just $
         object
           [ "wasp" .= wasp,
-            "depsChunk" .= toPackageJsonDependenciesString (resolvedWaspDeps ++ resolvedUserDeps)
+            "depsChunk" .= npmDepsToPackageJsonEntry (resolvedWaspDeps ++ resolvedUserDeps)
           ]
     )
   where


### PR DESCRIPTION
# Description

Now dev dependencies in package.json are no more hardcoded, instead they are generated (like dependencies) from ServerGenerator.hs and inserted as devDepsChunk.

Fixes # 93

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update