### PR TITLE
Get `npm install` during `wasp start` to output more details

### DIFF
--- a/waspc/src/Generator/ServerGenerator/Setup.hs
+++ b/waspc/src/Generator/ServerGenerator/Setup.hs
@@ -8,9 +8,18 @@ import qualified Generator.Job as J
 import Generator.Job.Process (runNodeCommandAsJob)
 import qualified Generator.ServerGenerator.Common as Common
 import StrongPath (Abs, Dir, Path, (</>))
+import qualified System.Info
 
 setupServer :: Path Abs (Dir ProjectRootDir) -> J.Job
 setupServer projectDir = do
   let serverDir = projectDir </> Common.serverRootDirInProjectRootDir
-  _ <- runNodeCommandAsJob serverDir "npm" ["install"] J.Server
-  runNodeCommandAsJob serverDir "npm" ["ls"] J.Server
+
+  let npmInstallServerCmd = ["npm", "install"]
+  let scriptArgs =
+        if System.Info.os == "darwin"
+          then -- NOTE: On MacOS, command that `script` should execute is treated as multiple arguments.
+            ["-Fq", "/dev/null"] ++ npmInstallServerCmd
+          else -- NOTE: On Linux, command that `script` should execute is treated as one argument.
+            ["-feqc", unwords npmInstallServerCmd, "/dev/null"]
+
+  runNodeCommandAsJob serverDir "script" scriptArgs J.Server

--- a/waspc/src/Generator/ServerGenerator/Setup.hs
+++ b/waspc/src/Generator/ServerGenerator/Setup.hs
@@ -12,4 +12,5 @@ import StrongPath (Abs, Dir, Path, (</>))
 setupServer :: Path Abs (Dir ProjectRootDir) -> J.Job
 setupServer projectDir = do
   let serverDir = projectDir </> Common.serverRootDirInProjectRootDir
-  runNodeCommandAsJob serverDir "npm" ["install"] J.Server
+  _ <- runNodeCommandAsJob serverDir "npm" ["install"] J.Server
+  runNodeCommandAsJob serverDir "npm" ["ls"] J.Server

--- a/waspc/src/Generator/WebAppGenerator/Setup.hs
+++ b/waspc/src/Generator/WebAppGenerator/Setup.hs
@@ -8,9 +8,18 @@ import qualified Generator.Job as J
 import Generator.Job.Process (runNodeCommandAsJob)
 import qualified Generator.WebAppGenerator.Common as Common
 import StrongPath (Abs, Dir, Path, (</>))
+import qualified System.Info
 
 setupWebApp :: Path Abs (Dir ProjectRootDir) -> J.Job
 setupWebApp projectDir = do
   let webAppDir = projectDir </> Common.webAppRootDirInProjectRootDir
-  _ <- runNodeCommandAsJob webAppDir "npm" ["install"] J.WebApp
-  runNodeCommandAsJob webAppDir "npm" ["ls"] J.WebApp
+
+  let npmInstallWebAppCmd = ["npm", "install"]
+  let scriptArgs =
+        if System.Info.os == "darwin"
+          then -- NOTE: On MacOS, command that `script` should execute is treated as multiple arguments.
+            ["-Fq", "/dev/null"] ++ npmInstallWebAppCmd
+          else -- NOTE: On Linux, command that `script` should execute is treated as one argument.
+            ["-feqc", unwords npmInstallWebAppCmd, "/dev/null"]
+
+  runNodeCommandAsJob webAppDir "script" scriptArgs J.WebApp

--- a/waspc/src/Generator/WebAppGenerator/Setup.hs
+++ b/waspc/src/Generator/WebAppGenerator/Setup.hs
@@ -12,4 +12,5 @@ import StrongPath (Abs, Dir, Path, (</>))
 setupWebApp :: Path Abs (Dir ProjectRootDir) -> J.Job
 setupWebApp projectDir = do
   let webAppDir = projectDir </> Common.webAppRootDirInProjectRootDir
-  runNodeCommandAsJob webAppDir "npm" ["install"] J.WebApp
+  _ <- runNodeCommandAsJob webAppDir "npm" ["install"] J.WebApp
+  runNodeCommandAsJob webAppDir "npm" ["ls"] J.WebApp


### PR DESCRIPTION
# Description

First possible solution suggested in the issue is excluded as there are no flags to be passed to `npm install`
Trying second solution, use script to cheat `npm install` into thinking it is being run interactively (like prisma commands do), doesn't seem to output more details as well.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update