### PR TITLE
Separated EvalCtx from evaluation input, removed duplication between Evaluator and DictEvaluator.

### DIFF
--- a/waspc/src/Analyzer/Evaluator/Combinators.hs
+++ b/waspc/src/Analyzer/Evaluator/Combinators.hs
@@ -35,11 +35,7 @@
 -- @{ title: "Home", content: "Hello world" }@ into
 -- @Page { title = "Home", author = Nothing, content = "Hello world" }@
 module Analyzer.Evaluator.Combinators
-  ( -- * Types
-    Evaluator,
-    DictEvaluator,
-
-    -- * Functions
+  ( -- * Functions
     runEvaluator,
 
     -- * "Evaluator" combinators
@@ -72,123 +68,124 @@ import Control.Arrow (left)
 import Data.Functor.Compose (Compose (Compose, getCompose))
 import qualified Data.HashMap.Strict as H
 
+-- TODO: Split into TypedExprEvaluator and DictEvaluator?
+
 -- | Bindings for currently evaluated declarations
 type Bindings = H.HashMap String Decl
 
 -- | The context in an evaluation.
-type EvalCtx a = (TD.TypeDefinitions, Bindings, a)
+type EvalCtx = (TD.TypeDefinitions, Bindings)
 
 -- | An evaluation from "a" to "b" with the evaluation context.
 -- We are using `Compose` because it results in an Applicative when it composes two Applicatives,
 -- meaning that our evaluators automatically become instance of Applicative.
-type (|>) a b = Compose ((->) (EvalCtx a)) (Either EvaluationError) b
-
--- | An evaluation from a typed expression to a value.
-newtype Evaluator a = Evaluator (TypedExpr |> a)
+newtype Evaluator a b = Evaluator (Compose ((->) EvalCtx) (Compose ((->) a) (Either EvaluationError)) b)
   deriving (Functor, Applicative)
 
-evaluator :: (EvalCtx TypedExpr -> Either EvaluationError a) -> Evaluator a
-evaluator = Evaluator . Compose
+evaluator :: (EvalCtx -> a -> Either EvaluationError b) -> Evaluator a b
+evaluator f = Evaluator $ Compose $ \ctx -> Compose $ f ctx
 
-runEvaluator :: Evaluator a -> TD.TypeDefinitions -> Bindings -> TypedExpr -> Either EvaluationError a
-runEvaluator (Evaluator f) typeDefs bindings expr = getCompose f (typeDefs, bindings, expr)
+evaluator' :: (a -> Either EvaluationError b) -> Evaluator a b
+evaluator' = evaluator . const
+
+runEvaluator :: Evaluator a b -> TD.TypeDefinitions -> Bindings -> a -> Either EvaluationError b
+runEvaluator (Evaluator f) typeDefs bindings = getCompose (getCompose f (typeDefs, bindings))
+
+type TypedExprEvaluator a = Evaluator TypedExpr a
 
 -- | A transformation from dictionary definition (which is a list of dictionary entries) to some type. A "Evaluator" can
 -- be created from a "DictEvaluator" with the "dict" combinator.
-newtype DictEvaluator a = DictEvaluator ([(String, TypedExpr)] |> a)
-  deriving (Functor, Applicative)
+type DictEvaluator a = Evaluator TypedDictEntries a
 
-dictEvaluator :: (EvalCtx [(String, TypedExpr)] -> Either EvaluationError a) -> DictEvaluator a
-dictEvaluator = DictEvaluator . Compose
-
-runDictEvaluator :: DictEvaluator a -> TD.TypeDefinitions -> Bindings -> [(String, TypedExpr)] -> Either EvaluationError a
-runDictEvaluator (DictEvaluator f) typeDefs bindings entries = getCompose f (typeDefs, bindings, entries)
+newtype TypedDictEntries = TypedDictEntries [(String, TypedExpr)]
 
 -- | An evaluator that expects a "StringLiteral".
-string :: Evaluator String
-string = evaluator $ \case
-  (_, _, StringLiteral str) -> pure str
-  (_, _, expr) -> Left $ ExpectedType T.StringType (exprType expr)
+string :: TypedExprEvaluator String
+string = evaluator' $ \case
+  StringLiteral str -> pure str
+  expr -> Left $ ExpectedType T.StringType (exprType expr)
 
 -- | An evaluator that expects an "IntegerLiteral" or "DoubleLiteral". A
 -- "DoubleLiteral" is rounded to the nearest whole number.
-integer :: Evaluator Integer
-integer = evaluator $ \case
-  (_, _, IntegerLiteral i) -> pure i
-  (_, _, DoubleLiteral x) -> pure $ round x
-  (_, _, expr) -> Left $ ExpectedType T.NumberType (exprType expr)
+integer :: TypedExprEvaluator Integer
+integer = evaluator' $ \case
+  IntegerLiteral i -> pure i
+  DoubleLiteral x -> pure $ round x
+  expr -> Left $ ExpectedType T.NumberType (exprType expr)
 
 -- | An evaluator that expects a "IntegerLiteral" or "DoubleLiteral".
-double :: Evaluator Double
-double = evaluator $ \case
-  (_, _, IntegerLiteral i) -> pure $ fromIntegral i
-  (_, _, DoubleLiteral x) -> pure x
-  (_, _, expr) -> Left $ ExpectedType T.NumberType (exprType expr)
+double :: TypedExprEvaluator Double
+double = evaluator' $ \case
+  IntegerLiteral i -> pure $ fromIntegral i
+  DoubleLiteral x -> pure x
+  expr -> Left $ ExpectedType T.NumberType (exprType expr)
 
 -- | An evaluator that expects a "BoolLiteral".
-bool :: Evaluator Bool
-bool = evaluator $ \case
-  (_, _, BoolLiteral b) -> pure b
-  (_, _, expr) -> Left $ ExpectedType T.BoolType (exprType expr)
+bool :: TypedExprEvaluator Bool
+bool = evaluator' $ \case
+  BoolLiteral b -> pure b
+  expr -> Left $ ExpectedType T.BoolType (exprType expr)
 
 -- | An evaluator that expects a "Var" bound to a "Decl" of type "a".
-decl :: forall a. TD.IsDeclType a => Evaluator a
-decl = evaluator $ \case
-  (_, bindings, Var var typ) -> case H.lookup var bindings of
+decl :: forall a. TD.IsDeclType a => TypedExprEvaluator a
+decl = evaluator $ \(_, bindings) -> \case
+  Var var typ -> case H.lookup var bindings of
     Nothing -> Left $ UndefinedVariable var
     Just dcl -> case fromDecl @a dcl of
       Nothing -> Left $ ForVariable var (ExpectedType (T.DeclType declTypeName) typ)
       Just (_dclName, dclValue) -> Right dclValue
-  (_, _, expr) -> Left $ ExpectedType (T.DeclType declTypeName) (exprType expr)
+  expr -> Left $ ExpectedType (T.DeclType declTypeName) (exprType expr)
   where
     declTypeName = TD.dtName $ TD.declType @a
 
 -- | An evaluator that expects a "Var" bound to an "EnumType" for "a".
-enum :: forall a. TD.IsEnumType a => Evaluator a
-enum = evaluator $ \case
-  (_, _, Var var _) -> TD.enumTypeFromVariant @a var
-  (_, _, expr) -> Left $ ExpectedType (T.EnumType $ TD.etName $ TD.enumType @a) (exprType expr)
+enum :: forall a. TD.IsEnumType a => TypedExprEvaluator a
+enum = evaluator' $ \case
+  Var var _ -> TD.enumTypeFromVariant @a var
+  expr -> Left $ ExpectedType (T.EnumType $ TD.etName $ TD.enumType @a) (exprType expr)
 
 -- | An evaluator that runs a "DictEvaluator". Expects a "Dict" expression and
 -- uses its entries to run the "DictEvaluator".
-dict :: DictEvaluator a -> Evaluator a
-dict dictEvalutor = evaluator $ \case
-  (typeDefs, bindings, Dict entries _) -> runDictEvaluator dictEvalutor typeDefs bindings entries
-  (_, _, expr) -> Left $ ExpectedDictType $ exprType expr
+dict :: DictEvaluator a -> TypedExprEvaluator a
+dict dictEvalutor = evaluator $ \(typeDefs, bindings) -> \case
+  Dict entries _ -> runEvaluator dictEvalutor typeDefs bindings $ TypedDictEntries entries
+  expr -> Left $ ExpectedDictType $ exprType expr
 
 -- | An evaluator that expects a "List" and runs the inner evaluator on each
 -- item in the list.
-list :: Evaluator a -> Evaluator [a]
-list inner = evaluator $ \case
-  (typeDefs, bindings, List values _) -> left InList $ mapM (runEvaluator inner typeDefs bindings) values
-  (_, _, expr) -> Left $ ExpectedListType $ exprType expr
+list :: TypedExprEvaluator a -> TypedExprEvaluator [a]
+list inner = evaluator $ \(typeDefs, bindings) -> \case
+  List values _ -> left InList $ mapM (runEvaluator inner typeDefs bindings) values
+  expr -> Left $ ExpectedListType $ exprType expr
 
 -- | An evaluator that expects an "ExtImport".
-extImport :: Evaluator E.ExtImport
-extImport = evaluator $ \case
-  (_, _, ExtImport name file) -> pure $ E.ExtImport name file
-  (_, _, expr) -> Left $ ExpectedType T.ExtImportType (exprType expr)
+extImport :: TypedExprEvaluator E.ExtImport
+extImport = evaluator' $ \case
+  ExtImport name file -> pure $ E.ExtImport name file
+  expr -> Left $ ExpectedType T.ExtImportType (exprType expr)
 
 -- | An evaluator that expects a "JSON".
-json :: Evaluator E.JSON
-json = evaluator $ \case
-  (_, _, JSON str) -> pure $ E.JSON str
-  (_, _, expr) -> Left $ ExpectedType (T.QuoterType "json") (exprType expr)
+json :: TypedExprEvaluator E.JSON
+json = evaluator' $ \case
+  JSON str -> pure $ E.JSON str
+  expr -> Left $ ExpectedType (T.QuoterType "json") (exprType expr)
 
 -- | An evaluator that expects a "PSL".
-psl :: Evaluator E.PSL
-psl = evaluator $ \case
-  (_, _, PSL str) -> pure $ E.PSL str
-  (_, _, expr) -> Left $ ExpectedType (T.QuoterType "psl") (exprType expr)
+psl :: TypedExprEvaluator E.PSL
+psl = evaluator' $ \case
+  PSL str -> pure $ E.PSL str
+  expr -> Left $ ExpectedType (T.QuoterType "psl") (exprType expr)
 
 -- | A dictionary evaluator that requires the field to exist.
-field :: String -> Evaluator a -> DictEvaluator a
-field key valueEvaluator = dictEvaluator $ \(typeDefs, bindings, entries) -> case lookup key entries of
-  Nothing -> Left $ MissingField key
-  Just value -> left (InField key) $ runEvaluator valueEvaluator typeDefs bindings value
+field :: String -> TypedExprEvaluator a -> DictEvaluator a
+field key valueEvaluator = evaluator $
+  \(typeDefs, bindings) (TypedDictEntries entries) -> case lookup key entries of
+    Nothing -> Left $ MissingField key
+    Just value -> left (InField key) $ runEvaluator valueEvaluator typeDefs bindings value
 
 -- | A dictionary evaluator that allows the field to be missing.
-maybeField :: String -> Evaluator a -> DictEvaluator (Maybe a)
-maybeField key valueEvaluator = dictEvaluator $ \(typeDefs, bindings, entries) -> case lookup key entries of
-  Nothing -> pure Nothing
-  Just value -> Just <$> left (InField key) (runEvaluator valueEvaluator typeDefs bindings value)
+maybeField :: String -> TypedExprEvaluator a -> DictEvaluator (Maybe a)
+maybeField key valueEvaluator = evaluator $
+  \(typeDefs, bindings) (TypedDictEntries entries) -> case lookup key entries of
+    Nothing -> pure Nothing
+    Just value -> Just <$> left (InField key) (runEvaluator valueEvaluator typeDefs bindings value)


### PR DESCRIPTION
There are two commits -> first separates context from input, second one removes duplication between Evaluator and DictEvaluator. Check it out, we can merge only specific commits if that will be needed.

Hm I just realized that with second commit we loose some of the type safety that newtype gives us. Not sure if that is a problem or not. In theory, somebody could combine the combinators wrong I guess. Not right now, but in the future if some combinators work with two different evaluators that have same shape but are really different, then that could be an issue. Although that could also be solved by using newtype on the type parameter of the Evaluator -> hm yes maybe that is the way to go, if somebody wants to make sure stuff is different.
EDIT: I added newtype to represent TypedDictEntries, that solves the problem from above.