### PR TITLE
Added IsDeclType constraint to Decl, hidden its internal representation.

### DIFF
--- a/waspc/src/Analyzer/Evaluator.hs
+++ b/waspc/src/Analyzer/Evaluator.hs
@@ -9,7 +9,8 @@ module Analyzer.Evaluator
   )
 where
 
-import Analyzer.Evaluator.Decl (Decl, takeDecls)
+import Analyzer.Evaluator.Decl (Decl)
+import Analyzer.Evaluator.Decl.Operations (takeDecls)
 import Analyzer.Evaluator.EvaluationError
 import Analyzer.Evaluator.Types
 import Analyzer.Type

--- a/waspc/src/Analyzer/Evaluator/Combinators.hs
+++ b/waspc/src/Analyzer/Evaluator/Combinators.hs
@@ -47,6 +47,7 @@ module Analyzer.Evaluator.Combinators
 where
 
 import Analyzer.Evaluator.Decl
+import Analyzer.Evaluator.Decl.Operations (fromDecl)
 import Analyzer.Evaluator.EvaluationError
 import qualified Analyzer.Evaluator.Types as E
 import qualified Analyzer.Type as T
@@ -55,7 +56,6 @@ import qualified Analyzer.TypeDefinitions as TD
 import Control.Arrow (left)
 import Data.Functor.Compose (Compose (Compose, getCompose))
 import qualified Data.HashMap.Strict as H
-import Data.Typeable (cast)
 
 -- | Bindings for currently evaluated declarations
 type Bindings = H.HashMap String Decl
@@ -119,9 +119,9 @@ decl :: forall a. TD.IsDeclType a => Evaluator a
 decl = evaluator $ \case
   (_, bindings, Var var typ) -> case H.lookup var bindings of
     Nothing -> Left $ UndefinedVariable var
-    Just (Decl _ value) -> case cast value :: Maybe a of
+    Just dcl -> case fromDecl @a dcl of
       Nothing -> Left $ ForVariable var (ExpectedType (T.DeclType $ TD.declTypeName @a) typ)
-      Just a -> Right a
+      Just (_, declValue) -> Right declValue
   (_, _, expr) -> Left $ ExpectedType (T.DeclType $ TD.declTypeName @a) (exprType expr)
 
 -- | An evaluator that expects a "Var" bound to an "EnumType" for "a".

--- a/waspc/src/Analyzer/Evaluator/Decl.hs
+++ b/waspc/src/Analyzer/Evaluator/Decl.hs
@@ -1,35 +1,6 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TupleSections #-}
-
 module Analyzer.Evaluator.Decl
-  ( Decl (Decl),
-    takeDecls,
+  ( Decl,
   )
 where
 
-import Data.Maybe (mapMaybe)
-import Data.Typeable (Typeable, cast)
-
--- | Used to store a heterogenous lists of evaluated declarations during
---   evaluation.
-data Decl where
-  -- | @Decl "Name" value@ results from a declaration statement "declType Name value".
-  Decl :: (Typeable a) => String -> a -> Decl
-
--- | Extracts all declarations of a certain type from a @[Decl]@s
---
---  Example:
---
---  @
---  data Person = Person { name :: String, age :: Integer } deriving Generic
---  data Building = Building { address :: String } deriving Generic
---  let decls = [ Decl "Bob" $ Person "Bob" 42
---              , Decl "Office" $ Building "1 Road St"
---              , Decl "Alice" $ Person "Alice" 32
---              ]
---  takeDecls @Person decls == [("Bob", Person "Bob" 42), ("Alice", Person "Alice" 32)]
---  @
-takeDecls :: (Typeable a) => [Decl] -> [(String, a)]
-takeDecls = mapMaybe $ \case
-  Decl name value -> (name,) <$> cast value
+import Analyzer.Evaluator.Decl.Internal

--- a/waspc/src/Analyzer/Evaluator/Decl/Internal.hs
+++ b/waspc/src/Analyzer/Evaluator/Decl/Internal.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE GADTs #-}
+
+module Analyzer.Evaluator.Decl.Internal
+  ( Decl (Decl),
+  )
+where
+
+import Data.Typeable (Typeable)
+
+-- | Used to store a heterogenous lists of evaluated declarations during
+--   evaluation.
+data Decl where
+  -- | @Decl "Name" value@ results from a declaration statement "declType Name value".
+  Decl :: (Typeable a) => String -> a -> Decl

--- a/waspc/src/Analyzer/Evaluator/Decl/Operations.hs
+++ b/waspc/src/Analyzer/Evaluator/Decl/Operations.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+
+module Analyzer.Evaluator.Decl.Operations
+  ( takeDecls,
+    makeDecl,
+    fromDecl,
+  )
+where
+
+import Analyzer.Evaluator.Decl.Internal
+import Analyzer.TypeDefinitions.Class (IsDeclType)
+import Data.Maybe (mapMaybe)
+import Data.Typeable (Typeable, cast)
+
+-- | Extracts all declarations of a certain type from a @[Decl]@s
+--
+--  Example:
+--
+--  @
+--  data Person = Person { name :: String, age :: Integer } deriving Generic
+--  data Building = Building { address :: String } deriving Generic
+--  let decls = [ Decl "Bob" $ Person "Bob" 42
+--              , Decl "Office" $ Building "1 Road St"
+--              , Decl "Alice" $ Person "Alice" 32
+--              ]
+--  takeDecls @Person decls == [("Bob", Person "Bob" 42), ("Alice", Person "Alice" 32)]
+--  @
+takeDecls :: (Typeable a, IsDeclType a) => [Decl] -> [(String, a)]
+takeDecls = mapMaybe fromDecl
+
+makeDecl :: (Typeable a, IsDeclType a) => String -> a -> Decl
+makeDecl = Decl
+
+fromDecl :: (Typeable a, IsDeclType a) => Decl -> Maybe (String, a)
+fromDecl (Decl name value) = (name,) <$> cast value

--- a/waspc/src/Analyzer/TypeDefinitions.hs
+++ b/waspc/src/Analyzer/TypeDefinitions.hs
@@ -19,7 +19,7 @@ module Analyzer.TypeDefinitions
   )
 where
 
-import Analyzer.Evaluator.Decl (Decl (Decl))
+import Analyzer.Evaluator.Decl.Operations (makeDecl)
 import Analyzer.TypeDefinitions.Class
 import Analyzer.TypeDefinitions.Type
 import qualified Data.HashMap.Strict as M
@@ -55,7 +55,7 @@ addDeclType lib =
         DeclType
           { dtName = declTypeName @typ,
             dtBodyType = declTypeBodyType @typ,
-            dtDeclFromAST = \typeDefs bindings name value -> Decl name <$> declTypeFromAST @typ typeDefs bindings value
+            dtDeclFromAST = \typeDefs bindings name value -> makeDecl name <$> declTypeFromAST @typ typeDefs bindings value
           }
    in lib {declTypes = M.insert (declTypeName @typ) decl $ declTypes lib}
 


### PR DESCRIPTION
This way `Decl`, or heterogeneous type used to store different IsDeclType types, is more opaque and you can't put something in it that is not IsDeclType.