### PR TITLE
IsDeclType/IsEnumType classes now return DeclType/EnumType values instead of individual values

### DIFF
--- a/waspc/src/Analyzer/Evaluator/Combinators.hs
+++ b/waspc/src/Analyzer/Evaluator/Combinators.hs
@@ -137,15 +137,17 @@ decl = evaluator $ \case
   (_, bindings, Var var typ) -> case H.lookup var bindings of
     Nothing -> Left $ UndefinedVariable var
     Just dcl -> case fromDecl @a dcl of
-      Nothing -> Left $ ForVariable var (ExpectedType (T.DeclType $ TD.declTypeName @a) typ)
-      Just (_, declValue) -> Right declValue
-  (_, _, expr) -> Left $ ExpectedType (T.DeclType $ TD.declTypeName @a) (exprType expr)
+      Nothing -> Left $ ForVariable var (ExpectedType (T.DeclType declTypeName) typ)
+      Just (_dclName, dclValue) -> Right dclValue
+  (_, _, expr) -> Left $ ExpectedType (T.DeclType declTypeName) (exprType expr)
+  where
+    declTypeName = TD.dtName $ TD.declType @a
 
 -- | An evaluator that expects a "Var" bound to an "EnumType" for "a".
 enum :: forall a. TD.IsEnumType a => Evaluator a
 enum = evaluator $ \case
   (_, _, Var var _) -> TD.enumTypeFromVariant @a var
-  (_, _, expr) -> Left $ ExpectedType (T.EnumType $ TD.enumTypeName @a) (exprType expr)
+  (_, _, expr) -> Left $ ExpectedType (T.EnumType $ TD.etName $ TD.enumType @a) (exprType expr)
 
 -- | An evaluator that runs a "DictEvaluator". Expects a "Dict" expression and
 -- uses its entries to run the "DictEvaluator".

--- a/waspc/src/Analyzer/TypeDefinitions.hs
+++ b/waspc/src/Analyzer/TypeDefinitions.hs
@@ -19,7 +19,6 @@ module Analyzer.TypeDefinitions
   )
 where
 
-import Analyzer.Evaluator.Decl.Operations (makeDecl)
 import Analyzer.TypeDefinitions.Class
 import Analyzer.TypeDefinitions.Type
 import qualified Data.HashMap.Strict as M
@@ -50,14 +49,9 @@ getEnumType name (TypeDefinitions _ ets) = M.lookup name ets
 --  let exampleDefinitions = addDeclType @App empty
 --  @
 addDeclType :: forall typ. (IsDeclType typ) => TypeDefinitions -> TypeDefinitions
-addDeclType lib =
-  let decl =
-        DeclType
-          { dtName = declTypeName @typ,
-            dtBodyType = declTypeBodyType @typ,
-            dtDeclFromAST = \typeDefs bindings name value -> makeDecl name <$> declTypeFromAST @typ typeDefs bindings value
-          }
-   in lib {declTypes = M.insert (declTypeName @typ) decl $ declTypes lib}
+addDeclType typeDefs =
+  let declType' = declType @typ
+   in typeDefs {declTypes = M.insert (dtName declType') declType' $ declTypes typeDefs}
 
 -- | Add an enum type to type definitions. Requires the type to be in the form
 --   of a Wasp enum. See "IsEnum" for requirements.
@@ -71,5 +65,5 @@ addDeclType lib =
 --   @
 addEnumType :: forall typ. (IsEnumType typ) => TypeDefinitions -> TypeDefinitions
 addEnumType lib =
-  let enum = EnumType {etName = enumTypeName @typ, etVariants = enumTypeVariants @typ}
-   in lib {enumTypes = M.insert (enumTypeName @typ) enum $ enumTypes lib}
+  let enumType' = enumType @typ
+   in lib {enumTypes = M.insert (etName enumType') enumType' $ enumTypes lib}

--- a/waspc/src/Analyzer/TypeDefinitions/Type.hs
+++ b/waspc/src/Analyzer/TypeDefinitions/Type.hs
@@ -19,8 +19,13 @@ data EnumType = EnumType
 data DeclType = DeclType
   { dtName :: String,
     dtBodyType :: Type,
-    -- | Same as "IsDeclType.declTypeFromAST", but also takes the name of the
-    -- declaration and returns a "Decl".
+    -- | Evaluates a Wasp "TypedExpr" to a Wasp AST declaration, or an error.
+    --
+    -- For @dtDeclFromAST typeDefs bindings name expr@:
+    -- - "typeDefs" is the type definitions used in the Analyzer
+    -- - "bindings" contains the values of all the declarations evaluated so far
+    -- - "name" is name of the declaration
+    -- - "expr" is the expression that should be evaluated by this function
     --
     -- __Examples__
     --


### PR DESCRIPTION
I was interested what would this look if we do it, so I gave it a try. It seems to me like this is an improvement, since we remove some of the duplication between classes and their corresponding data types.

IsDeclType class now has only one method, `declType :: DeclType`. Since evaluation method of IsDeclType was used only in evaluation method of DeclType, I removed it. We could add it back if you think it would be useful to have it.

IsEnumType now has `enumType :: EnumType`, but it also kept the evaluation method, since EnumType doesn't have one and the one from IsEnumType is useful as it is due to polymorphism. So, I left it there.

I believe I like this as it strengthens the relationship between classes and corresponding data types while also removing duplication. I am not sure if there is any bad side to this -> if there is and you are aware of it, pls let me know.

I would love to hear what you think about this @craigmc08 !