### PR TITLE
Move bash completion to Haskell

### DIFF
--- a/waspc/cli/Command/BashCompletion.hs
+++ b/waspc/cli/Command/BashCompletion.hs
@@ -6,22 +6,32 @@ module Command.BashCompletion
 where
 
 import Command (Command)
+import Control.Exception (assert)
 import Control.Monad.IO.Class (liftIO)
+import Data.List (isPrefixOf)
 import Paths_waspc (getDataFileName)
+import qualified System.Environment as ENV
 
-bashCompletion :: [String] -> Command ()
-bashCompletion args = case args of
-  [] -> listCommands
-  ["db"] -> listCommandsDb
-  _ -> liftIO . putStrLn $ ""
-
--- return available options for wasp <command>
-listCommands :: Command ()
-listCommands = liftIO . putStrLn $ unlines ["new", "version", "start", "db", "clean", "build", "telemetry", "deps"]
-
--- return available options for wasp db <command>
-listCommandsDb :: Command ()
-listCommandsDb = liftIO . putStrLn $ unlines ["migrate-dev", "studio"]
+-- generate bash completion depending on commands input
+bashCompletion :: Command ()
+bashCompletion = do
+  -- COMP_LINE is exposed by the bash `complete` builtin (https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html)
+  inputEntered <- liftIO (ENV.getEnv "COMP_LINE")
+  let inputWords = words inputEntered
+  let inputArgs = assert (head inputArgs == "wasp") $ tail inputWords
+  case inputArgs of
+    [] -> listCommands commands
+    ["db"] -> listCommands dbSubCommands
+    [cmdPrefix] -> listMatchingCommands cmdPrefix commands
+    ["db", cmdPrefix] -> listMatchingCommands cmdPrefix dbSubCommands
+    _ -> liftIO . putStrLn $ ""
+  where
+    commands = ["new", "version", "start", "db", "clean", "build", "telemetry", "deps"]
+    dbSubCommands = ["migrate-dev", "studio"]
+    listMatchingCommands :: String -> [String] -> Command ()
+    listMatchingCommands cmdPrefix cmdList = listCommands $ filter (cmdPrefix `isPrefixOf`) cmdList
+    listCommands :: [String] -> Command ()
+    listCommands cmdList = liftIO . putStrLn $ unlines cmdList
 
 -- generate the bash completion script
 generateBashCompletionScript :: Command ()

--- a/waspc/cli/Command/Call.hs
+++ b/waspc/cli/Command/Call.hs
@@ -12,5 +12,5 @@ data Call
   | Deps
   | PrintBashCompletionInstruction
   | GenerateBashCompletionScript
-  | BashCompletionListCommands [String]
+  | BashCompletionListCommands
   | Unknown [String] -- all args

--- a/waspc/cli/Main.hs
+++ b/waspc/cli/Main.hs
@@ -37,7 +37,7 @@ main = do
         ["deps"] -> Command.Call.Deps
         ["completion"] -> Command.Call.PrintBashCompletionInstruction
         ["completion:generate"] -> Command.Call.GenerateBashCompletionScript
-        ("completion:list" : subCommand) -> Command.Call.BashCompletionListCommands subCommand
+        ["completion:list"] -> Command.Call.BashCompletionListCommands
         _ -> Command.Call.Unknown args
 
   telemetryThread <- Async.async $ runCommand $ Telemetry.considerSendingData commandCall
@@ -54,7 +54,7 @@ main = do
     Command.Call.Deps -> runCommand deps
     Command.Call.PrintBashCompletionInstruction -> runCommand $ printBashCompletionInstruction
     Command.Call.GenerateBashCompletionScript -> runCommand $ generateBashCompletionScript
-    Command.Call.BashCompletionListCommands subCommand -> runCommand $ bashCompletion subCommand
+    Command.Call.BashCompletionListCommands -> runCommand $ bashCompletion
     Command.Call.Unknown _ -> printUsage
 
   -- If sending of telemetry data is still not done 1 second since commmand finished, abort it.

--- a/waspc/data/Cli/bash-completion
+++ b/waspc/data/Cli/bash-completion
@@ -1,23 +1,5 @@
-_wasp()
-{
-    
-    local cur prev
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
-
-    case ${COMP_CWORD} in
-        1)
-            # auto complete for wasp <command>
-            _wasp_commands=$( wasp completion:list )
-            COMPREPLY=( $(compgen -W "${_wasp_commands}" -- "${cur}") )
-            ;;
-        2)
-            # auto complete for subcommand wasp <command> <subcommand>
-            _wasp_second_commands=$( wasp completion:list ${prev} )
-            COMPREPLY=( $(compgen -W "${_wasp_second_commands}" -- "${cur}") )
-            ;;
-        *)
-            COMPREPLY=()
-    esac
+function _wasp {
+    wasp completion:list
 }
-complete -o default -o nospace -F _wasp wasp
+
+complete -o default -o nospace -C _wasp wasp


### PR DESCRIPTION
# Description

This patch moves majority of the bash completion logic from Bash to
    Haskell taking advantage of the environment variables exposed by the
    `complete` builtin to infer and suggest possible outputs.

Fixes # (issue)

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update