### PR TITLE
(WIP): Act on dependency changes

### DIFF
--- a/waspc/cli/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/Wasp/Cli/Command/Build.hs
@@ -12,6 +12,7 @@ import System.Directory
   ( doesDirectoryExist,
     removeDirectoryRecursive,
   )
+import Wasp (Wasp)
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( alphaWarningMessage,
@@ -21,7 +22,6 @@ import Wasp.Cli.Command.Compile (compileIOWithOptions)
 import qualified Wasp.Cli.Common as Common
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
-import Wasp (Wasp)
 
 build :: Command ()
 build = do

--- a/waspc/cli/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/Wasp/Cli/Command/Build.hs
@@ -21,6 +21,7 @@ import Wasp.Cli.Command.Compile (compileIOWithOptions)
 import qualified Wasp.Cli.Common as Common
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
+import Wasp (Wasp)
 
 build :: Command ()
 build = do
@@ -41,13 +42,13 @@ build = do
   buildResult <- liftIO $ buildIO waspProjectDir buildDir
   case buildResult of
     Left compileError -> throwError $ CommandError $ "Build failed: " ++ compileError
-    Right () -> liftIO $ putStrLn "Code has been successfully built! Check it out in .wasp/build directory.\n"
+    Right _ -> liftIO $ putStrLn "Code has been successfully built! Check it out in .wasp/build directory.\n"
   liftIO $ putStrLn alphaWarningMessage
 
 buildIO ::
   Path' Abs (Dir Common.WaspProjectDir) ->
   Path' Abs (Dir Wasp.Lib.ProjectRootDir) ->
-  IO (Either String ())
+  IO (Either String Wasp)
 buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir buildDir
   where
     options =

--- a/waspc/cli/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/Wasp/Cli/Command/Build.hs
@@ -12,7 +12,6 @@ import System.Directory
   ( doesDirectoryExist,
     removeDirectoryRecursive,
   )
-import Wasp (Wasp)
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( alphaWarningMessage,
@@ -22,6 +21,7 @@ import Wasp.Cli.Command.Compile (compileIOWithOptions)
 import qualified Wasp.Cli.Common as Common
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
+import Wasp.Wasp (Wasp)
 
 build :: Command ()
 build = do

--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -55,6 +55,7 @@ compileIOWithOptions ::
   Path' Abs (Dir Common.WaspProjectDir) ->
   Path' Abs (Dir Wasp.Lib.ProjectRootDir) ->
   IO (Either String Wasp)
+-- TODO: Use throwIO instead of Either to return exceptions?
 compileIOWithOptions options waspProjectDir outDir = runExceptT $ do
   -- TODO: Use throwIO instead of Either to return exceptions?
   wasp <-

--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -55,7 +55,6 @@ compileIOWithOptions ::
   Path' Abs (Dir Common.WaspProjectDir) ->
   Path' Abs (Dir Wasp.Lib.ProjectRootDir) ->
   IO (Either String Wasp)
--- TODO: Use throwIO instead of Either to return exceptions?
 compileIOWithOptions options waspProjectDir outDir = runExceptT $ do
   -- TODO: Use throwIO instead of Either to return exceptions?
   wasp <-

--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -8,7 +8,6 @@ where
 import Control.Monad.Except (runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
 import StrongPath (Abs, Dir, Path', (</>))
-import Wasp
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
@@ -22,6 +21,7 @@ import qualified Wasp.Cli.Common as Common
 import Wasp.Common (WaspProjectDir)
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
+import Wasp.Wasp
 
 compile :: Command ()
 compile = do

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -24,25 +24,26 @@ start = do
   waspRoot <- findWaspProjectRootDirFromCwd
   let outDir = waspRoot </> Common.dotWaspDirInWaspProjectDir </> Common.generatedCodeDirInDotWaspDir
 
-  -- TODO: Do smart install -> if we need to install stuff, install it, otherwise don't.
-  --   This should be responsibility of Generator, it should tell us how to install stuff.
-  --   But who checks out if stuff needs to be installed at all? That should probably be
-  --   Generator again. After installation, it should return some kind of data that describes that installation.
-  --   Then, next time, we give it data we have about last installation, and it uses that
-  --   to decide if installation needs to happen or not. If it happens, it returnes new data again.
-  --   Right now we have setup/installation being called, but it has not support for being "smart" yet.
-  waspSaysC "Setting up generated project..."
-  setupResult <- liftIO $ Wasp.Lib.setup outDir
-  case setupResult of
-    Left setupError -> throwError $ CommandError $ "\nSetup failed: " ++ setupError
-    Right () -> waspSaysC "\nSetup successful.\n"
-
   waspSaysC "Compiling wasp code..."
   compilationResult <- liftIO $ compileIO waspRoot outDir
   case compilationResult of
     Left compileError -> throwError $ CommandError $ "Compilation failed: " ++ compileError
     Right wasp -> do
       waspSaysC "Code has been successfully compiled, project has been generated.\n"
+
+      -- TODO: Do smart install -> if we need to install stuff, install it, otherwise don't.
+      --   This should be responsibility of Generator, it should tell us how to install stuff.
+      --   But who checks out if stuff needs to be installed at all? That should probably be
+      --   Generator again. After installation, it should return some kind of data that describes that installation.
+      --   Then, next time, we give it data we have about last installation, and it uses that
+      --   to decide if installation needs to happen or not. If it happens, it returnes new data again.
+      --   Right now we have setup/installation being called, but it has not support for being "smart" yet.
+      waspSaysC "Setting up generated project..."
+      setupResult <- liftIO $ Wasp.Lib.setup outDir
+      case setupResult of
+        Left setupError -> throwError $ CommandError $ "\nSetup failed: " ++ setupError
+        Right () -> waspSaysC "\nSetup successful.\n"
+
       waspSaysC "\nListening for file changes..."
       waspSaysC "Starting up generated project..."
 

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -42,7 +42,6 @@ start = do
   case compilationResult of
     Left compileError -> throwError $ CommandError $ "Compilation failed: " ++ compileError
     Right wasp -> do
-
       waspSaysC "Code has been successfully compiled, project has been generated.\n"
       waspSaysC "\nListening for file changes..."
       waspSaysC "Starting up generated project..."

--- a/waspc/cli/Wasp/Cli/Command/Watch.hs
+++ b/waspc/cli/Wasp/Cli/Command/Watch.hs
@@ -3,32 +3,19 @@ module Wasp.Cli.Command.Watch
   )
 where
 
-import Cli.Common (buildDirInDotWaspDir, dotWaspDirInWaspProjectDir, waspSays)
-import qualified Cli.Common as Common
-import Command (Command, CommandError (..))
-import Command.Compile (compileIO)
-import Control.Concurrent.Async (concurrently)
 import Control.Concurrent.Chan (Chan, newChan, readChan)
 import Control.Monad (when)
-import Control.Monad.Except (throwError)
-import Control.Monad.State (MonadIO (liftIO))
 import Data.List (isSuffixOf)
 import Data.Time.Clock (UTCTime, getCurrentTime)
-import qualified Generator.Job as J
-import Generator.Job.Process (runNodeCommandAsJob)
-import qualified Generator.WebAppGenerator.Common as Common
-import Generator.WebAppGenerator.Setup (setupWebApp)
-import qualified Lib
 import StrongPath (Abs, Dir, Path', (</>))
 import qualified StrongPath as SP
-import System.Exit (ExitCode (ExitSuccess))
 import qualified System.FSNotify as FSN
 import qualified System.FilePath as FP
-import Wasp (Wasp, getNpmDependencies)
 import Wasp.Cli.Command.Compile (compileIO)
 import Wasp.Cli.Common (waspSays)
 import qualified Wasp.Cli.Common as Common
 import qualified Wasp.Lib
+import Wasp.Wasp (Wasp, getNpmDependencies)
 
 -- TODO: Another possible problem: on re-generation, wasp re-generates a lot of files, even those that should not
 --   be generated again, since it is not smart enough yet to know which files do not need to be regenerated.
@@ -75,13 +62,6 @@ watch waspProjectDir outDir initialWasp = FSN.withManager $ \mgr -> do
           when dependenciesChanged $ do
             waspSays "Dependencies changed, please restart the server"
             recompile currentWasp
-            -- WIP: Restart server or re-run setup and compile phase
-            -- chan <- newChan
-            -- let path = waspProjectDir </> Cli.Common.dotWaspDirInWaspProjectDir </> Cli.Common.buildDirInDotWaspDir
-            -- let _ = concurrently (setupWebApp path chan)
-            -- waspSays "NPM Installed again"
-            -- recompile currentWasp
-            -- WIP
             return ()
 
     -- TODO: This is a hardcoded approach to ignoring most of the common tmp files that editors

--- a/waspc/cli/Wasp/Cli/Command/Watch.hs
+++ b/waspc/cli/Wasp/Cli/Command/Watch.hs
@@ -24,11 +24,11 @@ import qualified StrongPath as SP
 import System.Exit (ExitCode (ExitSuccess))
 import qualified System.FSNotify as FSN
 import qualified System.FilePath as FP
+import Wasp (Wasp, getNpmDependencies)
 import Wasp.Cli.Command.Compile (compileIO)
 import Wasp.Cli.Common (waspSays)
 import qualified Wasp.Cli.Common as Common
 import qualified Wasp.Lib
-import Wasp (Wasp, getNpmDependencies)
 
 -- TODO: Another possible problem: on re-generation, wasp re-generates a lot of files, even those that should not
 --   be generated again, since it is not smart enough yet to know which files do not need to be regenerated.

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -28,7 +28,7 @@ compile ::
   Path' Abs (Dir WaspProjectDir) ->
   Path' Abs (Dir ProjectRootDir) ->
   CompileOptions ->
-  IO (Either CompileError ())
+  IO (Either CompileError Wasp)
 compile waspDir outDir options = do
   maybeWaspFile <- findWaspFile waspDir
   case maybeWaspFile of
@@ -46,7 +46,7 @@ compile waspDir outDir options = do
             )
             >>= generateCode
   where
-    generateCode wasp = Generator.writeWebAppCode wasp outDir options >> return (Right ())
+    generateCode wasp = Generator.writeWebAppCode wasp outDir options >> return (Right wasp)
 
 enrichWaspASTBasedOnCompileOptions :: Wasp -> CompileOptions -> IO Wasp
 enrichWaspASTBasedOnCompileOptions wasp options = do


### PR DESCRIPTION
# Description

This PR implements #269

To implement it I primarily followed the suggestions at the comment section of the issue.  Now, `compile` does not returns a `()` but it returns `Wasp`. All functions that relied on `compile` where updated to support this new return type.

At the moment, this is how it looks: 

![image](https://user-images.githubusercontent.com/13141462/132157544-bd924696-3b26-4f34-889f-5c4d6b4146b7.png)

This is clearly not optimal, as even though I get to log a suggestion about restarting the server, it quickly gets lost within the app information logged after recompilation.

So my natural inclination would be, instead of figuring out a way of log the suggestion last, just figure a way to restart the server.

**How to restart server**

Though this is a concern I have, I'm not sure how to restart the server. Here, I'm mentioning restarting the server, because the development server does not seems to recognize changes in `node_modules`, so a plain `npm install` will not ensure having the new dependencies (conclusion after some tests, please correct me if I'm wrong). Then, restarting the server seems to be the only plausible option.

From what I've seen wasp is starting the server within `Lib.Start` using channels, and my first idea was to return this channel to then be able to communicate with it and trigger a restart. However, I'm not super experienced with channels in Haskell. How could the proper way to trigger a server restart could look like?

Thanks a lot for the help and details on every response, much appreciated!

## Type of change

Please select the option(s) that is more relevant.

- [x] New feature (non-breaking change which adds functionality)