### PR TITLE
fix spelling mistake in react component

### DIFF
--- a/waspc/data/Cli/templates/new/ext/MainPage.js
+++ b/waspc/data/Cli/templates/new/ext/MainPage.js
@@ -16,7 +16,7 @@ const MainPage = () => {
           Open <code>ext/MainPage.js</code> to edit it.
         </h3>
 
-        <div class="buttons">
+        <div className="buttons">
           <a
             className="button button-filled"
             href="https://wasp-lang.dev/docs/tutorials/todo-app"


### PR DESCRIPTION
I Fixed a Spelling mistake in MainPage.js

It was a small change from `class=` to the react equivalent `className=`.

PS. I don't know if I should have opened an issue, it seems like the kind of thing that there is only one solution to.
