### PR TITLE
Improved docs to avoid issue with missing bash command on getting-started page

### DIFF
--- a/web/docs/getting-started.md
+++ b/web/docs/getting-started.md
@@ -14,7 +14,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 ### Node.js >= 12.18.0
 
 ```shell-session
-$ node -v  # >= v12.18.0
+node -v  # >= v12.18.0
 ```
 
 We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing your Node.js installation version(s).
@@ -29,18 +29,18 @@ We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing your Node.j
 
   Then, install a version of node that you need (any >= 12.18.0), e.g.:
   ```shell-session
-  $ nvm install 12
+  nvm install 12
   ```
 
   Finally, whenever you need to ensure specific version of node is used, run e.g.
   ```shell-session
-  $ nvm use 12
+  nvm use 12
   ```
   to set the node version for current shell session.
 
   You can run
   ```shell-session
-  $ node -v
+  node -v
   ```
   to check the version of node currently being used in this shell session.
 

--- a/web/docs/tutorials/todo-app/auth.md
+++ b/web/docs/tutorials/todo-app/auth.md
@@ -29,7 +29,7 @@ psl=}
 
 Run:
 ```shell-session
-$ wasp db migrate-dev
+wasp db migrate-dev
 ```
 to propagate the schema change (we added User).
 
@@ -157,7 +157,7 @@ Ok, time to try out how this works!
 
 Now, we can again run
 ```shell-session
-$ wasp start
+wasp start
 ```
 
 Try going to `/` in our web app -> it will now ask you to log in, and if you follow the link, you will end up at `/login`.
@@ -165,7 +165,7 @@ Once you log in or sign up, you will be sent back to `/` and you will see the to
 
 Let's now see how things look in the database! Run:
 ```shell-session
-$ wasp db studio
+wasp db studio
 ```
 <img alt="Database demonstration - password hashing"
      src={useBaseUrl('img/wasp_db_hash_demonstration.gif')}
@@ -201,7 +201,7 @@ psl=}
 
 We modified entities by adding User-Task relation, so let's run
 ```shell-session
-$ wasp db migrate-dev
+wasp db migrate-dev
 ```
 to create a database schema migration and apply it to the database.
 
@@ -256,13 +256,13 @@ Right, that should be it!
 
 Run
 ```shell-session
-$ wasp start
+wasp start
 ```
 and everything should work as expected now! Each user has their own tasks only they can see and edit.
 
 Try playing around with our app, adding a few users and some tasks. Then run:
 ```shell-session
-$ wasp db studio
+wasp db studio
 ```
 <img alt="Database demonstration"
      src={useBaseUrl('img/wasp_db_demonstration.gif')}

--- a/web/docs/tutorials/todo-app/creating-new-project.md
+++ b/web/docs/tutorials/todo-app/creating-new-project.md
@@ -6,12 +6,12 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Run the following command in your terminal to create a new Wasp project:
 ```shell-session
-$ wasp new TodoApp
+wasp new TodoApp
 ```
 Enter the created directory and run:
 ```shell-session
-$ cd TodoApp
-$ wasp start
+cd TodoApp
+wasp start
 ```
 You have just ran your app in the development mode!
 

--- a/web/docs/tutorials/todo-app/dependencies.md
+++ b/web/docs/tutorials/todo-app/dependencies.md
@@ -19,7 +19,7 @@ json=}
 
 Run (if it is already running, stop it first and then run it again)
 ```shell-session
-$ wasp start
+wasp start
 ```
 to have Wasp download and install new dependency (that happens on start of `wasp start`).
 

--- a/web/docs/tutorials/todo-app/task-entity.md
+++ b/web/docs/tutorials/todo-app/task-entity.md
@@ -21,13 +21,13 @@ Since Wasp uses [Prisma](https://www.prisma.io) as a database, definition of an 
 
 After this change and before running `wasp start`, we first need to run:
 ```shell-session
-$ wasp db migrate-dev
+wasp db migrate-dev
 ```
 This instructs Prisma to create a new database schema migration (you'll see a new directory `migrations/` appeared in the root dir of our app) and apply it to the database.
 
 To take a look at the database and the new `Task` schema, run:
 ```shell-session
-$ wasp db studio
+wasp db studio
 ```
 
 <img alt="Todo App - Db studio showing Task schema"


### PR DESCRIPTION
# Description

CLI commands in docs should not be prefixed with `$`, otherwise, after copy/paste with will produce an error `$: command not found`

Fixes # (issue)
NONE

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update