### PR TITLE
auth: Add onAuthSucceededRedirectTo option

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/auth/forms/Login.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/forms/Login.js
@@ -1,3 +1,4 @@
+{{={= =}=}}
 import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
@@ -13,8 +14,8 @@ const LoginForm = () => {
     event.preventDefault()
     try {
       await login(emailFieldVal, passwordFieldVal)
-
-      history.push('/')
+      // Redirect to configured page, defaults to /.
+      history.push('{= onAuthSucceededRedirectTo =}')
     } catch (err) {
       console.log(err)
       window.alert('Error:' + err.message)

--- a/waspc/data/Generator/templates/react-app/src/auth/forms/Signup.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/forms/Signup.js
@@ -1,3 +1,4 @@
+{{={= =}=}}
 import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
@@ -19,8 +20,8 @@ const SignupForm = () => {
       setEmailFieldVal('')
       setPasswordFieldVal('')
 
-      // Redirect to main page.
-      history.push('/')
+      // Redirect to configured page, defaults to /.
+      history.push('{= onAuthSucceededRedirectTo =}')
     } catch (err) {
       console.log(err)
       window.alert('Error:' + err.message)

--- a/waspc/examples/todoApp/ext/pages/ProfilePage.js
+++ b/waspc/examples/todoApp/ext/pages/ProfilePage.js
@@ -1,7 +1,12 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 export const ProfilePage = ({ user }) => {
   return (
+    <>
     <div>I am Profile page for { user.email }!</div>
+    <br />
+      <Link to='/'>Go to dashboard</Link>
+    </>
   )
 }

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -12,7 +12,8 @@ json=}
 auth {
     userEntity: User,
     methods: [ EmailAndPassword ],
-    onAuthFailedRedirectTo: "/login"
+    onAuthFailedRedirectTo: "/login",
+    onAuthSucceededRedirectTo: "/profile"
 }
 
 entity User {=psl

--- a/waspc/src/Wasp/Wasp/Auth.hs
+++ b/waspc/src/Wasp/Wasp/Auth.hs
@@ -7,7 +7,8 @@ where
 data Auth = Auth
   { _userEntity :: !String,
     _methods :: [AuthMethod],
-    _onAuthFailedRedirectTo :: !String
+    _onAuthFailedRedirectTo :: !String,
+    _onAuthSucceededRedirectTo :: !String
   }
   deriving (Show, Eq)
 

--- a/waspc/test/Parser/ParserTest.hs
+++ b/waspc/test/Parser/ParserTest.hs
@@ -38,7 +38,8 @@ spec_parseWasp =
                     Wasp.Auth.Auth
                       { Wasp.Auth._userEntity = "User",
                         Wasp.Auth._methods = [Wasp.Auth.EmailAndPassword],
-                        Wasp.Auth._onAuthFailedRedirectTo = "/test"
+                        Wasp.Auth._onAuthFailedRedirectTo = "/test",
+                        Wasp.Auth._onAuthSucceededRedirectTo = "/"
                       },
                   WaspElementRoute $
                     R.Route


### PR DESCRIPTION
# Description

Allows a user to specify a redirect target in case of successful authentication.
This used to be hardcoded to /, and the current implementation will fallback to that if the property is not specified.
 
Change-type: minor
Signed-off-by: Giovanni Garufi <nazrhom@gmail.com>

Fixes #327 

## Notes

This does not include changes to documentation, happy to update docs (i.e. https://wasp-lang.dev/docs/tutorials/todo-app/auth) if you can point me to where those are.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update