### PR TITLE
Bump resolver to the latest LTS version, lts-18.15 for ghc-8.10.7.

### DIFF
--- a/waspc/stack.yaml
+++ b/waspc/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-18.0
+resolver: lts-18.15
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This is the version of ghc that ghcup recommends. Seems to go well with hls.

```
> haskell-language-server-8.10.7
...
Files that failed:
 * /.../wasp/waspc/Setup.hs
 * /.../wasp/waspc/testEnv.hs
 * /.../wasp/waspc/test/TastyDiscoverDriver.hs

Completed (181 files worked, 3 files failed)
```