### PR TITLE
Flag when new project name is a reserved word.

### DIFF
--- a/waspc/cli/Command/CreateNewProject.hs
+++ b/waspc/cli/Command/CreateNewProject.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE  ViewPatterns #-}
 module Command.CreateNewProject
   ( createNewProject,
   )
@@ -10,6 +11,7 @@ import qualified Command.Common
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data
+import Data.List (intercalate)
 import Data.Char (isLetter)
 import StrongPath (Abs, Dir, File', Path', Rel, reldir, relfile, (</>))
 import qualified StrongPath as SP
@@ -18,19 +20,16 @@ import qualified System.Directory
 import qualified System.FilePath as FP
 import Text.Printf (printf)
 import qualified Util.Terminal as Term
+import Lexer (reservedNames)
 
 newtype ProjectName = ProjectName {_projectName :: String}
 
 createNewProject :: String -> Command ()
-createNewProject projectNameStr = do
-  case parseProjectName projectNameStr of
-    Left err -> throwError $ CommandError err
-    Right projectName -> createNewProject' projectName
-  where
-    parseProjectName name =
-      if all isLetter name
-        then Right $ ProjectName name
-        else Left "Please use only letters for project name."
+createNewProject (all isLetter -> False) =
+  throwError $ CommandError "Please use only letters for a new project's name."
+createNewProject ((`elem` reservedNames) -> True) =
+  throwError . CommandError $ "Please pick a project name not one of these reserved words:\n\t" ++ intercalate "\n\t" reservedNames
+createNewProject name = createNewProject' (ProjectName name)
 
 createNewProject' :: ProjectName -> Command ()
 createNewProject' (ProjectName projectName) = do

--- a/waspc/cli/Command/CreateNewProject.hs
+++ b/waspc/cli/Command/CreateNewProject.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE  ViewPatterns #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module Command.CreateNewProject
   ( createNewProject,
   )
@@ -11,8 +12,9 @@ import qualified Command.Common
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data
-import Data.List (intercalate)
 import Data.Char (isLetter)
+import Data.List (intercalate)
+import Lexer (reservedNames)
 import StrongPath (Abs, Dir, File', Path', Rel, reldir, relfile, (</>))
 import qualified StrongPath as SP
 import System.Directory (createDirectory, getCurrentDirectory)
@@ -20,7 +22,6 @@ import qualified System.Directory
 import qualified System.FilePath as FP
 import Text.Printf (printf)
 import qualified Util.Terminal as Term
-import Lexer (reservedNames)
 
 newtype ProjectName = ProjectName {_projectName :: String}
 


### PR DESCRIPTION
# Description

Adds an additional check of the project name before creating a project.

```
> stack ghci waspc:wasp
> :main new _
Error: Please use only letters for a new project's name.
> :main new true
Error: Please pick a project name not one of these reserved words:
	import
	from
	app
	dependencies
	page
	route
	entity
	auth
	query
	action
	string
	boolean
	true
	false
> :main new foo
Created new Wasp app in ./foo directory!
To run it, do:

    cd foo
    wasp start
```

Fixes #354

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update