### PR TITLE
Renamed wasp cli executable from wasp to wasp-cli.

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -77,23 +77,23 @@ to ensure all the unit tests are passing (this will also build the project if ne
 
 ### Executable
 ```
-stack exec wasp
+stack exec wasp-cli
 ```
-to run the `wasp` executable that you just built!
+to run the `wasp-cli` executable that you just built!
 It should print "Usage" information.
 
-You can pass more arguments by just adding them to the command, e.g.: `stack exec wasp new MyProject`.
+You can pass more arguments by just adding them to the command, e.g.: `stack exec wasp-cli new MyProject`.
 
 ### Run example app
 Position yourself in `waspc/examples/todoApp/` and run
 ```
-stack exec wasp db migrate-dev
+stack exec wasp-cli db migrate-dev
 ```
 to update database schema (this is done only on schema changes).
 
 Then,
 ```
-stack exec wasp start
+stack exec wasp-cli start
 ```
 to run web app in development mode.
 
@@ -111,7 +111,7 @@ NOTE: Reload page if blank.
    Fix any errors shown by `ghcid`.
    Rinse and repeat.
 4. Once close to done, run `stack test` to confirm that project is passing tests (new and old).
-5. If needed, confirm that `examples/todoApp/` is working correctly by running `stack build` first, to build the wasp executable, and then by running that executable with `stack exec wasp start` from the `examples/todoApp/` dir -> this will run the web app in development mode with the current version of your Wasp code.
+5. If needed, confirm that `examples/todoApp/` is working correctly by running `stack build` first, to build the wasp executable, and then by running that executable with `stack exec wasp-cli start` from the `examples/todoApp/` dir -> this will run the web app in development mode with the current version of your Wasp code.
    Manually inspect that app behaves ok: In the future we will add automatic integration tests, but for now testing is manual.
 6. When all is ready, squash commits into one commit (or a few if that makes sense) and create a PR. 
    Keep an eye on CI tests -> they should all be passing, if not, look into it.
@@ -174,7 +174,7 @@ On any changes you do to the source code of Wasp, Wasp project gets recompiled, 
 ## Building / development (detailed)
 Some useful stack commands:
 - `stack build` to build the project, including `wasp` binary which is both CLI and compiler in one.
-- `stack exec wasp <arguments>` to run the `wasp` binary that you have built.
+- `stack exec wasp-cli <arguments>` to run the `wasp` binary that you have built.
 - `stack test` to build the whole project + tests and then also run tests.
 - `stack build --file-watch` -> live watch, reruns every time a file changes. But we prefer using `ghcid`, it is faster.
 - `stack build --pedantic` -> sets -Wall and -Werror ghc options.

--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -74,7 +74,7 @@ library:
     - template-haskell
 
 executables:
-  wasp:
+  wasp-cli:
     main:                Main.hs
     source-dirs:         cli 
     ghc-options:

--- a/waspc/run
+++ b/waspc/run
@@ -16,7 +16,7 @@ DEFAULT_COLOR="\033[39m"
 
 BUILD_CMD="stack build"
 TEST_CMD="$BUILD_CMD --test"
-EXEC_CMD="stack exec wasp $ARGS"
+EXEC_CMD="stack exec wasp-cli $ARGS"
 GHCID_CMD="ghcid --command=stack ghci"
 
 echo_and_eval () {
@@ -38,7 +38,7 @@ print_usage () {
                     "Builds the project."
     print_usage_cmd "test" \
                     "Builds the project and executes tests."
-    print_usage_cmd "wasp <args>" \
+    print_usage_cmd "wasp-cli <args>" \
                     "Builds the project once and runs the wasp executable while forwarding arguments."
     print_usage_cmd "ghcid" \
                     "Runs ghcid, which watches source file changes and reports errors. Does not watch tests."

--- a/waspc/tools/make_binary_package.sh
+++ b/waspc/tools/make_binary_package.sh
@@ -10,7 +10,7 @@ DST=$PWD/${1:-wasp.tar.gz}
 
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t wasp-bin-package)"
 
-cp "$(stack path --local-install-root)"/bin/wasp "$TMP_DIR/wasp-bin"
+cp "$(stack path --local-install-root)"/bin/wasp-cli "$TMP_DIR/wasp-bin"
 cp -R "$(stack path --project-root)/data" "$TMP_DIR/data"
 
 cd "$TMP_DIR"


### PR DESCRIPTION
Workaround for https://github.com/commercialhaskell/stack/issues/5636 .