### PR TITLE
./run script can now run stan - static analyzer.

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -105,7 +105,7 @@ NOTE: Reload page if blank.
 
 ## Typical development workflow
 1. Create a new feature branch from `master`.
-2. Run `run ghcid`: this will run a process that watches the Haskell project and reports any Haskell compiler errors. Leave it running.  
+2. Run `./run ghcid` from the root of the project: this will run a process that watches the Haskell project and reports any Haskell compiler errors. Leave it running.  
    NOTE: You will need to install `ghcid` globally first, you can do it with `stack install ghcid`.
 3. Do a change in the codebase (most often in `lib/` or `cli/` or `data/`) (together with tests if that makes sense: see "Tests").
    Fix any errors shown by `ghcid`.

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -198,6 +198,7 @@ You can run `./run help` to learn how to use it.
 
 Examples:
  - `./run ghcid-test` will run ghcid that watches tests, while passing correct arguments to ghcid.
+ - `./run stan` will run static analysis of the codebase.
 
 
 ## Tests
@@ -246,28 +247,14 @@ Hlint already adds a lot of extensions on its own so this is not a very often pr
 
 ## Static Analysis
 
-Run [stan](https://github.com/kowainik/stan) to produce a static analysis report.
+We use [stan](https://github.com/kowainik/stan) to statically analyze our codebase.
 
-A build of the `waspc` package writes the [HIE
-files](https://gitlab.haskell.org/ghc/ghc/-/wikis/hie-files) that stan reads so
-waspc and stan need to be built with the same version of GHC.
+The easiest way to run it is to use
+```
+./run stan
+```
+This will build the codebase, run stan on it (while installing it first, if needed, with the correct version of GHC) and then write results to the CLI and also generate report in the `stan.html`.
 
-```
-# package.yaml
-ghc-options:
-  - -fwrite-ide-info
-  - -hiedir=.hie
-```
-
-We use `--stack-yaml=stack-stan.yaml` to avoid burdening the waspc build with
-dependencies only the stan tool needs (being careful to match resolvers) and we
-set `--local-bin-path=.bin` to install stan in a project relative directory.
-
-```
-> stack build
-> stack build stan --stack-yaml=stack-stan.yaml
-> .bin/stan
-```
 
 ## Formatting
 For formatting Haskell code we use [Ormolu](https://github.com/tweag/ormolu).

--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -42,6 +42,8 @@ dependencies:
 ghc-options:
   - -Wall
   - -optP-Wno-nonportable-include-path # To avoid warning caused by .../autogen/cabal_macros.h. on OSX.
+  # -fwrite-ide-info and -hiedir=.hie tell GHC to write compile-time information about the code
+  # to .hie directory. This information can then be used by other tools, e.g. stan (static analyzer).
   - -fwrite-ide-info
   - -hiedir=.hie
 

--- a/waspc/run
+++ b/waspc/run
@@ -15,13 +15,15 @@ LIGHT_CYAN="\033[96m"
 DEFAULT_COLOR="\033[39m"
 
 BUILD_CMD="stack build"
+BUILD_ALL_CMD="stack build --bench --no-run-benchmarks --test --no-run-tests"
+STAN_CMD="$BUILD_ALL_CMD && stack install stan --stack-yaml=stack-stan.yaml && .bin/stan report $ARGS"
 TEST_CMD="$BUILD_CMD --test"
 EXEC_CMD="stack exec wasp-cli $ARGS"
 GHCID_CMD="ghcid --command=stack ghci"
 
 echo_and_eval () {
     echo -e $"${LIGHT_CYAN}Running:${DEFAULT_COLOR}" $1 "\n"
-    $1
+    eval $1
 }
 
 echo_bold () { echo -e $"${BOLD}${1}${RESET}"; }
@@ -40,6 +42,8 @@ print_usage () {
                     "Builds the project and executes tests."
     print_usage_cmd "wasp-cli <args>" \
                     "Builds the project once and runs the wasp executable while forwarding arguments."
+    print_usage_cmd "stan <args>" \
+                    "Builds the project and runs static code analysis on it, generating stan.html."
     print_usage_cmd "ghcid" \
                     "Runs ghcid, which watches source file changes and reports errors. Does not watch tests."
     print_usage_cmd "ghcid-test" \
@@ -62,10 +66,13 @@ case $COMMAND in
     test)
         echo_and_eval "$TEST_CMD"
         ;;
-    wasp)
+    wasp-cli)
         echo_and_eval "$BUILD_CMD"
         echo
         echo_and_eval "$EXEC_CMD"
+        ;;
+    stan)
+        echo_and_eval "$STAN_CMD"
         ;;
     *)
         print_usage


### PR DESCRIPTION
@philderbeast , you might find this interesting -> we have this `run` script that we use to make it easier for contributors to run stuff, so I modified it so it can run `stan`, which also enabled me to remove some of the details from the README.