### PR TITLE
Fix nvm installation instructions on dark mode

### DIFF
--- a/web/docs/getting-started.md
+++ b/web/docs/getting-started.md
@@ -23,7 +23,7 @@ We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing your Node.j
   <summary style={{cursor: 'pointer', 'textDecoration': 'underline'}}>
     Quick guide on installing/using nvm
   </summary>
-  <div style={{background: '#eeeeee', padding: '10px'}}>
+  <div>
 
   Install nvm via your OS package manager (aptitude, pacman, homebrew, ...) or alternatively via [nvm install script](https://github.com/nvm-sh/nvm#install--update-script).
 


### PR DESCRIPTION
# Description
Removed inline background and padding styles. Looks okay on both dark and light mode. This seems to be the only place where summary/details are used. Lmk if you know any that I didn't catch.

Fixes #324 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)