### PR TITLE
fix: Propagate deletion of db migrations from Wasp src to the generated project

### DIFF
--- a/waspc/src/Wasp/Common.hs
+++ b/waspc/src/Wasp/Common.hs
@@ -1,6 +1,15 @@
 module Wasp.Common
-  ( WaspProjectDir,
+  ( DbMigrationsDir,
+    WaspProjectDir,
+    dbMigrationsDirInWaspProjectDir,
   )
 where
 
+import StrongPath (Dir, Path', Rel, reldir)
+
 data WaspProjectDir -- Root dir of Wasp project, containing source files.
+
+data DbMigrationsDir
+
+dbMigrationsDirInWaspProjectDir :: Path' (Rel WaspProjectDir) (Dir DbMigrationsDir)
+dbMigrationsDirInWaspProjectDir = [reldir|migrations|]

--- a/waspc/src/Wasp/Generator.hs
+++ b/waspc/src/Wasp/Generator.hs
@@ -15,6 +15,7 @@ import qualified StrongPath as SP
 import Wasp.CompileOptions (CompileOptions)
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.DbGenerator (genDb)
+import qualified Wasp.Generator.DbGenerator as DbGenerator
 import Wasp.Generator.DockerGenerator (genDockerFiles)
 import Wasp.Generator.FileDraft (FileDraft, write)
 import Wasp.Generator.ServerGenerator (genServer)
@@ -34,6 +35,7 @@ writeWebAppCode wasp dstDir compileOptions = do
   writeFileDrafts dstDir (generateWebApp wasp compileOptions)
   ServerGenerator.preCleanup wasp dstDir compileOptions
   writeFileDrafts dstDir (genServer wasp compileOptions)
+  DbGenerator.preCleanup wasp dstDir compileOptions
   writeFileDrafts dstDir (genDb wasp compileOptions)
   writeFileDrafts dstDir (genDockerFiles wasp compileOptions)
   writeDotWaspInfo dstDir

--- a/waspc/src/Wasp/Wasp.hs
+++ b/waspc/src/Wasp/Wasp.hs
@@ -27,6 +27,8 @@ module Wasp.Wasp
     getExternalCodeFiles,
     setDotEnvFile,
     getDotEnvFile,
+    setMigrationsDir,
+    getMigrationsDir,
     setIsBuild,
     getIsBuild,
     setNpmDependencies,
@@ -35,8 +37,9 @@ module Wasp.Wasp
 where
 
 import Data.Aeson (ToJSON (..), object, (.=))
-import StrongPath (Abs, File', Path')
+import StrongPath (Abs, Dir, File', Path')
 import qualified Wasp.AppSpec.ExternalCode as ExternalCode
+import Wasp.Common (DbMigrationsDir)
 import qualified Wasp.Util as U
 import qualified Wasp.Wasp.Action as Wasp.Action
 import Wasp.Wasp.App
@@ -58,6 +61,7 @@ data Wasp = Wasp
     waspJsImports :: [JsImport],
     externalCodeFiles :: [ExternalCode.File],
     dotEnvFile :: Maybe (Path' Abs File'),
+    migrationsDir :: Maybe (Path' Abs (Dir DbMigrationsDir)),
     isBuild :: Bool
   }
   deriving (Show, Eq)
@@ -82,6 +86,7 @@ fromWaspElems elems =
       waspJsImports = [],
       externalCodeFiles = [],
       dotEnvFile = Nothing,
+      migrationsDir = Nothing,
       isBuild = False
     }
 
@@ -108,6 +113,14 @@ getDotEnvFile = dotEnvFile
 
 setDotEnvFile :: Wasp -> Maybe (Path' Abs File') -> Wasp
 setDotEnvFile wasp file = wasp {dotEnvFile = file}
+
+-- * Migrations dir
+
+getMigrationsDir :: Wasp -> Maybe (Path' Abs (Dir DbMigrationsDir))
+getMigrationsDir = migrationsDir
+
+setMigrationsDir :: Wasp -> Maybe (Path' Abs (Dir DbMigrationsDir)) -> Wasp
+setMigrationsDir wasp dir = wasp {migrationsDir = dir}
 
 -- * Js imports
 


### PR DESCRIPTION
# Description

Right now, if you delete the `migrations` dir from the Wasp project root dir and run `wasp start` or `wasp build`, any previously generated `migrations` dir will remain in the generated code -> it will not get removed! Instead, we want it to get removed.

Fixes #211

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update