### PR TITLE
Better type errors

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -234,6 +234,8 @@ Not only that, but Haskell build tools don't have a good support for mixing them
 Tests are run with `stack test`.
 You can do `stack test --coverage` to see the coverage.
 
+To run individual test, you can do `stack test --test-arguments "-p \"Some test description to match\""`.
+
 We don't yet have any integration (e2e) tests, but we plan to add them at some point.
 For now, best way is to manually run a Wasp app with `wasp start` and try stuff out.
 

--- a/waspc/src/Wasp/Analyzer.hs
+++ b/waspc/src/Wasp/Analyzer.hs
@@ -112,8 +112,7 @@ module Wasp.Analyzer
     analyze,
     takeDecls,
     AnalyzeError (..),
-    getErrorMessage,
-    getErrorSourcePosition,
+    getErrorMessageAndCtx,
     SourcePosition (..),
   )
 where
@@ -123,8 +122,7 @@ import Control.Monad ((>=>))
 import Wasp.Analyzer.AnalyzeError
   ( AnalyzeError (..),
     SourcePosition (..),
-    getErrorMessage,
-    getErrorSourcePosition,
+    getErrorMessageAndCtx,
   )
 import Wasp.Analyzer.Evaluator (Decl, evaluate, takeDecls)
 import Wasp.Analyzer.Parser (parse)

--- a/waspc/src/Wasp/Analyzer/AnalyzeError.hs
+++ b/waspc/src/Wasp/Analyzer/AnalyzeError.hs
@@ -1,13 +1,15 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Wasp.Analyzer.AnalyzeError
   ( AnalyzeError (..),
-    getErrorMessage,
-    getErrorSourcePosition,
+    getErrorMessageAndCtx,
     SourcePosition (..),
   )
 where
 
+import Control.Arrow (first)
 import qualified Wasp.Analyzer.Evaluator.EvaluationError as EE
-import Wasp.Analyzer.Parser (SourcePosition (..))
+import Wasp.Analyzer.Parser (Ctx, SourcePosition (..))
 import qualified Wasp.Analyzer.Parser.ParseError as PE
 import qualified Wasp.Analyzer.TypeChecker.TypeError as TE
 import Wasp.Util (indent)
@@ -18,12 +20,8 @@ data AnalyzeError
   | EvaluationError EE.EvaluationError
   deriving (Show, Eq)
 
-getErrorMessage :: AnalyzeError -> String
-getErrorMessage (ParseError e) = "Parse error:\n" ++ indent 2 (PE.getErrorMessage e)
-getErrorMessage (TypeError e) = "Type error:\n" ++ error "TODO"
-getErrorMessage (EvaluationError e) = "Evaluation error:\n" ++ error "TODO"
-
-getErrorSourcePosition :: AnalyzeError -> SourcePosition
-getErrorSourcePosition (ParseError e) = PE.getSourcePosition e
-getErrorSourcePosition (TypeError e) = error "TODO"
-getErrorSourcePosition (EvaluationError e) = error "TODO"
+getErrorMessageAndCtx :: AnalyzeError -> (String, Ctx)
+getErrorMessageAndCtx = \case
+  ParseError e -> first (("Parse error:\n" ++) . indent 2) $ PE.getErrorMessageAndCtx e
+  TypeError e -> first (("Type error:\n" ++) . indent 2) $ TE.getErrorMessageAndCtx e
+  EvaluationError _e -> error "TODO"

--- a/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedDictExpr.hs
+++ b/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedDictExpr.hs
@@ -11,4 +11,4 @@ import qualified Wasp.Analyzer.TypeChecker.AST as TypedAST
 -- be created from a "TypedDictExprEvaluation" with the "dict" combinator.
 type TypedDictExprEvaluation a = Evaluation TypedDictEntries a
 
-newtype TypedDictEntries = TypedDictEntries [(String, TypedAST.TypedExpr)]
+newtype TypedDictEntries = TypedDictEntries [(String, TypedAST.WithCtx TypedAST.TypedExpr)]

--- a/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedDictExpr/Combinators.hs
+++ b/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedDictExpr/Combinators.hs
@@ -12,13 +12,15 @@ import Wasp.Analyzer.Evaluator.Evaluation.Internal (evaluation, runEvaluation)
 import Wasp.Analyzer.Evaluator.Evaluation.TypedDictExpr (TypedDictEntries (..), TypedDictExprEvaluation)
 import Wasp.Analyzer.Evaluator.Evaluation.TypedExpr (TypedExprEvaluation)
 import qualified Wasp.Analyzer.Evaluator.EvaluationError as EvaluationError
+import Wasp.Analyzer.TypeChecker.AST (withCtx)
 import qualified Wasp.Analyzer.TypeChecker.AST as TypedAST
 
 -- | An evaluation that runs a "TypedDictExprEvaluation". Expects a "Dict" expression and
 -- uses its entries to run the "TypedDictExprEvaluation".
 dict :: TypedDictExprEvaluation a -> TypedExprEvaluation a
-dict dictEvalutor = evaluation $ \(typeDefs, bindings) -> \case
-  TypedAST.Dict entries _ -> runEvaluation dictEvalutor typeDefs bindings $ TypedDictEntries entries
+dict dictEvaluator = evaluation $ \(typeDefs, bindings) -> withCtx $ \_ctx -> \case
+  TypedAST.Dict entries _ ->
+    runEvaluation dictEvaluator typeDefs bindings $ TypedDictEntries entries
   expr -> Left $ EvaluationError.ExpectedDictType $ TypedAST.exprType expr
 
 -- | A dictionary evaluation that requires the field to exist.

--- a/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedExpr.hs
+++ b/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedExpr.hs
@@ -6,4 +6,4 @@ where
 import Wasp.Analyzer.Evaluator.Evaluation.Internal (Evaluation)
 import qualified Wasp.Analyzer.TypeChecker.AST as TypedAST
 
-type TypedExprEvaluation a = Evaluation TypedAST.TypedExpr a
+type TypedExprEvaluation a = Evaluation (TypedAST.WithCtx TypedAST.TypedExpr) a

--- a/waspc/src/Wasp/Analyzer/Parser.hs
+++ b/waspc/src/Wasp/Analyzer/Parser.hs
@@ -16,6 +16,12 @@ module Wasp.Analyzer.Parser
     AST (..),
     Stmt (..),
     Expr (..),
+    WithCtx (..),
+    withCtx,
+    ctxFromPos,
+    getCtxPos,
+    fromWithCtx,
+    Ctx (..),
     Identifier,
     ExtImportName (..),
     ParseError (..),
@@ -28,9 +34,11 @@ where
 import Control.Monad.Except (runExcept)
 import Control.Monad.State (evalStateT)
 import Wasp.Analyzer.Parser.AST
+import Wasp.Analyzer.Parser.Ctx (Ctx (..), WithCtx (..), ctxFromPos, fromWithCtx, getCtxPos, withCtx)
 import Wasp.Analyzer.Parser.Monad (initialState)
 import Wasp.Analyzer.Parser.ParseError
 import qualified Wasp.Analyzer.Parser.Parser as P
+import Wasp.Analyzer.Parser.SourcePosition (SourcePosition (..))
 import Wasp.Analyzer.Parser.Token
 
 parse :: String -> Either ParseError AST

--- a/waspc/src/Wasp/Analyzer/Parser/AST.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/AST.hs
@@ -7,24 +7,29 @@ module Wasp.Analyzer.Parser.AST
   )
 where
 
+import Wasp.Analyzer.Parser.Ctx
 import Wasp.AppSpec.ExtImport (ExtImportName (..))
 
-newtype AST = AST {astStmts :: [Stmt]} deriving (Eq, Show)
+newtype AST = AST {astStmts :: [WithCtx Stmt]} deriving (Eq, Show)
 
--- Decl <declType> <name> <body>
-data Stmt = Decl Identifier Identifier Expr deriving (Eq, Show)
-
-data Expr
-  = Dict [(Identifier, Expr)]
-  | List [Expr]
-  | Tuple (Expr, Expr, [Expr])
-  | StringLiteral String
-  | IntegerLiteral Integer
-  | DoubleLiteral Double
-  | BoolLiteral Bool
-  | ExtImport ExtImportName String
-  | Var Identifier
-  | Quoter Identifier String
+data Stmt
+  = -- | Decl <declType> <declName> <declBody>
+    Decl Identifier Identifier (WithCtx Expr)
   deriving (Eq, Show)
+
+{- ORMOLU_DISABLE -}
+data Expr
+  = Dict           [(Identifier, WithCtx Expr)]
+  | List           [WithCtx Expr]
+  | Tuple          (WithCtx Expr, WithCtx Expr, [WithCtx Expr])
+  | StringLiteral  String
+  | IntegerLiteral Integer
+  | DoubleLiteral  Double
+  | BoolLiteral    Bool
+  | ExtImport      ExtImportName String
+  | Var            Identifier
+  | Quoter         Identifier String
+  deriving (Eq, Show)
+{- ORMOLU_ENABLE -}
 
 type Identifier = String

--- a/waspc/src/Wasp/Analyzer/Parser/Ctx.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/Ctx.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveFunctor #-}
+
+module Wasp.Analyzer.Parser.Ctx
+  ( WithCtx (..),
+    withCtx,
+    Ctx (..),
+    ctxFromPos,
+    getCtxPos,
+    fromWithCtx,
+  )
+where
+
+import Wasp.Analyzer.Parser.SourcePosition (SourcePosition)
+
+data WithCtx a = WithCtx Ctx a
+  deriving (Eq, Show, Functor)
+
+withCtx :: (Ctx -> a -> b) -> WithCtx a -> b
+withCtx f (WithCtx ctx x) = f ctx x
+
+-- | Gives parsing context to AST nodes -> e.g. source position from which they originated.
+-- TODO: Instead of having just SourcePosition, it would be better to have SourceRegion, since errors
+-- usually refer to a region and not just one position/char in the code.
+-- This is captured in an issue https://github.com/wasp-lang/wasp/issues/404 .
+data Ctx = Ctx
+  { ctxSourcePosition :: SourcePosition
+  }
+  deriving (Show, Eq)
+
+ctxFromPos :: SourcePosition -> Ctx
+ctxFromPos pos = Ctx {ctxSourcePosition = pos}
+
+getCtxPos :: Ctx -> SourcePosition
+getCtxPos = ctxSourcePosition
+
+fromWithCtx :: WithCtx a -> a
+fromWithCtx (WithCtx _ a) = a

--- a/waspc/src/Wasp/Analyzer/Parser/Lexer.x
+++ b/waspc/src/Wasp/Analyzer/Parser/Lexer.x
@@ -125,10 +125,13 @@ lexer parseToken = do
       putInput input'
       lexer parseToken
     AlexToken input' tokenLength action -> do
-      -- Token is made before `updatePosition` so that its `tokenPosition` points to
-      -- the start of the token's lexeme.
-      token <- action $ take tokenLength remainingSource
-      updatePosition $ take tokenLength remainingSource
+      -- Creating token and remembering its position via setPositionOfLastScannedTokenToCurrent
+      -- are done before `updatePosition`, while current parser position still points to
+      -- the start of the token's lexeme, to ensure that position gets used.
+      let lexeme = take tokenLength remainingSource
+      token <- action lexeme
+      setPositionOfLastScannedTokenToCurrent
+      updatePosition lexeme
       putInput input'
       parseToken token
 

--- a/waspc/src/Wasp/Analyzer/Parser/SourcePosition.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/SourcePosition.hs
@@ -1,0 +1,8 @@
+module Wasp.Analyzer.Parser.SourcePosition
+  ( SourcePosition (..),
+  )
+where
+
+-- | The first character on the first line is at position @Position 1 1@
+-- @SourcePosition <line> <column>@
+data SourcePosition = SourcePosition Int Int deriving (Eq, Show)

--- a/waspc/src/Wasp/Analyzer/Parser/Token.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/Token.hs
@@ -1,7 +1,6 @@
 module Wasp.Analyzer.Parser.Token where
 
--- | The first character on the first line is at position @Position 1 1@
-data SourcePosition = SourcePosition Int Int deriving (Eq, Show)
+import Wasp.Analyzer.Parser.SourcePosition (SourcePosition)
 
 data TokenType
   = TLParen

--- a/waspc/src/Wasp/Analyzer/StdTypeDefinitions/Entity.hs
+++ b/waspc/src/Wasp/Analyzer/StdTypeDefinitions/Entity.hs
@@ -22,7 +22,7 @@ instance IsDeclType Entity where
           Decl.makeDecl @Entity declName <$> declEvaluate typeDefinitions bindings expr
       }
 
-  declEvaluate _ _ expr = case expr of
+  declEvaluate _ _ (TC.AST.WithCtx _ctx expr) = case expr of
     TC.AST.PSL pslString ->
       left (ER.ParseError . ER.EvaluationParseErrorParsec) $
         makeEntity <$> Parsec.parse Wasp.Psl.Parser.Model.body "" pslString

--- a/waspc/src/Wasp/Analyzer/Type.hs
+++ b/waspc/src/Wasp/Analyzer/Type.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Wasp.Analyzer.Type
   ( Type (..),
     DictEntryType (..),
@@ -6,6 +8,7 @@ module Wasp.Analyzer.Type
 where
 
 import qualified Data.HashMap.Strict as H
+import Data.List (intercalate)
 
 -- | All possible types in Wasp.
 data Type
@@ -24,7 +27,25 @@ data Type
   | BoolType
   | ExtImportType
   | QuoterType String
-  deriving (Eq, Show)
+  deriving (Eq)
+
+instance Show Type where
+  show = \case
+    DeclType typeName -> typeName ++ " (declaration type)"
+    EnumType typeName -> typeName ++ " (enum type)"
+    DictType keyValueMap ->
+      let showEntry (k, v) = "  " ++ k ++ ": " ++ show v
+       in case H.toList keyValueMap of
+            [entry] -> "{" ++ showEntry entry ++ "}"
+            entries -> "{\n" ++ intercalate ",\n" (map (("  " ++) . showEntry) entries) ++ "\n}"
+    ListType typ -> "[" ++ show typ ++ "]"
+    EmptyListType -> "[]"
+    TupleType (t1, t2, ts) -> "(" ++ (intercalate ", " $ show <$> (t1 : t2 : ts)) ++ ")"
+    StringType -> "string"
+    NumberType -> "number"
+    BoolType -> "bool"
+    ExtImportType -> "external import"
+    QuoterType tag -> "{=" ++ tag ++ " " ++ tag ++ "=}"
 
 -- | The type of an entry in a `Dict`.
 data DictEntryType

--- a/waspc/src/Wasp/Analyzer/TypeChecker.hs
+++ b/waspc/src/Wasp/Analyzer/TypeChecker.hs
@@ -9,10 +9,13 @@ module Wasp.Analyzer.TypeChecker
     TypedAST (..),
     TypedStmt (..),
     TypedExpr (..),
+    WithCtx (..),
 
     -- ** Errors
     TypeError (..),
-    TypeCoerceReason (..),
+    TypeCoercionError (..),
+    TypeCoercionErrorReason (..),
+    getErrorMessageAndCtx,
 
     -- * Type Checking Functions
     typeCheck,

--- a/waspc/src/Wasp/Analyzer/TypeChecker/AST.hs
+++ b/waspc/src/Wasp/Analyzer/TypeChecker/AST.hs
@@ -4,31 +4,39 @@ module Wasp.Analyzer.TypeChecker.AST
     TypedExpr (..),
     Identifier,
     ExtImportName (..),
+    WithCtx (..),
+    withCtx,
     exprType,
   )
 where
 
 import Wasp.Analyzer.Parser (ExtImportName (..), Identifier)
+import Wasp.Analyzer.Parser.Ctx (WithCtx (..), withCtx)
 import Wasp.Analyzer.Type
 
-newtype TypedAST = TypedAST {typedStmts :: [TypedStmt]} deriving (Eq, Show)
+newtype TypedAST = TypedAST {typedStmts :: [WithCtx TypedStmt]} deriving (Eq, Show)
 
-data TypedStmt = Decl Identifier TypedExpr Type deriving (Eq, Show)
-
-data TypedExpr
-  = Dict [(Identifier, TypedExpr)] Type
-  | List [TypedExpr] Type
-  | Tuple (TypedExpr, TypedExpr, [TypedExpr]) Type
-  | StringLiteral String
-  | IntegerLiteral Integer
-  | DoubleLiteral Double
-  | BoolLiteral Bool
-  | ExtImport ExtImportName String
-  | Var Identifier Type
-  | -- TODO: When adding quoters to TypeDefinitions, these JSON/PSL variants will have to be changed
-    JSON String
-  | PSL String
+data TypedStmt
+  = -- | Decl <declName> <declBody> <declType>
+    Decl Identifier (WithCtx TypedExpr) Type
   deriving (Eq, Show)
+
+{- ORMOLU_DISABLE -}
+data TypedExpr
+  = Dict           [(Identifier, WithCtx TypedExpr)] Type
+  | List           [WithCtx TypedExpr] Type
+  | Tuple          (WithCtx TypedExpr, WithCtx TypedExpr, [WithCtx TypedExpr]) Type
+  | StringLiteral  String
+  | IntegerLiteral Integer
+  | DoubleLiteral  Double
+  | BoolLiteral    Bool
+  | ExtImport      ExtImportName String
+  | Var            Identifier Type
+  | -- TODO: When adding quoters to TypeDefinitions, these JSON/PSL variants will have to be changed
+    JSON           String
+  | PSL            String
+  deriving (Eq, Show)
+{- ORMOLU_ENABLE -}
 
 -- | Given a @TypedExpr@, determines its @Type@.
 exprType :: TypedExpr -> Type

--- a/waspc/src/Wasp/Analyzer/TypeDefinitions/Class/IsDeclType.hs
+++ b/waspc/src/Wasp/Analyzer/TypeDefinitions/Class/IsDeclType.hs
@@ -8,7 +8,7 @@ where
 import Data.Typeable (Typeable)
 import Wasp.Analyzer.Evaluator.Bindings (Bindings)
 import Wasp.Analyzer.Evaluator.EvaluationError (EvaluationError)
-import Wasp.Analyzer.TypeChecker.AST (TypedExpr)
+import Wasp.Analyzer.TypeChecker.AST (TypedExpr, WithCtx)
 import Wasp.Analyzer.TypeDefinitions.Internal (DeclType, TypeDefinitions)
 import qualified Wasp.AppSpec.Core.Decl as AppSpecDecl
 
@@ -47,4 +47,4 @@ class (Typeable a, AppSpecDecl.IsDecl a) => IsDeclType a where
   -- and @4@ is declaration body.
   -- @declEvaluate@ function would then be called somewhat like:
   -- @declEvaluate @Test typeDefs bindings (NumberLiteral 4)@
-  declEvaluate :: TypeDefinitions -> Bindings -> TypedExpr -> Either EvaluationError a
+  declEvaluate :: TypeDefinitions -> Bindings -> WithCtx TypedExpr -> Either EvaluationError a

--- a/waspc/src/Wasp/Analyzer/TypeDefinitions/Internal.hs
+++ b/waspc/src/Wasp/Analyzer/TypeDefinitions/Internal.hs
@@ -9,7 +9,7 @@ import qualified Data.HashMap.Strict as M
 import Wasp.Analyzer.Evaluator.Bindings (Bindings, DeclName)
 import Wasp.Analyzer.Evaluator.EvaluationError (EvaluationError)
 import Wasp.Analyzer.Type (Type)
-import Wasp.Analyzer.TypeChecker.AST (TypedExpr)
+import Wasp.Analyzer.TypeChecker.AST (TypedExpr, WithCtx)
 import Wasp.AppSpec.Core.Decl (Decl)
 
 -- | Describes a specific declaration type in Wasp.
@@ -25,7 +25,7 @@ data DeclType = DeclType
     --
     -- Check @declEvaluate@ of @IsDeclType@ typeclass for more information,
     -- since @dtEvaluate@ is really a value-level version of @declEvaluate@.
-    dtEvaluate :: TypeDefinitions -> Bindings -> DeclName -> TypedExpr -> Either EvaluationError Decl
+    dtEvaluate :: TypeDefinitions -> Bindings -> DeclName -> WithCtx TypedExpr -> Either EvaluationError Decl
   }
 
 -- | Describes a specific enum type in Wasp.

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -6,6 +6,8 @@ module Wasp.Util
     headSafe,
     jsonSet,
     indent,
+    concatShortPrefixAndText,
+    concatPrefixAndText,
   )
 where
 
@@ -49,3 +51,54 @@ jsonSet _ _ _ = error "Input JSON must be an object"
 
 indent :: Int -> String -> String
 indent numSpaces = intercalate "\n" . map (replicate numSpaces ' ' ++) . splitOn "\n"
+
+-- | Given a prefix and text, concatenates them in the following manner:
+-- <prefix> <text_line_1>
+--          <text_line_2>
+--              ...
+--          <text_line_N>
+--
+-- __Examples__
+--
+-- @
+-- >>> putStrLn $ concatShortPrefixAndText "Log: " "Written to file foo.txt"
+-- Log: Written to file foo.txt
+-- @
+--
+-- @
+-- >>> putStrLn $ concatShortPrefixAndText "Log: " "Written to file foo.txt\nWritten to file bar.txt"
+-- Log: Written to file foo.txt
+--      Written to file bar.txt
+-- @
+concatShortPrefixAndText :: String -> String -> String
+concatShortPrefixAndText prefix "" = prefix
+concatShortPrefixAndText prefix text =
+  let (l : ls) = lines text
+   in prefix ++ l ++ if null ls then "" else "\n" ++ indent (length prefix) (intercalate "\n" ls)
+
+-- | Given a prefix and text, concatenates them in the following manner:
+-- - If just one line of text:
+-- <prefix> <one_and_only_line_of_text>
+-- - If multiple lines of text:
+-- <prefix>
+--   <text_line_1>
+--   <text_line_2>
+--       ...
+--   <text_line_N>
+--
+-- __Examples__
+--
+-- @
+-- >>> putStrLn $ concatPrefixAndText "Log messages from the somelog.txt file: " "Written to file foo.txt"
+-- Log messages from the somelog.txt file: Written to file foo.txt
+-- @
+--
+-- @
+-- >>> putStrLn $ concatPrefixAndText "Log messages from the somelog.txt file:" "Written to file foo.txt\nWritten to file bar.txt"
+-- Log messages from the somelog.txt file:
+--   Written to file foo.txt
+--   Written to file bar.txt
+-- @
+concatPrefixAndText :: String -> String -> String
+concatPrefixAndText prefix text =
+  if length (lines text) <= 1 then prefix ++ text else prefix ++ "\n" ++ indent 2 text

--- a/waspc/test/Analyzer/EvaluatorTest.hs
+++ b/waspc/test/Analyzer/EvaluatorTest.hs
@@ -84,7 +84,7 @@ data SemanticVersion = SemanticVersion Int Int Int
 
 instance HasCustomEvaluation SemanticVersion where
   waspType = T.StringType
-  evaluation = E.evaluation' $ \case
+  evaluation = E.evaluation' . TypedAST.withCtx $ \_ctx -> \case
     TypedAST.StringLiteral str -> case splitOn "." str of
       [major, minor, patch] ->
         maybe

--- a/waspc/test/Analyzer/Parser/ParseErrorTest.hs
+++ b/waspc/test/Analyzer/Parser/ParseErrorTest.hs
@@ -1,5 +1,6 @@
 module Analyzer.Parser.ParseErrorTest where
 
+import Analyzer.TestUtil (ctx, pos)
 import Test.Tasty.Hspec
 import Wasp.Analyzer.Parser.ParseError
 import Wasp.Analyzer.Parser.Token
@@ -7,39 +8,31 @@ import Wasp.Analyzer.Parser.Token
 spec_ParseErrorTest :: Spec
 spec_ParseErrorTest = do
   describe "Analyzer.Parser.ParseError" $ do
-    let unexpectedCharError = UnexpectedChar '!' (SourcePosition 2 42)
-        unexpectedTokenErrorNoSuggestions =
-          UnexpectedToken (Token TLCurly (SourcePosition 2 3) "{") []
-        unexpectedTokenErrorWithSuggestions =
-          UnexpectedToken
-            (Token TRCurly (SourcePosition 100 18) "}")
-            ["<identifier>", ","]
-        quoterDifferentTagsError =
-          QuoterDifferentTags
-            ("foo", SourcePosition 1 5)
-            ("bar", SourcePosition 1 20)
-    describe "getErrorMessage returns human readable error message" $ do
-      it "for UnexpectedChar error" $ do
-        getErrorMessage unexpectedCharError `shouldBe` "Unexpected character: !"
-      it "for UnexpectedToken error" $ do
-        getErrorMessage unexpectedTokenErrorNoSuggestions
-          `shouldBe` "Unexpected token: {"
-        getErrorMessage unexpectedTokenErrorWithSuggestions
-          `shouldBe` ( "Unexpected token: }\n"
-                         ++ "Expected one of the following tokens instead: <identifier> ,"
-                     )
-      it "for QuoterDifferentTags error" $ do
-        getErrorMessage quoterDifferentTagsError
-          `shouldBe` "Quoter tags don't match: {=foo ... bar=}"
+    describe "getErrorMessageAndCtx returns a human readable error message and the correct position" $ do
+      let unexpectedCharError = UnexpectedChar '!' (pos 2 42)
+          unexpectedTokenErrorNoSuggestions =
+            UnexpectedToken (Token TLCurly (pos 2 3) "{") []
+          unexpectedTokenErrorWithSuggestions =
+            UnexpectedToken
+              (Token TRCurly (pos 100 18) "}")
+              ["<identifier>", ","]
+          quoterDifferentTagsError =
+            QuoterDifferentTags
+              ("foo", pos 1 5)
+              ("bar", pos 1 20)
 
-    describe "getSourcePosition returns correct position" $ do
       it "for UnexpectedChar error" $ do
-        getSourcePosition unexpectedCharError `shouldBe` SourcePosition 2 42
+        getErrorMessageAndCtx unexpectedCharError `shouldBe` ("Unexpected character: !", ctx 2 42)
+
       it "for UnexpectedToken error" $ do
-        getSourcePosition unexpectedTokenErrorNoSuggestions
-          `shouldBe` SourcePosition 2 3
-        getSourcePosition unexpectedTokenErrorWithSuggestions
-          `shouldBe` SourcePosition 100 18
+        getErrorMessageAndCtx unexpectedTokenErrorNoSuggestions
+          `shouldBe` ("Unexpected token: {", ctx 2 3)
+        getErrorMessageAndCtx unexpectedTokenErrorWithSuggestions
+          `shouldBe` ( "Unexpected token: }\n"
+                         ++ "Expected one of the following tokens instead: <identifier> ,",
+                       ctx 100 18
+                     )
+
       it "for QuoterDifferentTags error" $ do
-        getSourcePosition quoterDifferentTagsError
-          `shouldBe` SourcePosition 1 20
+        getErrorMessageAndCtx quoterDifferentTagsError
+          `shouldBe` ("Quoter tags don't match: {=foo ... bar=}", ctx 1 20)

--- a/waspc/test/Analyzer/TestUtil.hs
+++ b/waspc/test/Analyzer/TestUtil.hs
@@ -1,0 +1,16 @@
+module Analyzer.TestUtil where
+
+import qualified Wasp.Analyzer.Parser as P
+import qualified Wasp.Analyzer.TypeChecker as T
+
+pos :: Int -> Int -> P.SourcePosition
+pos line column = P.SourcePosition line column
+
+ctx :: Int -> Int -> P.Ctx
+ctx line column = P.ctxFromPos $ P.SourcePosition line column
+
+wctx :: Int -> Int -> a -> P.WithCtx a
+wctx line column = P.WithCtx (ctx line column)
+
+fromWithCtx :: P.WithCtx T.TypedExpr -> T.TypedExpr
+fromWithCtx = P.fromWithCtx

--- a/waspc/test/UtilTest.hs
+++ b/waspc/test/UtilTest.hs
@@ -71,3 +71,23 @@ spec_indent = do
       indent 3 "foo\nbar" `shouldBe` "   foo\n   bar"
     it "when text is already somewhat indented" $ do
       indent 4 "  foo\n  bar" `shouldBe` "      foo\n      bar"
+
+spec_concatShortPrefixAndText :: Spec
+spec_concatShortPrefixAndText = do
+  describe "concatShortPrefixAndText should" $ do
+    it "return prefix if text is empty" $ do
+      concatShortPrefixAndText "--" "" `shouldBe` "--"
+    it "directly concat if text has single line" $ do
+      concatShortPrefixAndText " - " "foo" `shouldBe` " - foo"
+    it "align the rest of the lines in text with the first line" $ do
+      concatShortPrefixAndText " - " "foo\nbar" `shouldBe` " - foo\n   bar"
+
+spec_concatPrefixAndText :: Spec
+spec_concatPrefixAndText = do
+  describe "concatPrefixAndText should" $ do
+    it "return prefix if text is empty" $ do
+      concatPrefixAndText "some prefix: " "" `shouldBe` "some prefix: "
+    it "directly concat if text has single line" $ do
+      concatPrefixAndText "prefix: " "foo" `shouldBe` "prefix: foo"
+    it "put all the text below the prefix, indented for 2 spaces, if text has multiple lines" $ do
+      concatPrefixAndText "prefix: " "foo\nbar" `shouldBe` "prefix: \n  foo\n  bar"


### PR DESCRIPTION
- Added Parser.Ctx to the Parser.AST and TypeChecker.AST, providing context for each AST node on how it was parsed (for now that is only source position). It might be interesting to see how WithCtx works. Composition like this is a typical way in Haskell to add shared / repeated state to multiple data constructors / types.
- Also added Parser.Ctx to TypeError. Now we can get message and context for each error.
- Added nice error messages for TypeError.

This required quite some changes to propagate the context/source position through the whole code, but it works and it seems quite nice / practical to me!
Errors are certainly 100x more useful now that we can report precise location.

For context, what is yet missing on the error side (to be done in the future PRs):
- Nice error messages and context for EvaluationError
- Have errors report SourceRegion instead of SourcePosition (inside Parser.Ctx).