### PR TITLE
Better evaluator errors

### DIFF
--- a/waspc/src/Wasp/Analyzer/AnalyzeError.hs
+++ b/waspc/src/Wasp/Analyzer/AnalyzeError.hs
@@ -24,4 +24,4 @@ getErrorMessageAndCtx :: AnalyzeError -> (String, Ctx)
 getErrorMessageAndCtx = \case
   ParseError e -> first (("Parse error:\n" ++) . indent 2) $ PE.getErrorMessageAndCtx e
   TypeError e -> first (("Type error:\n" ++) . indent 2) $ TE.getErrorMessageAndCtx e
-  EvaluationError _e -> error "TODO"
+  EvaluationError e -> first (("Evaluation error:\n" ++) . indent 2) $ EE.getErrorMessageAndCtx e

--- a/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedDictExpr.hs
+++ b/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedDictExpr.hs
@@ -11,4 +11,5 @@ import qualified Wasp.Analyzer.TypeChecker.AST as TypedAST
 -- be created from a "TypedDictExprEvaluation" with the "dict" combinator.
 type TypedDictExprEvaluation a = Evaluation TypedDictEntries a
 
-newtype TypedDictEntries = TypedDictEntries [(String, TypedAST.WithCtx TypedAST.TypedExpr)]
+-- | This first WithCtx carries the context of the dictionary that contains these entries.
+newtype TypedDictEntries = TypedDictEntries (TypedAST.WithCtx [(String, TypedAST.WithCtx TypedAST.TypedExpr)])

--- a/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedDictExpr/Combinators.hs
+++ b/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedDictExpr/Combinators.hs
@@ -11,34 +11,35 @@ import Control.Arrow (left)
 import Wasp.Analyzer.Evaluator.Evaluation.Internal (evaluation, runEvaluation)
 import Wasp.Analyzer.Evaluator.Evaluation.TypedDictExpr (TypedDictEntries (..), TypedDictExprEvaluation)
 import Wasp.Analyzer.Evaluator.Evaluation.TypedExpr (TypedExprEvaluation)
-import qualified Wasp.Analyzer.Evaluator.EvaluationError as EvaluationError
-import Wasp.Analyzer.TypeChecker.AST (withCtx)
+import Wasp.Analyzer.Evaluator.EvaluationError (mkEvaluationError)
+import qualified Wasp.Analyzer.Evaluator.EvaluationError as ER
+import Wasp.Analyzer.TypeChecker.AST (WithCtx (..), withCtx)
 import qualified Wasp.Analyzer.TypeChecker.AST as TypedAST
 
 -- | An evaluation that runs a "TypedDictExprEvaluation". Expects a "Dict" expression and
 -- uses its entries to run the "TypedDictExprEvaluation".
 dict :: TypedDictExprEvaluation a -> TypedExprEvaluation a
-dict dictEvaluator = evaluation $ \(typeDefs, bindings) -> withCtx $ \_ctx -> \case
+dict dictEvaluator = evaluation $ \(typeDefs, bindings) -> withCtx $ \ctx -> \case
   TypedAST.Dict entries _ ->
-    runEvaluation dictEvaluator typeDefs bindings $ TypedDictEntries entries
-  expr -> Left $ EvaluationError.ExpectedDictType $ TypedAST.exprType expr
+    runEvaluation dictEvaluator typeDefs bindings $ TypedDictEntries $ WithCtx ctx entries
+  expr -> Left $ mkEvaluationError ctx $ ER.ExpectedDictType $ TypedAST.exprType expr
 
 -- | A dictionary evaluation that requires the field to exist.
 field :: String -> TypedExprEvaluation a -> TypedDictExprEvaluation a
 field key valueEvaluation = evaluation $
-  \(typeDefs, bindings) (TypedDictEntries entries) -> case lookup key entries of
-    Nothing -> Left $ EvaluationError.MissingField key
+  \(typeDefs, bindings) (TypedDictEntries (WithCtx dictCtx entries)) -> case lookup key entries of
+    Nothing -> Left $ mkEvaluationError dictCtx $ ER.MissingDictField key
     Just value ->
-      left (EvaluationError.WithContext (EvaluationError.InField key)) $
+      left (mkEvaluationError dictCtx . ER.WithEvalErrorCtx (ER.InField key)) $
         runEvaluation valueEvaluation typeDefs bindings value
 
 -- | A dictionary evaluation that allows the field to be missing.
 maybeField :: String -> TypedExprEvaluation a -> TypedDictExprEvaluation (Maybe a)
 maybeField key valueEvaluation = evaluation $
-  \(typeDefs, bindings) (TypedDictEntries entries) -> case lookup key entries of
+  \(typeDefs, bindings) (TypedDictEntries (WithCtx dictCtx entries)) -> case lookup key entries of
     Nothing -> pure Nothing
     Just value ->
       Just
         <$> left
-          (EvaluationError.WithContext (EvaluationError.InField key))
+          (mkEvaluationError dictCtx . ER.WithEvalErrorCtx (ER.InField key))
           (runEvaluation valueEvaluation typeDefs bindings value)

--- a/waspc/src/Wasp/Analyzer/Evaluator/EvaluationError.hs
+++ b/waspc/src/Wasp/Analyzer/Evaluator/EvaluationError.hs
@@ -1,35 +1,49 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Wasp.Analyzer.Evaluator.EvaluationError
   ( EvaluationError (..),
-    EvaluationErrorContext (..),
+    EvalErrorCtx (..),
     EvaluationParseError (..),
+    EvaluationError' (..),
+    mkEvaluationError,
+    getErrorMessageAndCtx,
   )
 where
 
+import Control.Arrow (first)
+import Data.List (intercalate)
 import qualified Text.Parsec
+import Wasp.Analyzer.Parser.Ctx (Ctx, WithCtx (..))
 import Wasp.Analyzer.Type (Type)
+import Wasp.Util (concatPrefixAndText, indent)
 
-data EvaluationError
+newtype EvaluationError = EvaluationError (WithCtx EvaluationError')
+  deriving (Show, Eq)
+
+{- ORMOLU_DISABLE -}
+data EvaluationError'
   = -- | "ExpectedType expected actual"
-    ExpectedType Type Type
+    ExpectedType       Type Type
   | -- | "ExpectedDictType actual"
-    ExpectedDictType Type
+    ExpectedDictType   Type
   | -- | "ExpectedListType actual"
-    ExpectedListType Type
+    ExpectedListType   Type
   | -- | "ExpectedTupleType expectedTupleSize actualType"
     ExpectedTupleType Int Type
   | -- | "UndefinedVariable varName"
-    UndefinedVariable String
-  | -- | "InvalidEnumVariant enumType enumValue"
-    InvalidEnumVariant String String
-  | -- | "MissingField fieldName"
-    MissingField String
+    UndefinedVariable  String
+  | -- | "InvalidEnumVariant enumType validEnumVariants actualEnumVariant"
+    InvalidEnumVariant String [String] String
+  | -- | "MissingDictField fieldName"
+    MissingDictField   String
   | -- | In case when evaluation includes parsing and it fails.
-    ParseError EvaluationParseError
+    ParseError         EvaluationParseError
   | -- | Not an actual error, but a wrapper that provides additional context.
-    WithContext EvaluationErrorContext EvaluationError
+    WithEvalErrorCtx   EvalErrorCtx EvaluationError
   deriving (Show, Eq)
+{- ORMOLU_ENABLE -}
 
-data EvaluationErrorContext
+data EvalErrorCtx
   = -- | InField fieldName
     InField String
   | InList
@@ -44,3 +58,61 @@ data EvaluationParseError
   | -- | In case when evaluation does some general parsing and it fails.
     EvaluationParseError String
   deriving (Show, Eq)
+
+mkEvaluationError :: Ctx -> EvaluationError' -> EvaluationError
+mkEvaluationError ctx e = EvaluationError $ WithCtx ctx e
+
+getErrorMessageAndCtx :: EvaluationError -> (String, Ctx)
+getErrorMessageAndCtx (EvaluationError (WithCtx ctx evalError)) = case evalError of
+  ExpectedType expectedType actualType ->
+    ( intercalate
+        "\n"
+        [ concatPrefixAndText "Expected type: " (show expectedType),
+          concatPrefixAndText "Actual type:   " (show actualType)
+        ],
+      ctx
+    )
+  ExpectedDictType actualType ->
+    ( intercalate
+        "\n"
+        [ "Expected a dictionary.",
+          concatPrefixAndText "Actual type: " (show actualType)
+        ],
+      ctx
+    )
+  ExpectedListType actualType ->
+    ( intercalate
+        "\n"
+        [ "Expected a list.",
+          concatPrefixAndText "Actual type: " (show actualType)
+        ],
+      ctx
+    )
+  ExpectedTupleType expectedTupleSize actualType ->
+    ( intercalate
+        "\n"
+        [ "Expected a tuple of size " ++ show expectedTupleSize ++ ".",
+          concatPrefixAndText "Actual type: " (show actualType)
+        ],
+      ctx
+    )
+  UndefinedVariable varName -> ("Undefined variable " ++ varName, ctx)
+  InvalidEnumVariant enumType validEnumVariants actualEnumVariant ->
+    ( "Expected value of enum type '" ++ enumType
+        ++ "' but got value '"
+        ++ actualEnumVariant
+        ++ "'\n"
+        ++ "Valid values: "
+        ++ intercalate " | " validEnumVariants,
+      ctx
+    )
+  MissingDictField fieldName -> ("Missing dictionary field '" ++ fieldName ++ "'", ctx)
+  ParseError (EvaluationParseErrorParsec e) -> ("Parse error:\n" ++ indent 2 (show e), ctx)
+  ParseError (EvaluationParseError msg) -> ("Parse error:\n" ++ indent 2 msg, ctx)
+  WithEvalErrorCtx evalCtx subError ->
+    let evalCtxMsg = case evalCtx of
+          InField fieldName -> "In dictionary field '" ++ fieldName ++ "':"
+          InList -> "In list:"
+          InTuple -> "In tuple:"
+          ForVariable varName -> "For variable '" ++ varName ++ "':"
+     in first (((evalCtxMsg ++ "\n") ++) . indent 2) $ getErrorMessageAndCtx subError

--- a/waspc/src/Wasp/Analyzer/StdTypeDefinitions/Entity.hs
+++ b/waspc/src/Wasp/Analyzer/StdTypeDefinitions/Entity.hs
@@ -5,6 +5,7 @@ module Wasp.Analyzer.StdTypeDefinitions.Entity () where
 
 import Control.Arrow (left)
 import qualified Text.Parsec as Parsec
+import Wasp.Analyzer.Evaluator.EvaluationError (mkEvaluationError)
 import qualified Wasp.Analyzer.Evaluator.EvaluationError as ER
 import qualified Wasp.Analyzer.Type as Type
 import qualified Wasp.Analyzer.TypeChecker.AST as TC.AST
@@ -22,8 +23,8 @@ instance IsDeclType Entity where
           Decl.makeDecl @Entity declName <$> declEvaluate typeDefinitions bindings expr
       }
 
-  declEvaluate _ _ (TC.AST.WithCtx _ctx expr) = case expr of
+  declEvaluate _ _ (TC.AST.WithCtx ctx expr) = case expr of
     TC.AST.PSL pslString ->
-      left (ER.ParseError . ER.EvaluationParseErrorParsec) $
+      left (ER.mkEvaluationError ctx . ER.ParseError . ER.EvaluationParseErrorParsec) $
         makeEntity <$> Parsec.parse Wasp.Psl.Parser.Model.body "" pslString
-    _ -> Left $ ER.ExpectedType (Type.QuoterType "psl") (TC.AST.exprType expr)
+    _ -> Left $ mkEvaluationError ctx $ ER.ExpectedType (Type.QuoterType "psl") (TC.AST.exprType expr)

--- a/waspc/src/Wasp/Analyzer/TypeDefinitions/Class/IsEnumType.hs
+++ b/waspc/src/Wasp/Analyzer/TypeDefinitions/Class/IsEnumType.hs
@@ -6,7 +6,6 @@ module Wasp.Analyzer.TypeDefinitions.Class.IsEnumType
 where
 
 import Data.Typeable (Typeable)
-import Wasp.Analyzer.Evaluator.EvaluationError (EvaluationError)
 import Wasp.Analyzer.TypeDefinitions.Internal (EnumType)
 
 -- | Marks Haskell type as a representation of a specific Wasp enum type.
@@ -19,7 +18,7 @@ class Typeable a => IsEnumType a where
 
   -- | Converts a string to a Haskell value of this type.
   --
-  -- @mapM_ enumEvaluate (etVariants enumType) == Right ()@ should be true
+  -- @mapM_ enumEvaluate (etVariants enumType) == Just ()@ should be true
   -- for all instances of "IsEnumType".
   --
   -- __Examples__
@@ -27,5 +26,5 @@ class Typeable a => IsEnumType a where
   -- >>> data Example = Foo | Bar
   -- >>> instance IsEnumType Example where {- omitted -}
   -- >>> enumEvaluate "Foo"
-  -- Foo
-  enumEvaluate :: String -> Either EvaluationError a
+  -- Just Foo
+  enumEvaluate :: String -> Maybe a

--- a/waspc/test/Analyzer/Evaluation/EvaluationErrorTest.hs
+++ b/waspc/test/Analyzer/Evaluation/EvaluationErrorTest.hs
@@ -1,0 +1,27 @@
+module Analyzer.Evaluation.EvaluationErrorTest where
+
+import Analyzer.TestUtil (ctx)
+import Test.Tasty.Hspec
+import Wasp.Analyzer.Evaluator.EvaluationError
+import Wasp.Analyzer.Type (Type (..))
+
+spec_EvaluationError :: Spec
+spec_EvaluationError = do
+  describe "Analyzer.Evaluator.EvaluationError" $ do
+    describe "getErrorMessageAndCtx works correctly for" $ do
+      it "InvalidEnumVariant error" $ do
+        let ctx1 = ctx 1 1
+        let err = mkEvaluationError ctx1 $ InvalidEnumVariant "Animal" ["Cow", "Dog"] "Car"
+        getErrorMessageAndCtx err
+          `shouldBe` ( "Expected value of enum type 'Animal' but got value 'Car'"
+                         ++ "\nValid values: Cow | Dog",
+                       ctx1
+                     )
+      it "ExpectedType error" $ do
+        let ctx1 = ctx 1 4
+        let err = mkEvaluationError ctx1 $ ExpectedType NumberType StringType
+        getErrorMessageAndCtx err `shouldBe` ("Expected type: number\nActual type:   string", ctx1)
+      it "ExpectedTupleType error" $ do
+        let ctx1 = ctx 1 4
+        let err = mkEvaluationError ctx1 $ ExpectedTupleType 3 StringType
+        getErrorMessageAndCtx err `shouldBe` ("Expected a tuple of size 3.\nActual type: string", ctx1)

--- a/waspc/test/Analyzer/EvaluatorTest.hs
+++ b/waspc/test/Analyzer/EvaluatorTest.hs
@@ -84,14 +84,15 @@ data SemanticVersion = SemanticVersion Int Int Int
 
 instance HasCustomEvaluation SemanticVersion where
   waspType = T.StringType
-  evaluation = E.evaluation' . TypedAST.withCtx $ \_ctx -> \case
+  evaluation = E.evaluation' . TypedAST.withCtx $ \ctx -> \case
     TypedAST.StringLiteral str -> case splitOn "." str of
       [major, minor, patch] ->
         maybe
           ( Left $
-              EvaluationError.ParseError $
-                EvaluationError.EvaluationParseError
-                  "Failed parsing semantic version -> some part is not int"
+              EvaluationError.mkEvaluationError ctx $
+                EvaluationError.ParseError $
+                  EvaluationError.EvaluationParseError
+                    "Failed parsing semantic version -> some part is not int"
           )
           pure
           $ do
@@ -101,10 +102,14 @@ instance HasCustomEvaluation SemanticVersion where
             return $ SemanticVersion majorInt minorInt patchInt
       _ ->
         Left $
-          EvaluationError.ParseError $
-            EvaluationError.EvaluationParseError
-              "Failed parsing semantic version -> it doesn't have 3 comma separated parts."
-    expr -> Left $ EvaluationError.ExpectedType T.StringType (TypedAST.exprType expr)
+          EvaluationError.mkEvaluationError ctx $
+            EvaluationError.ParseError $
+              EvaluationError.EvaluationParseError
+                "Failed parsing semantic version -> it doesn't have 3 comma separated parts."
+    expr ->
+      Left $
+        EvaluationError.mkEvaluationError ctx $
+          EvaluationError.ExpectedType T.StringType (TypedAST.exprType expr)
 
 data Custom = Custom
   {version :: SemanticVersion}


### PR DESCRIPTION
Same thing as for ParseError and for TypeError, but now for EvaluatorError -> I enriched errors with Ctx (source position) information and taught them how to display themselves and report ctx/position.