### PR TITLE
TypeError now uses WithCtx internally.

### DIFF
--- a/waspc/src/Wasp/Analyzer/TypeChecker.hs
+++ b/waspc/src/Wasp/Analyzer/TypeChecker.hs
@@ -13,6 +13,8 @@ module Wasp.Analyzer.TypeChecker
 
     -- ** Errors
     TypeError (..),
+    TypeError' (..),
+    mkTypeError,
     TypeCoercionError (..),
     TypeCoercionErrorReason (..),
     getErrorMessageAndCtx,

--- a/waspc/test/Analyzer/TypeCheckerTest.hs
+++ b/waspc/test/Analyzer/TypeCheckerTest.hs
@@ -48,8 +48,9 @@ spec_TypeChecker = do
                 }
         let actual = typeCheck typeDefs ast
         let expectedError =
-              WeakenError (ctx 1 1) $
-                TypeCoercionError (wctx 2 2 $ IntegerLiteral 5) StringType ReasonUncoercable
+              mkTypeError (ctx 1 1) $
+                WeakenError $
+                  TypeCoercionError (wctx 2 2 $ IntegerLiteral 5) StringType ReasonUncoercable
         actual `shouldBe` Left expectedError
       it "Properly hoists declarations" $ do
         let mAst = P.parse "llnode Head { value: 2, next: Tail } llnode Tail { value: 3 }"

--- a/waspc/test/AnalyzerTest.hs
+++ b/waspc/test/AnalyzerTest.hs
@@ -176,7 +176,7 @@ spec_Analyzer = do
               [ "route HomeRoute { path: \"/\", page: NonExistentPage }"
               ]
       takeDecls @Route <$> analyze source
-        `shouldBe` Left (TypeError $ TC.UndefinedIdentifier (ctx 1 36) "NonExistentPage")
+        `shouldBe` Left (TypeError $ TC.mkTypeError (ctx 1 36) $ TC.UndefinedIdentifier "NonExistentPage")
 
     it "Returns a type error if referenced declaration is of wrong type" $ do
       let source =


### PR DESCRIPTION
Improved TypeError a bit based on what I learned when doing EvaluationError -> that I can use WithCtx in it to add ctx to it, instead directly embedding it into every error.