### PR TITLE
Parse context now tracks source region instead of source position

### DIFF
--- a/waspc/src/Wasp/Analyzer/Parser.hs
+++ b/waspc/src/Wasp/Analyzer/Parser.hs
@@ -19,7 +19,8 @@ module Wasp.Analyzer.Parser
     WithCtx (..),
     withCtx,
     ctxFromPos,
-    getCtxPos,
+    ctxFromRgn,
+    getCtxRgn,
     fromWithCtx,
     Ctx (..),
     Identifier,
@@ -34,7 +35,7 @@ where
 import Control.Monad.Except (runExcept)
 import Control.Monad.State (evalStateT)
 import Wasp.Analyzer.Parser.AST
-import Wasp.Analyzer.Parser.Ctx (Ctx (..), WithCtx (..), ctxFromPos, fromWithCtx, getCtxPos, withCtx)
+import Wasp.Analyzer.Parser.Ctx (Ctx (..), WithCtx (..), ctxFromPos, ctxFromRgn, fromWithCtx, getCtxRgn, withCtx)
 import Wasp.Analyzer.Parser.Monad (initialState)
 import Wasp.Analyzer.Parser.ParseError
 import qualified Wasp.Analyzer.Parser.Parser as P

--- a/waspc/src/Wasp/Analyzer/Parser/Ctx.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/Ctx.hs
@@ -5,12 +5,14 @@ module Wasp.Analyzer.Parser.Ctx
     withCtx,
     Ctx (..),
     ctxFromPos,
-    getCtxPos,
+    ctxFromRgn,
+    getCtxRgn,
     fromWithCtx,
   )
 where
 
 import Wasp.Analyzer.Parser.SourcePosition (SourcePosition)
+import Wasp.Analyzer.Parser.SourceRegion (SourceRegion (..))
 
 data WithCtx a = WithCtx Ctx a
   deriving (Eq, Show, Functor)
@@ -18,20 +20,20 @@ data WithCtx a = WithCtx Ctx a
 withCtx :: (Ctx -> a -> b) -> WithCtx a -> b
 withCtx f (WithCtx ctx x) = f ctx x
 
--- | Gives parsing context to AST nodes -> e.g. source position from which they originated.
--- TODO: Instead of having just SourcePosition, it would be better to have SourceRegion, since errors
--- usually refer to a region and not just one position/char in the code.
--- This is captured in an issue https://github.com/wasp-lang/wasp/issues/404 .
+-- | Gives parsing context to AST nodes -> e.g. source region from which they originated.
 data Ctx = Ctx
-  { ctxSourcePosition :: SourcePosition
+  { ctxSourceRegion :: SourceRegion
   }
   deriving (Show, Eq)
 
 ctxFromPos :: SourcePosition -> Ctx
-ctxFromPos pos = Ctx {ctxSourcePosition = pos}
+ctxFromPos pos = Ctx {ctxSourceRegion = SourceRegion pos pos}
 
-getCtxPos :: Ctx -> SourcePosition
-getCtxPos = ctxSourcePosition
+ctxFromRgn :: SourcePosition -> SourcePosition -> Ctx
+ctxFromRgn posStart posEnd = Ctx {ctxSourceRegion = SourceRegion posStart posEnd}
+
+getCtxRgn :: Ctx -> SourceRegion
+getCtxRgn = ctxSourceRegion
 
 fromWithCtx :: WithCtx a -> a
 fromWithCtx (WithCtx _ a) = a

--- a/waspc/src/Wasp/Analyzer/Parser/SourcePosition.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/SourcePosition.hs
@@ -1,8 +1,23 @@
 module Wasp.Analyzer.Parser.SourcePosition
   ( SourcePosition (..),
+    calcNextPosition,
   )
 where
 
 -- | The first character on the first line is at position @Position 1 1@
 -- @SourcePosition <line> <column>@
 data SourcePosition = SourcePosition Int Int deriving (Eq, Show)
+
+-- | Scan the source fragment character by character and update position based on it.
+-- Important thing that this function does is ensure that newlines are correctly handled.
+calcNextPosition ::
+  SourceFragment ->
+  -- | Start position of source fragment (first char).
+  SourcePosition ->
+  -- | Source position right after the source fragment (position after the last char).
+  SourcePosition
+calcNextPosition [] position = position
+calcNextPosition ('\n' : cs) (SourcePosition line _) = calcNextPosition cs $ SourcePosition (line + 1) 1
+calcNextPosition (_ : cs) (SourcePosition line col) = calcNextPosition cs $ SourcePosition line (col + 1)
+
+type SourceFragment = String

--- a/waspc/src/Wasp/Analyzer/Parser/SourceRegion.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/SourceRegion.hs
@@ -1,0 +1,22 @@
+module Wasp.Analyzer.Parser.SourceRegion
+  ( SourceRegion (..),
+    getRgnStart,
+    getRgnEnd,
+  )
+where
+
+import Wasp.Analyzer.Parser.SourcePosition
+
+-- | @SourceRegion <regionStart> <regionEnd>@
+-- where @regionStart@ is position of the first character in the region while @regionEnd@
+-- is the position of the last character in the region.
+-- So, if we have `app MyApp {` and we want to capture the `MyApp`,
+-- we would do it with @SourceRegion (SourcePosition 1 5) (SourcePosition 1 9)@.
+data SourceRegion = SourceRegion SourcePosition SourcePosition
+  deriving (Eq, Show)
+
+getRgnStart :: SourceRegion -> SourcePosition
+getRgnStart (SourceRegion start _) = start
+
+getRgnEnd :: SourceRegion -> SourcePosition
+getRgnEnd (SourceRegion _ end) = end

--- a/waspc/src/Wasp/Analyzer/Parser/Token.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/Token.hs
@@ -1,6 +1,6 @@
 module Wasp.Analyzer.Parser.Token where
 
-import Wasp.Analyzer.Parser.SourcePosition (SourcePosition)
+import Wasp.Analyzer.Parser.SourcePosition (SourcePosition, calcNextPosition)
 
 data TokenType
   = TLParen
@@ -27,7 +27,12 @@ data TokenType
 
 data Token = Token
   { tokenType :: TokenType,
-    tokenPosition :: SourcePosition,
+    tokenStartPosition :: SourcePosition,
     tokenLexeme :: String
   }
   deriving (Eq, Show)
+
+-- | Calculates source position of the last character in the token lexeme.
+calcTokenEndPos :: Token -> SourcePosition
+calcTokenEndPos (Token _ startPos "") = startPos
+calcTokenEndPos t = calcNextPosition (init $ tokenLexeme t) (tokenStartPosition t)

--- a/waspc/test/Analyzer/Evaluation/EvaluationErrorTest.hs
+++ b/waspc/test/Analyzer/Evaluation/EvaluationErrorTest.hs
@@ -10,7 +10,7 @@ spec_EvaluationError = do
   describe "Analyzer.Evaluator.EvaluationError" $ do
     describe "getErrorMessageAndCtx works correctly for" $ do
       it "InvalidEnumVariant error" $ do
-        let ctx1 = ctx 1 1
+        let ctx1 = ctx (1, 1) (1, 10)
         let err = mkEvaluationError ctx1 $ InvalidEnumVariant "Animal" ["Cow", "Dog"] "Car"
         getErrorMessageAndCtx err
           `shouldBe` ( "Expected value of enum type 'Animal' but got value 'Car'"
@@ -18,10 +18,10 @@ spec_EvaluationError = do
                        ctx1
                      )
       it "ExpectedType error" $ do
-        let ctx1 = ctx 1 4
+        let ctx1 = ctx (1, 4) (2, 5)
         let err = mkEvaluationError ctx1 $ ExpectedType NumberType StringType
         getErrorMessageAndCtx err `shouldBe` ("Expected type: number\nActual type:   string", ctx1)
       it "ExpectedTupleType error" $ do
-        let ctx1 = ctx 1 4
+        let ctx1 = ctx (1, 4) (2, 5)
         let err = mkEvaluationError ctx1 $ ExpectedTupleType 3 StringType
         getErrorMessageAndCtx err `shouldBe` ("Expected a tuple of size 3.\nActual type: string", ctx1)

--- a/waspc/test/Analyzer/Parser/ParseErrorTest.hs
+++ b/waspc/test/Analyzer/Parser/ParseErrorTest.hs
@@ -1,6 +1,6 @@
 module Analyzer.Parser.ParseErrorTest where
 
-import Analyzer.TestUtil (ctx, pos)
+import Analyzer.TestUtil (ctx, pos, wctx)
 import Test.Tasty.Hspec
 import Wasp.Analyzer.Parser.ParseError
 import Wasp.Analyzer.Parser.Token
@@ -18,21 +18,21 @@ spec_ParseErrorTest = do
               ["<identifier>", ","]
           quoterDifferentTagsError =
             QuoterDifferentTags
-              ("foo", pos 1 5)
-              ("bar", pos 1 20)
+              (wctx (1, 5) (1, 7) "foo")
+              (wctx (1, 20) (1, 22) "bar")
 
       it "for UnexpectedChar error" $ do
-        getErrorMessageAndCtx unexpectedCharError `shouldBe` ("Unexpected character: !", ctx 2 42)
+        getErrorMessageAndCtx unexpectedCharError `shouldBe` ("Unexpected character: !", ctx (2, 42) (2, 42))
 
       it "for UnexpectedToken error" $ do
         getErrorMessageAndCtx unexpectedTokenErrorNoSuggestions
-          `shouldBe` ("Unexpected token: {", ctx 2 3)
+          `shouldBe` ("Unexpected token: {", ctx (2, 3) (2, 3))
         getErrorMessageAndCtx unexpectedTokenErrorWithSuggestions
           `shouldBe` ( "Unexpected token: }\n"
                          ++ "Expected one of the following tokens instead: <identifier> ,",
-                       ctx 100 18
+                       ctx (100, 18) (100, 18)
                      )
 
       it "for QuoterDifferentTags error" $ do
         getErrorMessageAndCtx quoterDifferentTagsError
-          `shouldBe` ("Quoter tags don't match: {=foo ... bar=}", ctx 1 20)
+          `shouldBe` ("Quoter tags don't match: {=foo ... bar=}", ctx (1, 5) (1, 22))

--- a/waspc/test/Analyzer/Parser/SourcePositionTest.hs
+++ b/waspc/test/Analyzer/Parser/SourcePositionTest.hs
@@ -1,0 +1,18 @@
+module Analyzer.Parser.SourcePositionTest where
+
+import Test.Tasty.Hspec
+import Wasp.Analyzer.Parser.SourcePosition
+
+spec_SourcePositionTest :: Spec
+spec_SourcePositionTest = do
+  describe "Analyzer.Parser.SourcePosition" $ do
+    describe "calcNextPosition works correctly" $ do
+      it "when source is empty" $ do
+        calcNextPosition "" (SourcePosition 1 5) `shouldBe` SourcePosition 1 5
+      it "when source has no newlines" $ do
+        calcNextPosition "foo + bar" (SourcePosition 1 5) `shouldBe` SourcePosition 1 14
+        calcNextPosition "app App { }" (SourcePosition 3 1) `shouldBe` SourcePosition 3 12
+      it "when source has newlines" $ do
+        calcNextPosition "foo\nbar\nbuzz" (SourcePosition 3 4) `shouldBe` SourcePosition 5 5
+        calcNextPosition "app App {\n  test: Hi\n}" (SourcePosition 2 1) `shouldBe` SourcePosition 4 2
+        calcNextPosition "foo\nbar\n" (SourcePosition 2 1) `shouldBe` SourcePosition 4 1

--- a/waspc/test/Analyzer/Parser/TokenTest.hs
+++ b/waspc/test/Analyzer/Parser/TokenTest.hs
@@ -1,0 +1,14 @@
+module Analyzer.Parser.TokenTest where
+
+import Test.Tasty.Hspec
+import Wasp.Analyzer.Parser.SourcePosition
+import Wasp.Analyzer.Parser.Token
+
+spec_TokenTest :: Spec
+spec_TokenTest = do
+  describe "Analyzer.Parser.Token" $ do
+    it "calcTokenEndPos works correctly" $ do
+      calcTokenEndPos (Token (TIdentifier "foo") (SourcePosition 2 3) "foo") `shouldBe` SourcePosition 2 5
+      calcTokenEndPos (Token (TString "foo") (SourcePosition 5 10) "\"foo\"") `shouldBe` SourcePosition 5 14
+      calcTokenEndPos (Token TLSquare (SourcePosition 2 3) "[") `shouldBe` SourcePosition 2 3
+      calcTokenEndPos (Token TEOF (SourcePosition 2 3) "") `shouldBe` SourcePosition 2 3

--- a/waspc/test/Analyzer/ParserTest.hs
+++ b/waspc/test/Analyzer/ParserTest.hs
@@ -24,21 +24,21 @@ spec_Parser = do
               ]
       let ast =
             AST
-              [ wctx 1 1 $
+              [ wctx (1, 1) (10, 1) $
                   Decl "test" "Decl" $
-                    wctx 1 11 $
+                    wctx (1, 11) (10, 1) $
                       Dict
-                        [ ("string", wctx 2 11 $ StringLiteral "Hello Wasp =}"),
-                          ("escapedString", wctx 3 18 $ StringLiteral "Look, a \""),
-                          ("integer", wctx 4 12 $ IntegerLiteral 42),
-                          ("real", wctx 5 9 $ DoubleLiteral 3.14),
-                          ("yes", wctx 6 8 $ BoolLiteral True),
-                          ("no", wctx 7 7 $ BoolLiteral False),
-                          ("ident", wctx 8 10 $ Var "Wasp"),
+                        [ ("string", wctx (2, 11) (2, 25) $ StringLiteral "Hello Wasp =}"),
+                          ("escapedString", wctx (3, 18) (3, 29) $ StringLiteral "Look, a \""),
+                          ("integer", wctx (4, 12) (4, 13) $ IntegerLiteral 42),
+                          ("real", wctx (5, 9) (5, 12) $ DoubleLiteral 3.14),
+                          ("yes", wctx (6, 8) (6, 11) $ BoolLiteral True),
+                          ("no", wctx (7, 7) (7, 11) $ BoolLiteral False),
+                          ("ident", wctx (8, 10) (8, 13) $ Var "Wasp"),
                           ( "innerDict",
-                            wctx 9 14 $
+                            wctx (9, 14) (9, 36) $
                               Dict
-                                [ ("innerDictReal", wctx 9 31 $ DoubleLiteral 2.17)
+                                [ ("innerDictReal", wctx (9, 31) (9, 34) $ DoubleLiteral 2.17)
                                 ]
                           )
                         ]
@@ -55,32 +55,36 @@ spec_Parser = do
               ]
       let ast =
             AST
-              [ wctx 1 1 $
+              [ wctx (1, 1) (4, 1) $
                   Decl "test" "Imports" $
-                    wctx 1 14 $
+                    wctx (1, 14) (4, 1) $
                       Dict
-                        [ ("module", wctx 2 11 $ ExtImport (ExtImportModule "Page") "page.jsx"),
-                          ("field", wctx 3 10 $ ExtImport (ExtImportField "Page") "page.jsx")
+                        [ ("module", wctx (2, 11) (2, 37) $ ExtImport (ExtImportModule "Page") "page.jsx"),
+                          ("field", wctx (3, 10) (3, 40) $ ExtImport (ExtImportField "Page") "page.jsx")
                         ]
               ]
       parse source `shouldBe` Right ast
 
     it "Parses unary lists" $ do
       let source = "test Decl [ 1 ]"
-      let ast = AST [wctx 1 1 $ Decl "test" "Decl" $ wctx 1 11 $ List [wctx 1 13 $ IntegerLiteral 1]]
+      let ast =
+            AST
+              [ wctx (1, 1) (1, 15) $
+                  Decl "test" "Decl" $ wctx (1, 11) (1, 15) $ List [wctx (1, 13) (1, 13) $ IntegerLiteral 1]
+              ]
       parse source `shouldBe` Right ast
 
     it "Parses lists of multiple elements" $ do
       let source = "test Decl [ 1, 2, 3 ]"
       let ast =
             AST
-              [ wctx 1 1 $
+              [ wctx (1, 1) (1, 21) $
                   Decl "test" "Decl" $
-                    wctx 1 11 $
+                    wctx (1, 11) (1, 21) $
                       List
-                        [ wctx 1 13 $ IntegerLiteral 1,
-                          wctx 1 16 $ IntegerLiteral 2,
-                          wctx 1 19 $ IntegerLiteral 3
+                        [ wctx (1, 13) (1, 13) $ IntegerLiteral 1,
+                          wctx (1, 16) (1, 16) $ IntegerLiteral 2,
+                          wctx (1, 19) (1, 19) $ IntegerLiteral 3
                         ]
               ]
       parse source `shouldBe` Right ast
@@ -89,12 +93,12 @@ spec_Parser = do
       let source = "test Decl { dict: {}, list: [] }"
       let ast =
             AST
-              [ wctx 1 1 $
+              [ wctx (1, 1) (1, 32) $
                   Decl "test" "Decl" $
-                    wctx 1 11 $
+                    wctx (1, 11) (1, 32) $
                       Dict
-                        [ ("dict", wctx 1 19 $ Dict []),
-                          ("list", wctx 1 29 $ List [])
+                        [ ("dict", wctx (1, 19) (1, 20) $ Dict []),
+                          ("list", wctx (1, 29) (1, 30) $ List [])
                         ]
               ]
       parse source `shouldBe` Right ast
@@ -108,11 +112,11 @@ spec_Parser = do
               ]
       let ast =
             AST
-              [ wctx 1 1 $
+              [ wctx (1, 1) (3, 1) $
                   Decl "test" "Decl" $
-                    wctx 1 11 $
+                    wctx (1, 11) (3, 1) $
                       Dict
-                        [("list", wctx 2 9 $ List [wctx 2 11 $ IntegerLiteral 1])]
+                        [("list", wctx (2, 9) (2, 14) $ List [wctx (2, 11) (2, 11) $ IntegerLiteral 1])]
               ]
       parse source `shouldBe` Right ast
 
@@ -126,38 +130,38 @@ spec_Parser = do
               ]
       let ast =
             AST
-              [ wctx 1 1 $
+              [ wctx (1, 1) (1, 20) $
                   Decl "test" "Pair" $
-                    wctx 1 11 $
+                    wctx (1, 11) (1, 20) $
                       Tuple
-                        ( wctx 1 12 $ IntegerLiteral 1,
-                          wctx 1 15 $ StringLiteral "foo",
+                        ( wctx (1, 12) (1, 12) $ IntegerLiteral 1,
+                          wctx (1, 15) (1, 19) $ StringLiteral "foo",
                           []
                         ),
-                wctx 2 1 $
+                wctx (2, 1) (2, 25) $
                   Decl "test" "Triple" $
-                    wctx 2 13 $
+                    wctx (2, 13) (2, 25) $
                       Tuple
-                        ( wctx 2 14 $ IntegerLiteral 1,
-                          wctx 2 17 $ StringLiteral "foo",
-                          [wctx 2 24 $ IntegerLiteral 2]
+                        ( wctx (2, 14) (2, 14) $ IntegerLiteral 1,
+                          wctx (2, 17) (2, 21) $ StringLiteral "foo",
+                          [wctx (2, 24) (2, 24) $ IntegerLiteral 2]
                         ),
-                wctx 3 1 $
+                wctx (3, 1) (3, 34) $
                   Decl "test" "Quadruple" $
-                    wctx 3 16 $
+                    wctx (3, 16) (3, 34) $
                       Tuple
-                        ( wctx 3 17 $ IntegerLiteral 1,
-                          wctx 3 20 $ StringLiteral "foo",
-                          [ wctx 3 27 $ IntegerLiteral 2,
-                            wctx 3 30 $ BoolLiteral True
+                        ( wctx (3, 17) (3, 17) $ IntegerLiteral 1,
+                          wctx (3, 20) (3, 24) $ StringLiteral "foo",
+                          [ wctx (3, 27) (3, 27) $ IntegerLiteral 2,
+                            wctx (3, 30) (3, 33) $ BoolLiteral True
                           ]
                         ),
-                wctx 4 1 $
+                wctx (4, 1) (4, 29) $
                   Decl "test" "TrailingComma" $
-                    wctx 4 20 $
+                    wctx (4, 20) (4, 29) $
                       Tuple
-                        ( wctx 4 21 $ IntegerLiteral 42,
-                          wctx 4 25 $ IntegerLiteral 314,
+                        ( wctx (4, 21) (4, 22) $ IntegerLiteral 42,
+                          wctx (4, 25) (4, 27) $ IntegerLiteral 314,
                           []
                         )
               ]
@@ -172,9 +176,9 @@ spec_Parser = do
               ]
       let ast =
             AST
-              [ wctx 1 1 $
+              [ wctx (1, 1) (3, 5) $
                   Decl "test" "PSL" $
-                    wctx 1 10 $
+                    wctx (1, 10) (3, 5) $
                       Quoter "psl" "\n  id Int @id\n"
               ]
       parse source `shouldBe` Right ast
@@ -188,9 +192,9 @@ spec_Parser = do
               ]
       let ast =
             AST
-              [ wctx 1 1 $
+              [ wctx (1, 1) (3, 6) $
                   Decl "test" "JSON" $
-                    wctx 1 11 $ Quoter "json" "\n  \"key\": \"value\"\n"
+                    wctx (1, 11) (3, 6) $ Quoter "json" "\n  \"key\": \"value\"\n"
               ]
       parse source `shouldBe` Right ast
 
@@ -206,8 +210,8 @@ spec_Parser = do
               ]
       let ast =
             AST
-              [ wctx 1 1 $ Decl "test" "JSON" $ wctx 1 11 $ Quoter "json" "\n  \"key\": \"value\"\n",
-                wctx 4 1 $ Decl "test" "JSON2" $ wctx 4 12 $ Quoter "json" "\n  \"key\": \"value\"\n"
+              [ wctx (1, 1) (3, 6) $ Decl "test" "JSON" $ wctx (1, 11) (3, 6) $ Quoter "json" "\n  \"key\": \"value\"\n",
+                wctx (4, 1) (6, 6) $ Decl "test" "JSON2" $ wctx (4, 12) (6, 6) $ Quoter "json" "\n  \"key\": \"value\"\n"
               ]
       parse source `shouldBe` Right ast
 
@@ -219,13 +223,13 @@ spec_Parser = do
       parse "test Case1 {=foo {=foo foo=} foo=}" `shouldSatisfy` isLeft
       parse "test Case2 {=foo foo=} foo=}" `shouldSatisfy` isLeft
       parse "test Case3 {=foo {=foo foo=}"
-        `shouldBe` Right (AST [wctx 1 1 $ Decl "test" "Case3" $ wctx 1 12 $ Quoter "foo" " {=foo "])
+        `shouldBe` Right (AST [wctx (1, 1) (1, 28) $ Decl "test" "Case3" $ wctx (1, 12) (1, 28) $ Quoter "foo" " {=foo "])
       parse "test Case4 {=foo {=bar foo=}"
-        `shouldBe` Right (AST [wctx 1 1 $ Decl "test" "Case4" $ wctx 1 12 $ Quoter "foo" " {=bar "])
+        `shouldBe` Right (AST [wctx (1, 1) (1, 28) $ Decl "test" "Case4" $ wctx (1, 12) (1, 28) $ Quoter "foo" " {=bar "])
       parse "test Case5 {=foo bar=} foo=}"
-        `shouldBe` Right (AST [wctx 1 1 $ Decl "test" "Case5" $ wctx 1 12 $ Quoter "foo" " bar=} "])
+        `shouldBe` Right (AST [wctx (1, 1) (1, 28) $ Decl "test" "Case5" $ wctx (1, 12) (1, 28) $ Quoter "foo" " bar=} "])
       parse "test Case6 {=foo {=bar bar=} foo=}"
-        `shouldBe` Right (AST [wctx 1 1 $ Decl "test" "Case6" $ wctx 1 12 $ Quoter "foo" " {=bar bar=} "])
+        `shouldBe` Right (AST [wctx (1, 1) (1, 34) $ Decl "test" "Case6" $ wctx (1, 12) (1, 34) $ Quoter "foo" " {=bar bar=} "])
 
     it "Requires dictionaries to have an ending bracket" $ do
       let source = "test Decl {"
@@ -234,7 +238,7 @@ spec_Parser = do
               UnexpectedToken
                 ( Token
                     { tokenType = TEOF,
-                      tokenPosition = SourcePosition 1 12,
+                      tokenStartPosition = SourcePosition 1 12,
                       tokenLexeme = ""
                     }
                 )
@@ -249,8 +253,8 @@ spec_Parser = do
               ]
       let ast =
             AST
-              [ wctx 1 1 $ Decl "constant" "Pi" $ wctx 1 13 $ DoubleLiteral 3.14159,
-                wctx 2 1 $ Decl "constant" "E" $ wctx 2 13 $ DoubleLiteral 2.71828
+              [ wctx (1, 1) (1, 19) $ Decl "constant" "Pi" $ wctx (1, 13) (1, 19) $ DoubleLiteral 3.14159,
+                wctx (2, 1) (2, 19) $ Decl "constant" "E" $ wctx (2, 13) (2, 19) $ DoubleLiteral 2.71828
               ]
       parse source `shouldBe` Right ast
 
@@ -273,7 +277,7 @@ spec_Parser = do
                 UnexpectedToken
                   ( Token
                       { tokenType = TString "Declaration",
-                        tokenPosition = SourcePosition 1 6,
+                        tokenStartPosition = SourcePosition 1 6,
                         tokenLexeme = "\"Declaration\""
                       }
                   )
@@ -293,7 +297,7 @@ spec_Parser = do
                 UnexpectedToken
                   ( Token
                       { tokenType = TIdentifier "b",
-                        tokenPosition = SourcePosition 3 3,
+                        tokenStartPosition = SourcePosition 3 3,
                         tokenLexeme = "b"
                       }
                   )

--- a/waspc/test/Analyzer/TestUtil.hs
+++ b/waspc/test/Analyzer/TestUtil.hs
@@ -6,11 +6,11 @@ import qualified Wasp.Analyzer.TypeChecker as T
 pos :: Int -> Int -> P.SourcePosition
 pos line column = P.SourcePosition line column
 
-ctx :: Int -> Int -> P.Ctx
-ctx line column = P.ctxFromPos $ P.SourcePosition line column
+ctx :: (Int, Int) -> (Int, Int) -> P.Ctx
+ctx (a, b) (c, d) = P.ctxFromRgn (pos a b) (pos c d)
 
-wctx :: Int -> Int -> a -> P.WithCtx a
-wctx line column = P.WithCtx (ctx line column)
+wctx :: (Int, Int) -> (Int, Int) -> a -> P.WithCtx a
+wctx start end = P.WithCtx (ctx start end)
 
 fromWithCtx :: P.WithCtx T.TypedExpr -> T.TypedExpr
 fromWithCtx = P.fromWithCtx

--- a/waspc/test/AnalyzerTest.hs
+++ b/waspc/test/AnalyzerTest.hs
@@ -176,7 +176,7 @@ spec_Analyzer = do
               [ "route HomeRoute { path: \"/\", page: NonExistentPage }"
               ]
       takeDecls @Route <$> analyze source
-        `shouldBe` Left (TypeError $ TC.mkTypeError (ctx 1 36) $ TC.UndefinedIdentifier "NonExistentPage")
+        `shouldBe` Left (TypeError $ TC.mkTypeError (ctx (1, 36) (1, 50)) $ TC.UndefinedIdentifier "NonExistentPage")
 
     it "Returns a type error if referenced declaration is of wrong type" $ do
       let source =
@@ -184,7 +184,7 @@ spec_Analyzer = do
               [ "route HomeRoute { path: \"/\",  page: HomeRoute }"
               ]
       analyze source
-        `errorMessageShouldBe` ( ctx 1 37,
+        `errorMessageShouldBe` ( ctx (1, 37) (1, 45),
                                  intercalate
                                    "\n"
                                    [ "Type error:",
@@ -215,7 +215,7 @@ spec_Analyzer = do
                   "}"
                 ]
         analyze source
-          `errorMessageShouldBe` ( ctx 4 29,
+          `errorMessageShouldBe` ( ctx (4, 29) (4, 30),
                                    intercalate
                                      "\n"
                                      [ "Type error:",
@@ -239,7 +239,7 @@ spec_Analyzer = do
                   "}"
                 ]
         analyze source
-          `errorMessageShouldBe` ( ctx 5 29,
+          `errorMessageShouldBe` ( ctx (5, 29) (5, 35),
                                    intercalate
                                      "\n"
                                      [ "Type error:",
@@ -258,7 +258,7 @@ spec_Analyzer = do
                   "}"
                 ]
         analyze source
-          `errorMessageShouldBe` ( ctx 1 11,
+          `errorMessageShouldBe` ( ctx (1, 11) (3, 1),
                                    intercalate
                                      "\n"
                                      [ "Type error:",


### PR DESCRIPTION
Now we have region in source (instead of just single position) for each part of AST and errors!