### PR TITLE
Make CLI operation results more clear in output

### DIFF
--- a/waspc/cli/Wasp/Cli/Command.hs
+++ b/waspc/cli/Wasp/Cli/Command.hs
@@ -9,6 +9,7 @@ where
 
 import Control.Monad.Except (ExceptT, MonadError, runExceptT)
 import Control.Monad.IO.Class (MonadIO)
+import qualified Wasp.Util.Terminal as Term
 
 newtype Command a = Command {_runCommand :: ExceptT CommandError IO a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadError CommandError)
@@ -17,7 +18,7 @@ runCommand :: Command a -> IO ()
 runCommand cmd = do
   errorOrResult <- runExceptT $ _runCommand cmd
   case errorOrResult of
-    Left cmdError -> putStrLn $ "Error: " ++ _errorMsg cmdError
+    Left cmdError -> putStrLn $ Term.applyStyles [Term.Red] (_errorMsg cmdError)
     Right _ -> return ()
 
 -- TODO: What if we want to recognize errors in order to handle them?

--- a/waspc/cli/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/Wasp/Cli/Command/Build.hs
@@ -16,9 +16,11 @@ import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( alphaWarningMessage,
     findWaspProjectRootDirFromCwd,
+    waspSaysC,
   )
 import Wasp.Cli.Command.Compile (compileIOWithOptions)
 import qualified Wasp.Cli.Common as Common
+import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
 
@@ -31,18 +33,17 @@ build = do
       buildDirFilePath = SP.fromAbsDir buildDir
 
   doesBuildDirExist <- liftIO $ doesDirectoryExist buildDirFilePath
-  when doesBuildDirExist $
-    liftIO $ do
-      putStrLn "Clearing the content of the .wasp/build directory..."
-      removeDirectoryRecursive buildDirFilePath
-      putStrLn "Successfully cleared the contents of the .wasp/build directory.\n"
+  when doesBuildDirExist $ do
+    waspSaysC $ asWaspStartMessage "Clearing the content of the .wasp/build directory..."
+    liftIO $ removeDirectoryRecursive buildDirFilePath
+    waspSaysC $ asWaspSuccessMessage "Successfully cleared the contents of the .wasp/build directory."
 
-  liftIO $ putStrLn "Building wasp project..."
+  waspSaysC $ asWaspStartMessage "Building wasp project..."
   buildResult <- liftIO $ buildIO waspProjectDir buildDir
   case buildResult of
-    Left compileError -> throwError $ CommandError $ "Build failed: " ++ compileError
-    Right () -> liftIO $ putStrLn "Code has been successfully built! Check it out in .wasp/build directory.\n"
-  liftIO $ putStrLn alphaWarningMessage
+    Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Build failed:" ++ compileError
+    Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully built! Check it out in .wasp/build directory."
+  waspSaysC alphaWarningMessage
 
 buildIO ::
   Path' Abs (Dir Common.WaspProjectDir) ->

--- a/waspc/cli/Wasp/Cli/Command/Clean.hs
+++ b/waspc/cli/Wasp/Cli/Command/Clean.hs
@@ -9,19 +9,19 @@ import System.Directory
   ( doesDirectoryExist,
     removeDirectoryRecursive,
   )
-import System.IO (hFlush, stdout)
 import Wasp.Cli.Command (Command)
-import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd)
+import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd, waspSaysC)
 import qualified Wasp.Cli.Common as Common
+import Wasp.Cli.Terminal (asWaspStartMessage, asWaspSuccessMessage)
 
 clean :: Command ()
 clean = do
   waspProjectDir <- findWaspProjectRootDirFromCwd
   let dotWaspDirFp = SP.toFilePath $ waspProjectDir SP.</> Common.dotWaspDirInWaspProjectDir
-  liftIO $ putStrLn "Deleting .wasp/ directory..." >> hFlush stdout
+  waspSaysC $ asWaspStartMessage "Deleting .wasp/ directory..."
   doesDotWaspDirExist <- liftIO $ doesDirectoryExist dotWaspDirFp
   if doesDotWaspDirExist
-    then liftIO $ do
-      removeDirectoryRecursive dotWaspDirFp
-      putStrLn "Deleted .wasp/ directory."
-    else liftIO $ putStrLn "Nothing to delete: .wasp directory does not exist."
+    then do
+      liftIO $ removeDirectoryRecursive dotWaspDirFp
+      waspSaysC $ asWaspSuccessMessage "Deleted .wasp/ directory."
+    else waspSaysC "Nothing to delete: .wasp directory does not exist."

--- a/waspc/cli/Wasp/Cli/Command/Common.hs
+++ b/waspc/cli/Wasp/Cli/Command/Common.hs
@@ -23,6 +23,7 @@ import Wasp.Cli.Common
   ( dotWaspRootFileInWaspProjectDir,
     waspSays,
   )
+import Wasp.Cli.Terminal (asWaspFailureMessage)
 import Wasp.Common (WaspProjectDir)
 
 findWaspProjectRoot :: Path' Abs (Dir ()) -> Command (Path' Abs (Dir WaspProjectDir))
@@ -40,10 +41,11 @@ findWaspProjectRoot currentDir = do
       findWaspProjectRoot parentDir
   where
     notFoundError =
-      CommandError
-        ( "Couldn't find wasp project root - make sure"
-            ++ " you are running this command from Wasp project."
-        )
+      CommandError $
+        asWaspFailureMessage "Wasp command failed:"
+          ++ ( "Couldn't find wasp project root - make sure"
+                 ++ " you are running this command from a Wasp project."
+             )
 
 findWaspProjectRootDirFromCwd :: Command (Path' Abs (Dir WaspProjectDir))
 findWaspProjectRootDirFromCwd = do

--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -18,6 +18,7 @@ import Wasp.Cli.Command.Db.Migrate
     copyDbMigrationsDir,
   )
 import qualified Wasp.Cli.Common as Common
+import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import Wasp.Common (WaspProjectDir)
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
@@ -29,11 +30,11 @@ compile = do
         waspProjectDir </> Common.dotWaspDirInWaspProjectDir
           </> Common.generatedCodeDirInDotWaspDir
 
-  waspSaysC "Compiling wasp code..."
+  waspSaysC $ asWaspStartMessage "Compiling wasp code..."
   compilationResult <- liftIO $ compileIO waspProjectDir outDir
   case compilationResult of
-    Left compileError -> throwError $ CommandError $ "Compilation failed: " ++ compileError
-    Right () -> waspSaysC "Code has been successfully compiled, project has been generated.\n"
+    Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Compilation failed:" ++ compileError
+    Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully compiled, project has been generated."
 
 -- | Compiles Wasp source code in waspProjectDir directory and generates a project
 --   in given outDir directory.

--- a/waspc/cli/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/Wasp/Cli/Command/CreateNewProject.hs
@@ -19,6 +19,7 @@ import Wasp.AppSpec.ExternalCode (SourceExternalCodeDir)
 import Wasp.Cli.Command (Command, CommandError (..))
 import qualified Wasp.Cli.Command.Common as Command.Common
 import qualified Wasp.Cli.Common as Common
+import Wasp.Cli.Terminal (asWaspFailureMessage)
 import qualified Wasp.Data
 import Wasp.Lexer (reservedNames)
 import qualified Wasp.Util.Terminal as Term
@@ -27,9 +28,9 @@ newtype ProjectName = ProjectName {_projectName :: String}
 
 createNewProject :: String -> Command ()
 createNewProject (all isLetter -> False) =
-  throwError $ CommandError "Please use only letters for a new project's name."
+  throwError $ CommandError $ asWaspFailureMessage "Project creation failed:" ++ "Please use only letters for a new project's name."
 createNewProject ((`elem` reservedNames) -> True) =
-  throwError . CommandError $ "Please pick a project name not one of these reserved words:\n\t" ++ intercalate "\n\t" reservedNames
+  throwError . CommandError $ asWaspFailureMessage "Project creation failed:" ++ "Please pick a project name not one of these reserved words:\n\t" ++ intercalate "\n\t" reservedNames
 createNewProject name = createNewProject' (ProjectName name)
 
 createNewProject' :: ProjectName -> Command ()
@@ -38,10 +39,11 @@ createNewProject' (ProjectName projectName) = do
   waspProjectDir <- case SP.parseAbsDir $ absCwd FP.</> projectName of
     Left err ->
       throwError $
-        CommandError
-          ( "Failed to parse absolute path to wasp project dir: "
-              ++ show err
-          )
+        CommandError $
+          asWaspFailureMessage "Project creation failed:"
+            ++ ( "Failed to parse absolute path to wasp project dir: "
+                   ++ show err
+               )
     Right sp -> return sp
   liftIO $ do
     createDirectorySP waspProjectDir

--- a/waspc/cli/Wasp/Cli/Command/Telemetry.hs
+++ b/waspc/cli/Wasp/Cli/Command/Telemetry.hs
@@ -17,6 +17,7 @@ import Wasp.Cli.Command.Common (waspSaysC)
 import Wasp.Cli.Command.Telemetry.Common (ensureTelemetryCacheDirExists)
 import qualified Wasp.Cli.Command.Telemetry.Project as TlmProject
 import qualified Wasp.Cli.Command.Telemetry.User as TlmUser
+import Wasp.Cli.Terminal (asWaspFailureMessage)
 
 isTelemetryDisabled :: IO Bool
 isTelemetryDisabled = isJust <$> ENV.lookupEnv "WASP_TELEMETRY_DISABLE"
@@ -53,7 +54,7 @@ telemetry = do
 considerSendingData :: Command.Call.Call -> Command ()
 considerSendingData cmdCall = (`catchError` const (return ())) $ do
   telemetryDisabled <- liftIO isTelemetryDisabled
-  when telemetryDisabled $ throwError $ CommandError "Telemetry disabled by user."
+  when telemetryDisabled $ throwError $ CommandError $ asWaspFailureMessage "Telemetry disabled by user."
 
   telemetryCacheDirPath <- liftIO ensureTelemetryCacheDirExists
 

--- a/waspc/cli/Wasp/Cli/Command/Watch.hs
+++ b/waspc/cli/Wasp/Cli/Command/Watch.hs
@@ -16,6 +16,7 @@ import qualified System.FilePath as FP
 import Wasp.Cli.Command.Compile (compileIO)
 import Wasp.Cli.Common (waspSays)
 import qualified Wasp.Cli.Common as Common
+import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import qualified Wasp.Lib
 
 -- TODO: Another possible problem: on re-generation, wasp re-generates a lot of files, even those that should not
@@ -78,11 +79,11 @@ watch waspProjectDir outDir = FSN.withManager $ \mgr -> do
 
     recompile :: IO ()
     recompile = do
-      waspSays "Recompiling on file change..."
+      waspSays $ asWaspStartMessage "Recompiling on file change..."
       compilationResult <- compileIO waspProjectDir outDir
       case compilationResult of
-        Left err -> waspSays $ "Recompilation on file change failed: " ++ err
-        Right () -> waspSays "Recompilation on file change succeeded."
+        Left err -> waspSays $ asWaspFailureMessage "Recompilation on file change failed:" ++ err
+        Right () -> waspSays $ asWaspSuccessMessage "Recompilation on file change succeeded."
       return ()
 
     -- TODO: This is a hardcoded approach to ignoring most of the common tmp files that editors

--- a/waspc/cli/Wasp/Cli/Terminal.hs
+++ b/waspc/cli/Wasp/Cli/Terminal.hs
@@ -1,5 +1,9 @@
 module Wasp.Cli.Terminal
   ( title,
+    asWaspMessage,
+    asWaspStartMessage,
+    asWaspSuccessMessage,
+    asWaspFailureMessage,
   )
 where
 
@@ -7,3 +11,30 @@ import qualified Wasp.Util.Terminal as Term
 
 title :: String -> String
 title = Term.applyStyles [Term.Bold]
+
+asWaspMessage :: String -> String
+asWaspMessage = waspMessageWithEmoji ""
+
+asWaspStartMessage :: String -> String
+asWaspStartMessage = waspMessageWithEmoji "🐝"
+
+asWaspSuccessMessage :: String -> String
+asWaspSuccessMessage = waspMessageWithEmoji "✅"
+
+asWaspFailureMessage :: String -> String
+-- Add a bit more padding on errors for more pronounced
+-- visibility and better display of any following error context.
+asWaspFailureMessage str = concat ["\n", waspMessageWithEmoji "❌" errorStr, "\n"]
+  where
+    errorStr = "[Error] " ++ str
+
+waspMessageWithEmoji :: String -> String -> String
+waspMessageWithEmoji emoji message = concat ["\n", prefix, " ", message, " ", suffix, "\n"]
+  where
+    prefix = emoji ++ " ---"
+    prefixAndMessageLength = length prefix + length message
+    idealLength = 80
+    -- Pad suffix until returned message is the ideal length. However, if we have to go
+    -- beyond ideal length due to input length, just use 3 at the end to match the prefix.
+    rightPadLength = max 3 (idealLength - prefixAndMessageLength)
+    suffix = concat (replicate rightPadLength "-")


### PR DESCRIPTION
# Description

This change attempts to make it more clear when Wasp operations succeed or fail by adding emojis, colors, and dashes. This helps differentiate it against other output from Client/Server/DB.

Normal Wasp CLI output is a yellow color. When we attempt to start an operation, the emoji is 🐝 . When we succeed, it is ✅. When we fail, it is ❌ and the font should be colored red.

_Note, this focuses on the CLI level only and does not help propagate errors from Wasp app generation code. That should also be done and is captured in this existing issue: https://github.com/wasp-lang/wasp/issues/123_ 

`wasp start` example:

![Screen Shot 2022-01-03 at 12 56 03 PM](https://user-images.githubusercontent.com/523636/147963383-1664249a-dce6-4a06-b1d5-e50e810a470c.png)

Closes #212

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update