### PR TITLE
Make Generator responsible for copying migrations dir from source to generated project

### DIFF
--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -13,10 +13,6 @@ import Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
     waspSaysC,
   )
-import Wasp.Cli.Command.Db.Migrate
-  ( MigrationDirCopyDirection (..),
-    copyDbMigrationsDir,
-  )
 import qualified Wasp.Cli.Common as Common
 import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import Wasp.Common (WaspProjectDir)
@@ -59,5 +55,3 @@ compileIOWithOptions options waspProjectDir outDir = runExceptT $ do
   -- TODO: Use throwIO instead of Either to return exceptions?
   liftIO (Wasp.Lib.compile waspProjectDir outDir options)
     >>= either throwError return
-  liftIO (copyDbMigrationsDir CopyMigDirDown waspProjectDir outDir)
-    >>= maybe (return ()) (throwError . ("Copying migration folder failed: " ++))

--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -78,6 +78,7 @@ library:
     - mtl
     - strong-path
     - template-haskell
+    - path-io
 
 executables:
   wasp-cli:

--- a/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
@@ -1,14 +1,22 @@
 module Wasp.Generator.DbGenerator.Operations
-  ( migrateDev,
+  ( migrateDevAndCopyToSource,
   )
 where
 
 import Control.Concurrent (Chan, newChan, readChan)
 import Control.Concurrent.Async (concurrently)
+import Control.Monad.Catch (catch)
+import qualified Path as P
 import StrongPath (Abs, Dir, Path')
+import qualified StrongPath as SP
 import System.Exit (ExitCode (..))
+import Wasp.Common (DbMigrationsDir)
 import Wasp.Generator.Common (ProjectRootDir)
+import Wasp.Generator.DbGenerator (dbMigrationsDirInDbRootDir, dbRootDirInProjectRootDir)
 import qualified Wasp.Generator.DbGenerator.Jobs as DbJobs
+import Wasp.Generator.FileDraft.WriteableMonad
+  ( WriteableMonad (copyDirectoryRecursive),
+  )
 import Wasp.Generator.Job (JobMessage)
 import qualified Wasp.Generator.Job as J
 import Wasp.Generator.Job.IO (printJobMessage)
@@ -20,13 +28,26 @@ printJobMsgsUntilExitReceived chan = do
     J.JobOutput {} -> printJobMessage jobMsg >> printJobMsgsUntilExitReceived chan
     J.JobExit {} -> return ()
 
-migrateDev :: Path' Abs (Dir ProjectRootDir) -> IO (Either String ())
-migrateDev projectDir = do
+-- | Migrates in the generated project context and then copies the migrations dir back
+-- up to the wasp project dir to ensure they remain in sync.
+migrateDevAndCopyToSource :: Path' Abs (Dir DbMigrationsDir) -> Path' Abs (Dir ProjectRootDir) -> IO (Either String ())
+migrateDevAndCopyToSource dbMigrationsDirInWaspProjectDirAbs genProjectRootDirAbs = do
   chan <- newChan
   (_, dbExitCode) <-
     concurrently
       (printJobMsgsUntilExitReceived chan)
-      (DbJobs.migrateDev projectDir chan)
+      (DbJobs.migrateDev genProjectRootDirAbs chan)
   case dbExitCode of
-    ExitSuccess -> return (Right ())
+    ExitSuccess -> copyMigrationsBackToSource genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs
     ExitFailure code -> return $ Left $ "Migrate (dev) failed with exit code: " ++ show code
+
+-- | Copies the DB migrations from the generated project dir back up to theh wasp project dir
+copyMigrationsBackToSource :: Path' Abs (Dir ProjectRootDir) -> Path' Abs (Dir DbMigrationsDir) -> IO (Either String ())
+copyMigrationsBackToSource genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs =
+  do
+    copyDirectoryRecursive genProjectMigrationsDir waspMigrationsDir >> return (Right ())
+      `catch` (\e -> return $ Left $ show (e :: P.PathException))
+      `catch` (\e -> return $ Left $ show (e :: IOError))
+  where
+    waspMigrationsDir = SP.castDir dbMigrationsDirInWaspProjectDirAbs
+    genProjectMigrationsDir = SP.castDir $ genProjectRootDirAbs SP.</> dbRootDirInProjectRootDir SP.</> dbMigrationsDirInDbRootDir

--- a/waspc/src/Wasp/Generator/FileDraft.hs
+++ b/waspc/src/Wasp/Generator/FileDraft.hs
@@ -5,13 +5,15 @@ module Wasp.Generator.FileDraft
     createCopyFileDraft,
     createCopyFileDraftIfExists,
     createTextFileDraft,
+    createCopyDirFileDraft,
   )
 where
 
 import qualified Data.Aeson as Aeson
 import Data.Text (Text)
-import StrongPath (Abs, File', Path', Rel)
+import StrongPath (Abs, Dir', File', Path', Rel)
 import Wasp.Generator.Common (ProjectRootDir)
+import qualified Wasp.Generator.FileDraft.CopyDirFileDraft as CopyDirFD
 import qualified Wasp.Generator.FileDraft.CopyFileDraft as CopyFD
 import qualified Wasp.Generator.FileDraft.TemplateFileDraft as TmplFD
 import qualified Wasp.Generator.FileDraft.TextFileDraft as TextFD
@@ -21,15 +23,21 @@ import Wasp.Generator.Templates (TemplatesDir)
 -- | FileDraft unites different file draft types into a single type,
 --   so that in the rest of the system they can be passed around as heterogeneous
 --   collection when needed.
+--
+-- TODO: revisit the quick and dirty Linux interpretation of "everything is a file"
+-- and treating a directory (`CopyDirFileDraft`) as a `FileDraft`. As is, this may be
+-- a source of potential confusion and possibly tech debt to resolve later.
 data FileDraft
   = FileDraftTemplateFd TmplFD.TemplateFileDraft
   | FileDraftCopyFd CopyFD.CopyFileDraft
+  | FileDraftCopyDirFd CopyDirFD.CopyDirFileDraft
   | FileDraftTextFd TextFD.TextFileDraft
   deriving (Show, Eq)
 
 instance Writeable FileDraft where
   write dstDir (FileDraftTemplateFd draft) = write dstDir draft
   write dstDir (FileDraftCopyFd draft) = write dstDir draft
+  write dstDir (FileDraftCopyDirFd draft) = write dstDir draft
   write dstDir (FileDraftTextFd draft) = write dstDir draft
 
 createTemplateFileDraft ::
@@ -61,6 +69,14 @@ createCopyFileDraftIfExists dstPath srcPath =
       { CopyFD._dstPath = dstPath,
         CopyFD._srcPath = srcPath,
         CopyFD._failIfSrcDoesNotExist = False
+      }
+
+createCopyDirFileDraft :: Path' (Rel ProjectRootDir) Dir' -> Path' Abs Dir' -> FileDraft
+createCopyDirFileDraft dstPath srcPath =
+  FileDraftCopyDirFd $
+    CopyDirFD.CopyDirFileDraft
+      { CopyDirFD._dstPath = dstPath,
+        CopyDirFD._srcPath = srcPath
       }
 
 createTextFileDraft :: Path' (Rel ProjectRootDir) File' -> Text -> FileDraft

--- a/waspc/src/Wasp/Generator/FileDraft/CopyDirFileDraft.hs
+++ b/waspc/src/Wasp/Generator/FileDraft/CopyDirFileDraft.hs
@@ -1,0 +1,40 @@
+module Wasp.Generator.FileDraft.CopyDirFileDraft
+  ( CopyDirFileDraft (..),
+  )
+where
+
+import Control.Monad (when)
+import StrongPath
+  ( Abs,
+    Dir',
+    Path',
+    Rel,
+    (</>),
+  )
+import qualified StrongPath as SP
+import Wasp.Generator.Common (ProjectRootDir)
+import Wasp.Generator.FileDraft.Writeable
+import Wasp.Generator.FileDraft.WriteableMonad (WriteableMonad (copyDirectoryRecursive, createDirectoryIfMissing), doesDirectoryExist)
+
+-- | File draft based on another dir that is to be recursively copied.
+--
+-- TODO: revisit the quick and dirty Linux interpretation of "everything is a file"
+-- and treating a directory (`CopyDirFileDraft`) as a `FileDraft`. As is, this may be
+-- a source of potential confusion and possibly tech debt to resolve later.
+data CopyDirFileDraft = CopyDirFileDraft
+  { -- | Path where the dir will be copied to.
+    _dstPath :: !(Path' (Rel ProjectRootDir) Dir'),
+    -- | Absolute path of source dir to copy.
+    _srcPath :: !(Path' Abs Dir')
+  }
+  deriving (Show, Eq)
+
+instance Writeable CopyDirFileDraft where
+  write projectRootAbsPath draft = do
+    srcDirExists <- doesDirectoryExist $ SP.fromAbsDir srcPathAbsDir
+    when srcDirExists $ do
+      createDirectoryIfMissing True (SP.fromAbsDir dstPathAbsDir)
+      copyDirectoryRecursive srcPathAbsDir dstPathAbsDir
+    where
+      srcPathAbsDir = _srcPath draft
+      dstPathAbsDir = projectRootAbsPath </> _dstPath draft

--- a/waspc/test/Generator/WebAppGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGeneratorTest.hs
@@ -6,6 +6,7 @@ import System.FilePath ((</>))
 import Test.Tasty.Hspec
 import qualified Wasp.CompileOptions as CompileOptions
 import Wasp.Generator.FileDraft
+import qualified Wasp.Generator.FileDraft.CopyDirFileDraft as CopyDirFD
 import qualified Wasp.Generator.FileDraft.CopyFileDraft as CopyFD
 import qualified Wasp.Generator.FileDraft.TemplateFileDraft as TmplFD
 import qualified Wasp.Generator.FileDraft.TextFileDraft as TextFD
@@ -73,4 +74,5 @@ existsFdWithDst fds dstPath = any ((== dstPath) . getFileDraftDstPath) fds
 getFileDraftDstPath :: FileDraft -> FilePath
 getFileDraftDstPath (FileDraftTemplateFd fd) = SP.toFilePath $ TmplFD._dstPath fd
 getFileDraftDstPath (FileDraftCopyFd fd) = SP.toFilePath $ CopyFD._dstPath fd
+getFileDraftDstPath (FileDraftCopyDirFd fd) = SP.toFilePath $ CopyDirFD._dstPath fd
 getFileDraftDstPath (FileDraftTextFd fd) = SP.toFilePath $ TextFD._dstPath fd


### PR DESCRIPTION
# Description

The DB migration process needs to happen in the context of the generated project. Currently, the copying down of the Wasp source migrations folder is handled in the CLI migrate command, as well as CLI compile command. CLI migrate also copies it back up from the generated project once complete.

The Generator should really be responsible for copying the source migration dir down so they are always in sync. Additionally, the migrate logic should take care of copying back up so CLI or other callers do not need to know about that final step.

This change does the following two things:
1) Ensures in DbGenerator that the Wasp source migrations folder gets copied down into the generated project by introducing a new `FileDraft` called `CopyDirFileDraft`. This copies the `migrationsDir` in `Wasp` into the generated project.

2) When the migrate dev operation runs, not only should it perform the migration in the project context, but it should also be in charge of copying the migrations dir back up to the Wasp source.

Closes #105

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update