### PR TITLE
Warn user if Prisma needs to be re-generated because of prisma.schema changes

### DIFF
--- a/waspc/cli/Wasp/Cli/Command/Common.hs
+++ b/waspc/cli/Wasp/Cli/Command/Common.hs
@@ -2,6 +2,8 @@ module Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
     findWaspProjectRoot,
     waspSaysC,
+    waspScreamsC,
+    waspWarnsC,
     alphaWarningMessage,
   )
 where
@@ -22,6 +24,8 @@ import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Common
   ( dotWaspRootFileInWaspProjectDir,
     waspSays,
+    waspScreams,
+    waspWarns,
   )
 import Wasp.Cli.Terminal (asWaspFailureMessage)
 import Wasp.Common (WaspProjectDir)
@@ -54,6 +58,12 @@ findWaspProjectRootDirFromCwd = do
 
 waspSaysC :: String -> Command ()
 waspSaysC = liftIO . waspSays
+
+waspWarnsC :: String -> Command ()
+waspWarnsC = liftIO . waspWarns
+
+waspScreamsC :: String -> Command ()
+waspScreamsC = liftIO . waspScreams
 
 alphaWarningMessage :: String
 alphaWarningMessage =

--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -79,6 +79,7 @@ library:
     - strong-path >= 1.1.2.0
     - template-haskell
     - path-io
+    - cryptohash-sha256
 
 executables:
   wasp-cli:

--- a/waspc/src/Wasp/Generator.hs
+++ b/waspc/src/Wasp/Generator.hs
@@ -45,8 +45,8 @@ writeWebAppCode spec dstDir = do
       preCleanup spec dstDir
       writeFileDrafts dstDir fileDrafts
       writeDotWaspInfo dstDir
-      afterWriteWarnings <- afterWriteChecks spec dstDir
-      return (generatorWarnings ++ afterWriteWarnings, [])
+      generatedCodeCheckWarnings <- checkGeneratedCode spec dstDir
+      return (generatorWarnings ++ generatedCodeCheckWarnings, [])
 
 genApp :: AppSpec -> Generator [FileDraft]
 genApp spec =
@@ -55,8 +55,8 @@ genApp spec =
     <++> genDb spec
     <++> genDockerFiles spec
 
-afterWriteChecks :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO [GeneratorWarning]
-afterWriteChecks spec dstDir = DbGenerator.afterWriteChecks spec dstDir
+checkGeneratedCode :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO [GeneratorWarning]
+checkGeneratedCode spec dstDir = DbGenerator.checkGeneratedCode spec dstDir
 
 preCleanup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ()
 preCleanup spec dstDir = do

--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -6,16 +6,18 @@ module Wasp.Generator.DbGenerator
     dbRootDirInProjectRootDir,
     dbMigrationsDirInDbRootDir,
     dbSchemaFileInProjectRootDir,
+    writeDbSchemaChecksumToFile,
+    afterWriteChecks,
   )
 where
 
 import Control.Monad (when)
 import Data.Aeson (object, (.=))
 import Data.Maybe (fromMaybe, isNothing, maybeToList)
-import StrongPath (Abs, Dir, File', Path', Rel, reldir, relfile, (</>))
+import StrongPath (Abs, Dir, File, File', Path', Rel, reldir, relfile, (</>))
 import qualified StrongPath as SP
-import System.Directory (doesDirectoryExist, removeDirectoryRecursive)
-import Wasp.AppSpec (AppSpec)
+import System.Directory (doesDirectoryExist, doesFileExist, removeDirectoryRecursive)
+import Wasp.AppSpec (AppSpec, getEntities)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Db as AS.Db
@@ -23,15 +25,20 @@ import qualified Wasp.AppSpec.Entity as AS.Entity
 import Wasp.Common (DbMigrationsDir)
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.FileDraft (FileDraft, createCopyDirFileDraft, createTemplateFileDraft)
-import Wasp.Generator.Monad (Generator, GeneratorError (..), logAndThrowGeneratorError)
+import Wasp.Generator.Monad (Generator, GeneratorError (..), GeneratorWarning (GenericGeneratorWarning), logAndThrowGeneratorError)
 import Wasp.Generator.Templates (TemplatesDir)
 import qualified Wasp.Psl.Ast.Model as Psl.Ast.Model
 import qualified Wasp.Psl.Generator.Model as Psl.Generator.Model
-import Wasp.Util ((<:>))
+import Wasp.Util (Hex (Hex), checksumFromFilePath, (<:>))
 
 data DbRootDir
 
 data DbTemplatesDir
+
+-- | This file represents the checksum of schema.prisma
+-- at the point at which db migrate-dev is run. It is used
+-- to help warn the user of instances they may need to migrate.
+data DbSchemaChecksumFile
 
 dbRootDirInProjectRootDir :: Path' (Rel ProjectRootDir) (Dir DbRootDir)
 dbRootDirInProjectRootDir = [reldir|db|]
@@ -53,9 +60,17 @@ dbSchemaFileInProjectRootDir = dbRootDirInProjectRootDir </> dbSchemaFileInDbRoo
 dbMigrationsDirInDbRootDir :: Path' (Rel DbRootDir) (Dir DbMigrationsDir)
 dbMigrationsDirInDbRootDir = [reldir|migrations|]
 
+dbSchemaChecksumFileInDbRootDir :: Path' (Rel DbRootDir) (File DbSchemaChecksumFile)
+dbSchemaChecksumFileInDbRootDir = [relfile|schema.prisma.wasp-checksum|]
+
+dbSchemaChecksumFileInProjectRootDir :: Path' (Rel ProjectRootDir) (File DbSchemaChecksumFile)
+dbSchemaChecksumFileInProjectRootDir = dbRootDirInProjectRootDir </> dbSchemaChecksumFileInDbRootDir
+
 preCleanup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ()
-preCleanup spec projectRootDir = do
-  deleteGeneratedMigrationsDirIfRedundant spec projectRootDir
+preCleanup = deleteGeneratedMigrationsDirIfRedundant
+
+afterWriteChecks :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO [GeneratorWarning]
+afterWriteChecks = checkIfDbSchemaWasUsedForLastMigration
 
 genDb :: AppSpec -> Generator [FileDraft]
 genDb spec =
@@ -72,6 +87,37 @@ deleteGeneratedMigrationsDirIfRedundant spec projectRootDir = do
     putStrLn "Successfully deleted."
   where
     projectMigrationsDirAbsFilePath = SP.fromAbsDir $ projectRootDir </> dbRootDirInProjectRootDir </> dbMigrationsDirInDbRootDir
+
+-- | This function warns the user to run `wasp db migrate-dev` under certain conditions. But first, a few preliminaries:
+--   - This function relies on the latest schema.prisma, and thus should run after the writing of FileDrafts has occurred.
+--   - A non-empty schema.prisma should always exist in the generated project dir, even if the user has no entities defined.
+--     `wasp new` will create one with a `datasource db {}` and `generator client {}`, for example.
+--   - A schema.prisma.wasp-checksum file is created/updated each time `wasp db migrate-dev` is run locally and contains checksum(schema.prisma).
+--
+-- Given that, there are two cases in which we wish to warn the user to run `wasp db migrate-dev`:
+-- (1) If schema.prisma.wasp-checksum exists, but is not equal to checksum(schema.prisma), we know they made changes to schema.prisma and should migrate.
+-- (2) If schema.prisma.wasp-checksum does not exist, but the user has entities defined in schema.prisma (and thus, AppSpec).
+--     This could imply they have never migrated locally, or that they have but are simply missing their generated project dir.
+--     Common scenarios for the second warning include:
+--       - After a fresh checkout, or after `wasp clean`; possible false positives in these cases, but for safety, it's still preferable to warn.
+--       - When they previously had no entities and just added their first.
+checkIfDbSchemaWasUsedForLastMigration :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO [GeneratorWarning]
+checkIfDbSchemaWasUsedForLastMigration spec projectRootDir = do
+  dbSchemaChecksumFileExists <- doesFileExist dbSchemaChecksumFp
+
+  if dbSchemaChecksumFileExists
+    then do
+      Hex dbSchemaFileChecksum <- checksumFromFilePath dbSchemaFp
+      dbChecksumFileContents <- readFile dbSchemaChecksumFp
+      return $ warnIf (dbSchemaFileChecksum /= dbChecksumFileContents) "Your Prisma schema has changed, you should run `wasp db migrate-dev`."
+    else return $ warnIf entitiesExist "Please run `wasp db migrate-dev` to ensure the local project is fully initialized."
+  where
+    dbSchemaFp = SP.fromAbsFile $ projectRootDir </> dbSchemaFileInProjectRootDir
+    dbSchemaChecksumFp = SP.fromAbsFile $ projectRootDir </> dbSchemaChecksumFileInProjectRootDir
+    entitiesExist = not . null $ getEntities spec
+
+    warnIf :: Bool -> String -> [GeneratorWarning]
+    warnIf b msg = if b then [GenericGeneratorWarning msg] else []
 
 genPrismaSchema :: AppSpec -> Generator FileDraft
 genPrismaSchema spec = do
@@ -107,3 +153,13 @@ genMigrationsDir spec =
       Just $ createCopyDirFileDraft (SP.castDir genProjectMigrationsDir) (SP.castDir waspMigrationsDir)
   where
     genProjectMigrationsDir = dbRootDirInProjectRootDir </> dbMigrationsDirInDbRootDir
+
+writeDbSchemaChecksumToFile :: Path' Abs (Dir ProjectRootDir) -> IO ()
+writeDbSchemaChecksumToFile genProjectRootDir = do
+  dbSchemaExists <- doesFileExist dbSchemaFp
+  when dbSchemaExists $ do
+    Hex checksum <- checksumFromFilePath dbSchemaFp
+    writeFile dbSchemaChecksumFp checksum
+  where
+    dbSchemaFp = SP.fromAbsFile $ genProjectRootDir </> dbSchemaFileInProjectRootDir
+    dbSchemaChecksumFp = SP.fromAbsFile $ genProjectRootDir </> dbSchemaChecksumFileInProjectRootDir

--- a/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
@@ -12,7 +12,11 @@ import qualified StrongPath as SP
 import System.Exit (ExitCode (..))
 import Wasp.Common (DbMigrationsDir)
 import Wasp.Generator.Common (ProjectRootDir)
-import Wasp.Generator.DbGenerator (dbMigrationsDirInDbRootDir, dbRootDirInProjectRootDir)
+import Wasp.Generator.DbGenerator
+  ( dbMigrationsDirInDbRootDir,
+    dbRootDirInProjectRootDir,
+    writeDbSchemaChecksumToFile,
+  )
 import qualified Wasp.Generator.DbGenerator.Jobs as DbJobs
 import Wasp.Generator.FileDraft.WriteableMonad
   ( WriteableMonad (copyDirectoryRecursive),
@@ -28,7 +32,7 @@ printJobMsgsUntilExitReceived chan = do
     J.JobOutput {} -> printJobMessage jobMsg >> printJobMsgsUntilExitReceived chan
     J.JobExit {} -> return ()
 
--- | Migrates in the generated project context and then copies the migrations dir back
+-- | Migrates in the generated project context, stores checksum, and then copies the migrations dir back
 -- up to the wasp project dir to ensure they remain in sync.
 migrateDevAndCopyToSource :: Path' Abs (Dir DbMigrationsDir) -> Path' Abs (Dir ProjectRootDir) -> IO (Either String ())
 migrateDevAndCopyToSource dbMigrationsDirInWaspProjectDirAbs genProjectRootDirAbs = do
@@ -38,8 +42,13 @@ migrateDevAndCopyToSource dbMigrationsDirInWaspProjectDirAbs genProjectRootDirAb
       (printJobMsgsUntilExitReceived chan)
       (DbJobs.migrateDev genProjectRootDirAbs chan)
   case dbExitCode of
-    ExitSuccess -> copyMigrationsBackToSource genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs
+    ExitSuccess -> finalizeMigration genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs
     ExitFailure code -> return $ Left $ "Migrate (dev) failed with exit code: " ++ show code
+
+finalizeMigration :: Path' Abs (Dir ProjectRootDir) -> Path' Abs (Dir DbMigrationsDir) -> IO (Either String ())
+finalizeMigration genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs = do
+  writeDbSchemaChecksumToFile genProjectRootDirAbs
+  copyMigrationsBackToSource genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs
 
 -- | Copies the DB migrations from the generated project dir back up to theh wasp project dir
 copyMigrationsBackToSource :: Path' Abs (Dir ProjectRootDir) -> Path' Abs (Dir DbMigrationsDir) -> IO (Either String ())

--- a/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
@@ -32,7 +32,7 @@ printJobMsgsUntilExitReceived chan = do
     J.JobOutput {} -> printJobMessage jobMsg >> printJobMsgsUntilExitReceived chan
     J.JobExit {} -> return ()
 
--- | Migrates in the generated project context, stores checksum, and then copies the migrations dir back
+-- | Migrates in the generated project context and then copies the migrations dir back
 -- up to the wasp project dir to ensure they remain in sync.
 migrateDevAndCopyToSource :: Path' Abs (Dir DbMigrationsDir) -> Path' Abs (Dir ProjectRootDir) -> IO (Either String ())
 migrateDevAndCopyToSource dbMigrationsDirInWaspProjectDirAbs genProjectRootDirAbs = do
@@ -46,9 +46,9 @@ migrateDevAndCopyToSource dbMigrationsDirInWaspProjectDirAbs genProjectRootDirAb
     ExitFailure code -> return $ Left $ "Migrate (dev) failed with exit code: " ++ show code
 
 finalizeMigration :: Path' Abs (Dir ProjectRootDir) -> Path' Abs (Dir DbMigrationsDir) -> IO (Either String ())
-finalizeMigration genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs = do
-  writeDbSchemaChecksumToFile genProjectRootDirAbs
+finalizeMigration genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs =
   copyMigrationsBackToSource genProjectRootDirAbs dbMigrationsDirInWaspProjectDirAbs
+    <* writeDbSchemaChecksumToFile genProjectRootDirAbs
 
 -- | Copies the DB migrations from the generated project dir back up to theh wasp project dir
 copyMigrationsBackToSource :: Path' Abs (Dir ProjectRootDir) -> Path' Abs (Dir DbMigrationsDir) -> IO (Either String ())

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -1,5 +1,11 @@
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
 module Wasp.Util
-  ( camelToKebabCase,
+  ( Checksum,
+    camelToKebabCase,
+    checksumFromString,
+    checksumFromText,
+    checksumFromByteString,
     onFirst,
     toLowerFirst,
     toUpperFirst,
@@ -12,16 +18,25 @@ module Wasp.Util
     leftPad,
     (<++>),
     (<:>),
+    bytestringToHex,
+    Hex (..), -- TODO(shayne): Should we put this into Internal? Or make hexFromString smart constructor?
+    checksumFromFilePath,
   )
 where
 
 import Control.Monad (liftM2)
+import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as B
+import qualified Data.ByteString.UTF8 as BSU
 import Data.Char (isUpper, toLower, toUpper)
 import qualified Data.HashMap.Strict as M
 import Data.List (intercalate)
 import Data.List.Split (splitOn)
+import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Text.Printf (printf)
 
 camelToKebabCase :: String -> String
 camelToKebabCase "" = ""
@@ -131,3 +146,25 @@ infixr 5 <:>
 
 (<:>) :: Monad m => m a -> m [a] -> m [a]
 (<:>) = liftM2 (:)
+
+type Checksum = Hex
+
+checksumFromString :: String -> Checksum
+checksumFromString = bytestringToHex . SHA256.hash . BSU.fromString
+
+checksumFromText :: Text -> Checksum
+checksumFromText = bytestringToHex . SHA256.hash . TextEncoding.encodeUtf8
+
+checksumFromByteString :: BSU.ByteString -> Checksum
+checksumFromByteString = bytestringToHex . SHA256.hash
+
+checksumFromFilePath :: FilePath -> IO Checksum
+checksumFromFilePath file = do
+  contents <- B.readFile file
+  return $ checksumFromByteString contents
+
+newtype Hex = Hex String
+  deriving (Show, Eq, Ord, Aeson.ToJSON, Aeson.FromJSON)
+
+bytestringToHex :: B.ByteString -> Hex
+bytestringToHex = Hex . concatMap (printf "%02x") . B.unpack

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -19,7 +19,8 @@ module Wasp.Util
     (<++>),
     (<:>),
     bytestringToHex,
-    Hex (..), -- TODO(shayne): Should we put this into Internal? Or make hexFromString smart constructor?
+    hexFromString,
+    hexToString,
     checksumFromFilePath,
   )
 where
@@ -159,12 +160,16 @@ checksumFromByteString :: BSU.ByteString -> Checksum
 checksumFromByteString = bytestringToHex . SHA256.hash
 
 checksumFromFilePath :: FilePath -> IO Checksum
-checksumFromFilePath file = do
-  contents <- B.readFile file
-  return $ checksumFromByteString contents
+checksumFromFilePath file = checksumFromByteString <$> B.readFile file
 
 newtype Hex = Hex String
   deriving (Show, Eq, Ord, Aeson.ToJSON, Aeson.FromJSON)
 
 bytestringToHex :: B.ByteString -> Hex
 bytestringToHex = Hex . concatMap (printf "%02x") . B.unpack
+
+hexFromString :: String -> Hex
+hexFromString = Hex
+
+hexToString :: Hex -> String
+hexToString (Hex s) = s

--- a/waspc/test/UtilTest.hs
+++ b/waspc/test/UtilTest.hs
@@ -117,9 +117,9 @@ spec_insertAt = do
 spec_hex :: Spec
 spec_hex = do
   it "Correctly transforms bytestring to hex" $ do
-    bytestringToHex "test" `shouldBe` Hex "74657374"
+    bytestringToHex "test" `shouldBe` hexFromString "74657374"
 
 spec_checksum :: Spec
 spec_checksum = do
   it "Correctly calculates checksum of string" $ do
-    checksumFromString "test" `shouldBe` Hex "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    checksumFromString "test" `shouldBe` hexFromString "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"

--- a/waspc/test/UtilTest.hs
+++ b/waspc/test/UtilTest.hs
@@ -113,3 +113,13 @@ spec_insertAt = do
     it "insert given list at the end of host list if index is equal or bigger than host list length" $ do
       insertAt [0] 3 [1, 2, 3] `shouldBe` ([1, 2, 3, 0] :: [Int])
       insertAt [0] 4 [1, 2, 3] `shouldBe` ([1, 2, 3, 0] :: [Int])
+
+spec_hex :: Spec
+spec_hex = do
+  it "Correctly transforms bytestring to hex" $ do
+    bytestringToHex "test" `shouldBe` Hex "74657374"
+
+spec_checksum :: Spec
+spec_checksum = do
+  it "Correctly calculates checksum of string" $ do
+    checksumFromString "test" `shouldBe` Hex "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"


### PR DESCRIPTION
# Description

Currently, we do not warn users if Prisma needs to be re-generated via `wasp db migrate-dev` when they change their entities or db blocks. These changes will update `schema.prisma`, but if they do not apply it, it will not take effect.

This PR does two things:
- Every time `wasp db migrate-dev` is run, we take the SHA-256 checksum of the current `schema.prisma` file we are migrating against and store it as `schema.prisma.wasp-checksum` in the same .wasp/out/db dir. This means it is only local to the developer and serves as some sort of proof of prior local migration run.
- As part of Generation, we diff the `schema.prisma.wasp-checksum` file against the checksum of the current `schema.prisma` file. If they differ, we know the user has an unreflected update and they need to run `wasp db migrate-dev`. If they have no `schema.prisma.wasp-checksum` file but have entities, we also warn them to migrate.
  - Note: These checks run every compile, so not only `start` but `watch` too, so we can display an error to the console if they edit while still running.

Fixes #214 

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update