### PR TITLE
Adds a Generator monad for more flexible error/warning handling and propagation

### DIFF
--- a/waspc/cli/Wasp/Cli/Command/Watch.hs
+++ b/waspc/cli/Wasp/Cli/Command/Watch.hs
@@ -14,7 +14,7 @@ import qualified StrongPath as SP
 import qualified System.FSNotify as FSN
 import qualified System.FilePath as FP
 import Wasp.Cli.Command.Compile (compileIO)
-import Wasp.Cli.Common (waspSays)
+import Wasp.Cli.Common (waspSays, waspScreams)
 import qualified Wasp.Cli.Common as Common
 import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import qualified Wasp.Lib
@@ -82,7 +82,7 @@ watch waspProjectDir outDir = FSN.withManager $ \mgr -> do
       waspSays $ asWaspStartMessage "Recompiling on file change..."
       compilationResult <- compileIO waspProjectDir outDir
       case compilationResult of
-        Left err -> waspSays $ asWaspFailureMessage "Recompilation on file change failed:" ++ err
+        Left err -> waspScreams $ asWaspFailureMessage "Recompilation on file change failed:" ++ err
         Right () -> waspSays $ asWaspSuccessMessage "Recompilation on file change succeeded."
       return ()
 

--- a/waspc/cli/Wasp/Cli/Common.hs
+++ b/waspc/cli/Wasp/Cli/Common.hs
@@ -9,6 +9,8 @@ module Wasp.Cli.Common
     generatedCodeDirInDotWaspDir,
     buildDirInDotWaspDir,
     waspSays,
+    waspWarns,
+    waspScreams,
   )
 where
 
@@ -44,3 +46,9 @@ extCodeDirInWaspProjectDir = [reldir|ext|]
 
 waspSays :: String -> IO ()
 waspSays what = putStrLn $ Term.applyStyles [Term.Yellow] what
+
+waspWarns :: String -> IO ()
+waspWarns what = putStrLn $ Term.applyStyles [Term.Magenta] what
+
+waspScreams :: String -> IO ()
+waspScreams what = putStrLn $ Term.applyStyles [Term.Red] what

--- a/waspc/cli/Wasp/Cli/Terminal.hs
+++ b/waspc/cli/Wasp/Cli/Terminal.hs
@@ -4,6 +4,7 @@ module Wasp.Cli.Terminal
     asWaspStartMessage,
     asWaspSuccessMessage,
     asWaspFailureMessage,
+    asWaspWarningMessage,
   )
 where
 
@@ -20,6 +21,11 @@ asWaspStartMessage = waspMessageWithEmoji "🐝"
 
 asWaspSuccessMessage :: String -> String
 asWaspSuccessMessage = waspMessageWithEmoji "✅"
+
+asWaspWarningMessage :: String -> String
+asWaspWarningMessage str = concat ["\n", waspMessageWithEmoji "👀" errorStr, "\n"]
+  where
+    errorStr = "[Warning] " ++ str
 
 asWaspFailureMessage :: String -> String
 -- Add a bit more padding on errors for more pronounced

--- a/waspc/src/Wasp/Generator/DockerGenerator.hs
+++ b/waspc/src/Wasp/Generator/DockerGenerator.hs
@@ -12,26 +12,29 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.Entity as AS.Entity
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.FileDraft (FileDraft, createTemplateFileDraft)
+import Wasp.Generator.Monad (Generator)
 import Wasp.Generator.Templates (TemplatesDir)
 
-genDockerFiles :: AppSpec -> [FileDraft]
-genDockerFiles spec = genDockerfile spec : [genDockerignore spec]
+genDockerFiles :: AppSpec -> Generator [FileDraft]
+genDockerFiles spec = sequence [genDockerfile spec, genDockerignore spec]
 
 -- TODO: Inject paths to server and db files/dirs, right now they are hardcoded in the templates.
-genDockerfile :: AppSpec -> FileDraft
+genDockerfile :: AppSpec -> Generator FileDraft
 genDockerfile spec =
-  createTemplateFileDraft
-    ([relfile|Dockerfile|] :: Path' (Rel ProjectRootDir) File')
-    ([relfile|Dockerfile|] :: Path' (Rel TemplatesDir) File')
-    ( Just $
-        object
-          [ "usingPrisma" .= not (null $ AS.getDecls @AS.Entity.Entity spec)
-          ]
-    )
+  return $
+    createTemplateFileDraft
+      ([relfile|Dockerfile|] :: Path' (Rel ProjectRootDir) File')
+      ([relfile|Dockerfile|] :: Path' (Rel TemplatesDir) File')
+      ( Just $
+          object
+            [ "usingPrisma" .= not (null $ AS.getDecls @AS.Entity.Entity spec)
+            ]
+      )
 
-genDockerignore :: AppSpec -> FileDraft
+genDockerignore :: AppSpec -> Generator FileDraft
 genDockerignore _ =
-  createTemplateFileDraft
-    ([relfile|.dockerignore|] :: Path' (Rel ProjectRootDir) File')
-    ([relfile|dockerignore|] :: Path' (Rel TemplatesDir) File')
-    Nothing
+  return $
+    createTemplateFileDraft
+      ([relfile|.dockerignore|] :: Path' (Rel ProjectRootDir) File')
+      ([relfile|dockerignore|] :: Path' (Rel TemplatesDir) File')
+      Nothing

--- a/waspc/src/Wasp/Generator/ExternalCodeGenerator.hs
+++ b/waspc/src/Wasp/Generator/ExternalCodeGenerator.hs
@@ -10,22 +10,23 @@ import qualified Wasp.AppSpec.ExternalCode as EC
 import qualified Wasp.Generator.ExternalCodeGenerator.Common as C
 import Wasp.Generator.ExternalCodeGenerator.Js (generateJsFile)
 import qualified Wasp.Generator.FileDraft as FD
+import Wasp.Generator.Monad (Generator)
 
 -- | Takes external code files from Wasp and generates them in new location as part of the generated project.
 -- It might not just copy them but also do some changes on them, as needed.
 generateExternalCodeDir ::
   C.ExternalCodeGeneratorStrategy ->
   [EC.File] ->
-  [FD.FileDraft]
-generateExternalCodeDir strategy = map (generateFile strategy)
+  Generator [FD.FileDraft]
+generateExternalCodeDir strategy = mapM (generateFile strategy)
 
-generateFile :: C.ExternalCodeGeneratorStrategy -> EC.File -> FD.FileDraft
+generateFile :: C.ExternalCodeGeneratorStrategy -> EC.File -> Generator FD.FileDraft
 generateFile strategy file
   | extension `elem` [".js", ".jsx"] = generateJsFile strategy file
   | otherwise =
     let relDstPath = C._extCodeDirInProjectRootDir strategy </> dstPathInGenExtCodeDir
         absSrcPath = EC.fileAbsPath file
-     in FD.createCopyFileDraft relDstPath absSrcPath
+     in return $ FD.createCopyFileDraft relDstPath absSrcPath
   where
     dstPathInGenExtCodeDir :: Path' (Rel C.GeneratedExternalCodeDir) File'
     dstPathInGenExtCodeDir = C.castRelPathFromSrcToGenExtCodeDir $ EC.filePathInExtCodeDir file

--- a/waspc/src/Wasp/Generator/ExternalCodeGenerator/Js.hs
+++ b/waspc/src/Wasp/Generator/ExternalCodeGenerator/Js.hs
@@ -15,9 +15,10 @@ import qualified Wasp.AppSpec.ExternalCode as EC
 import Wasp.Generator.ExternalCodeGenerator.Common (GeneratedExternalCodeDir)
 import qualified Wasp.Generator.ExternalCodeGenerator.Common as C
 import qualified Wasp.Generator.FileDraft as FD
+import Wasp.Generator.Monad (Generator)
 
-generateJsFile :: C.ExternalCodeGeneratorStrategy -> EC.File -> FD.FileDraft
-generateJsFile strategy file = FD.createTextFileDraft dstPath text'
+generateJsFile :: C.ExternalCodeGeneratorStrategy -> EC.File -> Generator FD.FileDraft
+generateJsFile strategy file = return $ FD.createTextFileDraft dstPath text'
   where
     filePathInSrcExtCodeDir = EC.filePathInExtCodeDir file
 

--- a/waspc/src/Wasp/Generator/Monad.hs
+++ b/waspc/src/Wasp/Generator/Monad.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Wasp.Generator.Monad
+  ( Generator,
+    GeneratorError (..),
+    GeneratorWarning (..),
+    catchGeneratorError,
+    logAndThrowGeneratorError,
+    logGeneratorWarning,
+    runGenerator,
+  )
+where
+
+import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
+import qualified Control.Monad.Except as MonadExcept
+import Control.Monad.Identity (Identity (runIdentity))
+import Control.Monad.State (MonadState, StateT (runStateT), modify)
+import Data.List.NonEmpty (NonEmpty, fromList)
+
+-- | Generator is a monad transformer stack where we abstract away the underlying
+-- concrete monad transformers with the helper functions below. This will allow us
+-- to refactor and add more transformers (or swap them) without any caller changes.
+--
+-- The outer Either layer represents the last error that halted generation. Any error logged and thrown is fatal.
+-- The mechanism to catch errors is only there to assist in collecting more errors, not recover.
+-- There may optionally be additional errors or non-fatal warnings logged in the State.
+newtype Generator a = Generator
+  { _runGenerator :: ExceptT GeneratorError (StateT GeneratorState Identity) a
+  }
+  deriving
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadState GeneratorState,
+      MonadError GeneratorError
+    )
+
+data GeneratorState = GeneratorState
+  { warnings :: [GeneratorWarning],
+    errors :: [GeneratorError]
+  }
+
+data GeneratorError = GenericGeneratorError String
+
+instance Show GeneratorError where
+  show (GenericGeneratorError e) = e
+
+data GeneratorWarning = GenericGeneratorWarning String
+
+instance Show GeneratorWarning where
+  show (GenericGeneratorWarning e) = e
+
+-- Runs the generator and either returns a result, or a list of 1 or more errors.
+-- Results in error if any error was ever logged and thrown (even if caught).
+-- Even if successful there may be warnings, so they are always included.
+runGenerator :: Generator a -> ([GeneratorWarning], Either (NonEmpty GeneratorError) a)
+runGenerator generator =
+  let (errorOrResult, finalState) = runIdentity $ runStateT (runExceptT (_runGenerator generator)) initialState
+   in (warnings finalState, loggedErrorsOrResult (errorOrResult, errors finalState))
+  where
+    initialState = GeneratorState {warnings = [], errors = []}
+
+    loggedErrorsOrResult (Right result, []) = Right result
+    loggedErrorsOrResult (Left _, []) = error "Generator produced error, but had empty log - this should never happen!"
+    loggedErrorsOrResult (_, loggedErrors) = Left $ fromList loggedErrors
+
+-- This logs a warning but does not short circuit the computation.
+logGeneratorWarning :: GeneratorWarning -> Generator ()
+logGeneratorWarning w = modify $ \GeneratorState {errors = errors', warnings = warnings'} ->
+  GeneratorState {errors = errors', warnings = w : warnings'}
+
+-- This logs an error and does throw, thus short-circuiting the computation until caught.
+logAndThrowGeneratorError :: GeneratorError -> Generator a
+logAndThrowGeneratorError e = logGeneratorError >> throwError e
+  where
+    logGeneratorError :: Generator ()
+    logGeneratorError = modify $ \GeneratorState {errors = errors', warnings = warnings'} ->
+      GeneratorState {errors = e : errors', warnings = warnings'}
+
+-- This stops the short-circuiting from above, if ever desired, but cannot be used for full recovery.
+-- Once one error is logged and thrown the result will be error. This function exists to log
+-- more errors on the way up.
+catchGeneratorError :: Generator a -> (GeneratorError -> Generator a) -> Generator a
+catchGeneratorError = MonadExcept.catchError

--- a/waspc/src/Wasp/Generator/ServerGenerator/ConfigG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/ConfigG.hs
@@ -10,10 +10,11 @@ import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import Wasp.Generator.FileDraft (FileDraft)
+import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.ServerGenerator.Common as C
 
-genConfigFile :: AppSpec -> FileDraft
-genConfigFile spec = C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
+genConfigFile :: AppSpec -> Generator FileDraft
+genConfigFile spec = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     tmplFile = C.srcDirInServerTemplatesDir </> SP.castRel configFileInSrcDir
     dstFile = C.serverSrcDirInServerRootDir </> configFileInSrcDir

--- a/waspc/src/Wasp/Generator/WebAppGenerator/OperationsGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/OperationsGenerator.hs
@@ -18,31 +18,31 @@ import qualified Wasp.AppSpec.Action as AS.Action
 import qualified Wasp.AppSpec.Operation as AS.Operation
 import qualified Wasp.AppSpec.Query as AS.Query
 import Wasp.Generator.FileDraft (FileDraft)
+import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.ServerGenerator as ServerGenerator
 import qualified Wasp.Generator.ServerGenerator.OperationsRoutesG as ServerOperationsRoutesG
 import qualified Wasp.Generator.WebAppGenerator.Common as C
 import qualified Wasp.Generator.WebAppGenerator.OperationsGenerator.ResourcesG as Resources
+import Wasp.Util ((<++>))
 
-genOperations :: AppSpec -> [FileDraft]
+genOperations :: AppSpec -> Generator [FileDraft]
 genOperations spec =
-  concat
-    [ genQueries spec,
-      genActions spec,
-      [C.mkTmplFd $ C.asTmplFile [relfile|src/operations/index.js|]],
-      Resources.genResources spec
-    ]
+  genQueries spec
+    <++> genActions spec
+    <++> return [C.mkTmplFd $ C.asTmplFile [relfile|src/operations/index.js|]]
+    <++> Resources.genResources spec
 
-genQueries :: AppSpec -> [FileDraft]
-genQueries spec =
-  map (genQuery spec) (AS.getQueries spec)
-    ++ [C.mkTmplFd $ C.asTmplFile [relfile|src/queries/index.js|]]
+genQueries :: AppSpec -> Generator [FileDraft]
+genQueries spec = do
+  queriesFds <- mapM (genQuery spec) (AS.getQueries spec)
+  return $ queriesFds ++ [C.mkTmplFd $ C.asTmplFile [relfile|src/queries/index.js|]]
 
-genActions :: AppSpec -> [FileDraft]
+genActions :: AppSpec -> Generator [FileDraft]
 genActions spec =
-  map (genAction spec) (AS.getActions spec)
+  mapM (genAction spec) (AS.getActions spec)
 
-genQuery :: AppSpec -> (String, AS.Query.Query) -> FileDraft
-genQuery _ (queryName, query) = C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
+genQuery :: AppSpec -> (String, AS.Query.Query) -> Generator FileDraft
+genQuery _ (queryName, query) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     tmplFile = C.asTmplFile [relfile|src/queries/_query.js|]
 
@@ -59,8 +59,8 @@ genQuery _ (queryName, query) = C.mkTmplFdWithDstAndData tmplFile dstFile (Just 
         ]
     operation = AS.Operation.QueryOp queryName query
 
-genAction :: AppSpec -> (String, AS.Action.Action) -> FileDraft
-genAction _ (actionName, action) = C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
+genAction :: AppSpec -> (String, AS.Action.Action) -> Generator FileDraft
+genAction _ (actionName, action) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     tmplFile = C.asTmplFile [relfile|src/actions/_action.js|]
 

--- a/waspc/src/Wasp/Generator/WebAppGenerator/OperationsGenerator/ResourcesG.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/OperationsGenerator/ResourcesG.hs
@@ -7,10 +7,11 @@ import Data.Aeson (object)
 import StrongPath (relfile)
 import Wasp.AppSpec (AppSpec)
 import Wasp.Generator.FileDraft (FileDraft)
+import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.WebAppGenerator.Common as C
 
-genResources :: AppSpec -> [FileDraft]
-genResources _ = [C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)]
+genResources :: AppSpec -> Generator [FileDraft]
+genResources _ = return [C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)]
   where
     tmplFile = C.asTmplFile [relfile|src/operations/resources.js|]
     dstFile = C.asWebAppFile [relfile|src/operations/resources.js|] -- TODO: Un-hardcode this by combining path to operations dir with path to resources file in it.

--- a/waspc/src/Wasp/Generator/WebAppGenerator/RouterGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/RouterGenerator.hs
@@ -17,6 +17,7 @@ import qualified Wasp.AppSpec.ExtImport as AS.ExtImport
 import qualified Wasp.AppSpec.Page as AS.Page
 import qualified Wasp.AppSpec.Route as AS.Route
 import Wasp.Generator.FileDraft (FileDraft)
+import Wasp.Generator.Monad (Generator)
 import Wasp.Generator.WebAppGenerator.Common (asTmplFile, asWebAppSrcFile)
 import qualified Wasp.Generator.WebAppGenerator.Common as C
 
@@ -59,12 +60,13 @@ instance ToJSON PageTemplateData where
         "importFrom" .= _importFrom pageTD
       ]
 
-generateRouter :: AppSpec -> FileDraft
-generateRouter spec =
-  C.mkTmplFdWithDstAndData
-    (asTmplFile $ [reldir|src|] </> routerPath)
-    targetPath
-    (Just $ toJSON templateData)
+generateRouter :: AppSpec -> Generator FileDraft
+generateRouter spec = do
+  return $
+    C.mkTmplFdWithDstAndData
+      (asTmplFile $ [reldir|src|] </> routerPath)
+      targetPath
+      (Just $ toJSON templateData)
   where
     routerPath = [relfile|router.js|]
     templateData = createRouterTemplateData spec
@@ -88,6 +90,7 @@ createRouteTemplateData spec namedRoute@(_, route) =
       _targetComponent = determineRouteTargetComponent spec namedRoute
     }
 
+-- NOTE: This should be prevented by Analyzer, so use error since it should not be possible
 determineRouteTargetComponent :: AppSpec -> (String, AS.Route.Route) -> String
 determineRouteTargetComponent spec (_, route) =
   maybe

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -10,9 +10,12 @@ module Wasp.Util
     concatPrefixAndText,
     insertAt,
     leftPad,
+    (<++>),
+    (<:>),
   )
 where
 
+import Control.Monad (liftM2)
 import qualified Data.Aeson as Aeson
 import Data.Char (isUpper, toLower, toUpper)
 import qualified Data.HashMap.Strict as M
@@ -118,3 +121,13 @@ insertAt :: [a] -> Int -> [a] -> [a]
 insertAt theInsert idx host =
   let (before, after) = splitAt idx host
    in before ++ theInsert ++ after
+
+infixr 5 <++>
+
+(<++>) :: Monad m => m [a] -> m [a] -> m [a]
+(<++>) = liftM2 (++)
+
+infixr 5 <:>
+
+(<:>) :: Monad m => m a -> m [a] -> m [a]
+(<:>) = liftM2 (:)

--- a/waspc/test/Generator/WebAppGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGeneratorTest.hs
@@ -12,6 +12,7 @@ import qualified Wasp.Generator.FileDraft.CopyDirFileDraft as CopyDirFD
 import qualified Wasp.Generator.FileDraft.CopyFileDraft as CopyFD
 import qualified Wasp.Generator.FileDraft.TemplateFileDraft as TmplFD
 import qualified Wasp.Generator.FileDraft.TextFileDraft as TextFD
+import Wasp.Generator.Monad (runGenerator)
 import Wasp.Generator.WebAppGenerator
 import qualified Wasp.Generator.WebAppGenerator.Common as Common
 
@@ -46,7 +47,7 @@ spec_WebAppGenerator = do
     --   that they will successfully be written, it checks only that their
     --   destinations are correct.
     it "Given a simple AppSpec, creates file drafts at expected destinations" $ do
-      let fileDrafts = generateWebApp testAppSpec
+      let (_, Right fileDrafts) = runGenerator $ generateWebApp testAppSpec
       let expectedFileDraftDstPaths =
             map (SP.toFilePath Common.webAppRootDirInProjectRootDir </>) $
               concat


### PR DESCRIPTION
# Description

Currently all generation functions return `FileDrafts` directly, and if they have an error, they just `error`. This is not ideal. It would be good if we can throw/catch errors, but also add warnings to the output. This change introduces a `Generator` monad transformer stack to handle the propagation of errors (both fatal and non-fatal) to allow callers to react accordingly, as well as support for any warnings.

I updated nearly all instances of `gen* :: ... -> FileDraft` to `gen* :: ... -> Generator FileDraft`, and this represents most of the changes.

Closes #123

## Examples

This is an example of an error that previously was just `error`, when you try to `wasp build` but with SQLite as your db. Now we can throw that as a fatal generation error and it shows up nicely, too:
<img width="1002" alt="Screen Shot 2022-01-21 at 9 01 00 AM" src="https://user-images.githubusercontent.com/523636/150539899-a6e823e8-7acd-47fe-a00d-0c3f424baf7d.png">

This is an example of two dummy warnings deep in the call hierarchy:
<img width="1002" alt="Screen Shot 2022-01-21 at 9 00 15 AM" src="https://user-images.githubusercontent.com/523636/150539917-919062dd-7a10-4d02-835a-e1055fb29655.png">

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update