### PR TITLE
When we build, do not copy .env

### DIFF
--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -83,12 +83,13 @@ preCleanup _ outDir = do
 genDotEnv :: AppSpec -> Generator [FileDraft]
 genDotEnv spec = return $
   case AS.dotEnvFile spec of
-    Just srcFilePath ->
-      [ createCopyFileDraft
-          (C.serverRootDirInProjectRootDir </> dotEnvInServerRootDir)
-          srcFilePath
-      ]
-    Nothing -> []
+    Just srcFilePath
+      | not $ AS.isBuild spec ->
+        [ createCopyFileDraft
+            (C.serverRootDirInProjectRootDir </> dotEnvInServerRootDir)
+            srcFilePath
+        ]
+    _ -> []
 
 dotEnvInServerRootDir :: Path' (Rel C.ServerRootDir) File'
 dotEnvInServerRootDir = [relfile|.env|]


### PR DESCRIPTION
# Description

When we do a build we do not when to copy .env file, only for dev mode.

Fixes # (issue) #413 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update