### PR TITLE
We cannot build unless we use the right version of npm

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "2.0.0-beta.6",
@@ -18,6 +19,10 @@
         "react-dom": "^17.0.1",
         "react-modal": "^3.14.3",
         "url-loader": "^4.1.1"
+      },
+      "engines": {
+        "node": "16",
+        "npm": "8"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -4074,7 +4079,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -8306,7 +8310,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -14299,7 +14302,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,10 @@
     "react-modal": "^3.14.3",
     "url-loader": "^4.1.1"
   },
+  "engines": {
+    "node": "16",
+    "npm": "8"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
# Description

The engines field in package.json only gets blocked with the appropriate
.npmrc, which is provided.

If we allow earlier versions of npm to operate together with later
versions, we get massive package-lock.json changes switching it
from v1 to v2 and back again. We want to avoid this churn.

When you try the wrong node/npm version, you get a message like this:

```
$ npm install
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for web@0.0.0: wanted: {"node":"16","npm":"8"} (current: {"node":"14.17.6","npm":"6.14.15"})
npm ERR! notsup Not compatible with your version of node/npm: web@0.0.0
npm ERR! notsup Not compatible with your version of node/npm: web@0.0.0
npm ERR! notsup Required: {"node":"16","npm":"8"}
npm ERR! notsup Actual:   {"npm":"6.14.15","node":"14.17.6"}
```

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update