### PR TITLE
Adds Prisma client generation during app generation

### DIFF
--- a/waspc/src/Wasp/Generator.hs
+++ b/waspc/src/Wasp/Generator.hs
@@ -46,7 +46,7 @@ writeWebAppCode spec dstDir = do
       preCleanup spec dstDir
       writeFileDrafts dstDir fileDrafts
       writeDotWaspInfo dstDir
-      (dbGeneratorWarnings, dbGeneratorErrors) <- postGenDbGeneratorActions spec dstDir
+      (dbGeneratorWarnings, dbGeneratorErrors) <- postWriteDbGeneratorActions spec dstDir
       return (generatorWarnings ++ dbGeneratorWarnings, dbGeneratorErrors)
 
 genApp :: AppSpec -> Generator [FileDraft]
@@ -76,8 +76,9 @@ writeDotWaspInfo dstDir = do
   let dstPath = dstDir </> [relfile|.waspinfo|]
   Data.Text.IO.writeFile (SP.toFilePath dstPath) (Data.Text.pack content)
 
-postGenDbGeneratorActions :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
-postGenDbGeneratorActions spec dstDir = do
+-- | This function operates on generated code, and thus assumes the file drafts were written to disk
+postWriteDbGeneratorActions :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
+postWriteDbGeneratorActions spec dstDir = do
   dbGeneratorWarnings <- maybeToList <$> DbGenerator.warnIfDbSchemaChangedSinceLastMigration spec dstDir
   dbGeneratorErrors <- maybeToList <$> DbGenerator.genPrismaClient dstDir
   return (dbGeneratorWarnings, dbGeneratorErrors)

--- a/waspc/src/Wasp/Generator.hs
+++ b/waspc/src/Wasp/Generator.hs
@@ -6,7 +6,6 @@ module Wasp.Generator
 where
 
 import Data.List.NonEmpty (toList)
-import Data.Maybe (maybeToList)
 import qualified Data.Text
 import qualified Data.Text.IO
 import Data.Time.Clock
@@ -46,7 +45,7 @@ writeWebAppCode spec dstDir = do
       preCleanup spec dstDir
       writeFileDrafts dstDir fileDrafts
       writeDotWaspInfo dstDir
-      (dbGeneratorWarnings, dbGeneratorErrors) <- postWriteDbGeneratorActions spec dstDir
+      (dbGeneratorWarnings, dbGeneratorErrors) <- DbGenerator.postWriteDbGeneratorActions spec dstDir
       return (generatorWarnings ++ dbGeneratorWarnings, dbGeneratorErrors)
 
 genApp :: AppSpec -> Generator [FileDraft]
@@ -75,10 +74,3 @@ writeDotWaspInfo dstDir = do
   let content = "Generated on " ++ show currentTime ++ " by waspc version " ++ show version ++ " ."
   let dstPath = dstDir </> [relfile|.waspinfo|]
   Data.Text.IO.writeFile (SP.toFilePath dstPath) (Data.Text.pack content)
-
--- | This function operates on generated code, and thus assumes the file drafts were written to disk
-postWriteDbGeneratorActions :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
-postWriteDbGeneratorActions spec dstDir = do
-  dbGeneratorWarnings <- maybeToList <$> DbGenerator.warnIfDbSchemaChangedSinceLastMigration spec dstDir
-  dbGeneratorErrors <- maybeToList <$> DbGenerator.genPrismaClient dstDir
-  return (dbGeneratorWarnings, dbGeneratorErrors)

--- a/waspc/src/Wasp/Generator/Common.hs
+++ b/waspc/src/Wasp/Generator/Common.hs
@@ -2,6 +2,7 @@ module Wasp.Generator.Common
   ( ProjectRootDir,
     nodeVersion,
     nodeVersionAsText,
+    prismaVersion,
   )
 where
 
@@ -19,3 +20,6 @@ nodeVersionAsText :: String
 nodeVersionAsText = printf "%d.%d.%d" major minor patch
   where
     (major, minor, patch) = nodeVersion
+
+prismaVersion :: String
+prismaVersion = "2.22.1"

--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -36,64 +36,9 @@ import qualified Wasp.Psl.Ast.Model as Psl.Ast.Model
 import qualified Wasp.Psl.Generator.Model as Psl.Generator.Model
 import Wasp.Util (checksumFromFilePath, hexToString, (<:>))
 
-preCleanup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ()
-preCleanup = deleteGeneratedMigrationsDirIfRedundant
-
 genDb :: AppSpec -> Generator [FileDraft]
 genDb spec =
   genPrismaSchema spec <:> (maybeToList <$> genMigrationsDir spec)
-
--- | This function operates on generated code, and thus assumes the file drafts were written to disk
-postWriteDbGeneratorActions :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
-postWriteDbGeneratorActions spec dstDir = do
-  dbGeneratorWarnings <- maybeToList <$> warnIfDbSchemaChangedSinceLastMigration spec dstDir
-  dbGeneratorErrors <- maybeToList <$> genPrismaClient dstDir
-  return (dbGeneratorWarnings, dbGeneratorErrors)
-
-deleteGeneratedMigrationsDirIfRedundant :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ()
-deleteGeneratedMigrationsDirIfRedundant spec projectRootDir = do
-  let waspMigrationsDirMissing = isNothing $ AS.migrationsDir spec
-  projectMigrationsDirExists <- doesDirectoryExist projectMigrationsDirAbsFilePath
-  when (waspMigrationsDirMissing && projectMigrationsDirExists) $ do
-    putStrLn "A migrations directory does not exist in this Wasp root directory, but does in the generated project output directory."
-    putStrLn $ "Deleting directory: " ++ projectMigrationsDirAbsFilePath ++ " ..."
-    removeDirectoryRecursive projectMigrationsDirAbsFilePath
-    putStrLn "Successfully deleted."
-  where
-    projectMigrationsDirAbsFilePath = SP.fromAbsDir $ projectRootDir </> dbRootDirInProjectRootDir </> dbMigrationsDirInDbRootDir
-
--- | Checks if user needs to run `wasp db migrate-dev` due to changes they did in schema.prisma, and if so, returns a warning.
--- When doing this, it looks at schema.prisma in the generated project.
---
--- This function makes following assumptions:
---  - schema.prisma will exist in the generated project even if no Entities were defined.
---    Due to how Prisma itself works, this assumption is currently fulfilled.
---  - schema.prisma.wasp-checksum contains the checksum of the schema.prisma as it was during the last `wasp db migrate-dev`.
---
--- Given that, there are two cases in which we wish to warn the user to run `wasp db migrate-dev`:
--- (1) If schema.prisma.wasp-checksum exists, but is not equal to checksum(schema.prisma), we know they made changes to schema.prisma and should migrate.
--- (2) If schema.prisma.wasp-checksum does not exist, but the user has entities defined in schema.prisma (and thus, AppSpec).
---     This could imply they have never migrated locally, or that they have but are simply missing their generated project dir.
---     Common scenarios for the second warning include:
---       - After a fresh checkout, or after `wasp clean`; possible false positives in these cases, but for safety, it's still preferable to warn.
---       - When they previously had no entities and just added their first.
-warnIfDbSchemaChangedSinceLastMigration :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO (Maybe GeneratorWarning)
-warnIfDbSchemaChangedSinceLastMigration spec projectRootDir = do
-  dbSchemaChecksumFileExists <- doesFileExist dbSchemaChecksumFp
-
-  if dbSchemaChecksumFileExists
-    then do
-      dbSchemaFileChecksum <- hexToString <$> checksumFromFilePath dbSchemaFp
-      dbChecksumFileContents <- readFile dbSchemaChecksumFp
-      return $ warnIf (dbSchemaFileChecksum /= dbChecksumFileContents) "Your Prisma schema has changed, you should run `wasp db migrate-dev`."
-    else return $ warnIf entitiesExist "Please run `wasp db migrate-dev` to ensure the local project is fully initialized."
-  where
-    dbSchemaFp = SP.fromAbsFile $ projectRootDir </> dbSchemaFileInProjectRootDir
-    dbSchemaChecksumFp = SP.fromAbsFile $ projectRootDir </> dbSchemaChecksumOnLastMigrateFileProjectRootDir
-    entitiesExist = not . null $ getEntities spec
-
-    warnIf :: Bool -> String -> Maybe GeneratorWarning
-    warnIf b msg = if b then Just $ GenericGeneratorWarning msg else Nothing
 
 genPrismaSchema :: AppSpec -> Generator FileDraft
 genPrismaSchema spec = do
@@ -129,6 +74,61 @@ genMigrationsDir spec =
       Just $ createCopyDirFileDraft (SP.castDir genProjectMigrationsDir) (SP.castDir waspMigrationsDir)
   where
     genProjectMigrationsDir = dbRootDirInProjectRootDir </> dbMigrationsDirInDbRootDir
+
+preCleanup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ()
+preCleanup = deleteGeneratedMigrationsDirIfRedundant
+
+deleteGeneratedMigrationsDirIfRedundant :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ()
+deleteGeneratedMigrationsDirIfRedundant spec projectRootDir = do
+  let waspMigrationsDirMissing = isNothing $ AS.migrationsDir spec
+  projectMigrationsDirExists <- doesDirectoryExist projectMigrationsDirAbsFilePath
+  when (waspMigrationsDirMissing && projectMigrationsDirExists) $ do
+    putStrLn "A migrations directory does not exist in this Wasp root directory, but does in the generated project output directory."
+    putStrLn $ "Deleting directory: " ++ projectMigrationsDirAbsFilePath ++ " ..."
+    removeDirectoryRecursive projectMigrationsDirAbsFilePath
+    putStrLn "Successfully deleted."
+  where
+    projectMigrationsDirAbsFilePath = SP.fromAbsDir $ projectRootDir </> dbRootDirInProjectRootDir </> dbMigrationsDirInDbRootDir
+
+-- | This function operates on generated code, and thus assumes the file drafts were written to disk
+postWriteDbGeneratorActions :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
+postWriteDbGeneratorActions spec dstDir = do
+  dbGeneratorWarnings <- maybeToList <$> warnIfDbSchemaChangedSinceLastMigration spec dstDir
+  dbGeneratorErrors <- maybeToList <$> genPrismaClient dstDir
+  return (dbGeneratorWarnings, dbGeneratorErrors)
+
+-- | Checks if user needs to run `wasp db migrate-dev` due to changes they did in schema.prisma, and if so, returns a warning.
+-- When doing this, it looks at schema.prisma in the generated project.
+--
+-- This function makes following assumptions:
+--  - schema.prisma will exist in the generated project even if no Entities were defined.
+--    Due to how Prisma itself works, this assumption is currently fulfilled.
+--  - schema.prisma.wasp-checksum contains the checksum of the schema.prisma as it was during the last `wasp db migrate-dev`.
+--
+-- Given that, there are two cases in which we wish to warn the user to run `wasp db migrate-dev`:
+-- (1) If schema.prisma.wasp-checksum exists, but is not equal to checksum(schema.prisma), we know they made changes to schema.prisma and should migrate.
+-- (2) If schema.prisma.wasp-checksum does not exist, but the user has entities defined in schema.prisma (and thus, AppSpec).
+--     This could imply they have never migrated locally, or that they have but are simply missing their generated project dir.
+--     Common scenarios for the second warning include:
+--       - After a fresh checkout, or after `wasp clean`; possible false positives in these cases, but for safety, it's still preferable to warn.
+--       - When they previously had no entities and just added their first.
+warnIfDbSchemaChangedSinceLastMigration :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO (Maybe GeneratorWarning)
+warnIfDbSchemaChangedSinceLastMigration spec projectRootDir = do
+  dbSchemaChecksumFileExists <- doesFileExist dbSchemaChecksumFp
+
+  if dbSchemaChecksumFileExists
+    then do
+      dbSchemaFileChecksum <- hexToString <$> checksumFromFilePath dbSchemaFp
+      dbChecksumFileContents <- readFile dbSchemaChecksumFp
+      return $ warnIf (dbSchemaFileChecksum /= dbChecksumFileContents) "Your Prisma schema has changed, you should run `wasp db migrate-dev`."
+    else return $ warnIf entitiesExist "Please run `wasp db migrate-dev` to ensure the local project is fully initialized."
+  where
+    dbSchemaFp = SP.fromAbsFile $ projectRootDir </> dbSchemaFileInProjectRootDir
+    dbSchemaChecksumFp = SP.fromAbsFile $ projectRootDir </> dbSchemaChecksumOnLastMigrateFileProjectRootDir
+    entitiesExist = not . null $ getEntities spec
+
+    warnIf :: Bool -> String -> Maybe GeneratorWarning
+    warnIf b msg = if b then Just $ GenericGeneratorWarning msg else Nothing
 
 genPrismaClient :: Path' Abs (Dir ProjectRootDir) -> IO (Maybe GeneratorError)
 genPrismaClient projectRootDir = either (Just . GenericGeneratorError) (const Nothing) <$> DbOps.generatePrismaClient projectRootDir

--- a/waspc/src/Wasp/Generator/DbGenerator/Common.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Common.hs
@@ -1,0 +1,50 @@
+module Wasp.Generator.DbGenerator.Common
+  ( dbMigrationsDirInDbRootDir,
+    dbRootDirInProjectRootDir,
+    dbSchemaChecksumFileInProjectRootDir,
+    dbSchemaFileInDbTemplatesDir,
+    dbSchemaFileInProjectRootDir,
+    dbTemplatesDirInTemplatesDir,
+  )
+where
+
+import StrongPath (Dir, File, File', Path', Rel, reldir, relfile, (</>))
+import qualified StrongPath as SP
+import Wasp.Common (DbMigrationsDir)
+import Wasp.Generator.Common (ProjectRootDir)
+import Wasp.Generator.Templates (TemplatesDir)
+
+data DbRootDir
+
+data DbTemplatesDir
+
+-- | This file represents the checksum of schema.prisma
+-- at the point at which db migrate-dev was last run. It is used
+-- to help warn the user of instances they may need to migrate.
+data DbSchemaChecksumFile
+
+dbRootDirInProjectRootDir :: Path' (Rel ProjectRootDir) (Dir DbRootDir)
+dbRootDirInProjectRootDir = [reldir|db|]
+
+dbTemplatesDirInTemplatesDir :: Path' (Rel TemplatesDir) (Dir DbTemplatesDir)
+dbTemplatesDirInTemplatesDir = [reldir|db|]
+
+dbSchemaFileInDbTemplatesDir :: Path' (Rel DbTemplatesDir) File'
+dbSchemaFileInDbTemplatesDir = [relfile|schema.prisma|]
+
+dbSchemaFileInDbRootDir :: Path' (Rel DbRootDir) File'
+-- Generated schema file will be in the same relative location as the
+-- template file within templates dir.
+dbSchemaFileInDbRootDir = SP.castRel dbSchemaFileInDbTemplatesDir
+
+dbSchemaFileInProjectRootDir :: Path' (Rel ProjectRootDir) File'
+dbSchemaFileInProjectRootDir = dbRootDirInProjectRootDir </> dbSchemaFileInDbRootDir
+
+dbMigrationsDirInDbRootDir :: Path' (Rel DbRootDir) (Dir DbMigrationsDir)
+dbMigrationsDirInDbRootDir = [reldir|migrations|]
+
+dbSchemaChecksumFileInDbRootDir :: Path' (Rel DbRootDir) (File DbSchemaChecksumFile)
+dbSchemaChecksumFileInDbRootDir = [relfile|schema.prisma.wasp-checksum|]
+
+dbSchemaChecksumFileInProjectRootDir :: Path' (Rel ProjectRootDir) (File DbSchemaChecksumFile)
+dbSchemaChecksumFileInProjectRootDir = dbRootDirInProjectRootDir </> dbSchemaChecksumFileInDbRootDir

--- a/waspc/src/Wasp/Generator/DbGenerator/Common.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Common.hs
@@ -1,7 +1,8 @@
 module Wasp.Generator.DbGenerator.Common
   ( dbMigrationsDirInDbRootDir,
     dbRootDirInProjectRootDir,
-    dbSchemaChecksumFileInProjectRootDir,
+    dbSchemaChecksumOnLastMigrateFileProjectRootDir,
+    dbSchemaChecksumOnLastGenerateFileProjectRootDir,
     dbSchemaFileInDbTemplatesDir,
     dbSchemaFileInProjectRootDir,
     dbTemplatesDirInTemplatesDir,
@@ -19,9 +20,14 @@ data DbRootDir
 data DbTemplatesDir
 
 -- | This file represents the checksum of schema.prisma
--- at the point at which db migrate-dev was last run. It is used
+-- at the point at which `prisma db migrate-dev` was last run. It is used
 -- to help warn the user of instances they may need to migrate.
-data DbSchemaChecksumFile
+data DbSchemaChecksumOnLastMigrateFile
+
+-- | This file represents the checksum of schema.prisma
+-- at the point at which `prisma generate` was last run. It is used
+-- to know if we need to regenerate during generation or not.
+data DbSchemaChecksumOnLastGenerateFile
 
 dbRootDirInProjectRootDir :: Path' (Rel ProjectRootDir) (Dir DbRootDir)
 dbRootDirInProjectRootDir = [reldir|db|]
@@ -43,8 +49,14 @@ dbSchemaFileInProjectRootDir = dbRootDirInProjectRootDir </> dbSchemaFileInDbRoo
 dbMigrationsDirInDbRootDir :: Path' (Rel DbRootDir) (Dir DbMigrationsDir)
 dbMigrationsDirInDbRootDir = [reldir|migrations|]
 
-dbSchemaChecksumFileInDbRootDir :: Path' (Rel DbRootDir) (File DbSchemaChecksumFile)
-dbSchemaChecksumFileInDbRootDir = [relfile|schema.prisma.wasp-checksum|]
+dbSchemaChecksumOnLastMigrateFileInDbRootDir :: Path' (Rel DbRootDir) (File DbSchemaChecksumOnLastMigrateFile)
+dbSchemaChecksumOnLastMigrateFileInDbRootDir = [relfile|schema.prisma.wasp-migrate-checksum|]
 
-dbSchemaChecksumFileInProjectRootDir :: Path' (Rel ProjectRootDir) (File DbSchemaChecksumFile)
-dbSchemaChecksumFileInProjectRootDir = dbRootDirInProjectRootDir </> dbSchemaChecksumFileInDbRootDir
+dbSchemaChecksumOnLastMigrateFileProjectRootDir :: Path' (Rel ProjectRootDir) (File DbSchemaChecksumOnLastMigrateFile)
+dbSchemaChecksumOnLastMigrateFileProjectRootDir = dbRootDirInProjectRootDir </> dbSchemaChecksumOnLastMigrateFileInDbRootDir
+
+dbSchemaChecksumOnLastGenerateFileInDbRootDir :: Path' (Rel DbRootDir) (File DbSchemaChecksumOnLastGenerateFile)
+dbSchemaChecksumOnLastGenerateFileInDbRootDir = [relfile|schema.prisma.wasp-generate-checksum|]
+
+dbSchemaChecksumOnLastGenerateFileProjectRootDir :: Path' (Rel ProjectRootDir) (File DbSchemaChecksumOnLastGenerateFile)
+dbSchemaChecksumOnLastGenerateFileProjectRootDir = dbRootDirInProjectRootDir </> dbSchemaChecksumOnLastGenerateFileInDbRootDir

--- a/waspc/src/Wasp/Generator/DbGenerator/Common.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Common.hs
@@ -21,12 +21,12 @@ data DbTemplatesDir
 
 -- | This file represents the checksum of schema.prisma
 -- at the point at which `prisma db migrate-dev` was last run. It is used
--- to help warn the user of instances they may need to migrate.
+-- to help warn the user of instances when they may need to migrate.
 data DbSchemaChecksumOnLastMigrateFile
 
 -- | This file represents the checksum of schema.prisma
 -- at the point at which `prisma generate` was last run. It is used
--- to know if we need to regenerate during generation or not.
+-- to know if we need to regenerate schema.prisma during web app generation or not.
 data DbSchemaChecksumOnLastGenerateFile
 
 dbRootDirInProjectRootDir :: Path' (Rel ProjectRootDir) (Dir DbRootDir)

--- a/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
@@ -27,9 +27,11 @@ import Wasp.Generator.FileDraft.WriteableMonad
   )
 import Wasp.Generator.Job (JobMessage)
 import qualified Wasp.Generator.Job as J
-import Wasp.Generator.Job.IO (printJobMessage)
+import Wasp.Generator.Job.IO (printJobMessage, readJobMessagesAndPrintThemPrefixed)
 import Wasp.Util (checksumFromFilePath, hexToString)
 
+-- | NOTE(shayne): This appears to be used instead of readJobMessagesAndPrintThemPrefixed during migration
+-- as there is lots of Prisma cursor manipulation that causes the "DB:"" prefix to not come out right.
 printJobMsgsUntilExitReceived :: Chan JobMessage -> IO ()
 printJobMsgsUntilExitReceived chan = do
   jobMsg <- readChan chan
@@ -81,7 +83,7 @@ generatePrismaClient genProjectRootDirAbs = do
   chan <- newChan
   (_, dbExitCode) <-
     concurrently
-      (printJobMsgsUntilExitReceived chan)
+      (readJobMessagesAndPrintThemPrefixed chan)
       (DbJobs.runGenerate genProjectRootDirAbs chan)
   case dbExitCode of
     ExitSuccess -> return $ Right ()

--- a/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
@@ -67,6 +67,7 @@ copyMigrationsBackToSource genProjectRootDirAbs dbMigrationsDirInWaspProjectDirA
     waspMigrationsDir = SP.castDir dbMigrationsDirInWaspProjectDirAbs
     genProjectMigrationsDir = SP.castDir $ genProjectRootDirAbs SP.</> dbRootDirInProjectRootDir SP.</> dbMigrationsDirInDbRootDir
 
+-- | This function assumes the DB schema has been generated, as it will attempt to read it from the generated code.
 writeDbSchemaChecksumToFile :: Path' Abs (Dir ProjectRootDir) -> Path' (Rel ProjectRootDir) File' -> IO ()
 writeDbSchemaChecksumToFile genProjectRootDirAbs dbSchemaChecksumInProjectRootDir = do
   dbSchemaExists <- doesFileExist dbSchemaFp

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -29,7 +29,7 @@ import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
 import qualified Wasp.AppSpec.App.Server as AS.App.Server
 import qualified Wasp.AppSpec.Entity as AS.Entity
-import Wasp.Generator.Common (ProjectRootDir, nodeVersionAsText)
+import Wasp.Generator.Common (ProjectRootDir, nodeVersionAsText, prismaVersion)
 import Wasp.Generator.ExternalCodeGenerator (generateExternalCodeDir)
 import Wasp.Generator.ExternalCodeGenerator.Common (GeneratedExternalCodeDir)
 import Wasp.Generator.FileDraft (FileDraft, createCopyFileDraft)
@@ -131,7 +131,7 @@ waspNpmDeps =
       ("debug", "~2.6.9"),
       ("express", "~4.16.1"),
       ("morgan", "~1.9.1"),
-      ("@prisma/client", "2.22.1"),
+      ("@prisma/client", prismaVersion),
       ("jsonwebtoken", "^8.5.1"),
       ("secure-password", "^4.0.0"),
       ("dotenv", "8.2.0"),
@@ -143,7 +143,7 @@ waspNpmDevDeps =
   AS.Dependency.fromList
     [ ("nodemon", "^2.0.4"),
       ("standard", "^14.3.4"),
-      ("prisma", "2.22.1")
+      ("prisma", prismaVersion)
     ]
 
 genNpmrc :: Generator FileDraft


### PR DESCRIPTION
# Description

Currently, we do not regenerate the Prisma client as part of our overall app generation process. This means if the user makes changes to their Wasp files that impact schema.prisma, those changes won't be applied to the Prisma client until they run `wasp db migrate`. This is not ideal, and it would be much better if we made this a part of normal app generation, in line with the Prisma recommendation:

> Important: You need to re-run the prisma generate command after every change that's made to your Prisma schema to update the generated Prisma Client code.
Ref: https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client

## Important

The Prisma client generation step runs via `npx`, and is now run on whenever the prisma schema changes (and thus differs from schema.prisma.wasp-generate-checksum). One part of this we needed to solve was for this to work even if Prisma was not installed on the user's machine yet. This is because if it is not found, it prompts them to install it, and it uses the latest version. This change adds a function that tries `npx` commands that will fail if the exact version we use is not available locally, and then `npm install`s before retrying.

This process will also hide all output from `prisma generate` unless there is an error on retry.

Fixes #427

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update