### PR TITLE
fix: todo example error from missing entity

### DIFF
--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -77,7 +77,7 @@ query getTasks {
 
 query getNumTasks {
   fn: import { getNumTasks } from "@ext/queries.js",
-
+  entities: [Task],
   auth: false
 }
 


### PR DESCRIPTION
# Description

I just noticed the todo example was throwing server errors:

```
Server: POST /operations/get-num-tasks 500 2.724 ms - 1595
Server: TypeError: Cannot read property 'count' of undefined
Server (stderr):     at getNumTasks (file:///Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/src/ext-src/queries.js:23:32)
Server (stderr):     at default (file:///Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/src/queries/getNumTasks.js:9:10)
Server (stderr):     at file:///Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/src/routes/operations/getNumTasks.js:12:24
Server (stderr):     at file:///Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/src/utils.js:13:11
Server (stderr):     at Layer.handle [as handle_request] (/Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/node_modules/express/lib/router/layer.js:95:5)
Server (stderr):     at next (/Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/node_modules/express/lib/router/route.js:137:13)
Server (stderr):     at Route.dispatch (/Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/node_modules/express/lib/router/route.js:112:3)
Server (stderr):     at Layer.handle [as handle_request] (/Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/node_modules/express/lib/router/layer.js:95:5)
Server (stderr):     at /Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/node_modules/express/lib/router/index.js:281:22
Server (stderr):     at Function.process_params (/Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/server/node_modules/express/lib/router/index.js:335:12)
```

This was due to a missing `entities: [Task]` in the query declaration.

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update