### PR TITLE
269 compile and npm install

### DIFF
--- a/waspc/.gitignore
+++ b/waspc/.gitignore
@@ -2,6 +2,7 @@
 stack*.yaml.lock
 dist-newstyle
 waspc.cabal
+.vscode
 
 /out
 

--- a/waspc/cli/Wasp/Cli/Command/CompileAndSetup.hs
+++ b/waspc/cli/Wasp/Cli/Command/CompileAndSetup.hs
@@ -1,0 +1,38 @@
+module Wasp.Cli.Command.CompileAndSetup (compileAndSetup) where
+
+import Control.Monad.Except (throwError)
+import Control.Monad.IO.Class (liftIO)
+import StrongPath (Abs, Dir, Path')
+import Wasp.Cli.Command (Command, CommandError (..))
+import Wasp.Cli.Command.Common
+  ( waspSaysC,
+  )
+import Wasp.Cli.Command.Compile (compileIO)
+import qualified Wasp.Cli.Common as Common
+import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
+import qualified Wasp.Generator.Common
+import qualified Wasp.Lib
+
+compileAndSetup ::
+  Path' Abs (Dir Common.WaspProjectDir) ->
+  Path' Abs (Dir Wasp.Generator.Common.ProjectRootDir) ->
+  Command ()
+compileAndSetup waspRoot outDir = do
+  waspSaysC $ asWaspStartMessage "Compiling wasp code..."
+  compilationResult <- liftIO $ compileIO waspRoot outDir
+  case compilationResult of
+    Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Compilation failed:" ++ compileError
+    Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully compiled, project has been generated."
+
+  -- TODO: Do smart npm install -> if we need to install stuff, install it, otherwise don't.
+  --   This should be responsibility of Generator, it should tell us how to install stuff.
+  --   But who checks out if stuff needs to be installed at all? That should probably be
+  --   Generator again. After installation, it should return some kind of data that describes that installation.
+  --   Then, next time, we give it data we have about last installation, and it uses that
+  --   to decide if installation needs to happen or not. If it happens, it returnes new data again.
+  --   Right now we have setup/installation being called, but it has not support for being "smart" yet.
+  waspSaysC $ asWaspStartMessage "Setting up generated project..."
+  setupResult <- liftIO $ Wasp.Lib.setup outDir
+  case setupResult of
+    Left setupError -> throwError $ CommandError $ asWaspFailureMessage "Setup failed:" ++ setupError
+    Right () -> waspSaysC $ asWaspSuccessMessage "Setup successful."

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -28,25 +28,6 @@ start = do
 
   compileAndNpmInstall waspRoot outDir
 
-  -- waspSaysC $ asWaspStartMessage "Compiling wasp code..."
-  -- compilationResult <- liftIO $ compileIO waspRoot outDir
-  -- case compilationResult of
-  --   Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Compilation failed:" ++ compileError
-  --   Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully compiled, project has been generated."
-
-  -- -- TODO: Do smart npm install -> if we need to install stuff, install it, otherwise don't.
-  -- --   This should be responsibility of Generator, it should tell us how to install stuff.
-  -- --   But who checks out if stuff needs to be installed at all? That should probably be
-  -- --   Generator again. After installation, it should return some kind of data that describes that installation.
-  -- --   Then, next time, we give it data we have about last installation, and it uses that
-  -- --   to decide if installation needs to happen or not. If it happens, it returnes new data again.
-  -- --   Right now we have setup/installation being called, but it has not support for being "smart" yet.
-  -- waspSaysC $ asWaspStartMessage "Setting up generated project..."
-  -- setupResult <- liftIO $ Wasp.Lib.setup outDir
-  -- case setupResult of
-  --   Left setupError -> throwError $ CommandError $ asWaspFailureMessage "Setup failed:" ++ setupError
-  --   Right () -> waspSaysC $ asWaspSuccessMessage "Setup successful."
-
   waspSaysC $ asWaspStartMessage "Listening for file changes..."
   waspSaysC $ asWaspStartMessage "Starting up generated project..."
   watchOrStartResult <- liftIO $ race (watch waspRoot outDir) (Wasp.Lib.start outDir)

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -6,17 +6,16 @@ where
 import Control.Concurrent.Async (race)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
-import StrongPath (Abs, Dir, Path', (</>))
+import StrongPath ((</>))
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
     waspSaysC,
   )
-import Wasp.Cli.Command.Compile (compileIO)
+import Wasp.Cli.Command.CompileAndSetup (compileAndSetup)
 import Wasp.Cli.Command.Watch (watch)
 import qualified Wasp.Cli.Common as Common
-import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
-import qualified Wasp.Generator.Common
+import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage)
 import qualified Wasp.Lib
 
 -- | Does initial compile of wasp code and then runs the generated project.
@@ -36,27 +35,3 @@ start = do
     Right startResult -> case startResult of
       Left startError -> throwError $ CommandError $ asWaspFailureMessage "Start failed:" ++ startError
       Right () -> error "This should never happen, start should never end but it did."
-
-compileAndSetup ::
-  Path' Abs (Dir Common.WaspProjectDir) ->
-  Path' Abs (Dir Wasp.Generator.Common.ProjectRootDir) ->
-  Command ()
-compileAndSetup waspRoot outDir = do
-  waspSaysC $ asWaspStartMessage "Compiling wasp code..."
-  compilationResult <- liftIO $ compileIO waspRoot outDir
-  case compilationResult of
-    Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Compilation failed:" ++ compileError
-    Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully compiled, project has been generated."
-
-  -- TODO: Do smart install -> if we need to install stuff, install it, otherwise don't.
-  --   This should be responsibility of Generator, it should tell us how to install stuff.
-  --   But who checks out if stuff needs to be installed at all? That should probably be
-  --   Generator again. After installation, it should return some kind of data that describes that installation.
-  --   Then, next time, we give it data we have about last installation, and it uses that
-  --   to decide if installation needs to happen or not. If it happens, it returnes new data again.
-  --   Right now we have setup/installation being called, but it has not support for being "smart" yet.
-  waspSaysC $ asWaspStartMessage "Setting up generated project..."
-  setupResult <- liftIO $ Wasp.Lib.setup outDir
-  case setupResult of
-    Left setupError -> throwError $ CommandError $ asWaspFailureMessage "Setup failed:" ++ setupError
-    Right () -> waspSaysC $ asWaspSuccessMessage "Setup successful."

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -6,7 +6,7 @@ where
 import Control.Concurrent.Async (race)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
-import StrongPath ((</>))
+import StrongPath (Abs, Dir, Path', (</>))
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
@@ -16,6 +16,7 @@ import Wasp.Cli.Command.Compile (compileIO)
 import Wasp.Cli.Command.Watch (watch)
 import qualified Wasp.Cli.Common as Common
 import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
+import qualified Wasp.Generator.Common
 import qualified Wasp.Lib
 
 -- | Does initial compile of wasp code and then runs the generated project.
@@ -25,6 +26,41 @@ start = do
   waspRoot <- findWaspProjectRootDirFromCwd
   let outDir = waspRoot </> Common.dotWaspDirInWaspProjectDir </> Common.generatedCodeDirInDotWaspDir
 
+  compileAndNpmInstall waspRoot outDir
+
+  -- waspSaysC $ asWaspStartMessage "Compiling wasp code..."
+  -- compilationResult <- liftIO $ compileIO waspRoot outDir
+  -- case compilationResult of
+  --   Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Compilation failed:" ++ compileError
+  --   Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully compiled, project has been generated."
+
+  -- -- TODO: Do smart npm install -> if we need to install stuff, install it, otherwise don't.
+  -- --   This should be responsibility of Generator, it should tell us how to install stuff.
+  -- --   But who checks out if stuff needs to be installed at all? That should probably be
+  -- --   Generator again. After installation, it should return some kind of data that describes that installation.
+  -- --   Then, next time, we give it data we have about last installation, and it uses that
+  -- --   to decide if installation needs to happen or not. If it happens, it returnes new data again.
+  -- --   Right now we have setup/installation being called, but it has not support for being "smart" yet.
+  -- waspSaysC $ asWaspStartMessage "Setting up generated project..."
+  -- setupResult <- liftIO $ Wasp.Lib.setup outDir
+  -- case setupResult of
+  --   Left setupError -> throwError $ CommandError $ asWaspFailureMessage "Setup failed:" ++ setupError
+  --   Right () -> waspSaysC $ asWaspSuccessMessage "Setup successful."
+
+  waspSaysC $ asWaspStartMessage "Listening for file changes..."
+  waspSaysC $ asWaspStartMessage "Starting up generated project..."
+  watchOrStartResult <- liftIO $ race (watch waspRoot outDir) (Wasp.Lib.start outDir)
+  case watchOrStartResult of
+    Left () -> error "This should never happen, listening for file changes should never end but it did."
+    Right startResult -> case startResult of
+      Left startError -> throwError $ CommandError $ asWaspFailureMessage "Start failed:" ++ startError
+      Right () -> error "This should never happen, start should never end but it did."
+
+compileAndNpmInstall ::
+  Path' Abs (Dir Common.WaspProjectDir) ->
+  Path' Abs (Dir Wasp.Generator.Common.ProjectRootDir) ->
+  Command ()
+compileAndNpmInstall waspRoot outDir = do
   waspSaysC $ asWaspStartMessage "Compiling wasp code..."
   compilationResult <- liftIO $ compileIO waspRoot outDir
   case compilationResult of
@@ -43,12 +79,3 @@ start = do
   case setupResult of
     Left setupError -> throwError $ CommandError $ asWaspFailureMessage "Setup failed:" ++ setupError
     Right () -> waspSaysC $ asWaspSuccessMessage "Setup successful."
-
-  waspSaysC $ asWaspStartMessage "Listening for file changes..."
-  waspSaysC $ asWaspStartMessage "Starting up generated project..."
-  watchOrStartResult <- liftIO $ race (watch waspRoot outDir) (Wasp.Lib.start outDir)
-  case watchOrStartResult of
-    Left () -> error "This should never happen, listening for file changes should never end but it did."
-    Right startResult -> case startResult of
-      Left startError -> throwError $ CommandError $ asWaspFailureMessage "Start failed:" ++ startError
-      Right () -> error "This should never happen, start should never end but it did."

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -26,7 +26,7 @@ start = do
   waspRoot <- findWaspProjectRootDirFromCwd
   let outDir = waspRoot </> Common.dotWaspDirInWaspProjectDir </> Common.generatedCodeDirInDotWaspDir
 
-  compileAndNpmInstall waspRoot outDir
+  compileAndSetup waspRoot outDir
 
   waspSaysC $ asWaspStartMessage "Listening for file changes..."
   waspSaysC $ asWaspStartMessage "Starting up generated project..."
@@ -37,11 +37,11 @@ start = do
       Left startError -> throwError $ CommandError $ asWaspFailureMessage "Start failed:" ++ startError
       Right () -> error "This should never happen, start should never end but it did."
 
-compileAndNpmInstall ::
+compileAndSetup ::
   Path' Abs (Dir Common.WaspProjectDir) ->
   Path' Abs (Dir Wasp.Generator.Common.ProjectRootDir) ->
   Command ()
-compileAndNpmInstall waspRoot outDir = do
+compileAndSetup waspRoot outDir = do
   waspSaysC $ asWaspStartMessage "Compiling wasp code..."
   compilationResult <- liftIO $ compileIO waspRoot outDir
   case compilationResult of

--- a/waspc/cli/Wasp/Cli/Command/Watch.hs
+++ b/waspc/cli/Wasp/Cli/Command/Watch.hs
@@ -13,10 +13,11 @@ import StrongPath (Abs, Dir, Path', (</>))
 import qualified StrongPath as SP
 import qualified System.FSNotify as FSN
 import qualified System.FilePath as FP
-import Wasp.Cli.Command.Compile (compileIO)
-import Wasp.Cli.Common (waspSays, waspScreams)
+import Wasp.Cli.Command (runCommand)
+import Wasp.Cli.Command.CompileAndSetup (compileAndSetup)
+import Wasp.Cli.Common (waspSays)
 import qualified Wasp.Cli.Common as Common
-import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
+import Wasp.Cli.Terminal (asWaspStartMessage)
 import qualified Wasp.Lib
 
 -- TODO: Another possible problem: on re-generation, wasp re-generates a lot of files, even those that should not
@@ -80,11 +81,7 @@ watch waspProjectDir outDir = FSN.withManager $ \mgr -> do
     recompile :: IO ()
     recompile = do
       waspSays $ asWaspStartMessage "Recompiling on file change..."
-      compilationResult <- compileIO waspProjectDir outDir
-      case compilationResult of
-        Left err -> waspScreams $ asWaspFailureMessage "Recompilation on file change failed:" ++ err
-        Right () -> waspSays $ asWaspSuccessMessage "Recompilation on file change succeeded."
-      return ()
+      runCommand $ compileAndSetup waspProjectDir outDir
 
     -- TODO: This is a hardcoded approach to ignoring most of the common tmp files that editors
     --   create next to the source code. Bad thing here is that users can't modify this,


### PR DESCRIPTION
# Description

This factors out the compileAndSetup logic into its own function. We run this not only just after start, but also during the watch command. We don't skip setup yet if no dependencies changed, but this sets us up to do this in a single place.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update