### PR TITLE
Create bytes file draft (and a way to easily create json files with it)

### DIFF
--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -145,3 +145,4 @@ tests:
       - unordered-containers
       - strong-path
       - split
+      - bytestring

--- a/waspc/src/Wasp/Generator/FileDraft.hs
+++ b/waspc/src/Wasp/Generator/FileDraft.hs
@@ -6,6 +6,7 @@ module Wasp.Generator.FileDraft
     createCopyFileDraftIfExists,
     createTextFileDraft,
     createCopyDirFileDraft,
+    createBytesFileDraftFromJson,
   )
 where
 
@@ -13,6 +14,7 @@ import qualified Data.Aeson as Aeson
 import Data.Text (Text)
 import StrongPath (Abs, Dir', File', Path', Rel)
 import Wasp.Generator.Common (ProjectRootDir)
+import qualified Wasp.Generator.FileDraft.BytesFileDraft as BytesFD
 import qualified Wasp.Generator.FileDraft.CopyDirFileDraft as CopyDirFD
 import qualified Wasp.Generator.FileDraft.CopyFileDraft as CopyFD
 import qualified Wasp.Generator.FileDraft.TemplateFileDraft as TmplFD
@@ -32,6 +34,7 @@ data FileDraft
   | FileDraftCopyFd CopyFD.CopyFileDraft
   | FileDraftCopyDirFd CopyDirFD.CopyDirFileDraft
   | FileDraftTextFd TextFD.TextFileDraft
+  | FileDraftBytesFd BytesFD.BytesFileDraft
   deriving (Show, Eq)
 
 instance Writeable FileDraft where
@@ -39,6 +42,7 @@ instance Writeable FileDraft where
   write dstDir (FileDraftCopyFd draft) = write dstDir draft
   write dstDir (FileDraftCopyDirFd draft) = write dstDir draft
   write dstDir (FileDraftTextFd draft) = write dstDir draft
+  write dstDir (FileDraftBytesFd draft) = write dstDir draft
 
 createTemplateFileDraft ::
   Path' (Rel ProjectRootDir) File' ->
@@ -82,3 +86,7 @@ createCopyDirFileDraft dstPath srcPath =
 createTextFileDraft :: Path' (Rel ProjectRootDir) File' -> Text -> FileDraft
 createTextFileDraft dstPath content =
   FileDraftTextFd $ TextFD.TextFileDraft {TextFD._dstPath = dstPath, TextFD._content = content}
+
+createBytesFileDraftFromJson :: Path' (Rel ProjectRootDir) File' -> Aeson.Value -> FileDraft
+createBytesFileDraftFromJson dstPath content =
+  FileDraftBytesFd $ BytesFD.BytesFileDraft {BytesFD._dstPath = dstPath, BytesFD._content = Aeson.encode content}

--- a/waspc/src/Wasp/Generator/FileDraft/BytesFileDraft.hs
+++ b/waspc/src/Wasp/Generator/FileDraft/BytesFileDraft.hs
@@ -1,0 +1,27 @@
+module Wasp.Generator.FileDraft.BytesFileDraft
+  ( BytesFileDraft (..),
+  )
+where
+
+import Data.ByteString.Lazy (ByteString)
+import StrongPath (File', Path', Rel, (</>))
+import qualified StrongPath as SP
+import Wasp.Generator.Common (ProjectRootDir)
+import Wasp.Generator.FileDraft.Writeable
+import Wasp.Generator.FileDraft.WriteableMonad
+
+-- | File draft based on raw bytes
+data BytesFileDraft = BytesFileDraft
+  { -- | Path where file will be generated.
+    _dstPath :: !(Path' (Rel ProjectRootDir) File'),
+    _content :: ByteString
+  }
+  deriving (Show, Eq)
+
+instance Writeable BytesFileDraft where
+  write dstDir draft = do
+    createDirectoryIfMissing True (SP.fromAbsDir $ SP.parent absDraftDstPath)
+    writeFileFromByteString (SP.fromAbsFile absDraftDstPath) content
+    where
+      absDraftDstPath = dstDir </> _dstPath draft
+      content = _content draft

--- a/waspc/src/Wasp/Generator/FileDraft/WriteableMonad.hs
+++ b/waspc/src/Wasp/Generator/FileDraft/WriteableMonad.hs
@@ -5,6 +5,8 @@ where
 
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson as Aeson
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy
 import Data.Text (Text)
 import qualified Data.Text.IO
 import qualified Path.IO as PathIO
@@ -50,6 +52,8 @@ class (MonadIO m) => WriteableMonad m where
 
   writeFileFromText :: FilePath -> Text -> m ()
 
+  writeFileFromByteString :: FilePath -> ByteString -> m ()
+
   getTemplateFileAbsPath ::
     -- | Template file path.
     Path' (Rel Templates.TemplatesDir) File' ->
@@ -88,6 +92,7 @@ instance WriteableMonad IO where
   doesFileExist = System.Directory.doesFileExist
   doesDirectoryExist = System.Directory.doesDirectoryExist
   writeFileFromText = Data.Text.IO.writeFile
+  writeFileFromByteString = Data.ByteString.Lazy.writeFile
   getTemplateFileAbsPath = Templates.getTemplateFileAbsPath
   getTemplatesDirAbsPath = Templates.getTemplatesDirAbsPath
   compileAndRenderTemplate = Templates.compileAndRenderTemplate

--- a/waspc/test/Generator/FileDraft/BytesFileDraftTest.hs
+++ b/waspc/test/Generator/FileDraft/BytesFileDraftTest.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Generator.FileDraft.BytesFileDraftTest where
+
+import qualified Data.Aeson as Aeson
+import Data.Text.Lazy.Encoding (encodeUtf8)
+import Fixtures (systemSPRoot)
+import GHC.Generics
+import qualified Generator.MockWriteableMonad as Mock
+import qualified StrongPath as SP
+import Test.Tasty.Hspec (Spec, describe, it, shouldBe)
+import Wasp.Generator.FileDraft
+  ( Writeable (write),
+    createBytesFileDraftFromJson,
+  )
+
+data Person = Person
+  { name :: String,
+    score :: Int
+  }
+  deriving (Show, Eq, Generic, Aeson.ToJSON, Aeson.FromJSON)
+
+spec_JsonFileDraft :: Spec
+spec_JsonFileDraft = do
+  describe "write" $ do
+    it "Creates new BytesFileDraft from JSON" $ do
+      let mock = write dstDir fileDraft
+      let mockLogs = Mock.getMockLogs mock Mock.defaultMockConfig
+      Mock.createDirectoryIfMissing_calls mockLogs
+        `shouldBe` [(True, SP.toFilePath $ SP.parent expectedDstPath)]
+      Mock.writeFileFromByteString_calls mockLogs
+        `shouldBe` [(SP.toFilePath expectedDstPath, encodeUtf8 "{\"score\":107,\"name\":\"Foo Barson\"}")]
+  where
+    (dstDir, dstPath) =
+      ( systemSPRoot SP.</> [SP.reldir|a/b|],
+        [SP.relfile|c/d/dst.json|]
+      )
+    person = Person {name = "Foo Barson", score = 107}
+    fileDraft = createBytesFileDraftFromJson dstPath (Aeson.toJSON person)
+    expectedDstPath = dstDir SP.</> dstPath

--- a/waspc/test/Generator/WebAppGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGeneratorTest.hs
@@ -8,6 +8,7 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.Core.Decl as AS.Decl
 import Wasp.Generator.FileDraft
+import qualified Wasp.Generator.FileDraft.BytesFileDraft as BytesFD
 import qualified Wasp.Generator.FileDraft.CopyDirFileDraft as CopyDirFD
 import qualified Wasp.Generator.FileDraft.CopyFileDraft as CopyFD
 import qualified Wasp.Generator.FileDraft.TemplateFileDraft as TmplFD
@@ -91,3 +92,4 @@ getFileDraftDstPath (FileDraftTemplateFd fd) = SP.toFilePath $ TmplFD._dstPath f
 getFileDraftDstPath (FileDraftCopyFd fd) = SP.toFilePath $ CopyFD._dstPath fd
 getFileDraftDstPath (FileDraftCopyDirFd fd) = SP.toFilePath $ CopyDirFD._dstPath fd
 getFileDraftDstPath (FileDraftTextFd fd) = SP.toFilePath $ TextFD._dstPath fd
+getFileDraftDstPath (FileDraftBytesFd fd) = SP.toFilePath $ BytesFD._dstPath fd


### PR DESCRIPTION
# Description

Make it possible to create BytesFileDraft. The first one you can create for JSON. 

This is going to be handy to store all kinds of information, but most relevant right now is #269, where we want to track which dependencies are required.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update