### PR TITLE
App spec validation

### DIFF
--- a/waspc/src/Wasp/AppSpec.hs
+++ b/waspc/src/Wasp/AppSpec.hs
@@ -7,13 +7,11 @@ module Wasp.AppSpec
     takeDecls,
     Ref,
     refName,
-    getApp,
     getActions,
     getQueries,
     getEntities,
     getPages,
     getRoutes,
-    isAuthEnabled,
   )
 where
 
@@ -29,7 +27,7 @@ import qualified Wasp.AppSpec.ExternalCode as ExternalCode
 import Wasp.AppSpec.Page (Page)
 import Wasp.AppSpec.Query (Query)
 import Wasp.AppSpec.Route (Route)
-import Wasp.AppSpec.Valid (Valid, fromValid, (<$^>))
+import Wasp.AppSpec.Valid (Valid, fromValid, ($^))
 import Wasp.Common (DbMigrationsDir)
 
 -- | AppSpec is the main/central intermediate representation (IR) of the whole Wasp compiler,
@@ -75,18 +73,3 @@ getPages = getDecls @Page
 
 getRoutes :: AppSpec -> [(String, Route)]
 getRoutes = getDecls @Route
-
--- TODO: Move into Valid.AppSpec?
-getApp :: Valid AppSpec -> Valid (String, App)
-getApp spec =
-  let apps = getDecls @App <$> spec
-   in case fromValid apps of
-        [_] -> head <$> apps
-        apps' ->
-          error $
-            "Expected exactly 1 'app' declaration in Valid AppSpec, but found " ++ show (length apps')
-              ++ ". This should never happen."
-
--- TODO: Make it work on App instead of AppSpec? Move it somewhere, maybe to Valid.AppSpec?
-isAuthEnabled :: Valid AppSpec -> Bool
-isAuthEnabled spec = isJust (App.auth $ snd <$^> getApp spec)

--- a/waspc/src/Wasp/AppSpec.hs
+++ b/waspc/src/Wasp/AppSpec.hs
@@ -15,11 +15,8 @@ module Wasp.AppSpec
   )
 where
 
-import Data.Maybe (isJust)
 import StrongPath (Abs, Dir, File', Path')
 import Wasp.AppSpec.Action (Action)
-import Wasp.AppSpec.App (App)
-import qualified Wasp.AppSpec.App as App
 import Wasp.AppSpec.Core.Decl (Decl, IsDecl, takeDecls)
 import Wasp.AppSpec.Core.Ref (Ref, refName)
 import Wasp.AppSpec.Entity (Entity)
@@ -27,7 +24,6 @@ import qualified Wasp.AppSpec.ExternalCode as ExternalCode
 import Wasp.AppSpec.Page (Page)
 import Wasp.AppSpec.Query (Query)
 import Wasp.AppSpec.Route (Route)
-import Wasp.AppSpec.Valid (Valid, fromValid, ($^))
 import Wasp.Common (DbMigrationsDir)
 
 -- | AppSpec is the main/central intermediate representation (IR) of the whole Wasp compiler,

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -1,16 +1,44 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Wasp.AppSpec.Valid
-  ( Valid,
-    (<$^>),
+  ( Valid (Valid),
     fromValid,
+    ($^),
+    propagateValid,
+    (<$^>),
+    (<$^^>),
   )
 where
 
-import Wasp.AppSpec.Valid.Internal
+import Wasp.AppSpec.Valid.Internal (Valid (..))
+
+-- By defining @pattern Valid@, others can pattern match on `Valid`, but they can't construct it.
+
+pattern Valid :: a -> Valid a
+pattern Valid a <- MakeValid a
+
+-- NOTE: This is needed by compiler to know that Valid is the only pattern in the pattern set,
+--   so it doesn't warn about missing patterns.
+{-# COMPLETE Valid #-}
 
 fromValid :: Valid a -> a
-fromValid (Valid a) = a
+fromValid (MakeValid a) = a
 
-(<$^>) :: (a -> b) -> Valid a -> b
-(<$^>) f = f . fromValid
+($^) :: (a -> b) -> Valid a -> b
+($^) f = f . fromValid
+
+-- TODO: For this and for those below, make fixity infixr?
+infixl 4 $^ -- Same fixity as `<$>`.
+
+(<$^>) :: (Functor f) => (a -> f b) -> Valid a -> f (Valid b)
+(<$^>) f (MakeValid x) = fmap MakeValid (f x)
 
 infixl 4 <$^> -- Same fixity as `<$>`.
+
+(<$^^>) :: (Functor f1, Functor f2) => (a -> f1 (f2 b)) -> Valid a -> f1 (f2 (Valid b))
+(<$^^>) f (MakeValid x) = (fmap . fmap) MakeValid (f x)
+
+infixl 4 <$^^> -- Same fixity as `<$>`.
+
+propagateValid :: (Functor f) => Valid (f a) -> f (Valid a)
+propagateValid (MakeValid xs) = MakeValid <$> xs

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -1,7 +1,14 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 module Wasp.AppSpec.Valid
-  ( Valid (Valid),
+  ( -- |
+    -- Idea behind @Valid@ is that you use it to mark any data structure as valid,
+    -- by using @MakeValid@ constructor from "Valid.Internal", normally at the end of
+    -- your validation logic.
+    -- So, if you have some @data Foo = ...@, your validation logic would look smth like
+    -- @validateFoo :: Foo -> Valid Foo@.
+    -- Then, what @Valid@ does, is allow you to manipulate its contents, or to take them out of @Valid@.
+    Valid (Valid),
     fromValid,
     ($^),
     propagateValid,
@@ -27,7 +34,6 @@ fromValid (MakeValid a) = a
 ($^) :: (a -> b) -> Valid a -> b
 ($^) f = f . fromValid
 
--- TODO: For this and for those below, make fixity infixr?
 infixl 4 $^ -- Same fixity as `<$>`.
 
 (<$^>) :: (Functor f) => (a -> f b) -> Valid a -> f (Valid b)

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -1,0 +1,16 @@
+module Wasp.AppSpec.Valid
+  ( Valid,
+    (<$^>),
+    fromValid,
+  )
+where
+
+import Wasp.AppSpec.Valid.Internal
+
+fromValid :: Valid a -> a
+fromValid (Valid a) = a
+
+(<$^>) :: (a -> b) -> Valid a -> b
+(<$^>) f = f . fromValid
+
+infixl 4 <$^> -- Same fixity as `<$>`.

--- a/waspc/src/Wasp/AppSpec/Valid/AppSpec.hs
+++ b/waspc/src/Wasp/AppSpec/Valid/AppSpec.hs
@@ -26,7 +26,6 @@ validateAppSpec spec = do
     apps -> Left [GenericValidationError $ "Expected exactly 1 'app' declaration, but found " ++ show (length apps)]
   return $ MakeValid spec
 
--- TODO: Modify this to return (String, Valid App)?
 getApp :: Valid AppSpec -> Valid (String, App)
 getApp spec =
   let apps = getDecls @App <$> spec
@@ -37,6 +36,5 @@ getApp spec =
             "Expected exactly 1 'app' declaration in Valid AppSpec, but found " ++ show (length apps')
               ++ ". This should never happen, as this should have been already caught during AppSpec validation."
 
--- TODO: Make it work on App instead of AppSpec? If so, move to Valid.AppSpec.App.
 isAuthEnabled :: Valid AppSpec -> Bool
 isAuthEnabled spec = isJust (App.auth $ snd $^ getApp spec)

--- a/waspc/src/Wasp/AppSpec/Valid/AppSpec.hs
+++ b/waspc/src/Wasp/AppSpec/Valid/AppSpec.hs
@@ -1,0 +1,18 @@
+module Wasp.AppSpec.Valid.AppSpec
+  ( validateAppSpec,
+  )
+where
+
+import Wasp.AppSpec
+import Wasp.AppSpec.Valid.Internal (Valid (..))
+
+-- TODO: Separate this one into its own file.
+data ValidationError = GenericValidationError String
+
+-- TODO: add more checks?
+validateAppSpec :: AppSpec -> Either ValidationError (Valid AppSpec)
+validateAppSpec spec =
+  case getDecls @App spec of
+    [app] -> return ()
+    apps -> Left $ GenericValidationError "Expected exactly 1 'app' declaration, but found " ++ show (length apps)
+  return $ Valid spec

--- a/waspc/src/Wasp/AppSpec/Valid/AppSpec.hs
+++ b/waspc/src/Wasp/AppSpec/Valid/AppSpec.hs
@@ -1,18 +1,42 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Wasp.AppSpec.Valid.AppSpec
   ( validateAppSpec,
+    getApp,
+    isAuthEnabled,
   )
 where
 
-import Wasp.AppSpec
-import Wasp.AppSpec.Valid.Internal (Valid (..))
+import Data.Maybe (isJust)
+import Wasp.AppSpec (AppSpec, getDecls)
+import Wasp.AppSpec.App (App)
+import qualified Wasp.AppSpec.App as App
+import Wasp.AppSpec.Valid (fromValid, ($^))
+import Wasp.AppSpec.Valid.Internal (Valid (MakeValid))
 
 -- TODO: Separate this one into its own file.
 data ValidationError = GenericValidationError String
+  deriving (Eq, Show)
 
 -- TODO: add more checks?
-validateAppSpec :: AppSpec -> Either ValidationError (Valid AppSpec)
-validateAppSpec spec =
+validateAppSpec :: AppSpec -> Either [ValidationError] (Valid AppSpec)
+validateAppSpec spec = do
   case getDecls @App spec of
-    [app] -> return ()
-    apps -> Left $ GenericValidationError "Expected exactly 1 'app' declaration, but found " ++ show (length apps)
-  return $ Valid spec
+    [_] -> return ()
+    apps -> Left [GenericValidationError $ "Expected exactly 1 'app' declaration, but found " ++ show (length apps)]
+  return $ MakeValid spec
+
+-- TODO: Modify this to return (String, Valid App)?
+getApp :: Valid AppSpec -> Valid (String, App)
+getApp spec =
+  let apps = getDecls @App <$> spec
+   in case fromValid apps of
+        [_] -> head <$> apps
+        apps' ->
+          error $
+            "Expected exactly 1 'app' declaration in Valid AppSpec, but found " ++ show (length apps')
+              ++ ". This should never happen, as this should have been already caught during AppSpec validation."
+
+-- TODO: Make it work on App instead of AppSpec? If so, move to Valid.AppSpec.App.
+isAuthEnabled :: Valid AppSpec -> Bool
+isAuthEnabled spec = isJust (App.auth $ snd $^ getApp spec)

--- a/waspc/src/Wasp/AppSpec/Valid/Internal.hs
+++ b/waspc/src/Wasp/AppSpec/Valid/Internal.hs
@@ -2,5 +2,5 @@
 
 module Wasp.AppSpec.Valid.Internal where
 
-newtype Valid a = Valid a
+newtype Valid a = MakeValid a
   deriving (Functor, Show, Eq)

--- a/waspc/src/Wasp/AppSpec/Valid/Internal.hs
+++ b/waspc/src/Wasp/AppSpec/Valid/Internal.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE DeriveFunctor #-}
+
+module Wasp.AppSpec.Valid.Internal where
+
+newtype Valid a = Valid a
+  deriving (Functor, Show, Eq)

--- a/waspc/src/Wasp/Generator.hs
+++ b/waspc/src/Wasp/Generator.hs
@@ -14,6 +14,7 @@ import qualified Paths_waspc
 import StrongPath (Abs, Dir, Path', relfile, (</>))
 import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
+import Wasp.AppSpec.Valid (Valid)
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.DbGenerator (genDb)
 import qualified Wasp.Generator.DbGenerator as DbGenerator
@@ -35,7 +36,7 @@ import Wasp.Util ((<++>))
 --   NOTE(martin): What if there is already smth in the dstDir? It is probably best
 --     if we clean it up first? But we don't want this to end up with us deleting stuff
 --     from user's machine. Maybe we just overwrite and we are good?
-writeWebAppCode :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
+writeWebAppCode :: Valid AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
 writeWebAppCode spec dstDir = do
   let (generatorWarnings, generatorResult) = runGenerator $ genApp spec
 
@@ -48,14 +49,14 @@ writeWebAppCode spec dstDir = do
       (dbGeneratorWarnings, dbGeneratorErrors) <- DbGenerator.postWriteDbGeneratorActions spec dstDir
       return (generatorWarnings ++ dbGeneratorWarnings, dbGeneratorErrors)
 
-genApp :: AppSpec -> Generator [FileDraft]
+genApp :: Valid AppSpec -> Generator [FileDraft]
 genApp spec =
   generateWebApp spec
     <++> genServer spec
     <++> genDb spec
     <++> genDockerFiles spec
 
-preCleanup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ()
+preCleanup :: Valid AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ()
 preCleanup spec dstDir = do
   ServerGenerator.preCleanup spec dstDir
   DbGenerator.preCleanup spec dstDir

--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -20,7 +20,7 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Db as AS.Db
 import qualified Wasp.AppSpec.Entity as AS.Entity
-import Wasp.AppSpec.Valid (Valid, ($^), (<$^>), (<$^^>))
+import Wasp.AppSpec.Valid (Valid, ($^), (<$^^>))
 import qualified Wasp.AppSpec.Valid.AppSpec as VAS
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.DbGenerator.Common

--- a/waspc/src/Wasp/Generator/DockerGenerator.hs
+++ b/waspc/src/Wasp/Generator/DockerGenerator.hs
@@ -9,17 +9,17 @@ import Data.Aeson (object, (.=))
 import StrongPath (File', Path', Rel, relfile)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
-import qualified Wasp.AppSpec.Entity as AS.Entity
+import Wasp.AppSpec.Valid (Valid, (<$^^>))
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.FileDraft (FileDraft, createTemplateFileDraft)
 import Wasp.Generator.Monad (Generator)
 import Wasp.Generator.Templates (TemplatesDir)
 
-genDockerFiles :: AppSpec -> Generator [FileDraft]
+genDockerFiles :: Valid AppSpec -> Generator [FileDraft]
 genDockerFiles spec = sequence [genDockerfile spec, genDockerignore spec]
 
 -- TODO: Inject paths to server and db files/dirs, right now they are hardcoded in the templates.
-genDockerfile :: AppSpec -> Generator FileDraft
+genDockerfile :: Valid AppSpec -> Generator FileDraft
 genDockerfile spec =
   return $
     createTemplateFileDraft
@@ -27,11 +27,11 @@ genDockerfile spec =
       ([relfile|Dockerfile|] :: Path' (Rel TemplatesDir) File')
       ( Just $
           object
-            [ "usingPrisma" .= not (null $ AS.getDecls @AS.Entity.Entity spec)
+            [ "usingPrisma" .= not (null $ AS.getEntities <$^^> spec)
             ]
       )
 
-genDockerignore :: AppSpec -> Generator FileDraft
+genDockerignore :: Valid AppSpec -> Generator FileDraft
 genDockerignore _ =
   return $
     createTemplateFileDraft

--- a/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
@@ -9,7 +9,7 @@ import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
-import Wasp.AppSpec.Valid (Valid, ($^), (<$^>), (<$^^>))
+import Wasp.AppSpec.Valid (Valid, ($^), (<$^>))
 import qualified Wasp.AppSpec.Valid.AppSpec as VAS
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)

--- a/waspc/src/Wasp/Generator/ServerGenerator/ConfigG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/ConfigG.hs
@@ -8,7 +8,6 @@ import Data.Aeson (object, (.=))
 import StrongPath (File', Path', Rel, relfile, (</>))
 import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
-import qualified Wasp.AppSpec as AS
 import Wasp.AppSpec.Valid (Valid)
 import qualified Wasp.AppSpec.Valid.AppSpec as VAS
 import Wasp.Generator.FileDraft (FileDraft)

--- a/waspc/src/Wasp/Generator/ServerGenerator/ConfigG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/ConfigG.hs
@@ -9,18 +9,20 @@ import StrongPath (File', Path', Rel, relfile, (</>))
 import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
+import Wasp.AppSpec.Valid (Valid)
+import qualified Wasp.AppSpec.Valid.AppSpec as VAS
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.ServerGenerator.Common as C
 
-genConfigFile :: AppSpec -> Generator FileDraft
+genConfigFile :: Valid AppSpec -> Generator FileDraft
 genConfigFile spec = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     tmplFile = C.srcDirInServerTemplatesDir </> SP.castRel configFileInSrcDir
     dstFile = C.serverSrcDirInServerRootDir </> configFileInSrcDir
     tmplData =
       object
-        [ "isAuthEnabled" .= (AS.isAuthEnabled spec :: Bool)
+        [ "isAuthEnabled" .= (VAS.isAuthEnabled spec :: Bool)
         ]
 
 configFileInSrcDir :: Path' (Rel C.ServerSrcDir) File'

--- a/waspc/src/Wasp/Generator/ServerGenerator/OperationsG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/OperationsG.hs
@@ -19,6 +19,7 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.Action as AS.Action
 import qualified Wasp.AppSpec.Operation as AS.Operation
 import qualified Wasp.AppSpec.Query as AS.Query
+import Wasp.AppSpec.Valid (Valid (Valid), (<$^^>))
 import Wasp.Generator.ExternalCodeGenerator.Common (GeneratedExternalCodeDir)
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.JsImport (getJsImportDetailsForExtFnImport)
@@ -26,20 +27,20 @@ import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.ServerGenerator.Common as C
 import Wasp.Util ((<++>))
 
-genOperations :: AppSpec -> Generator [FileDraft]
+genOperations :: Valid AppSpec -> Generator [FileDraft]
 genOperations spec = genQueries spec <++> genActions spec
 
-genQueries :: AppSpec -> Generator [FileDraft]
-genQueries spec = mapM (genQuery spec) (AS.getQueries spec)
+genQueries :: Valid AppSpec -> Generator [FileDraft]
+genQueries spec = mapM (genQuery spec) (AS.getQueries <$^^> spec)
 
-genActions :: AppSpec -> Generator [FileDraft]
-genActions spec = mapM (genAction spec) (AS.getActions spec)
+genActions :: Valid AppSpec -> Generator [FileDraft]
+genActions spec = mapM (genAction spec) (AS.getActions <$^^> spec)
 
 -- | Here we generate JS file that basically imports JS query function provided by user,
 --   decorates it (mostly injects stuff into it) and exports. Idea is that the rest of the server,
 --   and user also, should use this new JS function, and not the old one directly.
-genQuery :: AppSpec -> (String, AS.Query.Query) -> Generator FileDraft
-genQuery _ (queryName, query) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
+genQuery :: Valid AppSpec -> (String, Valid AS.Query.Query) -> Generator FileDraft
+genQuery _ (queryName, Valid query) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     operation = AS.Operation.QueryOp queryName query
     tmplFile = C.asTmplFile [relfile|src/queries/_query.js|]
@@ -47,8 +48,8 @@ genQuery _ (queryName, query) = return $ C.mkTmplFdWithDstAndData tmplFile dstFi
     tmplData = operationTmplData operation
 
 -- | Analogous to genQuery.
-genAction :: AppSpec -> (String, AS.Action.Action) -> Generator FileDraft
-genAction _ (actionName, action) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
+genAction :: Valid AppSpec -> (String, Valid AS.Action.Action) -> Generator FileDraft
+genAction _ (actionName, Valid action) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     operation = AS.Operation.ActionOp actionName action
     tmplFile = [relfile|src/actions/_action.js|]

--- a/waspc/src/Wasp/Generator/WebAppGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/AuthG.hs
@@ -8,7 +8,6 @@ import Data.Aeson.Types (Pair)
 import Data.Maybe (fromMaybe)
 import StrongPath (File', Path', Rel', reldir, relfile, (</>))
 import Wasp.AppSpec (AppSpec)
-import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import Wasp.AppSpec.Valid (Valid, ($^), (<$^>))

--- a/waspc/src/Wasp/Generator/WebAppGenerator/OperationsGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/OperationsGenerator.hs
@@ -17,6 +17,7 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.Action as AS.Action
 import qualified Wasp.AppSpec.Operation as AS.Operation
 import qualified Wasp.AppSpec.Query as AS.Query
+import Wasp.AppSpec.Valid (Valid (Valid), (<$^^>))
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.ServerGenerator as ServerGenerator
@@ -25,24 +26,24 @@ import qualified Wasp.Generator.WebAppGenerator.Common as C
 import qualified Wasp.Generator.WebAppGenerator.OperationsGenerator.ResourcesG as Resources
 import Wasp.Util ((<++>))
 
-genOperations :: AppSpec -> Generator [FileDraft]
+genOperations :: Valid AppSpec -> Generator [FileDraft]
 genOperations spec =
   genQueries spec
     <++> genActions spec
     <++> return [C.mkTmplFd $ C.asTmplFile [relfile|src/operations/index.js|]]
     <++> Resources.genResources spec
 
-genQueries :: AppSpec -> Generator [FileDraft]
+genQueries :: Valid AppSpec -> Generator [FileDraft]
 genQueries spec = do
-  queriesFds <- mapM (genQuery spec) (AS.getQueries spec)
+  queriesFds <- mapM (genQuery spec) (AS.getQueries <$^^> spec)
   return $ queriesFds ++ [C.mkTmplFd $ C.asTmplFile [relfile|src/queries/index.js|]]
 
-genActions :: AppSpec -> Generator [FileDraft]
+genActions :: Valid AppSpec -> Generator [FileDraft]
 genActions spec =
-  mapM (genAction spec) (AS.getActions spec)
+  mapM (genAction spec) (AS.getActions <$^^> spec)
 
-genQuery :: AppSpec -> (String, AS.Query.Query) -> Generator FileDraft
-genQuery _ (queryName, query) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
+genQuery :: Valid AppSpec -> (String, Valid AS.Query.Query) -> Generator FileDraft
+genQuery _ (queryName, Valid query) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     tmplFile = C.asTmplFile [relfile|src/queries/_query.js|]
 
@@ -59,8 +60,8 @@ genQuery _ (queryName, query) = return $ C.mkTmplFdWithDstAndData tmplFile dstFi
         ]
     operation = AS.Operation.QueryOp queryName query
 
-genAction :: AppSpec -> (String, AS.Action.Action) -> Generator FileDraft
-genAction _ (actionName, action) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
+genAction :: Valid AppSpec -> (String, Valid AS.Action.Action) -> Generator FileDraft
+genAction _ (actionName, Valid action) = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     tmplFile = C.asTmplFile [relfile|src/actions/_action.js|]
 

--- a/waspc/src/Wasp/Generator/WebAppGenerator/OperationsGenerator/ResourcesG.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/OperationsGenerator/ResourcesG.hs
@@ -6,11 +6,12 @@ where
 import Data.Aeson (object)
 import StrongPath (relfile)
 import Wasp.AppSpec (AppSpec)
+import Wasp.AppSpec.Valid
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.WebAppGenerator.Common as C
 
-genResources :: AppSpec -> Generator [FileDraft]
+genResources :: Valid AppSpec -> Generator [FileDraft]
 genResources _ = return [C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)]
   where
     tmplFile = C.asTmplFile [relfile|src/operations/resources.js|]

--- a/waspc/src/Wasp/Generator/WebAppGenerator/RouterGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/RouterGenerator.hs
@@ -16,7 +16,7 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.ExtImport as AS.ExtImport
 import qualified Wasp.AppSpec.Page as AS.Page
 import qualified Wasp.AppSpec.Route as AS.Route
-import Wasp.AppSpec.Valid (Valid, ($^), (<$^>), (<$^^>))
+import Wasp.AppSpec.Valid (Valid, ($^), (<$^^>))
 import qualified Wasp.AppSpec.Valid.AppSpec as VAS
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)


### PR DESCRIPTION
The motivation for this behaviour was validating certain properties of AppSpec before it goes into Generator, so that Generator can have easier time due to not having to worry about certain properties being enforced or not.

Validations that we currently care about are:
- AppSpec should have exactly one `app` declaration.
- If a Page has `authRequired` set, then `app.auth` also needs to be defined.
- Entity provided to `app.auth.userEntity` needs to have field `email` of type `string` and field `password` with type `string`.

Especially important is the first one, because many parts of the Generator use `app` and them having to check it every time for existence would be impractical.

In Haskell, we normally want to capture as much info as we can in the type system, so compiler helps us. Therefore, the best validation is the one that is supported by the type system! So, the ideal validation in Haskell is when the output of the validation logic ensures via the type system that it can't be invalid.

For example, for AppSpec and having exactly one `app`, that could be smth like:
 - `validateAppSpec :: AppSpec -> Either [ValidationError] ValidAppSpec`
 - `data AppSpec = { ... , app :: Maybe App, ... }`
 - `data ValidAppSpec = { ... , app :: App, ... }`

So, output type guarantees that AppSpec has exactly one type, and don't have to worry about it ever again! There is no way we forget to validate AppSpec -> if we didn't validate it, we wouldn't be able to obtain ValidAppSpec at all. So this means validation was done successfully, if we have ValidAppSpec, and those properties that were validated are now encoded in the structure itself. There is a nice blog post by Alexis King about this: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/ .

So while that is ideal solution, I gave up on it relatively quickly, for the following reasons:
1. AppSpec is relatively complex and is also built from other structures (App, Page, Entity, ...). Duplicating all of these, or even a subset of them, would be a lot of work and would reduce our capability to make quick changes. Basically, we would be introducing a new intermediate representation (IR), and I felt that the cost of implementing and maintaining it is relatively high at this moment of time, compared to what we get. 
2. I wasn't assured that we will be able to catch all of the properties in the structure, at least not in the practical way. For example, the first one (1 `app`) is easy to catch in the structure. However, the second one (authRequired requiring app.auth) is already harder -> I think we could store the info about Pages that have authRequired into app.auth, and that way would ensure that property, but that would make it a bit impractical to deal with specific pages, since we would have to do lookup in the app.auth. Finally, the third one, with userEntity, I don't even have an idea how to encode that into the structure, at least not in any remotely practical fashion. And I am sure there will be more validation checks in the future.

Also, we need to note that this output structure (from validation) is still "mutable" -> not really mutable of course, we are in Haskell, but one function could make a copy of it with some part somewhat different, invalidate some the properties that way, but still propagate it to other functions, and again we don't have a guarantee that validated properties hold!

So just encoding stuff in the structure is not enough -> we also need to ensure that copies of structure that are invalid can't be created on the fly. We could ensure this by hiding field accessors for its records and exposing only getters (validation function would be the only one with access to actual accessors so it can perform construction).

So taking those two into account, that is really a lot of work.

Therefore, I concluded I could avoid replicating the structure and introducing new IR, if I would instead somehow "mark" it as validated. It would not be as elegant as encoding properties in the structure, but since anyway we can't encode all of them, who cares? At least we "color" the validated structure, and even if we use only parts of it, they would also be "colored" and we would know they passed validation -> because only the validation function can "color" stuff.
Therefore I created this PR, with `data Valid` that serves as this marker/color.
The problem however, that I wasn't aware at that point, is that I still have this problem where structure is "mutable", in the sense that invalid copies of it can be made on the fly -> this is because `data Valid` is Functor, and while I needed that to allow accessing parts of it while still keeping them colored, I forgot that if something is Functor you can basically put anything in it (`(\_ -> "Foo") <$> someFunctor` will put "Foo" into functor regardless of what is already in it). Which means you could easily "color"/"mark" anything if you had even one instance of "colored" value. And that kind of ruins the whole thing! Again, solution is allowing only predefined getters, so we are sure it is a piece of existing structure that is being returned, but that would again require quite some boilerplate. And as you can see in the code, dealing with `Valid` and moving stuff out of it or manipulating them while inside of it is already complicated enough, so I at the very end concluded this is also just too complex at the time being.

I will leave this PR often for a bit still, just so you can see what it took to implement this, as I used some fun things for the first time (`pattern synnonims` language extension). 

I wonder also if Lenses could somehow play into the whole thing, since they have the notion of Getter, but I haven't investigated that enough.

Conclusion: Real solution would need to do coloring OR use new IR, AND also make sure that only getters are available. In both cases, that is a lot of work and duplication, and I concluded it is best to skip it for now and go with the simplest solution, which you can see in another PR: https://github.com/wasp-lang/wasp/pull/459