### PR TITLE
Fixes error when running Prisma generate without entities

### DIFF
--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -22,6 +22,7 @@ module Wasp.Util
     hexFromString,
     hexToString,
     checksumFromFilePath,
+    ifM,
   )
 where
 
@@ -147,6 +148,9 @@ infixr 5 <:>
 
 (<:>) :: Monad m => m a -> m [a] -> m [a]
 (<:>) = liftM2 (:)
+
+ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM p x y = p >>= \b -> if b then x else y
 
 type Checksum = Hex
 


### PR DESCRIPTION
# Description

Running `prisma generate` without entities (like in a brand new project) results in an error. This adds a check to ensure we only run generate if the user has entities.

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update