### PR TITLE
Migrated Waspello to the new Wasp DSL syntax.

### DIFF
--- a/examples/waspello/main.wasp
+++ b/examples/waspello/main.wasp
@@ -1,29 +1,36 @@
 app trello {
-  title: "trello"
-}
+  title: "trello",
 
-db {
-  system: PostgreSQL
-}
+  db: {
+    system: PostgreSQL
+  },
 
-auth {
+  auth: {
     userEntity: User,
     methods: [ EmailAndPassword ],
     onAuthFailedRedirectTo: "/login"
+  },
+
+  dependencies: [
+    ("react-feather", "2.0.9"),
+    ("classnames", "2.3.1"),
+    ("react-tiny-popover", "6.0.5"),
+    ("react-beautiful-dnd", "13.1.0")
+  ]
 }
 
-route "/" -> page Main
+route MainRoute { path: "/", to: Main }
 page Main {
     authRequired: true,
     component: import Main from "@ext/MainPage.js"
 }
 
-route "/signup" -> page Signup
+route SignupRoute { path: "/signup", to: Signup }
 page Signup {
     component: import Signup from "@ext/SignupPage"
 }
 
-route "/login" -> page Login
+route LoginRoute { path: "/login", to: Login }
 page Login {
     component: import Login from "@ext/LoginPage"
 }
@@ -100,9 +107,3 @@ action updateCard {
     entities: [Card]
 }
 
-dependencies {=json
-    "react-feather": "2.0.9",
-    "classnames": "2.3.1",
-    "react-tiny-popover": "6.0.5",
-    "react-beautiful-dnd": "13.1.0"
-json=}

--- a/web/blog/2021-12-02-waspello.md
+++ b/web/blog/2021-12-02-waspello.md
@@ -131,7 +131,7 @@ The code for actions is very similar (we just need to use `action` keyword inste
 #### Pages, routing & components
 To display all the nice data we have, we'll use React components. There are no limits to how you can use React components within Wasp, the only one is that each `page` has its root component:
 ```js title="main.wasp | Declaration of a page & route in Wasp"
-route "/" -> page Main
+route MainRoute { path: "/", to: Main }
 page Main {
     authRequired: true,
     component: import Main from "@ext/MainPage.js"


### PR DESCRIPTION
Migrated Waspello example app to the new syntax - both the code and the associated blog post featuring Waspello code excerpts.