### PR TITLE
Fix error handling bug

### DIFF
--- a/waspc/data/Generator/templates/server/src/server.js
+++ b/waspc/data/Generator/templates/server/src/server.js
@@ -24,7 +24,7 @@ const startServer = async () => {
 
   server.listen(port)
 
-  server.on('error', () => {
+  server.on('error', (error) => {
     if (error.syscall !== 'listen') throw error
     const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
     // handle specific listen errors with friendly messages


### PR DESCRIPTION
# Description

I had an error in startServer, but the error handling itself had a bug so I couldn't see what it was. It turned out it was the port was already in use, but this message was suppressed. This fix made the real error show up.

Fixes #468

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update