### PR TITLE
465 wasp messages during setup phase

### DIFF
--- a/waspc/cli/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/Wasp/Cli/Command/Build.hs
@@ -20,6 +20,7 @@ import Wasp.Cli.Command.Common
   )
 import Wasp.Cli.Command.Compile (compileIOWithOptions)
 import qualified Wasp.Cli.Common as Common
+import Wasp.Cli.Message (cliSendMessage)
 import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
@@ -54,5 +55,6 @@ buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir bu
     options =
       CompileOptions
         { externalCodeDirPath = waspProjectDir </> Common.extCodeDirInWaspProjectDir,
-          isBuild = True
+          isBuild = True,
+          sendMessage = cliSendMessage
         }

--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -16,6 +16,7 @@ import Wasp.Cli.Command.Common
   )
 import Wasp.Cli.Common (waspWarns)
 import qualified Wasp.Cli.Common as Common
+import Wasp.Cli.Message (cliSendMessage)
 import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage, asWaspWarningMessage)
 import Wasp.Common (WaspProjectDir)
 import Wasp.CompileOptions (CompileOptions (..))
@@ -45,7 +46,8 @@ compileIO waspProjectDir outDir = compileIOWithOptions options waspProjectDir ou
     options =
       CompileOptions
         { externalCodeDirPath = waspProjectDir </> Common.extCodeDirInWaspProjectDir,
-          isBuild = False
+          isBuild = False,
+          sendMessage = cliSendMessage
         }
 
 compileIOWithOptions ::

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -27,6 +27,7 @@ start = do
   waspRoot <- findWaspProjectRootDirFromCwd
   let outDir = waspRoot </> Common.dotWaspDirInWaspProjectDir </> Common.generatedCodeDirInDotWaspDir
 
+  waspSaysC $ asWaspStartMessage "Starting compilation and setup phase. Hold tight..."
   compilationResult <- liftIO $ compileIO waspRoot outDir
   case compilationResult of
     Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Compilation failed:" ++ compileError

--- a/waspc/cli/Wasp/Cli/Message.hs
+++ b/waspc/cli/Wasp/Cli/Message.hs
@@ -1,0 +1,21 @@
+module Wasp.Cli.Message (cliSendMessage) where
+
+import Wasp.Cli.Common (waspSays, waspScreams, waspWarns)
+import Wasp.Cli.Terminal
+  ( asWaspFailureMessage,
+    asWaspStartMessage,
+    asWaspSuccessMessage,
+    asWaspWarningMessage,
+  )
+import qualified Wasp.Message as Msg
+
+-- | Send a message using the CLI
+cliSendMessage :: Msg.SendMessage
+cliSendMessage (Msg.Start msg) =
+  waspSays $ asWaspStartMessage msg
+cliSendMessage (Msg.Success msg) =
+  waspSays $ asWaspSuccessMessage msg
+cliSendMessage (Msg.Failure msg) =
+  waspScreams $ asWaspFailureMessage msg
+cliSendMessage (Msg.Warning msg) =
+  waspWarns $ asWaspWarningMessage msg

--- a/waspc/src/Wasp/CompileOptions.hs
+++ b/waspc/src/Wasp/CompileOptions.hs
@@ -5,11 +5,16 @@ where
 
 import StrongPath (Abs, Dir, Path')
 import Wasp.AppSpec.ExternalCode (SourceExternalCodeDir)
+import Wasp.Message (SendMessage)
 
 -- TODO(martin): Should these be merged with Wasp data? Is it really a separate thing or not?
 --   It would be easier to pass around if it is part of Wasp data. But is it semantically correct?
 --   Maybe it is, even more than this!
 data CompileOptions = CompileOptions
   { externalCodeDirPath :: !(Path' Abs (Dir SourceExternalCodeDir)),
-    isBuild :: !Bool
+    isBuild :: !Bool,
+    -- We give the compiler the ability to send messages. The code that
+    -- invokes the compiler (such as the CLI) can then implement a way
+    -- to display these messages.
+    sendMessage :: SendMessage
   }

--- a/waspc/src/Wasp/Generator.hs
+++ b/waspc/src/Wasp/Generator.hs
@@ -24,6 +24,7 @@ import qualified Wasp.Generator.ServerGenerator as ServerGenerator
 import Wasp.Generator.Setup (runSetup)
 import qualified Wasp.Generator.Start
 import Wasp.Generator.WebAppGenerator (generateWebApp)
+import Wasp.Message (SendMessage)
 import Wasp.Util ((<++>))
 
 -- | Generates web app code from given Wasp and writes it to given destination directory.
@@ -34,8 +35,8 @@ import Wasp.Util ((<++>))
 --   NOTE(martin): What if there is already smth in the dstDir? It is probably best
 --     if we clean it up first? But we don't want this to end up with us deleting stuff
 --     from user's machine. Maybe we just overwrite and we are good?
-writeWebAppCode :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
-writeWebAppCode spec dstDir = do
+writeWebAppCode :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> SendMessage -> IO ([GeneratorWarning], [GeneratorError])
+writeWebAppCode spec dstDir sendMessage = do
   let (generatorWarnings, generatorResult) = runGenerator $ genApp spec
 
   case generatorResult of
@@ -44,7 +45,7 @@ writeWebAppCode spec dstDir = do
       preCleanup spec dstDir
       writeFileDrafts dstDir fileDrafts
       writeDotWaspInfo dstDir
-      (setupGeneratorWarnings, setupGeneratorErrors) <- runSetup spec dstDir
+      (setupGeneratorWarnings, setupGeneratorErrors) <- runSetup spec dstDir sendMessage
       return (generatorWarnings ++ setupGeneratorWarnings, setupGeneratorErrors)
 
 genApp :: AppSpec -> Generator [FileDraft]

--- a/waspc/src/Wasp/Generator/Setup.hs
+++ b/waspc/src/Wasp/Generator/Setup.hs
@@ -9,13 +9,21 @@ import Wasp.Generator.Common (ProjectRootDir)
 import qualified Wasp.Generator.DbGenerator as DbGenerator
 import Wasp.Generator.Monad (GeneratorError (..), GeneratorWarning (..))
 import Wasp.Generator.NpmInstall (ensureNpmInstall)
+import qualified Wasp.Message as Msg
 
-runSetup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO ([GeneratorWarning], [GeneratorError])
-runSetup spec dstDir = do
-  -- TODO: Use a monad transformer here in the future for better shortcircuiting behavior.
+runSetup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> Msg.SendMessage -> IO ([GeneratorWarning], [GeneratorError])
+runSetup spec dstDir sendMessage = do
+  sendMessage $ Msg.Start "Starting npm install..."
   (npmInstallWarnings, npmInstallErrors) <- ensureNpmInstall spec dstDir
   if null npmInstallErrors
     then do
+      sendMessage $ Msg.Success "Successfully completed npm install."
+      sendMessage $ Msg.Success "Setting up database..."
       (dbGeneratorWarnings, dbGeneratorErrors) <- DbGenerator.postWriteDbGeneratorActions spec dstDir
+      if null dbGeneratorErrors
+        then sendMessage $ Msg.Success "Database successfully set up."
+        else sendMessage $ Msg.Failure "Could not set up database."
       return (npmInstallWarnings ++ dbGeneratorWarnings, dbGeneratorErrors)
-    else return (npmInstallWarnings, npmInstallErrors)
+    else do
+      sendMessage $ Msg.Failure "npm install failed!"
+      return (npmInstallWarnings, npmInstallErrors)

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -14,7 +14,7 @@ import qualified Wasp.Analyzer as Analyzer
 import Wasp.Analyzer.AnalyzeError (getErrorMessageAndCtx)
 import qualified Wasp.AppSpec as AS
 import Wasp.Common (DbMigrationsDir, WaspProjectDir, dbMigrationsDirInWaspProjectDir)
-import Wasp.CompileOptions (CompileOptions)
+import Wasp.CompileOptions (CompileOptions, sendMessage)
 import qualified Wasp.CompileOptions as CompileOptions
 import Wasp.Error (showCompilerErrorForTerminal)
 import qualified Wasp.ExternalCode as ExternalCode
@@ -60,7 +60,7 @@ compile waspDir outDir options = do
                     AS.dotEnvFile = maybeDotEnvFile,
                     AS.isBuild = CompileOptions.isBuild options
                   }
-          (generatorWarnings, generatorErrors) <- Generator.writeWebAppCode appSpec outDir
+          (generatorWarnings, generatorErrors) <- Generator.writeWebAppCode appSpec outDir (sendMessage options)
           return (map show generatorWarnings, map show generatorErrors)
 
 findWaspFile :: Path' Abs (Dir WaspProjectDir) -> IO (Maybe (Path' Abs File'))

--- a/waspc/src/Wasp/Message.hs
+++ b/waspc/src/Wasp/Message.hs
@@ -1,0 +1,14 @@
+module Wasp.Message (Message (..), SendMessage) where
+
+-- This module defines a simple protocol for sending progress messages to a
+-- UI (like the CLI).
+-- The idea is that we want to report on phases that start, end either in
+-- success or failure, and can send warnings along the way.
+-- We use this protocol to give the generator (and in particular the setup phase)
+-- the capability to report on progress messages.
+-- This protocol is for sending messages for display in a UI.
+-- If you need success or failure another purpose use return values.
+
+data Message = Start String | Success String | Failure String | Warning String
+
+type SendMessage = Message -> IO ()


### PR DESCRIPTION
# Description

We introduce a SendMessage protocol that can be used to send messages.

The CLI implements this protocol to send messages and passes its implementation into the compile code. 

The setup phase uses this protocol to send messages.

Fixes # (issue)

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update