### PR TITLE
Ensures new-release script is run on `main` branch only

### DIFF
--- a/waspc/new-release
+++ b/waspc/new-release
@@ -15,7 +15,7 @@ import qualified Data.Text.IO       as T.IO
 import           System.Environment (getArgs)
 import           System.Exit        (ExitCode (..))
 import qualified Text.Regex.TDFA    as TR
-import           Turtle             (empty, shell)
+import           Turtle             (empty, shell, shellStrict)
 
 main = do
     args <- getArgs
@@ -25,6 +25,9 @@ main = do
 
 makeNewRelease :: String -> IO ()
 makeNewRelease newVersion = do
+    (ExitSuccess, branchName) <- shellStrict "git rev-parse --abbrev-ref HEAD" empty
+    when (T.strip branchName /= "main") $ error "You must run this script from the main branch!"
+
     oldPackageYamlContents <- T.unpack <$> T.IO.readFile "package.yaml"
 
     (newPackageYamlContents, oldVersion) <- updatePackageYaml oldPackageYamlContents newVersion


### PR DESCRIPTION
# Description

This change ensures you run the `./new-release <version>` script from the `main` branch only, to avoid accidental tags/deployments from other branches.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update