### PR TITLE
Fixes database setup message type

### DIFF
--- a/waspc/src/Wasp/Generator/Setup.hs
+++ b/waspc/src/Wasp/Generator/Setup.hs
@@ -18,7 +18,7 @@ runSetup spec dstDir sendMessage = do
   if null npmInstallErrors
     then do
       sendMessage $ Msg.Success "Successfully completed npm install."
-      sendMessage $ Msg.Success "Setting up database..."
+      sendMessage $ Msg.Start "Setting up database..."
       (dbGeneratorWarnings, dbGeneratorErrors) <- DbGenerator.postWriteDbGeneratorActions spec dstDir
       if null dbGeneratorErrors
         then sendMessage $ Msg.Success "Database successfully set up."


### PR DESCRIPTION
Small update to fix the database setup message type (go from checkmark to a bee).

Before:
<img width="681" alt="Screen Shot 2022-03-02 at 1 51 11 PM" src="https://user-images.githubusercontent.com/523636/156647063-d69554ae-7ed3-4731-a660-178978fc1c8f.png">

After:
<img width="680" alt="Screen Shot 2022-03-02 at 1 51 04 PM" src="https://user-images.githubusercontent.com/523636/156647085-b67051fe-3f78-4dff-afeb-bea888c500c5.png">

