### PR TITLE
Use send message protocol in cli

### DIFF
--- a/waspc/cli/Wasp/Cli/Command.hs
+++ b/waspc/cli/Wasp/Cli/Command.hs
@@ -9,7 +9,8 @@ where
 
 import Control.Monad.Except (ExceptT, MonadError, runExceptT)
 import Control.Monad.IO.Class (MonadIO)
-import qualified Wasp.Util.Terminal as Term
+import Wasp.Cli.Message (cliSendMessage)
+import qualified Wasp.Message as Msg
 
 newtype Command a = Command {_runCommand :: ExceptT CommandError IO a}
   deriving (Functor, Applicative, Monad, MonadIO, MonadError CommandError)
@@ -18,7 +19,7 @@ runCommand :: Command a -> IO ()
 runCommand cmd = do
   errorOrResult <- runExceptT $ _runCommand cmd
   case errorOrResult of
-    Left cmdError -> putStrLn $ Term.applyStyles [Term.Red] (_errorMsg cmdError)
+    Left cmdError -> cliSendMessage $ Msg.Failure (_errorMsg cmdError)
     Right _ -> return ()
 
 -- TODO: What if we want to recognize errors in order to handle them?

--- a/waspc/cli/Wasp/Cli/Command.hs
+++ b/waspc/cli/Wasp/Cli/Command.hs
@@ -19,9 +19,9 @@ runCommand :: Command a -> IO ()
 runCommand cmd = do
   errorOrResult <- runExceptT $ _runCommand cmd
   case errorOrResult of
-    Left cmdError -> cliSendMessage $ Msg.Failure (_errorMsg cmdError)
+    Left cmdError -> cliSendMessage $ Msg.Failure (_errorTitle cmdError) (_errorMsg cmdError)
     Right _ -> return ()
 
 -- TODO: What if we want to recognize errors in order to handle them?
 --   Should we add _commandErrorType? Should CommandError be parametrized by it, is that even possible?
-data CommandError = CommandError {_errorMsg :: !String}
+data CommandError = CommandError {_errorTitle :: !String, _errorMsg :: !String}

--- a/waspc/cli/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/Wasp/Cli/Command/Build.hs
@@ -44,7 +44,7 @@ build = do
   case buildResult of
     Left compileError -> throwError $ CommandError "Build failed" compileError
     Right () -> cliSendMessageC $ Msg.Success "Code has been successfully built! Check it out in .wasp/build directory."
-  cliSendMessageC $ Msg.Warning alphaWarningMessage
+  cliSendMessageC $ Msg.Warning "Build warning" alphaWarningMessage
 
 buildIO ::
   Path' Abs (Dir Common.WaspProjectDir) ->

--- a/waspc/cli/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/Wasp/Cli/Command/Build.hs
@@ -16,14 +16,14 @@ import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( alphaWarningMessage,
     findWaspProjectRootDirFromCwd,
-    waspSaysC,
   )
 import Wasp.Cli.Command.Compile (compileIOWithOptions)
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Cli.Common as Common
 import Wasp.Cli.Message (cliSendMessage)
-import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
+import qualified Wasp.Message as Msg
 
 build :: Command ()
 build = do
@@ -35,16 +35,16 @@ build = do
 
   doesBuildDirExist <- liftIO $ doesDirectoryExist buildDirFilePath
   when doesBuildDirExist $ do
-    waspSaysC $ asWaspStartMessage "Clearing the content of the .wasp/build directory..."
+    cliSendMessageC $ Msg.Start "Clearing the content of the .wasp/build directory..."
     liftIO $ removeDirectoryRecursive buildDirFilePath
-    waspSaysC $ asWaspSuccessMessage "Successfully cleared the contents of the .wasp/build directory."
+    cliSendMessageC $ Msg.Success "Successfully cleared the contents of the .wasp/build directory."
 
-  waspSaysC $ asWaspStartMessage "Building wasp project..."
+  cliSendMessageC $ Msg.Start "Building wasp project..."
   buildResult <- liftIO $ buildIO waspProjectDir buildDir
   case buildResult of
-    Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Build failed:" ++ compileError
-    Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully built! Check it out in .wasp/build directory."
-  waspSaysC alphaWarningMessage
+    Left compileError -> throwError $ CommandError $ "Build failed:" ++ compileError
+    Right () -> cliSendMessageC $ Msg.Success "Code has been successfully built! Check it out in .wasp/build directory."
+  cliSendMessageC $ Msg.Warning alphaWarningMessage
 
 buildIO ::
   Path' Abs (Dir Common.WaspProjectDir) ->

--- a/waspc/cli/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/Wasp/Cli/Command/Build.hs
@@ -42,7 +42,7 @@ build = do
   cliSendMessageC $ Msg.Start "Building wasp project..."
   buildResult <- liftIO $ buildIO waspProjectDir buildDir
   case buildResult of
-    Left compileError -> throwError $ CommandError $ "Build failed:" ++ compileError
+    Left compileError -> throwError $ CommandError "Build failed" compileError
     Right () -> cliSendMessageC $ Msg.Success "Code has been successfully built! Check it out in .wasp/build directory."
   cliSendMessageC $ Msg.Warning alphaWarningMessage
 

--- a/waspc/cli/Wasp/Cli/Command/Clean.hs
+++ b/waspc/cli/Wasp/Cli/Command/Clean.hs
@@ -10,18 +10,19 @@ import System.Directory
     removeDirectoryRecursive,
   )
 import Wasp.Cli.Command (Command)
-import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd, waspSaysC)
+import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd)
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Cli.Common as Common
-import Wasp.Cli.Terminal (asWaspStartMessage, asWaspSuccessMessage)
+import qualified Wasp.Message as Msg
 
 clean :: Command ()
 clean = do
   waspProjectDir <- findWaspProjectRootDirFromCwd
   let dotWaspDirFp = SP.toFilePath $ waspProjectDir SP.</> Common.dotWaspDirInWaspProjectDir
-  waspSaysC $ asWaspStartMessage "Deleting .wasp/ directory..."
+  cliSendMessageC $ Msg.Start "Deleting .wasp/ directory..."
   doesDotWaspDirExist <- liftIO $ doesDirectoryExist dotWaspDirFp
   if doesDotWaspDirExist
     then do
       liftIO $ removeDirectoryRecursive dotWaspDirFp
-      waspSaysC $ asWaspSuccessMessage "Deleted .wasp/ directory."
-    else waspSaysC "Nothing to delete: .wasp directory does not exist."
+      cliSendMessageC $ Msg.Success "Deleted .wasp/ directory."
+    else cliSendMessageC $ Msg.Success "Nothing to delete: .wasp directory does not exist."

--- a/waspc/cli/Wasp/Cli/Command/Common.hs
+++ b/waspc/cli/Wasp/Cli/Command/Common.hs
@@ -36,11 +36,11 @@ findWaspProjectRoot currentDir = do
       findWaspProjectRoot parentDir
   where
     notFoundError =
-      CommandError $
-        "Wasp command failed: "
-          ++ ( "Couldn't find wasp project root - make sure"
-                 ++ " you are running this command from a Wasp project."
-             )
+      CommandError
+        "Wasp command failed"
+        ( "Couldn't find wasp project root - make sure"
+            ++ " you are running this command from a Wasp project."
+        )
 
 findWaspProjectRootDirFromCwd :: Command (Path' Abs (Dir WaspProjectDir))
 findWaspProjectRootDirFromCwd = do

--- a/waspc/cli/Wasp/Cli/Command/Common.hs
+++ b/waspc/cli/Wasp/Cli/Command/Common.hs
@@ -1,9 +1,6 @@
 module Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
     findWaspProjectRoot,
-    waspSaysC,
-    waspScreamsC,
-    waspWarnsC,
     alphaWarningMessage,
   )
 where
@@ -21,13 +18,7 @@ import System.Directory
   )
 import qualified System.FilePath as FP
 import Wasp.Cli.Command (Command, CommandError (..))
-import Wasp.Cli.Common
-  ( dotWaspRootFileInWaspProjectDir,
-    waspSays,
-    waspScreams,
-    waspWarns,
-  )
-import Wasp.Cli.Terminal (asWaspFailureMessage)
+import Wasp.Cli.Common (dotWaspRootFileInWaspProjectDir)
 import Wasp.Common (WaspProjectDir)
 
 findWaspProjectRoot :: Path' Abs (Dir ()) -> Command (Path' Abs (Dir WaspProjectDir))
@@ -46,7 +37,7 @@ findWaspProjectRoot currentDir = do
   where
     notFoundError =
       CommandError $
-        asWaspFailureMessage "Wasp command failed:"
+        "Wasp command failed: "
           ++ ( "Couldn't find wasp project root - make sure"
                  ++ " you are running this command from a Wasp project."
              )
@@ -55,15 +46,6 @@ findWaspProjectRootDirFromCwd :: Command (Path' Abs (Dir WaspProjectDir))
 findWaspProjectRootDirFromCwd = do
   absCurrentDir <- liftIO getCurrentDirectory
   findWaspProjectRoot (fromJust $ SP.parseAbsDir absCurrentDir)
-
-waspSaysC :: String -> Command ()
-waspSaysC = liftIO . waspSays
-
-waspWarnsC :: String -> Command ()
-waspWarnsC = liftIO . waspWarns
-
-waspScreamsC :: String -> Command ()
-waspScreamsC = liftIO . waspScreams
 
 alphaWarningMessage :: String
 alphaWarningMessage =

--- a/waspc/cli/Wasp/Cli/Command/Common.hs
+++ b/waspc/cli/Wasp/Cli/Command/Common.hs
@@ -49,5 +49,5 @@ findWaspProjectRootDirFromCwd = do
 
 alphaWarningMessage :: String
 alphaWarningMessage =
-  "NOTE: Wasp is still in Alpha, therefore not yet production ready "
+  "Wasp is still in Alpha, therefore not yet production ready "
     ++ "and might change significantly in the future versions."

--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -31,7 +31,7 @@ compile = do
   cliSendMessageC $ Msg.Start "Compiling wasp code..."
   compilationResult <- liftIO $ compileIO waspProjectDir outDir
   case compilationResult of
-    Left compileError -> throwError $ CommandError $ "Compilation failed:" ++ compileError
+    Left compileError -> throwError $ CommandError "Compilation failed" compileError
     Right () -> cliSendMessageC $ Msg.Success "Code has been successfully compiled, project has been generated."
 
 -- | Compiles Wasp source code in waspProjectDir directory and generates a project

--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -65,4 +65,4 @@ compileIOWithOptions options waspProjectDir outDir = do
     formatMessages messages = intercalate "\n" $ map ("- " ++) messages
     displayWarnings [] = return ()
     displayWarnings warnings =
-      cliSendMessage $ Msg.Warning ("Your project compiled with warnings:" ++ formatMessages warnings ++ "\n\n")
+      cliSendMessage $ Msg.Warning "Your project compiled with warnings" (formatMessages warnings ++ "\n\n")

--- a/waspc/cli/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/Wasp/Cli/Command/Compile.hs
@@ -12,15 +12,14 @@ import StrongPath (Abs, Dir, Path', (</>))
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
-    waspSaysC,
   )
-import Wasp.Cli.Common (waspWarns)
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Cli.Common as Common
 import Wasp.Cli.Message (cliSendMessage)
-import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage, asWaspWarningMessage)
 import Wasp.Common (WaspProjectDir)
 import Wasp.CompileOptions (CompileOptions (..))
 import qualified Wasp.Lib
+import qualified Wasp.Message as Msg
 
 compile :: Command ()
 compile = do
@@ -29,11 +28,11 @@ compile = do
         waspProjectDir </> Common.dotWaspDirInWaspProjectDir
           </> Common.generatedCodeDirInDotWaspDir
 
-  waspSaysC $ asWaspStartMessage "Compiling wasp code..."
+  cliSendMessageC $ Msg.Start "Compiling wasp code..."
   compilationResult <- liftIO $ compileIO waspProjectDir outDir
   case compilationResult of
-    Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Compilation failed:" ++ compileError
-    Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully compiled, project has been generated."
+    Left compileError -> throwError $ CommandError $ "Compilation failed:" ++ compileError
+    Right () -> cliSendMessageC $ Msg.Success "Code has been successfully compiled, project has been generated."
 
 -- | Compiles Wasp source code in waspProjectDir directory and generates a project
 --   in given outDir directory.
@@ -66,4 +65,4 @@ compileIOWithOptions options waspProjectDir outDir = do
     formatMessages messages = intercalate "\n" $ map ("- " ++) messages
     displayWarnings [] = return ()
     displayWarnings warnings =
-      waspWarns $ asWaspWarningMessage "Your project compiled with warnings:" ++ formatMessages warnings ++ "\n\n"
+      cliSendMessage $ Msg.Warning ("Your project compiled with warnings:" ++ formatMessages warnings ++ "\n\n")

--- a/waspc/cli/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/Wasp/Cli/Command/CreateNewProject.hs
@@ -27,9 +27,13 @@ newtype ProjectName = ProjectName {_projectName :: String}
 
 createNewProject :: String -> Command ()
 createNewProject (all isLetter -> False) =
-  throwError $ CommandError $ "Project creation failed: " ++ "Please use only letters for a new project's name."
+  throwError $ CommandError "Project creation failed" "Please use only letters for a new project's name."
 createNewProject ((`elem` reservedNames) -> True) =
-  throwError . CommandError $ "Project creation failed: " ++ "Please pick a project name not one of these reserved words:\n\t" ++ intercalate "\n\t" reservedNames
+  throwError $
+    CommandError
+      "Project creation failed"
+      ( "Please pick a project name not one of these reserved words:\n\t" ++ intercalate "\n\t" reservedNames
+      )
 createNewProject name = createNewProject' (ProjectName name)
 
 createNewProject' :: ProjectName -> Command ()
@@ -38,11 +42,11 @@ createNewProject' (ProjectName projectName) = do
   waspProjectDir <- case SP.parseAbsDir $ absCwd FP.</> projectName of
     Left err ->
       throwError $
-        CommandError $
-          "Project creation failed: "
-            ++ ( "Failed to parse absolute path to wasp project dir: "
-                   ++ show err
-               )
+        CommandError
+          "Project creation failed"
+          ( "Failed to parse absolute path to wasp project dir: "
+              ++ show err
+          )
     Right sp -> return sp
   liftIO $ do
     createDirectorySP waspProjectDir

--- a/waspc/cli/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/Wasp/Cli/Command/CreateNewProject.hs
@@ -19,7 +19,6 @@ import Wasp.AppSpec.ExternalCode (SourceExternalCodeDir)
 import Wasp.Cli.Command (Command, CommandError (..))
 import qualified Wasp.Cli.Command.Common as Command.Common
 import qualified Wasp.Cli.Common as Common
-import Wasp.Cli.Terminal (asWaspFailureMessage)
 import qualified Wasp.Data
 import Wasp.Lexer (reservedNames)
 import qualified Wasp.Util.Terminal as Term
@@ -28,9 +27,9 @@ newtype ProjectName = ProjectName {_projectName :: String}
 
 createNewProject :: String -> Command ()
 createNewProject (all isLetter -> False) =
-  throwError $ CommandError $ asWaspFailureMessage "Project creation failed:" ++ "Please use only letters for a new project's name."
+  throwError $ CommandError $ "Project creation failed: " ++ "Please use only letters for a new project's name."
 createNewProject ((`elem` reservedNames) -> True) =
-  throwError . CommandError $ asWaspFailureMessage "Project creation failed:" ++ "Please pick a project name not one of these reserved words:\n\t" ++ intercalate "\n\t" reservedNames
+  throwError . CommandError $ "Project creation failed: " ++ "Please pick a project name not one of these reserved words:\n\t" ++ intercalate "\n\t" reservedNames
 createNewProject name = createNewProject' (ProjectName name)
 
 createNewProject' :: ProjectName -> Command ()
@@ -40,7 +39,7 @@ createNewProject' (ProjectName projectName) = do
     Left err ->
       throwError $
         CommandError $
-          asWaspFailureMessage "Project creation failed:"
+          "Project creation failed: "
             ++ ( "Failed to parse absolute path to wasp project dir: "
                    ++ show err
                )

--- a/waspc/cli/Wasp/Cli/Command/Db.hs
+++ b/waspc/cli/Wasp/Cli/Command/Db.hs
@@ -9,12 +9,13 @@ import Control.Concurrent.Async (concurrently)
 import Control.Monad.IO.Class (liftIO)
 import StrongPath ((</>))
 import Wasp.Cli.Command (Command, runCommand)
-import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd, waspSaysC)
+import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd)
 import Wasp.Cli.Command.Compile (compile)
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Cli.Common as Common
-import Wasp.Cli.Terminal (asWaspStartMessage)
 import Wasp.Generator.DbGenerator.Jobs (runStudio)
 import Wasp.Generator.Job.IO (readJobMessagesAndPrintThemPrefixed)
+import qualified Wasp.Message as Msg
 
 runDbCommand :: Command a -> IO ()
 runDbCommand = runCommand . makeDbCommand
@@ -37,7 +38,7 @@ studio = do
         waspProjectDir </> Common.dotWaspDirInWaspProjectDir
           </> Common.generatedCodeDirInDotWaspDir
 
-  waspSaysC $ asWaspStartMessage "Running studio..."
+  cliSendMessageC $ Msg.Start "Running studio..."
   chan <- liftIO newChan
 
   _ <- liftIO $ concurrently (readJobMessagesAndPrintThemPrefixed chan) (runStudio genProjectDir chan)

--- a/waspc/cli/Wasp/Cli/Command/Db/Migrate.hs
+++ b/waspc/cli/Wasp/Cli/Command/Db/Migrate.hs
@@ -11,12 +11,12 @@ import StrongPath ((</>))
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
-    waspSaysC,
   )
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Cli.Common as Cli.Common
-import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import qualified Wasp.Common
 import qualified Wasp.Generator.DbGenerator.Operations as DbOps
+import qualified Wasp.Message as Msg
 
 -- | NOTE(shayne): Performs database schema migration (based on current schema) in the generated project.
 -- This assumes the wasp project migrations dir was copied from wasp source project by a previous compile.
@@ -33,9 +33,9 @@ migrateDev maybeMigrationName = do
         waspProjectDir
           </> Wasp.Common.dbMigrationsDirInWaspProjectDir
 
-  waspSaysC $ asWaspStartMessage "Performing migration..."
+  cliSendMessageC $ Msg.Start "Performing migration..."
   migrateResult <- liftIO $ DbOps.migrateDevAndCopyToSource waspDbMigrationsDir genProjectRootDir maybeMigrationName
   case migrateResult of
     Left migrateError ->
-      throwError $ CommandError $ asWaspFailureMessage "Migrate dev failed:" ++ migrateError
-    Right () -> waspSaysC $ asWaspSuccessMessage "Migration done."
+      throwError $ CommandError $ "Migrate dev failed:" ++ migrateError
+    Right () -> cliSendMessageC $ Msg.Success "Migration done."

--- a/waspc/cli/Wasp/Cli/Command/Db/Migrate.hs
+++ b/waspc/cli/Wasp/Cli/Command/Db/Migrate.hs
@@ -37,5 +37,5 @@ migrateDev maybeMigrationName = do
   migrateResult <- liftIO $ DbOps.migrateDevAndCopyToSource waspDbMigrationsDir genProjectRootDir maybeMigrationName
   case migrateResult of
     Left migrateError ->
-      throwError $ CommandError $ "Migrate dev failed:" ++ migrateError
+      throwError $ CommandError "Migrate dev failed" migrateError
     Right () -> cliSendMessageC $ Msg.Success "Migration done."

--- a/waspc/cli/Wasp/Cli/Command/Info.hs
+++ b/waspc/cli/Wasp/Cli/Command/Info.hs
@@ -33,10 +33,10 @@ info =
     projectSize <- liftIO $ readDirectorySizeMB waspDir
     declsOrError <- liftIO $ parseWaspFile waspDir
     case declsOrError of
-      Left err -> cliSendMessageC $ Msg.Failure err
+      Left err -> cliSendMessageC $ Msg.Failure "Info failed" err
       Right decls -> do
         cliSendMessageC $
-          Msg.Notification $
+          Msg.Info $
             unlines
               [ "",
                 title "Project information",

--- a/waspc/cli/Wasp/Cli/Command/Info.hs
+++ b/waspc/cli/Wasp/Cli/Command/Info.hs
@@ -14,12 +14,14 @@ import qualified Wasp.Analyzer as Analyzer
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import Wasp.Cli.Command (Command)
-import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd, waspSaysC)
+import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd)
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Cli.Common as Cli.Common
 import Wasp.Cli.Terminal (title)
 import Wasp.Common (WaspProjectDir)
 import Wasp.Error (showCompilerErrorForTerminal)
 import Wasp.Lib (findWaspFile)
+import qualified Wasp.Message as Msg
 import Wasp.Util.IO (listDirectoryDeep)
 import qualified Wasp.Util.Terminal as Term
 
@@ -31,22 +33,23 @@ info =
     projectSize <- liftIO $ readDirectorySizeMB waspDir
     declsOrError <- liftIO $ parseWaspFile waspDir
     case declsOrError of
-      Left err -> waspSaysC err
+      Left err -> cliSendMessageC $ Msg.Failure err
       Right decls -> do
-        waspSaysC $
-          unlines
-            [ "",
-              title "Project information",
-              printInfo
-                "Name"
-                (fst $ head $ AS.takeDecls @AS.App.App decls),
-              printInfo
-                "Last compile"
-                compileInfo,
-              printInfo
-                "Project size"
-                projectSize
-            ]
+        cliSendMessageC $
+          Msg.Notification $
+            unlines
+              [ "",
+                title "Project information",
+                printInfo
+                  "Name"
+                  (fst $ head $ AS.takeDecls @AS.App.App decls),
+                printInfo
+                  "Last compile"
+                  compileInfo,
+                printInfo
+                  "Project size"
+                  projectSize
+              ]
 
 printInfo :: String -> String -> String
 printInfo key value = Term.applyStyles [Term.Cyan] key ++ ": " <> Term.applyStyles [Term.White] value

--- a/waspc/cli/Wasp/Cli/Command/Message.hs
+++ b/waspc/cli/Wasp/Cli/Command/Message.hs
@@ -1,0 +1,9 @@
+module Wasp.Cli.Command.Message (cliSendMessageC) where
+
+import Control.Monad.IO.Class (liftIO)
+import Wasp.Cli.Command (Command)
+import Wasp.Cli.Message (cliSendMessage)
+import qualified Wasp.Message as Msg
+
+cliSendMessageC :: Msg.Message -> Command ()
+cliSendMessageC = liftIO . cliSendMessage

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -10,15 +10,15 @@ import StrongPath ((</>))
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common
   ( findWaspProjectRootDirFromCwd,
-    waspSaysC,
   )
 import Wasp.Cli.Command.Compile
   ( compileIO,
   )
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.Watch (watch)
 import qualified Wasp.Cli.Common as Common
-import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
 import qualified Wasp.Lib
+import qualified Wasp.Message as Msg
 
 -- | Does initial compile of wasp code and then runs the generated project.
 -- It also listens for any file changes and recompiles and restarts generated project accordingly.
@@ -27,17 +27,17 @@ start = do
   waspRoot <- findWaspProjectRootDirFromCwd
   let outDir = waspRoot </> Common.dotWaspDirInWaspProjectDir </> Common.generatedCodeDirInDotWaspDir
 
-  waspSaysC $ asWaspStartMessage "Starting compilation and setup phase. Hold tight..."
+  cliSendMessageC $ Msg.Start "Starting compilation and setup phase. Hold tight..."
   compilationResult <- liftIO $ compileIO waspRoot outDir
   case compilationResult of
-    Left compileError -> throwError $ CommandError $ asWaspFailureMessage "Compilation failed:" ++ compileError
-    Right () -> waspSaysC $ asWaspSuccessMessage "Code has been successfully compiled, project has been generated."
+    Left compileError -> throwError $ CommandError $ "Compilation failed:" ++ compileError
+    Right () -> cliSendMessageC $ Msg.Success "Code has been successfully compiled, project has been generated."
 
-  waspSaysC $ asWaspStartMessage "Listening for file changes..."
-  waspSaysC $ asWaspStartMessage "Starting up generated project..."
+  cliSendMessageC $ Msg.Start "Listening for file changes..."
+  cliSendMessageC $ Msg.Start "Starting up generated project..."
   watchOrStartResult <- liftIO $ race (watch waspRoot outDir) (Wasp.Lib.start outDir)
   case watchOrStartResult of
     Left () -> error "This should never happen, listening for file changes should never end but it did."
     Right startResult -> case startResult of
-      Left startError -> throwError $ CommandError $ asWaspFailureMessage "Start failed:" ++ startError
+      Left startError -> throwError $ CommandError $ "Start failed:" ++ startError
       Right () -> error "This should never happen, start should never end but it did."

--- a/waspc/cli/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/Wasp/Cli/Command/Start.hs
@@ -30,7 +30,7 @@ start = do
   cliSendMessageC $ Msg.Start "Starting compilation and setup phase. Hold tight..."
   compilationResult <- liftIO $ compileIO waspRoot outDir
   case compilationResult of
-    Left compileError -> throwError $ CommandError $ "Compilation failed:" ++ compileError
+    Left compileError -> throwError $ CommandError "Compilation failed" compileError
     Right () -> cliSendMessageC $ Msg.Success "Code has been successfully compiled, project has been generated."
 
   cliSendMessageC $ Msg.Start "Listening for file changes..."
@@ -39,5 +39,5 @@ start = do
   case watchOrStartResult of
     Left () -> error "This should never happen, listening for file changes should never end but it did."
     Right startResult -> case startResult of
-      Left startError -> throwError $ CommandError $ "Start failed:" ++ startError
+      Left startError -> throwError $ CommandError "Start failed" startError
       Right () -> error "This should never happen, start should never end but it did."

--- a/waspc/cli/Wasp/Cli/Command/Telemetry.hs
+++ b/waspc/cli/Wasp/Cli/Command/Telemetry.hs
@@ -55,7 +55,7 @@ telemetry = do
 considerSendingData :: Command.Call.Call -> Command ()
 considerSendingData cmdCall = (`catchError` const (return ())) $ do
   telemetryDisabled <- liftIO isTelemetryDisabled
-  when telemetryDisabled $ throwError $ CommandError "Telemetry failed" "Telemetry disabled by user." 
+  when telemetryDisabled $ throwError $ CommandError "Telemetry failed" "Telemetry disabled by user."
 
   telemetryCacheDirPath <- liftIO ensureTelemetryCacheDirExists
 

--- a/waspc/cli/Wasp/Cli/Command/Telemetry.hs
+++ b/waspc/cli/Wasp/Cli/Command/Telemetry.hs
@@ -13,11 +13,11 @@ import qualified StrongPath as SP
 import qualified System.Environment as ENV
 import Wasp.Cli.Command (Command, CommandError (..))
 import qualified Wasp.Cli.Command.Call as Command.Call
-import Wasp.Cli.Command.Common (waspSaysC)
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.Telemetry.Common (ensureTelemetryCacheDirExists)
 import qualified Wasp.Cli.Command.Telemetry.Project as TlmProject
 import qualified Wasp.Cli.Command.Telemetry.User as TlmUser
-import Wasp.Cli.Terminal (asWaspFailureMessage)
+import qualified Wasp.Message as Msg
 
 isTelemetryDisabled :: IO Bool
 isTelemetryDisabled = isJust <$> ENV.lookupEnv "WASP_TELEMETRY_DISABLE"
@@ -26,16 +26,17 @@ isTelemetryDisabled = isJust <$> ENV.lookupEnv "WASP_TELEMETRY_DISABLE"
 telemetry :: Command ()
 telemetry = do
   telemetryDisabled <- liftIO isTelemetryDisabled
-  waspSaysC $
-    "Telemetry is currently: "
-      <> ( if telemetryDisabled
-             then "DISABLED"
-             else "ENABLED"
-         )
+  cliSendMessageC $
+    Msg.Notification $
+      "Telemetry is currently: "
+        <> ( if telemetryDisabled
+               then "DISABLED"
+               else "ENABLED"
+           )
 
   unless telemetryDisabled $ do
     telemetryCacheDirPath <- liftIO ensureTelemetryCacheDirExists
-    waspSaysC $ "Telemetry cache directory: " ++ SP.toFilePath telemetryCacheDirPath
+    cliSendMessageC $ Msg.Notification $ "Telemetry cache directory: " ++ SP.toFilePath telemetryCacheDirPath
 
     maybeProjectHash <- (Just <$> TlmProject.getWaspProjectPathHash) `catchError` const (return Nothing)
     for_ maybeProjectHash $ \projectHash -> do
@@ -43,9 +44,9 @@ telemetry = do
       for_ maybeProjectCache $ \projectCache -> do
         let maybeTimeOfLastSending = TlmProject.getTimeOfLastTelemetryDataSent projectCache
         for_ maybeTimeOfLastSending $ \timeOfLastSending -> do
-          waspSaysC $ "Last time telemetry data was sent for this project: " ++ show timeOfLastSending
+          cliSendMessageC $ Msg.Notification $ "Last time telemetry data was sent for this project: " ++ show timeOfLastSending
 
-  waspSaysC "Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details."
+  cliSendMessageC $ Msg.Notification "Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details."
 
 -- | Sends telemetry data about the current Wasp project, if conditions are met.
 -- If we are not in the Wasp project at the moment, nothing happens.
@@ -54,7 +55,7 @@ telemetry = do
 considerSendingData :: Command.Call.Call -> Command ()
 considerSendingData cmdCall = (`catchError` const (return ())) $ do
   telemetryDisabled <- liftIO isTelemetryDisabled
-  when telemetryDisabled $ throwError $ CommandError $ asWaspFailureMessage "Telemetry disabled by user."
+  when telemetryDisabled $ throwError $ CommandError "Telemetry disabled by user."
 
   telemetryCacheDirPath <- liftIO ensureTelemetryCacheDirExists
 

--- a/waspc/cli/Wasp/Cli/Command/Telemetry.hs
+++ b/waspc/cli/Wasp/Cli/Command/Telemetry.hs
@@ -27,7 +27,7 @@ telemetry :: Command ()
 telemetry = do
   telemetryDisabled <- liftIO isTelemetryDisabled
   cliSendMessageC $
-    Msg.Notification $
+    Msg.Info $
       "Telemetry is currently: "
         <> ( if telemetryDisabled
                then "DISABLED"
@@ -36,7 +36,7 @@ telemetry = do
 
   unless telemetryDisabled $ do
     telemetryCacheDirPath <- liftIO ensureTelemetryCacheDirExists
-    cliSendMessageC $ Msg.Notification $ "Telemetry cache directory: " ++ SP.toFilePath telemetryCacheDirPath
+    cliSendMessageC $ Msg.Info $ "Telemetry cache directory: " ++ SP.toFilePath telemetryCacheDirPath
 
     maybeProjectHash <- (Just <$> TlmProject.getWaspProjectPathHash) `catchError` const (return Nothing)
     for_ maybeProjectHash $ \projectHash -> do
@@ -44,9 +44,9 @@ telemetry = do
       for_ maybeProjectCache $ \projectCache -> do
         let maybeTimeOfLastSending = TlmProject.getTimeOfLastTelemetryDataSent projectCache
         for_ maybeTimeOfLastSending $ \timeOfLastSending -> do
-          cliSendMessageC $ Msg.Notification $ "Last time telemetry data was sent for this project: " ++ show timeOfLastSending
+          cliSendMessageC $ Msg.Info $ "Last time telemetry data was sent for this project: " ++ show timeOfLastSending
 
-  cliSendMessageC $ Msg.Notification "Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details."
+  cliSendMessageC $ Msg.Info "Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details."
 
 -- | Sends telemetry data about the current Wasp project, if conditions are met.
 -- If we are not in the Wasp project at the moment, nothing happens.
@@ -55,7 +55,7 @@ telemetry = do
 considerSendingData :: Command.Call.Call -> Command ()
 considerSendingData cmdCall = (`catchError` const (return ())) $ do
   telemetryDisabled <- liftIO isTelemetryDisabled
-  when telemetryDisabled $ throwError $ CommandError "Telemetry disabled by user."
+  when telemetryDisabled $ throwError $ CommandError "Telemetry failed" "Telemetry disabled by user." 
 
   telemetryCacheDirPath <- liftIO ensureTelemetryCacheDirExists
 

--- a/waspc/cli/Wasp/Cli/Command/Watch.hs
+++ b/waspc/cli/Wasp/Cli/Command/Watch.hs
@@ -82,7 +82,7 @@ watch waspProjectDir outDir = FSN.withManager $ \mgr -> do
       cliSendMessage $ Msg.Start "Recompiling on file change..."
       compilationResult <- compileIO waspProjectDir outDir
       case compilationResult of
-        Left err -> cliSendMessage $ Msg.Failure $ "Recompilation on file change failed:" ++ err
+        Left err -> cliSendMessage $ Msg.Failure "Recompilation on file change failed" err
         Right () -> cliSendMessage $ Msg.Success "Recompilation on file change succeeded."
       return ()
 

--- a/waspc/cli/Wasp/Cli/Command/Watch.hs
+++ b/waspc/cli/Wasp/Cli/Command/Watch.hs
@@ -14,10 +14,10 @@ import qualified StrongPath as SP
 import qualified System.FSNotify as FSN
 import qualified System.FilePath as FP
 import Wasp.Cli.Command.Compile (compileIO)
-import Wasp.Cli.Common (waspSays, waspScreams)
 import qualified Wasp.Cli.Common as Common
-import Wasp.Cli.Terminal (asWaspFailureMessage, asWaspStartMessage, asWaspSuccessMessage)
+import Wasp.Cli.Message (cliSendMessage)
 import qualified Wasp.Lib
+import qualified Wasp.Message as Msg
 
 -- TODO: Another possible problem: on re-generation, wasp re-generates a lot of files, even those that should not
 --   be generated again, since it is not smart enough yet to know which files do not need to be regenerated.
@@ -79,11 +79,11 @@ watch waspProjectDir outDir = FSN.withManager $ \mgr -> do
 
     recompile :: IO ()
     recompile = do
-      waspSays $ asWaspStartMessage "Recompiling on file change..."
+      cliSendMessage $ Msg.Start "Recompiling on file change..."
       compilationResult <- compileIO waspProjectDir outDir
       case compilationResult of
-        Left err -> waspScreams $ asWaspFailureMessage "Recompilation on file change failed:" ++ err
-        Right () -> waspSays $ asWaspSuccessMessage "Recompilation on file change succeeded."
+        Left err -> cliSendMessage $ Msg.Failure $ "Recompilation on file change failed:" ++ err
+        Right () -> cliSendMessage $ Msg.Success "Recompilation on file change succeeded."
       return ()
 
     -- TODO: This is a hardcoded approach to ignoring most of the common tmp files that editors

--- a/waspc/cli/Wasp/Cli/Message.hs
+++ b/waspc/cli/Wasp/Cli/Message.hs
@@ -11,13 +11,13 @@ import qualified Wasp.Message as Msg
 
 -- | Send a message using the CLI
 cliSendMessage :: Msg.SendMessage
-cliSendMessage (Msg.Notification msg) =
-  waspSays $ msg
+cliSendMessage (Msg.Info msg) =
+  waspSays msg
 cliSendMessage (Msg.Start msg) =
   waspSays $ asWaspStartMessage msg
 cliSendMessage (Msg.Success msg) =
   waspSays $ asWaspSuccessMessage msg
-cliSendMessage (Msg.Failure msg) =
-  waspScreams $ asWaspFailureMessage msg
+cliSendMessage (Msg.Failure title msg) =
+  waspScreams $ asWaspFailureMessage (title ++ ":") ++ msg
 cliSendMessage (Msg.Warning msg) =
   waspWarns $ asWaspWarningMessage msg

--- a/waspc/cli/Wasp/Cli/Message.hs
+++ b/waspc/cli/Wasp/Cli/Message.hs
@@ -11,6 +11,8 @@ import qualified Wasp.Message as Msg
 
 -- | Send a message using the CLI
 cliSendMessage :: Msg.SendMessage
+cliSendMessage (Msg.Notification msg) =
+  waspSays $ msg
 cliSendMessage (Msg.Start msg) =
   waspSays $ asWaspStartMessage msg
 cliSendMessage (Msg.Success msg) =

--- a/waspc/cli/Wasp/Cli/Message.hs
+++ b/waspc/cli/Wasp/Cli/Message.hs
@@ -19,5 +19,5 @@ cliSendMessage (Msg.Success msg) =
   waspSays $ asWaspSuccessMessage msg
 cliSendMessage (Msg.Failure title msg) =
   waspScreams $ asWaspFailureMessage (title ++ ":") ++ msg
-cliSendMessage (Msg.Warning msg) =
-  waspWarns $ asWaspWarningMessage msg
+cliSendMessage (Msg.Warning title msg) =
+  waspWarns $ asWaspWarningMessage (title ++ ":") ++ msg

--- a/waspc/src/Wasp/Generator/Setup.hs
+++ b/waspc/src/Wasp/Generator/Setup.hs
@@ -3,6 +3,7 @@ module Wasp.Generator.Setup
   )
 where
 
+import Control.Monad (when)
 import StrongPath (Abs, Dir, Path')
 import Wasp.AppSpec (AppSpec)
 import Wasp.Generator.Common (ProjectRootDir)
@@ -20,10 +21,7 @@ runSetup spec dstDir sendMessage = do
       sendMessage $ Msg.Success "Successfully completed npm install."
       sendMessage $ Msg.Start "Setting up database..."
       (dbGeneratorWarnings, dbGeneratorErrors) <- DbGenerator.postWriteDbGeneratorActions spec dstDir
-      if null dbGeneratorErrors
-        then sendMessage $ Msg.Success "Database successfully set up."
-        else sendMessage $ Msg.Failure "Could not set up database."
+      when (null dbGeneratorErrors) (sendMessage $ Msg.Success "Database successfully set up.")
       return (npmInstallWarnings ++ dbGeneratorWarnings, dbGeneratorErrors)
     else do
-      sendMessage $ Msg.Failure "npm install failed!"
       return (npmInstallWarnings, npmInstallErrors)

--- a/waspc/src/Wasp/Message.hs
+++ b/waspc/src/Wasp/Message.hs
@@ -9,6 +9,6 @@ module Wasp.Message (Message (..), SendMessage) where
 -- This protocol is for sending messages for display in a UI.
 -- If you need success or failure another purpose use return values.
 
-data Message = Notification String | Start String | Success String | Failure String | Warning String
+data Message = Info String | Warning String | Start String | Success String | Failure String String
 
 type SendMessage = Message -> IO ()

--- a/waspc/src/Wasp/Message.hs
+++ b/waspc/src/Wasp/Message.hs
@@ -9,6 +9,6 @@ module Wasp.Message (Message (..), SendMessage) where
 -- This protocol is for sending messages for display in a UI.
 -- If you need success or failure another purpose use return values.
 
-data Message = Start String | Success String | Failure String | Warning String
+data Message = Notification String | Start String | Success String | Failure String | Warning String
 
 type SendMessage = Message -> IO ()

--- a/waspc/src/Wasp/Message.hs
+++ b/waspc/src/Wasp/Message.hs
@@ -9,6 +9,6 @@ module Wasp.Message (Message (..), SendMessage) where
 -- This protocol is for sending messages for display in a UI.
 -- If you need success or failure another purpose use return values.
 
-data Message = Info String | Warning String | Start String | Success String | Failure String String
+data Message = Info String | Start String | Success String | Failure String String | Warning String String
 
 type SendMessage = Message -> IO ()


### PR DESCRIPTION
# Description

Use the SendMessage protocol in the cli instead of `waspSays` and friends, by using `cliSendMessage` (and the lifted variant for commands, `cliSendMessageC`) instead. Instead of using `asWaspFailureMessage` everywhere there is a command error, move the full error handling into the command error handler itself.

Fixes # (issue)

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update