### PR TITLE
Remove `python2` dep from e2e and update README

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -73,7 +73,7 @@ This might take a longer time (10 mins) if you are doing it for the very first t
 ```
 stack test
 ```
-to ensure all the unit tests are passing (this will also build the project if needed).
+to ensure all the unit and end-to-end tests are passing (this will also build the project if needed).
 
 ### Executable
 ```
@@ -231,13 +231,14 @@ All tests go into `test/` directory.
 This is convention for Haskell, opposite to mixing them with source code as in Javascript for example.
 Not only that, but Haskell build tools don't have a good support for mixing them with source files, so even if we wanted to do that it is just not worth the hassle.
 
-Tests are run with `stack test`.
+Tests are run with `stack test`. They include both unit tests, and end-to-end tests of basic CLI commands.
 You can do `stack test --coverage` to see the coverage.
 
-To run individual test, you can do `stack test --test-arguments "-p \"Some test description to match\""`.
+To run unit tests only, you can do `stack test :waspc-test`.
 
-We don't yet have any integration (e2e) tests, but we plan to add them at some point.
-For now, best way is to manually run a Wasp app with `wasp start` and try stuff out.
+To run end-to-end tests only, you can do `stack test :e2e-test`.
+
+To run individual test, you can do `stack test --test-arguments "-p \"Some test description to match\""`.
 
 ## Code analysis
 

--- a/waspc/e2e-test/GoldenTest.hs
+++ b/waspc/e2e-test/GoldenTest.hs
@@ -120,7 +120,8 @@ runGoldenTest goldenTest = do
 
         reformatJson :: FilePath -> IO ()
         reformatJson jsonFilePath =
-          BSL.writeFile jsonFilePath . AesonPretty.encodePretty' aesonPrettyConfig . unsafeDecodeAnyJson =<< B.readFile jsonFilePath
+          BSL.writeFile jsonFilePath . AesonPretty.encodePretty' aesonPrettyConfig . unsafeDecodeAnyJson
+            =<< B.readFile jsonFilePath
           where
             unsafeDecodeAnyJson :: B.ByteString -> Aeson.Value
             unsafeDecodeAnyJson = fromJust . Aeson.decodeStrict

--- a/waspc/e2e-test/GoldenTest.hs
+++ b/waspc/e2e-test/GoldenTest.hs
@@ -101,7 +101,7 @@ runGoldenTest goldenTest = do
       writeFile manifestAbsFp sortedRelativeFilePaths
 
     -- This function normalizes all package.json files for comparison as `npm install` can overwrite
-    -- them when creating/updating package-lock.json. Different versions of Node may produce different
+    -- them when creating/updating package-lock.json. Different versions of npm may produce different
     -- (but semantically equivalent) package.json files, thus triggering false positives.
     -- Ref: https://github.com/wasp-lang/wasp/issues/482
     reformatPackageJsonFiles :: [FilePath] -> IO ()

--- a/waspc/e2e-test/GoldenTest.hs
+++ b/waspc/e2e-test/GoldenTest.hs
@@ -102,7 +102,7 @@ runGoldenTest goldenTest = do
 
     -- This function normalizes all package.json files for comparison as `npm install` can overwrite
     -- them when creating/updating package-lock.json. Different versions of Node may produce different
-    -- package.json files, thus triggering false positives when diffing locally vs CI, for example.
+    -- (but semantically equivalent) package.json files, thus triggering false positives.
     -- Ref: https://github.com/wasp-lang/wasp/issues/482
     reformatPackageJsonFiles :: [FilePath] -> IO ()
     reformatPackageJsonFiles allOutputFilePaths = do

--- a/waspc/e2e-test/GoldenTest.hs
+++ b/waspc/e2e-test/GoldenTest.hs
@@ -106,17 +106,17 @@ runGoldenTest goldenTest = do
     -- Ref: https://github.com/wasp-lang/wasp/issues/482
     reformatPackageJsonFiles :: [FilePath] -> IO ()
     reformatPackageJsonFiles allOutputFilePaths = do
-      let packageJsonSuffix = FP.pathSeparator : "package.json"
-      let packageJsonFilePaths = filter (packageJsonSuffix `isSuffixOf`) allOutputFilePaths
+      let packageJsonFilePathSuffix = FP.pathSeparator : "package.json"
+      let packageJsonFilePaths = filter (packageJsonFilePathSuffix `isSuffixOf`) allOutputFilePaths
       mapM_ reformatJson packageJsonFilePaths
       where
         aesonPrettyConfig = Config {confIndent = Spaces 4, confCompare = compare, confNumFormat = Generic, confTrailingNewline = True}
-        reformatJson fp = do
-          let tmpFp = fp ++ ".tmp"
-          str <- BSL.readFile fp
+        reformatJson jsonFilePath = do
+          let tmpFilePath = jsonFilePath ++ ".tmp"
+          str <- BSL.readFile jsonFilePath
           -- NOTE: Aeson.decode into (:: Maybe Value) allows us to decode any
           -- valid JSON string, without specifying a schema.
           let json = fromJust (decode str :: Maybe Value)
-          let prettyJson = encodePretty' aesonPrettyConfig json
-          BSL.writeFile tmpFp prettyJson
-          renameFile tmpFp fp
+          let formattedJson = encodePretty' aesonPrettyConfig json
+          BSL.writeFile tmpFilePath formattedJson
+          renameFile tmpFilePath jsonFilePath

--- a/waspc/e2e-test/Tests/WaspBuildTest.hs
+++ b/waspc/e2e-test/Tests/WaspBuildTest.hs
@@ -2,9 +2,7 @@ module Tests.WaspBuildTest (waspBuild) where
 
 import GoldenTest (GoldenTest, makeGoldenTest)
 import ShellCommands
-  ( OutputDir (BuildOutputDir),
-    cdIntoCurrentProject,
-    reformatPackageJson,
+  ( cdIntoCurrentProject,
     setDbToPSQL,
     waspCliBuild,
     waspCliNew,
@@ -17,6 +15,5 @@ waspBuild =
       [ waspCliNew,
         cdIntoCurrentProject,
         setDbToPSQL,
-        waspCliBuild,
-        reformatPackageJson BuildOutputDir
+        waspCliBuild
       ]

--- a/waspc/e2e-test/Tests/WaspCompileTest.hs
+++ b/waspc/e2e-test/Tests/WaspCompileTest.hs
@@ -2,9 +2,7 @@ module Tests.WaspCompileTest (waspCompile) where
 
 import GoldenTest (GoldenTest, makeGoldenTest)
 import ShellCommands
-  ( OutputDir (DevOutputDir),
-    cdIntoCurrentProject,
-    reformatPackageJson,
+  ( cdIntoCurrentProject,
     waspCliCompile,
     waspCliNew,
   )
@@ -15,6 +13,5 @@ waspCompile =
     sequence
       [ waspCliNew,
         cdIntoCurrentProject,
-        waspCliCompile,
-        reformatPackageJson DevOutputDir
+        waspCliCompile
       ]

--- a/waspc/e2e-test/Tests/WaspMigrateTest.hs
+++ b/waspc/e2e-test/Tests/WaspMigrateTest.hs
@@ -2,10 +2,8 @@ module Tests.WaspMigrateTest (waspMigrate) where
 
 import GoldenTest (GoldenTest, makeGoldenTest)
 import ShellCommands
-  ( OutputDir (DevOutputDir),
-    appendToWaspFile,
+  ( appendToWaspFile,
     cdIntoCurrentProject,
-    reformatPackageJson,
     waspCliCompile,
     waspCliMigrate,
     waspCliNew,
@@ -26,6 +24,5 @@ waspMigrate = do
         cdIntoCurrentProject,
         waspCliCompile,
         appendToWaspFile entityDecl,
-        waspCliMigrate "foo",
-        reformatPackageJson DevOutputDir
+        waspCliMigrate "foo"
       ]

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
@@ -1,37 +1,37 @@
 {
-    "dependencies": {
-        "@prisma/client": "3.9.1",
-        "cookie-parser": "~1.4.4",
-        "cors": "^2.8.5",
-        "debug": "~2.6.9",
-        "dotenv": "8.2.0",
-        "express": "~4.16.1",
-        "helmet": "^4.6.0",
-        "jsonwebtoken": "^8.5.1",
-        "morgan": "~1.9.1",
-        "secure-password": "^4.0.0"
-    },
-    "devDependencies": {
-        "nodemon": "^2.0.4",
-        "prisma": "3.9.1",
-        "standard": "^14.3.4"
-    },
-    "engines": {
-        "node": ">=12.18.0"
-    },
-    "name": "server",
-    "nodemonConfig": {
-        "delay": "1000"
-    },
-    "private": true,
-    "scripts": {
-        "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",
-        "db-migrate-prod": "prisma migrate deploy --schema=../db/schema.prisma",
-        "debug": "DEBUG=server:* npm start",
-        "standard": "standard",
-        "start": "nodemon -r dotenv/config ./src/server.js",
-        "start-production": "NODE_ENV=production node ./src/server.js"
-    },
-    "type": "module",
-    "version": "0.0.0"
+  "dependencies": {
+    "@prisma/client": "3.9.1",
+    "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
+    "debug": "~2.6.9",
+    "dotenv": "8.2.0",
+    "express": "~4.16.1",
+    "helmet": "^4.6.0",
+    "jsonwebtoken": "^8.5.1",
+    "morgan": "~1.9.1",
+    "secure-password": "^4.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.4",
+    "prisma": "3.9.1",
+    "standard": "^14.3.4"
+  },
+  "engines": {
+    "node": ">=12.18.0"
+  },
+  "name": "server",
+  "nodemonConfig": {
+    "delay": "1000"
+  },
+  "private": true,
+  "scripts": {
+    "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",
+    "db-migrate-prod": "prisma migrate deploy --schema=../db/schema.prisma",
+    "debug": "DEBUG=server:* npm start",
+    "standard": "standard",
+    "start": "nodemon -r dotenv/config ./src/server.js",
+    "start-production": "NODE_ENV=production node ./src/server.js"
+  },
+  "type": "module",
+  "version": "0.0.0"
 }

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
@@ -1,37 +1,37 @@
 {
-    "browserslist": {
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ],
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ]
-    },
-    "dependencies": {
-        "axios": "^0.21.1",
-        "lodash": "^4.17.15",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0",
-        "react-query": "^2.14.1",
-        "react-router-dom": "^5.1.2",
-        "react-scripts": "4.0.3",
-        "uuid": "^3.4.0"
-    },
-    "devDependencies": {},
-    "eslintConfig": {
-        "extends": "react-app"
-    },
-    "name": "waspBuild",
-    "private": true,
-    "scripts": {
-        "build": "react-scripts build",
-        "eject": "react-scripts eject",
-        "start": "react-scripts start",
-        "test": "react-scripts test"
-    },
-    "version": "0.0.0"
+  "browserslist": {
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ]
+  },
+  "dependencies": {
+    "axios": "^0.21.1",
+    "lodash": "^4.17.15",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-query": "^2.14.1",
+    "react-router-dom": "^5.1.2",
+    "react-scripts": "4.0.3",
+    "uuid": "^3.4.0"
+  },
+  "devDependencies": {},
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "name": "waspBuild",
+  "private": true,
+  "scripts": {
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "start": "react-scripts start",
+    "test": "react-scripts test"
+  },
+  "version": "0.0.0"
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
@@ -1,37 +1,37 @@
 {
-    "dependencies": {
-        "@prisma/client": "3.9.1",
-        "cookie-parser": "~1.4.4",
-        "cors": "^2.8.5",
-        "debug": "~2.6.9",
-        "dotenv": "8.2.0",
-        "express": "~4.16.1",
-        "helmet": "^4.6.0",
-        "jsonwebtoken": "^8.5.1",
-        "morgan": "~1.9.1",
-        "secure-password": "^4.0.0"
-    },
-    "devDependencies": {
-        "nodemon": "^2.0.4",
-        "prisma": "3.9.1",
-        "standard": "^14.3.4"
-    },
-    "engines": {
-        "node": ">=12.18.0"
-    },
-    "name": "server",
-    "nodemonConfig": {
-        "delay": "1000"
-    },
-    "private": true,
-    "scripts": {
-        "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",
-        "db-migrate-prod": "prisma migrate deploy --schema=../db/schema.prisma",
-        "debug": "DEBUG=server:* npm start",
-        "standard": "standard",
-        "start": "nodemon -r dotenv/config ./src/server.js",
-        "start-production": "NODE_ENV=production node ./src/server.js"
-    },
-    "type": "module",
-    "version": "0.0.0"
+  "dependencies": {
+    "@prisma/client": "3.9.1",
+    "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
+    "debug": "~2.6.9",
+    "dotenv": "8.2.0",
+    "express": "~4.16.1",
+    "helmet": "^4.6.0",
+    "jsonwebtoken": "^8.5.1",
+    "morgan": "~1.9.1",
+    "secure-password": "^4.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.4",
+    "prisma": "3.9.1",
+    "standard": "^14.3.4"
+  },
+  "engines": {
+    "node": ">=12.18.0"
+  },
+  "name": "server",
+  "nodemonConfig": {
+    "delay": "1000"
+  },
+  "private": true,
+  "scripts": {
+    "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",
+    "db-migrate-prod": "prisma migrate deploy --schema=../db/schema.prisma",
+    "debug": "DEBUG=server:* npm start",
+    "standard": "standard",
+    "start": "nodemon -r dotenv/config ./src/server.js",
+    "start-production": "NODE_ENV=production node ./src/server.js"
+  },
+  "type": "module",
+  "version": "0.0.0"
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
@@ -1,37 +1,37 @@
 {
-    "browserslist": {
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ],
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ]
-    },
-    "dependencies": {
-        "axios": "^0.21.1",
-        "lodash": "^4.17.15",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0",
-        "react-query": "^2.14.1",
-        "react-router-dom": "^5.1.2",
-        "react-scripts": "4.0.3",
-        "uuid": "^3.4.0"
-    },
-    "devDependencies": {},
-    "eslintConfig": {
-        "extends": "react-app"
-    },
-    "name": "waspCompile",
-    "private": true,
-    "scripts": {
-        "build": "react-scripts build",
-        "eject": "react-scripts eject",
-        "start": "react-scripts start",
-        "test": "react-scripts test"
-    },
-    "version": "0.0.0"
+  "browserslist": {
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ]
+  },
+  "dependencies": {
+    "axios": "^0.21.1",
+    "lodash": "^4.17.15",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-query": "^2.14.1",
+    "react-router-dom": "^5.1.2",
+    "react-scripts": "4.0.3",
+    "uuid": "^3.4.0"
+  },
+  "devDependencies": {},
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "name": "waspCompile",
+  "private": true,
+  "scripts": {
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "start": "react-scripts start",
+    "test": "react-scripts test"
+  },
+  "version": "0.0.0"
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/db/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/db/package.json
@@ -1,8 +1,8 @@
 {
-  "devDependencies": {
-    "prisma": "^3.9.1"
-  },
-  "dependencies": {
-    "@prisma/client": "^3.9.1"
-  }
+    "dependencies": {
+        "@prisma/client": "^3.9.1"
+    },
+    "devDependencies": {
+        "prisma": "^3.9.1"
+    }
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/db/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/db/package.json
@@ -1,8 +1,8 @@
 {
-    "dependencies": {
-        "@prisma/client": "^3.9.1"
-    },
-    "devDependencies": {
-        "prisma": "^3.9.1"
-    }
+  "dependencies": {
+    "@prisma/client": "^3.9.1"
+  },
+  "devDependencies": {
+    "prisma": "^3.9.1"
+  }
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
@@ -1,37 +1,37 @@
 {
-    "dependencies": {
-        "@prisma/client": "3.9.1",
-        "cookie-parser": "~1.4.4",
-        "cors": "^2.8.5",
-        "debug": "~2.6.9",
-        "dotenv": "8.2.0",
-        "express": "~4.16.1",
-        "helmet": "^4.6.0",
-        "jsonwebtoken": "^8.5.1",
-        "morgan": "~1.9.1",
-        "secure-password": "^4.0.0"
-    },
-    "devDependencies": {
-        "nodemon": "^2.0.4",
-        "prisma": "3.9.1",
-        "standard": "^14.3.4"
-    },
-    "engines": {
-        "node": ">=12.18.0"
-    },
-    "name": "server",
-    "nodemonConfig": {
-        "delay": "1000"
-    },
-    "private": true,
-    "scripts": {
-        "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",
-        "db-migrate-prod": "prisma migrate deploy --schema=../db/schema.prisma",
-        "debug": "DEBUG=server:* npm start",
-        "standard": "standard",
-        "start": "nodemon -r dotenv/config ./src/server.js",
-        "start-production": "npm run db-migrate-prod && NODE_ENV=production node ./src/server.js"
-    },
-    "type": "module",
-    "version": "0.0.0"
+  "dependencies": {
+    "@prisma/client": "3.9.1",
+    "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
+    "debug": "~2.6.9",
+    "dotenv": "8.2.0",
+    "express": "~4.16.1",
+    "helmet": "^4.6.0",
+    "jsonwebtoken": "^8.5.1",
+    "morgan": "~1.9.1",
+    "secure-password": "^4.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.4",
+    "prisma": "3.9.1",
+    "standard": "^14.3.4"
+  },
+  "engines": {
+    "node": ">=12.18.0"
+  },
+  "name": "server",
+  "nodemonConfig": {
+    "delay": "1000"
+  },
+  "private": true,
+  "scripts": {
+    "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",
+    "db-migrate-prod": "prisma migrate deploy --schema=../db/schema.prisma",
+    "debug": "DEBUG=server:* npm start",
+    "standard": "standard",
+    "start": "nodemon -r dotenv/config ./src/server.js",
+    "start-production": "npm run db-migrate-prod && NODE_ENV=production node ./src/server.js"
+  },
+  "type": "module",
+  "version": "0.0.0"
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
@@ -1,37 +1,37 @@
 {
-    "browserslist": {
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ],
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ]
-    },
-    "dependencies": {
-        "axios": "^0.21.1",
-        "lodash": "^4.17.15",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0",
-        "react-query": "^2.14.1",
-        "react-router-dom": "^5.1.2",
-        "react-scripts": "4.0.3",
-        "uuid": "^3.4.0"
-    },
-    "devDependencies": {},
-    "eslintConfig": {
-        "extends": "react-app"
-    },
-    "name": "waspMigrate",
-    "private": true,
-    "scripts": {
-        "build": "react-scripts build",
-        "eject": "react-scripts eject",
-        "start": "react-scripts start",
-        "test": "react-scripts test"
-    },
-    "version": "0.0.0"
+  "browserslist": {
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ]
+  },
+  "dependencies": {
+    "axios": "^0.21.1",
+    "lodash": "^4.17.15",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-query": "^2.14.1",
+    "react-router-dom": "^5.1.2",
+    "react-scripts": "4.0.3",
+    "uuid": "^3.4.0"
+  },
+  "devDependencies": {},
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "name": "waspMigrate",
+  "private": true,
+  "scripts": {
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "start": "react-scripts start",
+    "test": "react-scripts test"
+  },
+  "version": "0.0.0"
 }

--- a/waspc/package.yaml
+++ b/waspc/package.yaml
@@ -160,6 +160,7 @@ tests:
       - filepath
       - yaml
       - aeson
+      - aeson-pretty
       - bytestring
       - process
       - directory


### PR DESCRIPTION
This removes the `python2` dependency that sorted the `package.json` files explicitly in test files via shell commands. Now, we do so in Haskell (using Aeson Pretty) implicitly in `runGoldenTest`.

This also updates the README with e2e info.

Closes #498

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update