### PR TITLE
Improve performance of writing FileDrafts

### DIFF
--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -130,13 +130,6 @@
             "file",
             "server/src/server.js"
         ],
-        "4f55cbd9d552d1cc072cc3f64e4856ee0268877b8303651c499214793057eaf8"
-    ],
-    [
-        [
-            "file",
-            "server/src/server.js"
-        ],
         "48b40cb20ce5d1171c9a01e28bfb2a1b0efefbee8cc210a52bf7f67aa8ec585b"
     ],
     [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -130,13 +130,6 @@
             "file",
             "server/src/server.js"
         ],
-        "4f55cbd9d552d1cc072cc3f64e4856ee0268877b8303651c499214793057eaf8"
-    ],
-    [
-        [
-            "file",
-            "server/src/server.js"
-        ],
         "48b40cb20ce5d1171c9a01e28bfb2a1b0efefbee8cc210a52bf7f67aa8ec585b"
     ],
     [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -130,13 +130,6 @@
             "file",
             "server/src/server.js"
         ],
-        "4f55cbd9d552d1cc072cc3f64e4856ee0268877b8303651c499214793057eaf8"
-    ],
-    [
-        [
-            "file",
-            "server/src/server.js"
-        ],
         "48b40cb20ce5d1171c9a01e28bfb2a1b0efefbee8cc210a52bf7f67aa8ec585b"
     ],
     [

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -150,7 +150,6 @@ genSrcDir :: AppSpec -> Generator [FileDraft]
 genSrcDir spec =
   sequence
     [ return $ C.mkSrcTmplFd $ C.asTmplSrcFile [relfile|app.js|],
-      return $ C.mkSrcTmplFd $ C.asTmplSrcFile [relfile|server.js|],
       return $ C.mkSrcTmplFd $ C.asTmplSrcFile [relfile|utils.js|],
       return $ C.mkSrcTmplFd $ C.asTmplSrcFile [relfile|core/AuthError.js|],
       return $ C.mkSrcTmplFd $ C.asTmplSrcFile [relfile|core/HttpError.js|],

--- a/waspc/test/Generator/WriteFileDraftsTest.hs
+++ b/waspc/test/Generator/WriteFileDraftsTest.hs
@@ -4,7 +4,7 @@ import Data.Bifunctor (Bifunctor (first))
 import Data.Maybe (fromJust)
 import Data.Text (pack)
 import qualified StrongPath as SP
-import Test.Tasty.Hspec (Spec, describe, it, shouldBe)
+import Test.Tasty.Hspec (Spec, describe, it, shouldBe, shouldMatchList)
 import Wasp.Generator.FileDraft (FileDraft (FileDraftTextFd), Writeable (getDstPath))
 import Wasp.Generator.FileDraft.TextFileDraft (TextFileDraft)
 import qualified Wasp.Generator.FileDraft.TextFileDraft as TextFD
@@ -53,7 +53,9 @@ spec_WriteFileDrafts =
                   updatedFdsWithChecksums,
                 deletedRelPathsToChecksums
               ]
-      fileDraftsToWriteAndFilesToDelete (Just relPathsToChecksums) fdsWithChecksums `shouldBe` (map fst $ newFdsWithChecksums ++ updatedFdsWithChecksums, map fst deletedRelPathsToChecksums)
+      let (fileDraftsToWrite, filesToDelete) = fileDraftsToWriteAndFilesToDelete (Just relPathsToChecksums) fdsWithChecksums
+      fileDraftsToWrite `shouldMatchList` map fst (newFdsWithChecksums ++ updatedFdsWithChecksums)
+      filesToDelete `shouldMatchList` map fst deletedRelPathsToChecksums
   where
     fromEither :: (a -> c) -> (b -> c) -> Either a b -> c
     fromEither f _ (Left a) = f a

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -101,7 +101,7 @@ library
     , path                  ^>= 0.9.2
     , path-io               ^>= 1.6.3
     , regex-tdfa            ^>= 1.3.1
-    , strong-path           ^>= 1.1.2
+    , strong-path           ^>= 1.1.3
     , unliftio              ^>= 0.2.20
     , utf8-string           ^>= 1.0.2
     , cryptonite            ^>= 0.29

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -101,7 +101,7 @@ library
     , path                  ^>= 0.9.2
     , path-io               ^>= 1.6.3
     , regex-tdfa            ^>= 1.3.1
-    , strong-path           ^>= 1.1.3
+    , strong-path           ^>= 1.1.4
     , unliftio              ^>= 0.2.20
     , utf8-string           ^>= 1.0.2
     , cryptonite            ^>= 0.29


### PR DESCRIPTION
# Description

This change improves the algorithmic complexity of writing `FileDraft`s by replacing nested list operations (n^2) with `HashMap` based lookup versions (n*logn).

It also fixes a bug that was discovered as part of this process where a `FileDraft` was written twice. It does not add a check to prevent that from reoccurring. That is for another issue: #517 

Fixes #503

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update