### PR TITLE
Check in CI that cabal freeze file is up to date.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,7 @@ jobs:
         run: ./run ormolu:check
 
       - name: Check if cabal freeze file is up to date
+        if: matrix.os == 'ubuntu-latest'
         run: |
           # We do the check by running `cabal freeze` and checking if cabal.project.freeze
           # changed. If it didn't, it is up to date, otherwise it is not.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,9 +85,10 @@ jobs:
         run: |
           # We do the check by running `cabal freeze` and checking if cabal.project.freeze
           # changed. If it didn't, it is up to date, otherwise it is not.
+          # If there is no cabal.project.freeze, or `cabal freeze` command failed, that is also red flag.
           [[ -f cabal.project.freeze ]] || exit 1
           OLD_FREEZE_SUM=$(md5sum cabal.project.freeze)
-          cabal freeze
+          cabal freeze || exit 1
           NEW_FREEZE_SUM=$(md5sum cabal.project.freeze)
           [[ "$NEW_FREEZE_SUM" == "$OLD_FREEZE_SUM" ]]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,10 +81,23 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: ./run ormolu:check
 
+      - name: Check if cabal freeze file is up to date
+        run: |
+          # We do the check by running `cabal freeze` and checking if cabal.project.freeze
+          # changed. If it didn't, it is up to date, otherwise it is not.
+          [[ -f cabal.project.freeze ]] || exit 1
+          OLD_FREEZE_SUM=$(md5sum cabal.project.freeze)
+          cabal freeze
+          NEW_FREEZE_SUM=$(md5sum cabal.project.freeze)
+          [[ "$NEW_FREEZE_SUM" == "$OLD_FREEZE_SUM" ]]
+
       - name: Build external dependencies 
         run: cabal build --enable-tests --enable-benchmarks --only-dependencies 
-      
-      - name: Build Wasp code & run tests
+
+      - name: Build wasp code
+        run: cabal build all
+
+      - name: Run tests
         run: cabal test
 
       - name: Create binary package (Unix)

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -100,7 +100,9 @@ NOTE: Reload page if blank.
 5. If needed, confirm that `examples/todoApp/` is working correctly by running `cabal build` first, to build the wasp executable, and then by running that executable with `cabal run wasp-cli start` from the `examples/todoApp/` dir -> this will run the web app in development mode with the current version of your Wasp code.
    Manually inspect that app behaves ok: In the future we will add automatic integration tests, but for now testing is manual.
 6. When all is ready, and if you modified any Haskell dependencies, regenerate the cabal freeze file.
-   You can do this by running `rm cabal.project.freeze && cabal freeze` (or `./run refreeze`).
+   You can do this by running `cabal freeze` to use the existing frozen dependencies while also capturing new changes you did -> you will likely want to do this if you added a new dependency and don't want to touch frozen versions of other dependencies.
+   Or, you can completely recreate freeze file by running `rm cabal.project.freeze && cabal freeze` (or `./run refreeze`) -> you will likely want to do this if you want to get updates for packages, or if just running `cabal freeze` is too restricted by versions currently captured in freeze file.
+   If not sure what to do, it is easiest and always ok to just do `./run refreeze`.
 7. Squash all the commits into a single commit (or a few in case it makes more sense) and create a PR. 
    Keep an eye on CI tests -> they should all be passing, if not, look into it.
 8. If your PR changes how users(Waspers) use Wasp, make sure to also create a PR that will update the documentation, which is in a [separate repo](https://wasp-lang.dev/docs/tutorials/getting-started).


### PR DESCRIPTION
We don't want to forget, by accident, to run `cabal freeze` after we make changes to cabal dependencies.

Therefore, I added check on CI that checks if cabal freeze is up to date. If it is, running `cabal freeze` command should be idempotent (should have no effect). If it is not, it will update the freeze file, so that is how we check.