### PR TITLE
Change termination behavior of Node process commands

### DIFF
--- a/waspc/src/Wasp/Generator/Job/Process.hs
+++ b/waspc/src/Wasp/Generator/Job/Process.hs
@@ -81,7 +81,7 @@ runProcessAsJob process jobType chan =
 
     terminateStreamingProcess streamingProcessHandle = do
       let processHandle = CP.streamingProcessHandleRaw streamingProcessHandle
-      P.terminateProcess processHandle
+      P.interruptProcessGroupOf processHandle
       return $ ExitFailure 1
 
 runNodeCommandAsJob :: Path' Abs (Dir a) -> String -> [String] -> J.JobType -> J.Job


### PR DESCRIPTION
# Description

We have noticed "port in use" errors over time that we have not been able to reliably reproduce, nor fix. This change is an attempt to fix them by noticing when we run `npm start` in the web-app directory to kickoff `react-scripts`, it will spawn a `node` child process that itself will spawn another `node` child process.

```bash
/bin/zsh│-zsh
└─ /Users/shayne/.nvm/versions/node/v16.14.0/bin/node│npm start
   └─ /Users/shayne/.nvm/versions/node/v16.14.0/bin/node /Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/web-app/node_modules/.bin/react-scripts start
      └─ /Users/shayne/.nvm/versions/node/v16.14.0/bin/node /Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/web-app/node_modules/react-scripts/scripts/start.js
```

If in terminal you `SIGTERM` or `SIGINT` or `SIGKILL` the top-level `npm` process, it will leave behind the grandchild process (and still holding its port).

```bash
# 75692 is the PID of the top-level npm process
# This shows the PID, Parent PID, and Process Group IDs
$ ps xao pid,ppid,pgid | grep 75692
75692 62921 75692
75694 75692 75692
75695 75694 75692

# Send SIGTERM to the top-level npm process
$ kill -15 75692

# We see the grandchild still exists
$ ps aux | grep react-scripts
shayne           75695   0.0  1.4 420622304 239472 s001  S     9:25AM   0:05.42 /Users/shayne/.nvm/versions/node/v16.14.0/bin/node /Users/shayne/dev/wasp/waspc/examples/todoApp/.wasp/out/web-app/node_modules/react-scripts/scripts/start.js

# And is holding the port still
$ lsof -i:3000
COMMAND   PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
node    75695 shayne   27u  IPv4 0xe2f87db9cfeed73f      0t0  TCP *:hbci (LISTEN)
```

This change takes us
- from [terminateProcess](https://hackage.haskell.org/package/process-1.6.14.0/docs/System-Process.html#v:terminateProcess), which attempts to send the just top-level `npm` process a `SIGTERM`
- to [interruptProcessGroupOf](https://hackage.haskell.org/package/process-1.6.14.0/docs/System-Process.html#v:interruptProcessGroupOf), which attempts to send a `SIGINT` to the entire process _group_ (the top-level `npm` process and all the `node` processes below it).

The switch to `SIGINT` as well should more closely mirror what these Node/npm commands are "used to" from a CTRL-C terminal behavior perspective.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update