### PR TITLE
Add a warning in the project file to run cabal update.

### DIFF
--- a/waspc/cabal.project
+++ b/waspc/cabal.project
@@ -19,4 +19,5 @@ jobs: $ncpus
 -- Ensures that tests print their output to stdout as they execute.
 test-show-details: direct
 
+-- WARNING: Run cabal update if your local package index is older than this date.
 index-state: 2022-03-22T14:16:26Z


### PR DESCRIPTION
There's already a note in `wapsc/README.md` about this.

> NOTE: You may need to run cabal update before attempting to build if it has been some time since your last update.

This PR adds a warning comment to the project file too, see #525.