### PR TITLE
Add missing react-app data-files

### DIFF
--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -27,6 +27,8 @@ data-files:
   Generator/templates/Dockerfile
   Generator/templates/dockerignore
   Generator/templates/react-app/gitignore
+  Generator/templates/react-app/npmrc
+  Generator/templates/react-app/nvmrc
   Generator/templates/server/gitignore
   Generator/templates/server/npmrc
   Generator/templates/server/nvmrc


### PR DESCRIPTION
We were missing two files in `data-files` for `react-app` that caused `wasp-cli` not to run properly after a `cabal install`.