### PR TITLE
Added 'context' field to our telemetry, specifically to recognize when Wasp is running on Gitpod.

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Telemetry.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Telemetry.hs
@@ -59,7 +59,7 @@ considerSendingData cmdCall = (`catchError` const (return ())) $ do
 
   telemetryCacheDirPath <- liftIO ensureTelemetryCacheDirExists
 
-  userSignature <- liftIO $ TlmUser.readOrCreateUserSignatureFile telemetryCacheDirPath
+  userSignature <- liftIO $ TlmUser.obtainUserSignature telemetryCacheDirPath
 
   maybeProjectHash <- (Just <$> TlmProject.getWaspProjectPathHash) `catchError` const (return Nothing)
   for_ maybeProjectHash $ \projectHash -> do

--- a/waspc/cli/src/Wasp/Cli/Command/Telemetry/User.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Telemetry/User.hs
@@ -18,11 +18,10 @@ import Wasp.Util (checksumFromString, hexToString)
 newtype UserSignature = UserSignature {_userSignatureValue :: String} deriving (Show)
 
 obtainUserSignature :: Path' Abs (Dir TelemetryCacheDir) -> IO UserSignature
-obtainUserSignature telemetryCacheDirPath = do
-  envSign <- getUserSignatureFromEnv
-  case envSign of
-    Just sign -> return sign
-    Nothing -> readOrCreateUserSignatureFile telemetryCacheDirPath
+obtainUserSignature telemetryCacheDirPath =
+  getUserSignatureFromEnv `butIfNothingDo` readOrCreateUserSignatureFile telemetryCacheDirPath
+  where
+    a `butIfNothingDo` b = a >>= maybe b return
 
 readOrCreateUserSignatureFile :: Path' Abs (Dir TelemetryCacheDir) -> IO UserSignature
 readOrCreateUserSignatureFile telemetryCacheDirPath = do

--- a/waspc/cli/src/Wasp/Cli/Command/Telemetry/User.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Telemetry/User.hs
@@ -12,16 +12,14 @@ import qualified StrongPath as SP
 import qualified System.Directory as SD
 import qualified System.Environment as ENV
 import Wasp.Cli.Command.Telemetry.Common (TelemetryCacheDir)
-import Wasp.Util (checksumFromString, hexToString)
+import Wasp.Util (checksumFromString, hexToString, orIfNothingM)
 
 -- Random, non-identifyable UUID used to represent user in analytics.
 newtype UserSignature = UserSignature {_userSignatureValue :: String} deriving (Show)
 
 obtainUserSignature :: Path' Abs (Dir TelemetryCacheDir) -> IO UserSignature
 obtainUserSignature telemetryCacheDirPath =
-  getUserSignatureFromEnv `butIfNothingDo` readOrCreateUserSignatureFile telemetryCacheDirPath
-  where
-    a `butIfNothingDo` b = a >>= maybe b return
+  getUserSignatureFromEnv `orIfNothingM` readOrCreateUserSignatureFile telemetryCacheDirPath
 
 readOrCreateUserSignatureFile :: Path' Abs (Dir TelemetryCacheDir) -> IO UserSignature
 readOrCreateUserSignatureFile telemetryCacheDirPath = do

--- a/waspc/cli/src/Wasp/Cli/Command/Telemetry/User.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Telemetry/User.hs
@@ -2,7 +2,7 @@
 
 module Wasp.Cli.Command.Telemetry.User
   ( UserSignature (..),
-    readOrCreateUserSignatureFile,
+    obtainUserSignature,
   )
 where
 
@@ -10,10 +10,19 @@ import qualified Data.UUID.V4 as UUID
 import StrongPath (Abs, Dir, File', Path', relfile)
 import qualified StrongPath as SP
 import qualified System.Directory as SD
+import qualified System.Environment as ENV
 import Wasp.Cli.Command.Telemetry.Common (TelemetryCacheDir)
+import Wasp.Util (checksumFromString, hexToString)
 
 -- Random, non-identifyable UUID used to represent user in analytics.
 newtype UserSignature = UserSignature {_userSignatureValue :: String} deriving (Show)
+
+obtainUserSignature :: Path' Abs (Dir TelemetryCacheDir) -> IO UserSignature
+obtainUserSignature telemetryCacheDirPath = do
+  envSign <- getUserSignatureFromEnv
+  case envSign of
+    Just sign -> return sign
+    Nothing -> readOrCreateUserSignatureFile telemetryCacheDirPath
 
 readOrCreateUserSignatureFile :: Path' Abs (Dir TelemetryCacheDir) -> IO UserSignature
 readOrCreateUserSignatureFile telemetryCacheDirPath = do
@@ -30,3 +39,7 @@ readOrCreateUserSignatureFile telemetryCacheDirPath = do
 
 getUserSignatureFilePath :: Path' Abs (Dir TelemetryCacheDir) -> Path' Abs File'
 getUserSignatureFilePath telemetryCacheDir = telemetryCacheDir SP.</> [relfile|signature|]
+
+getUserSignatureFromEnv :: IO (Maybe UserSignature)
+getUserSignatureFromEnv =
+  (fmap . fmap) (UserSignature . hexToString . checksumFromString) (ENV.lookupEnv "WASP_TELEMETRY_USER_ID")

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -25,6 +25,9 @@ module Wasp.Util
     checksumFromFilePath,
     checksumFromChecksums,
     ifM,
+    fromMaybeM,
+    orIfNothing,
+    orIfNothingM,
   )
 where
 
@@ -37,6 +40,7 @@ import Data.Char (isSpace, isUpper, toLower, toUpper)
 import qualified Data.HashMap.Strict as M
 import Data.List (intercalate)
 import Data.List.Split (splitOn)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -190,3 +194,12 @@ hexFromString = Hex
 
 hexToString :: Hex -> String
 hexToString (Hex s) = s
+
+fromMaybeM :: (Monad m) => m a -> m (Maybe a) -> m a
+fromMaybeM ma = (>>= maybe ma return)
+
+orIfNothing :: Maybe a -> a -> a
+orIfNothing = flip fromMaybe
+
+orIfNothingM :: (Monad m) => m (Maybe a) -> m a -> m a
+orIfNothingM = flip fromMaybeM


### PR DESCRIPTION
Idea is that in this field we can put whatever, and then use that later in analytics to distinguish events. So it is kind of like "anything goes" analytics field.

I haven't yet updated our wasp-bot to differently show analytics based on this, but we can do that later, for now we just want to get start sending enriched analytics data as soon as possible.

What I will also do is PR to gitpod, to set the env var WASP_TELEMETRY_CONTEXT to `gitpod`.

Then we release new version of wasp, and we will start tracking this stuff!