### PR TITLE
Change python to python3 in Dockerfile

### DIFF
--- a/waspc/data/Generator/templates/Dockerfile
+++ b/waspc/data/Generator/templates/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --no-cache -U upgrade # To ensure any potential security patches are app
 
 FROM base AS server-builder
 # Install packages needed to build native npm packages.
-RUN apk add --no-cache build-base libtool autoconf automake python
+RUN apk add --no-cache build-base libtool autoconf automake python3
 WORKDIR /app
 # Install npm packages, resulting in node_modules/.
 COPY server/package*.json ./server/

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "fd98e5a6add079e07153a3891f3db96af219101d3e5d200fd212af4f6545c1f9"
+        "93bb104c26d9c0e06b947bd9b2be153e579f599590d3fa8876db2ca777ce5183"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/Dockerfile
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache -U upgrade # To ensure any potential security patches are app
 
 FROM base AS server-builder
 # Install packages needed to build native npm packages.
-RUN apk add --no-cache build-base libtool autoconf automake python
+RUN apk add --no-cache build-base libtool autoconf automake python3
 WORKDIR /app
 # Install npm packages, resulting in node_modules/.
 COPY server/package*.json ./server/

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "fd98e5a6add079e07153a3891f3db96af219101d3e5d200fd212af4f6545c1f9"
+        "93bb104c26d9c0e06b947bd9b2be153e579f599590d3fa8876db2ca777ce5183"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/Dockerfile
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache -U upgrade # To ensure any potential security patches are app
 
 FROM base AS server-builder
 # Install packages needed to build native npm packages.
-RUN apk add --no-cache build-base libtool autoconf automake python
+RUN apk add --no-cache build-base libtool autoconf automake python3
 WORKDIR /app
 # Install npm packages, resulting in node_modules/.
 COPY server/package*.json ./server/

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "fd98e5a6add079e07153a3891f3db96af219101d3e5d200fd212af4f6545c1f9"
+        "93bb104c26d9c0e06b947bd9b2be153e579f599590d3fa8876db2ca777ce5183"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/Dockerfile
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache -U upgrade # To ensure any potential security patches are app
 
 FROM base AS server-builder
 # Install packages needed to build native npm packages.
-RUN apk add --no-cache build-base libtool autoconf automake python
+RUN apk add --no-cache build-base libtool autoconf automake python3
 WORKDIR /app
 # Install npm packages, resulting in node_modules/.
 COPY server/package*.json ./server/

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "96fc2e753a28976da21487906279eea4e68b54f77b24dc8bc6d4dac42b88b10d"
+        "a2e26d43bffd368f037c0ed7cb0362331b436c8beb36f952251212564cc2b8df"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/Dockerfile
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache -U upgrade # To ensure any potential security patches are app
 
 FROM base AS server-builder
 # Install packages needed to build native npm packages.
-RUN apk add --no-cache build-base libtool autoconf automake python
+RUN apk add --no-cache build-base libtool autoconf automake python3
 WORKDIR /app
 # Install npm packages, resulting in node_modules/.
 COPY server/package*.json ./server/


### PR DESCRIPTION
# Description

Our Dockerfile no longer works out of the box. This is possibly due to some alpine change, or a downstream repo change, where `python` is no longer installable. Changing to `python3` fixes this.

Fixes #572 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update