### PR TITLE
Adds cron support to pg-boss Jobs and documentation

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Deps.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Deps.hs
@@ -5,6 +5,7 @@ where
 
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
+import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd)
@@ -26,7 +27,11 @@ deps = do
       return
       appSpecOrCompileErrors
 
-  liftIO . putStrLn . unlines $
+  liftIO . putStrLn $ depsMessage appSpec
+
+depsMessage :: AppSpec -> String
+depsMessage appSpec =
+  unlines $
     [ "",
       title "Below are listed the dependencies that Wasp uses in your project. You can import and use these directly in the code as if you specified them yourself, but you can't change their versions.",
       ""

--- a/waspc/data/Generator/templates/server/src/jobs/_job.js
+++ b/waspc/data/Generator/templates/server/src/jobs/_job.js
@@ -2,4 +2,9 @@
 import { createJob } from './{= executorJobRelFP =}'
 {=& jobPerformFnImportStatement =}
 
-export const {= jobName =} = await createJob({ jobName: "{= jobName =}", jobFn: {= jobPerformFnName =}, defaultJobOptions: {=& jobPerformOptions =} })
+export const {= jobName =} = await createJob({
+  jobName: "{= jobName =}",
+  jobFn: {= jobPerformFnName =},
+  defaultJobOptions: {=& jobPerformOptions =},
+  jobSchedule: {=& jobSchedule =}
+})

--- a/waspc/data/Generator/templates/server/src/jobs/_job.js
+++ b/waspc/data/Generator/templates/server/src/jobs/_job.js
@@ -2,7 +2,7 @@
 import { createJob } from './{= executorJobRelFP =}'
 {=& jobPerformFnImportStatement =}
 
-export const {= jobName =} = await createJob({
+export const {= jobName =} = createJob({
   jobName: "{= jobName =}",
   jobFn: {= jobPerformFnName =},
   defaultJobOptions: {=& jobPerformOptions =},

--- a/waspc/data/Generator/templates/server/src/jobs/core/_allJobs.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/_allJobs.js
@@ -1,0 +1,8 @@
+{{={= =}=}}
+
+// This module exports all jobs and is imported by the server to ensure
+// any schedules that are not referenced are still loaded by NodeJS.
+
+{=# jobs =}
+export { {= name =} } from '../{= name =}.js'
+{=/ jobs =}

--- a/waspc/data/Generator/templates/server/src/jobs/core/passthroughJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/passthroughJob.js
@@ -36,7 +36,7 @@ class PassthroughJob extends Job {
     sleep(this.#delaySeconds * 1000).then(() => this.#jobFn(jobArgs))
     // NOTE: Dumb random ID generator, mainly so we don't have to add `uuid`
     // as a dependency in the server generator for something nobody will likely use.
-    let jobId = (Math.random() + 1).toString(36).substring(7)
+    const jobId = (Math.random() + 1).toString(36).substring(7)
     return new SubmittedJob(this, jobId)
   }
 }

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
@@ -21,10 +21,11 @@ function createPgBoss() {
   return new PgBoss(pgBossNewOptions)
 }
 
-let resolvePgBossStarted
+let resolvePgBossStarted, rejectPgBossStarted
 // Code that wants to access pg-boss must wait until it has been started.
-export const pgBossStarted = new Promise((resolve, _reject) => {
+export const pgBossStarted = new Promise((resolve, reject) => {
   resolvePgBossStarted = resolve
+  rejectPgBossStarted = reject
 })
 
 // Ensure pg-boss can only be started once during a server's lifetime.
@@ -54,8 +55,11 @@ export async function startPgBoss() {
   try {
     await boss.start()
   } catch (error) {
+    console.error('pg-boss failed to start!')
     console.error(error)
     pgBossStatus = PgBossStatus.Error
+    rejectPgBossStarted(boss)
+    return
   }
 
   resolvePgBossStarted(boss)

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,17 +1,17 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of PgBoss.
+// Add an escape hatch for advanced configuration of pg-boss.
 const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
-// Allows setup code that runs before PgBoss starts to register their PgBoss functions.
+// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
 let afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }
 
-// Ensure PgBoss can only be started once during a server's lifetime.
+// Ensure pg-boss can only be started once during a server's lifetime.
 let hasPgBossBeenStarted = false
 
 /**
@@ -20,7 +20,7 @@ let hasPgBossBeenStarted = false
  * `boss.start()` will automatically create them.
  * Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#start
  * 
- * After making this call, we can send PgBoss jobs and they will be persisted and acted upon.
+ * After making this call, we can send pg-boss jobs and they will be persisted and acted upon.
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
@@ -6,7 +6,7 @@ const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
 // Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-let afterStartCallbacks = []
+const afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
@@ -50,12 +50,14 @@ export async function startPgBoss() {
   pgBossStatus = PgBossStatus.Starting
   console.log('Starting pg-boss...')
 
-  boss.on('error', error => {
+  boss.on('error', error => console.error(error))
+  try {
+    await boss.start()
+  } catch (error) {
     console.error(error)
     pgBossStatus = PgBossStatus.Error
-  })
+  }
 
-  await boss.start()
   resolvePgBossStarted(boss)
 
   console.log('pg-boss started!')

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBoss.js
@@ -6,12 +6,12 @@ const boss = createPgBoss()
 function createPgBoss() {
   let pgBossNewOptions = { connectionString: config.databaseUrl }
   try {
-    // Add an escape hatch for advanced configuration of pg-boss.
+    // Add an escape hatch for advanced configuration of pg-boss to overwrite our defaults.
     if (process.env.PG_BOSS_NEW_OPTIONS) {
       pgBossNewOptions = JSON.parse(process.env.PG_BOSS_NEW_OPTIONS)
     }
-  } catch (error) {
-    console.error("Environment variable PG_BOSS_NEW_OPTIONS was not parsable by JSON.parse().")
+  } catch {
+    console.error("Environment variable PG_BOSS_NEW_OPTIONS was not parsable by JSON.parse()!")
   }
 
   return new PgBoss(pgBossNewOptions)

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -69,9 +69,9 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for `boss.send()` applied to every `submit()` invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5-field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
 export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
   // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
@@ -87,7 +87,7 @@ export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
 
-    // This tells pgBoss to run given worker function when job/payload with given job name is submitted.
+    // This tells pg-boss to run given worker function when job with that name is submitted.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#work
     await boss.work(jobName, jobFn)
 

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -5,7 +5,7 @@ import { SubmittedJob } from '../SubmittedJob.js'
 export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
 
 /**
- * A PgBoss specific SubmittedJob that adds additional PgBoss functionality.
+ * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
   constructor(job, jobId) {
@@ -19,7 +19,7 @@ class PgBossSubmittedJob extends SubmittedJob {
 }
 
 /**
- * This is a class repesenting a job that can be submitted to PgBoss.
+ * This is a class repesenting a job that can be submitted to pg-boss.
  * It is not yet submitted until the caller invokes `submit()` on an instance.
  * The caller can make as many calls to `submit()` as they wish.
  */
@@ -51,9 +51,9 @@ class PgBossJob extends Job {
   }
 
   /**
-   * Submits the job to PgBoss.
+   * Submits the job to pg-boss.
    * @param {object} jobArgs - The job arguments supplied by the user for their perform callback.
-   * @param {object} jobOptions - PgBoss specific options for `boss.send()`, which can override their defaultJobOptions.
+   * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
     const jobId = await boss.send(this.jobName, jobArgs,
@@ -68,12 +68,12 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - PgBoss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
  * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
  */
 export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before PgBoss starts. Therefore, anything that expects PgBoss to be running
+  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
   // should be registered as a callback passed to registerAfterStartCallback.
   registerAfterStartCallback(async () => {
     // As a safety precaution against undefined behavior of registering different

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -85,7 +85,7 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the new cron expression.
+    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
     if (jobSchedule !== null) {
       await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -86,8 +86,9 @@ export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {
     // If a job schedule is provided, we should schedule the recurring job.
     // If the schedule name already exists, it's updated to the provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
-    if (jobSchedule && jobSchedule.cron) {
-      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})
+    if (jobSchedule) {
+      const options = { ...defaultJobOptions, ...jobSchedule.options }
+      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.args || null, options)
     }
   })
 

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -11,9 +11,9 @@ class PgBossSubmittedJob extends SubmittedJob {
   constructor(boss, job, jobId) {
     super(job, jobId)
     this.pgBoss = {
-      async cancel() { return boss.cancel(jobId) },
-      async resume() { return boss.resume(jobId) },
-      async details() { return boss.getJobById(jobId) }
+      cancel: () => boss.cancel(jobId),
+      resume: () => boss.resume(jobId),
+      details: () => boss.getJobById(jobId),
     }
   }
 }
@@ -73,7 +73,7 @@ class PgBossJob extends Job {
  *                                     which can overriden in that call.
  * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
  */
-export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
+export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
   pgBossStarted.then(async (boss) => {
     // As a safety precaution against undefined behavior of registering different
     // functions for the same job name, remove all registered functions first.

--- a/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -71,7 +71,7 @@ class PgBossJob extends Job {
  * @param {fn} jobFn - The user-defined async job callback function.
  * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
 export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
   pgBossStarted.then(async (boss) => {

--- a/waspc/data/Generator/templates/server/src/jobs/core/simpleJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/simpleJob.js
@@ -7,7 +7,8 @@ export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It does not support `schedule`. It is dependency-free, however.
+ * It does not support `schedule`. It does not require any extra NPM dependencies
+ * or infrastructure, however.
  */
 class SimpleJob extends Job {
   #jobFn

--- a/waspc/data/Generator/templates/server/src/jobs/core/simpleJob.js
+++ b/waspc/data/Generator/templates/server/src/jobs/core/simpleJob.js
@@ -2,14 +2,14 @@ import { sleep } from '../../utils.js'
 import { Job } from './Job.js'
 import { SubmittedJob } from './SubmittedJob.js'
 
-export const PASSTHROUGH_EXECUTOR_NAME = Symbol('Passthrough')
+export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It is dependency-free, however.
+ * It does not support `schedule`. It is dependency-free, however.
  */
-class PassthroughJob extends Job {
+class SimpleJob extends Job {
   #jobFn
   #delaySeconds
 
@@ -20,7 +20,7 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - The number of seconds to delay invoking the Job function.
    */
   constructor(jobName, jobFn, delaySeconds = 0) {
-    super(jobName, PASSTHROUGH_EXECUTOR_NAME)
+    super(jobName, SIMPLE_EXECUTOR_NAME)
     this.#jobFn = jobFn
     this.#delaySeconds = delaySeconds
   }
@@ -29,7 +29,7 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - Used to delay the processing of the job by some number of seconds.
    */
   delay(delaySeconds) {
-    return new PassthroughJob(this.jobName, this.#jobFn, delaySeconds)
+    return new SimpleJob(this.jobName, this.#jobFn, delaySeconds)
   }
 
   async submit(jobArgs) {
@@ -42,5 +42,5 @@ class PassthroughJob extends Job {
 }
 
 export function createJob({ jobName, jobFn } = {}) {
-  return new PassthroughJob(jobName, jobFn)
+  return new SimpleJob(jobName, jobFn)
 }

--- a/waspc/data/Generator/templates/server/src/server.js
+++ b/waspc/data/Generator/templates/server/src/server.js
@@ -11,7 +11,7 @@ import config from './config.js'
 
 {=# isPgBossJobExecutorUsed =}
 import { startPgBoss } from './jobs/core/pgBoss/pgBoss.js'
-import * as allJobs from './jobs/core/allJobs.js'
+import './jobs/core/allJobs.js'
 {=/ isPgBossJobExecutorUsed =}
 
 const startServer = async () => {

--- a/waspc/data/Generator/templates/server/src/server.js
+++ b/waspc/data/Generator/templates/server/src/server.js
@@ -11,6 +11,7 @@ import config from './config.js'
 
 {=# isPgBossJobExecutorUsed =}
 import { startPgBoss } from './jobs/core/pgBoss/pgBoss.js'
+import * as allJobs from './jobs/core/allJobs.js'
 {=/ isPgBossJobExecutorUsed =}
 
 const startServer = async () => {

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/files.manifest
@@ -17,9 +17,9 @@ waspBuild/.wasp/build/server/src/ext-src/MainPage.js
 waspBuild/.wasp/build/server/src/ext-src/waspLogo.png
 waspBuild/.wasp/build/server/src/jobs/core/Job.js
 waspBuild/.wasp/build/server/src/jobs/core/SubmittedJob.js
-waspBuild/.wasp/build/server/src/jobs/core/passthroughJob.js
 waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBoss.js
 waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
+waspBuild/.wasp/build/server/src/jobs/core/simpleJob.js
 waspBuild/.wasp/build/server/src/routes/index.js
 waspBuild/.wasp/build/server/src/routes/operations/index.js
 waspBuild/.wasp/build/server/src/server.js

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/files.manifest
@@ -17,6 +17,7 @@ waspBuild/.wasp/build/server/src/ext-src/MainPage.js
 waspBuild/.wasp/build/server/src/ext-src/waspLogo.png
 waspBuild/.wasp/build/server/src/jobs/core/Job.js
 waspBuild/.wasp/build/server/src/jobs/core/SubmittedJob.js
+waspBuild/.wasp/build/server/src/jobs/core/allJobs.js
 waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBoss.js
 waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
 waspBuild/.wasp/build/server/src/jobs/core/simpleJob.js

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -151,7 +151,7 @@
             "file",
             "server/src/jobs/core/simpleJob.js"
         ],
-        "ac538ab0a437f0acd2056197488ea4c6c6d056d86c34a0a1e36bf80e515c12e5"
+        "36fe173d9f5128859196bfd3a661983df2d95eb34d165a469b840982b06cf59b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -137,7 +137,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "b3fa9bdd0b1409d15c91e22cfc07a12c8d9e7d791ab2b0a35bf0bf3ca439b643"
+        "23fbb367a1cfe7729798be1b5fc22c4f4ffbda2941944a61057f68f5e43e6184"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "1a792979f471071c76c4d906fd6b1473dd819151a87ef6696f501346f318e02c"
+        "3857d87db368c5014480b1840d29b262cbb431f99d7c102f45a1865878eecff4"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -137,14 +137,14 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "b6bc8378ba0870623fdf63620ceb60306f45616ef073bb399307784fe10b20c4"
+        "f87b5143ae3f53d6cf9e6f435a683d07a0663902431f9c98418226857234b25a"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "d55605f4699cdba098a7a52f6d4d69e4cd4deabf3234b08634f86fbcf9a31dc8"
+        "7d038e876648dc19f763ee30240e0dc59d95b8098419714d94ca12b7aeb60921"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "9f04cf045b5d6b6f2bfaa1089e80a3fdc10cf9b8b1cd95da35f1530b0277ba10"
+        "6a58878b76d5086454bc721dc779d0589eab6096913272910f390dc502a34708"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -128,6 +128,13 @@
     [
         [
             "file",
+            "server/src/jobs/core/allJobs.js"
+        ],
+        "90b1b3012216900efa82fff14911dcbf195fa2e449edb3b24ab80db0065d796f"
+    ],
+    [
+        [
+            "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
         "9821963d90b39058285343834c70e6f825d3d7696c738fd95539614b5e7d7b94"

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -137,14 +137,14 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "f87b5143ae3f53d6cf9e6f435a683d07a0663902431f9c98418226857234b25a"
+        "b3fa9bdd0b1409d15c91e22cfc07a12c8d9e7d791ab2b0a35bf0bf3ca439b643"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "7d038e876648dc19f763ee30240e0dc59d95b8098419714d94ca12b7aeb60921"
+        "1a792979f471071c76c4d906fd6b1473dd819151a87ef6696f501346f318e02c"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -128,23 +128,23 @@
     [
         [
             "file",
-            "server/src/jobs/core/passthroughJob.js"
-        ],
-        "5df690abebd10220346751adcfc157dd66f34a033abe017e34ac4e84287090bf"
-    ],
-    [
-        [
-            "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "23fbb367a1cfe7729798be1b5fc22c4f4ffbda2941944a61057f68f5e43e6184"
+        "9821963d90b39058285343834c70e6f825d3d7696c738fd95539614b5e7d7b94"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "3857d87db368c5014480b1840d29b262cbb431f99d7c102f45a1865878eecff4"
+        "9f04cf045b5d6b6f2bfaa1089e80a3fdc10cf9b8b1cd95da35f1530b0277ba10"
+    ],
+    [
+        [
+            "file",
+            "server/src/jobs/core/simpleJob.js"
+        ],
+        "ac538ab0a437f0acd2056197488ea4c6c6d056d86c34a0a1e36bf80e515c12e5"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/allJobs.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/allJobs.js
@@ -1,0 +1,4 @@
+
+// This module exports all jobs and is imported by the server to ensure
+// any schedules that are not referenced are still loaded by NodeJS.
+

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,18 +1,41 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of pg-boss.
-const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
-export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
+const boss = createPgBoss()
 
-// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-const afterStartCallbacks = []
-export function registerAfterStartCallback(callback) {
-  afterStartCallbacks.push(callback)
+function createPgBoss() {
+  let pgBossNewOptions = {
+    connectionString: config.databaseUrl,
+  }
+
+  // Add an escape hatch for advanced configuration of pg-boss to overwrite our defaults.
+  if (process.env.PG_BOSS_NEW_OPTIONS) {
+    try {
+      pgBossNewOptions = JSON.parse(process.env.PG_BOSS_NEW_OPTIONS)
+    }
+    catch {
+      console.error("Environment variable PG_BOSS_NEW_OPTIONS was not parsable by JSON.parse()!")
+    }
+  }
+
+  return new PgBoss(pgBossNewOptions)
 }
 
+let resolvePgBossStarted, rejectPgBossStarted
+// Code that wants to access pg-boss must wait until it has been started.
+export const pgBossStarted = new Promise((resolve, reject) => {
+  resolvePgBossStarted = resolve
+  rejectPgBossStarted = reject
+})
+
 // Ensure pg-boss can only be started once during a server's lifetime.
-let hasPgBossBeenStarted = false
+const PgBossStatus = {
+  Unstarted: 'Unstarted',
+  Starting: 'Starting',
+  Started: 'Started',
+  Error: 'Error'
+}
+let pgBossStatus = PgBossStatus.Unstarted
 
 /**
  * Prepares the target PostgreSQL database and begins job monitoring.
@@ -24,15 +47,23 @@ let hasPgBossBeenStarted = false
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {
-  if (!hasPgBossBeenStarted) {
-    console.log('Starting PgBoss...')
+  if (pgBossStatus !== PgBossStatus.Unstarted) { return }
+  pgBossStatus = PgBossStatus.Starting
+  console.log('Starting pg-boss...')
 
-    boss.on('error', error => console.error(error))
+  boss.on('error', error => console.error(error))
+  try {
     await boss.start()
-
-    afterStartCallbacks.forEach(fn => fn())
-
-    console.log('PgBoss started!')
-    hasPgBossBeenStarted = true
+  } catch (error) {
+    console.error('pg-boss failed to start!')
+    console.error(error)
+    pgBossStatus = PgBossStatus.Error
+    rejectPgBossStarted(boss)
+    return
   }
+
+  resolvePgBossStarted(boss)
+
+  console.log('pg-boss started!')
+  pgBossStatus = PgBossStatus.Started
 }

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,17 +1,17 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of PgBoss.
+// Add an escape hatch for advanced configuration of pg-boss.
 const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
-// Allows setup code that runs before PgBoss starts to register their PgBoss functions.
+// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
 let afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }
 
-// Ensure PgBoss can only be started once during a server's lifetime.
+// Ensure pg-boss can only be started once during a server's lifetime.
 let hasPgBossBeenStarted = false
 
 /**
@@ -20,7 +20,7 @@ let hasPgBossBeenStarted = false
  * `boss.start()` will automatically create them.
  * Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#start
  * 
- * After making this call, we can send PgBoss jobs and they will be persisted and acted upon.
+ * After making this call, we can send pg-boss jobs and they will be persisted and acted upon.
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBoss.js
@@ -6,7 +6,7 @@ const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
 // Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-let afterStartCallbacks = []
+const afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -69,9 +69,9 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for `boss.send()` applied to every `submit()` invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5-field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
 export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
   // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
@@ -87,7 +87,7 @@ export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
 
-    // This tells pgBoss to run given worker function when job/payload with given job name is submitted.
+    // This tells pg-boss to run given worker function when job with that name is submitted.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#work
     await boss.work(jobName, jobFn)
 

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -5,7 +5,7 @@ import { SubmittedJob } from '../SubmittedJob.js'
 export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
 
 /**
- * A PgBoss specific SubmittedJob that adds additional PgBoss functionality.
+ * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
   constructor(job, jobId) {
@@ -19,7 +19,7 @@ class PgBossSubmittedJob extends SubmittedJob {
 }
 
 /**
- * This is a class repesenting a job that can be submitted to PgBoss.
+ * This is a class repesenting a job that can be submitted to pg-boss.
  * It is not yet submitted until the caller invokes `submit()` on an instance.
  * The caller can make as many calls to `submit()` as they wish.
  */
@@ -51,9 +51,9 @@ class PgBossJob extends Job {
   }
 
   /**
-   * Submits the job to PgBoss.
+   * Submits the job to pg-boss.
    * @param {object} jobArgs - The job arguments supplied by the user for their perform callback.
-   * @param {object} jobOptions - PgBoss specific options for `boss.send()`, which can override their defaultJobOptions.
+   * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
     const jobId = await boss.send(this.jobName, jobArgs,
@@ -68,12 +68,12 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - PgBoss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
  * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
  */
 export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before PgBoss starts. Therefore, anything that expects PgBoss to be running
+  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
   // should be registered as a callback passed to registerAfterStartCallback.
   registerAfterStartCallback(async () => {
     // As a safety precaution against undefined behavior of registering different

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -85,7 +85,7 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the new cron expression.
+    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
     if (jobSchedule !== null) {
       await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -1,4 +1,4 @@
-import { boss, registerAfterStartCallback } from './pgBoss.js'
+import { pgBossStarted } from './pgBoss.js'
 import { Job } from '../Job.js'
 import { SubmittedJob } from '../SubmittedJob.js'
 
@@ -8,12 +8,12 @@ export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
  * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
-  constructor(job, jobId) {
+  constructor(boss, job, jobId) {
     super(job, jobId)
     this.pgBoss = {
-      async cancel() { return boss.cancel(jobId) },
-      async resume() { return boss.resume(jobId) },
-      async details() { return boss.getJobById(jobId) }
+      cancel: () => boss.cancel(jobId),
+      resume: () => boss.resume(jobId),
+      details: () => boss.getJobById(jobId),
     }
   }
 }
@@ -56,9 +56,10 @@ class PgBossJob extends Job {
    * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
+    const boss = await pgBossStarted
     const jobId = await boss.send(this.jobName, jobArgs,
       { ...this.#defaultJobOptions, ...(this.#startAfter && { startAfter: this.#startAfter }), ...jobOptions })
-    return new PgBossSubmittedJob(this, jobId)
+    return new PgBossSubmittedJob(boss, this, jobId)
   }
 }
 
@@ -70,12 +71,18 @@ class PgBossJob extends Job {
  * @param {fn} jobFn - The user-defined async job callback function.
  * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
-export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
-  // should be registered as a callback passed to registerAfterStartCallback.
-  registerAfterStartCallback(async () => {
+export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
+  // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
+  // template, or else the NodeJS module bootstrapping process will block and fail as it would then depend
+  // on a runtime resolution of the promise in `startServer()`.
+  // Since `pgBossStarted` will resolve in the future, it may appear possible to send pg-boss
+  // a job before we actually have registered the handler via `boss.work()`. However, even if NodeJS does
+  // not execute this callback before any job `submit()` calls, this is not a problem since pg-boss allows you
+  // to submit jobs even if there are no workers registered.
+  // Once they are registered, they will just start on the first job in their queue.
+  pgBossStarted.then(async (boss) => {
     // As a safety precaution against undefined behavior of registering different
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
@@ -85,10 +92,11 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
+    // If the schedule name already exists, it's updated to the provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
-    if (jobSchedule !== null) {
-      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})
+    if (jobSchedule) {
+      const options = { ...defaultJobOptions, ...jobSchedule.options }
+      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.args || null, options)
     }
   })
 

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/simpleJob.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/simpleJob.js
@@ -2,14 +2,14 @@ import { sleep } from '../../utils.js'
 import { Job } from './Job.js'
 import { SubmittedJob } from './SubmittedJob.js'
 
-export const PASSTHROUGH_EXECUTOR_NAME = Symbol('Passthrough')
+export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It is dependency-free, however.
+ * It does not support `schedule`. It is dependency-free, however.
  */
-class PassthroughJob extends Job {
+class SimpleJob extends Job {
   #jobFn
   #delaySeconds
 
@@ -20,7 +20,7 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - The number of seconds to delay invoking the Job function.
    */
   constructor(jobName, jobFn, delaySeconds = 0) {
-    super(jobName, PASSTHROUGH_EXECUTOR_NAME)
+    super(jobName, SIMPLE_EXECUTOR_NAME)
     this.#jobFn = jobFn
     this.#delaySeconds = delaySeconds
   }
@@ -29,18 +29,18 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - Used to delay the processing of the job by some number of seconds.
    */
   delay(delaySeconds) {
-    return new PassthroughJob(this.jobName, this.#jobFn, delaySeconds)
+    return new SimpleJob(this.jobName, this.#jobFn, delaySeconds)
   }
 
   async submit(jobArgs) {
     sleep(this.#delaySeconds * 1000).then(() => this.#jobFn(jobArgs))
     // NOTE: Dumb random ID generator, mainly so we don't have to add `uuid`
     // as a dependency in the server generator for something nobody will likely use.
-    let jobId = (Math.random() + 1).toString(36).substring(7)
+    const jobId = (Math.random() + 1).toString(36).substring(7)
     return new SubmittedJob(this, jobId)
   }
 }
 
 export function createJob({ jobName, jobFn } = {}) {
-  return new PassthroughJob(jobName, jobFn)
+  return new SimpleJob(jobName, jobFn)
 }

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/simpleJob.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/jobs/core/simpleJob.js
@@ -7,7 +7,8 @@ export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It does not support `schedule`. It is dependency-free, however.
+ * It does not support `schedule`. It does not require any extra NPM dependencies
+ * or infrastructure, however.
  */
 class SimpleJob extends Job {
   #jobFn

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/files.manifest
@@ -17,6 +17,7 @@ waspCompile/.wasp/out/server/src/ext-src/MainPage.js
 waspCompile/.wasp/out/server/src/ext-src/waspLogo.png
 waspCompile/.wasp/out/server/src/jobs/core/Job.js
 waspCompile/.wasp/out/server/src/jobs/core/SubmittedJob.js
+waspCompile/.wasp/out/server/src/jobs/core/allJobs.js
 waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
 waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
 waspCompile/.wasp/out/server/src/jobs/core/simpleJob.js

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/files.manifest
@@ -17,9 +17,9 @@ waspCompile/.wasp/out/server/src/ext-src/MainPage.js
 waspCompile/.wasp/out/server/src/ext-src/waspLogo.png
 waspCompile/.wasp/out/server/src/jobs/core/Job.js
 waspCompile/.wasp/out/server/src/jobs/core/SubmittedJob.js
-waspCompile/.wasp/out/server/src/jobs/core/passthroughJob.js
 waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
 waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+waspCompile/.wasp/out/server/src/jobs/core/simpleJob.js
 waspCompile/.wasp/out/server/src/routes/index.js
 waspCompile/.wasp/out/server/src/routes/operations/index.js
 waspCompile/.wasp/out/server/src/server.js

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -151,7 +151,7 @@
             "file",
             "server/src/jobs/core/simpleJob.js"
         ],
-        "ac538ab0a437f0acd2056197488ea4c6c6d056d86c34a0a1e36bf80e515c12e5"
+        "36fe173d9f5128859196bfd3a661983df2d95eb34d165a469b840982b06cf59b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -137,7 +137,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "b3fa9bdd0b1409d15c91e22cfc07a12c8d9e7d791ab2b0a35bf0bf3ca439b643"
+        "23fbb367a1cfe7729798be1b5fc22c4f4ffbda2941944a61057f68f5e43e6184"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "1a792979f471071c76c4d906fd6b1473dd819151a87ef6696f501346f318e02c"
+        "3857d87db368c5014480b1840d29b262cbb431f99d7c102f45a1865878eecff4"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -137,14 +137,14 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "b6bc8378ba0870623fdf63620ceb60306f45616ef073bb399307784fe10b20c4"
+        "f87b5143ae3f53d6cf9e6f435a683d07a0663902431f9c98418226857234b25a"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "d55605f4699cdba098a7a52f6d4d69e4cd4deabf3234b08634f86fbcf9a31dc8"
+        "7d038e876648dc19f763ee30240e0dc59d95b8098419714d94ca12b7aeb60921"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "9f04cf045b5d6b6f2bfaa1089e80a3fdc10cf9b8b1cd95da35f1530b0277ba10"
+        "6a58878b76d5086454bc721dc779d0589eab6096913272910f390dc502a34708"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -128,6 +128,13 @@
     [
         [
             "file",
+            "server/src/jobs/core/allJobs.js"
+        ],
+        "90b1b3012216900efa82fff14911dcbf195fa2e449edb3b24ab80db0065d796f"
+    ],
+    [
+        [
+            "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
         "9821963d90b39058285343834c70e6f825d3d7696c738fd95539614b5e7d7b94"

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -137,14 +137,14 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "f87b5143ae3f53d6cf9e6f435a683d07a0663902431f9c98418226857234b25a"
+        "b3fa9bdd0b1409d15c91e22cfc07a12c8d9e7d791ab2b0a35bf0bf3ca439b643"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "7d038e876648dc19f763ee30240e0dc59d95b8098419714d94ca12b7aeb60921"
+        "1a792979f471071c76c4d906fd6b1473dd819151a87ef6696f501346f318e02c"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -128,23 +128,23 @@
     [
         [
             "file",
-            "server/src/jobs/core/passthroughJob.js"
-        ],
-        "5df690abebd10220346751adcfc157dd66f34a033abe017e34ac4e84287090bf"
-    ],
-    [
-        [
-            "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "23fbb367a1cfe7729798be1b5fc22c4f4ffbda2941944a61057f68f5e43e6184"
+        "9821963d90b39058285343834c70e6f825d3d7696c738fd95539614b5e7d7b94"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "3857d87db368c5014480b1840d29b262cbb431f99d7c102f45a1865878eecff4"
+        "9f04cf045b5d6b6f2bfaa1089e80a3fdc10cf9b8b1cd95da35f1530b0277ba10"
+    ],
+    [
+        [
+            "file",
+            "server/src/jobs/core/simpleJob.js"
+        ],
+        "ac538ab0a437f0acd2056197488ea4c6c6d056d86c34a0a1e36bf80e515c12e5"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/allJobs.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/allJobs.js
@@ -1,0 +1,4 @@
+
+// This module exports all jobs and is imported by the server to ensure
+// any schedules that are not referenced are still loaded by NodeJS.
+

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,18 +1,41 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of pg-boss.
-const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
-export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
+const boss = createPgBoss()
 
-// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-const afterStartCallbacks = []
-export function registerAfterStartCallback(callback) {
-  afterStartCallbacks.push(callback)
+function createPgBoss() {
+  let pgBossNewOptions = {
+    connectionString: config.databaseUrl,
+  }
+
+  // Add an escape hatch for advanced configuration of pg-boss to overwrite our defaults.
+  if (process.env.PG_BOSS_NEW_OPTIONS) {
+    try {
+      pgBossNewOptions = JSON.parse(process.env.PG_BOSS_NEW_OPTIONS)
+    }
+    catch {
+      console.error("Environment variable PG_BOSS_NEW_OPTIONS was not parsable by JSON.parse()!")
+    }
+  }
+
+  return new PgBoss(pgBossNewOptions)
 }
 
+let resolvePgBossStarted, rejectPgBossStarted
+// Code that wants to access pg-boss must wait until it has been started.
+export const pgBossStarted = new Promise((resolve, reject) => {
+  resolvePgBossStarted = resolve
+  rejectPgBossStarted = reject
+})
+
 // Ensure pg-boss can only be started once during a server's lifetime.
-let hasPgBossBeenStarted = false
+const PgBossStatus = {
+  Unstarted: 'Unstarted',
+  Starting: 'Starting',
+  Started: 'Started',
+  Error: 'Error'
+}
+let pgBossStatus = PgBossStatus.Unstarted
 
 /**
  * Prepares the target PostgreSQL database and begins job monitoring.
@@ -24,15 +47,23 @@ let hasPgBossBeenStarted = false
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {
-  if (!hasPgBossBeenStarted) {
-    console.log('Starting PgBoss...')
+  if (pgBossStatus !== PgBossStatus.Unstarted) { return }
+  pgBossStatus = PgBossStatus.Starting
+  console.log('Starting pg-boss...')
 
-    boss.on('error', error => console.error(error))
+  boss.on('error', error => console.error(error))
+  try {
     await boss.start()
-
-    afterStartCallbacks.forEach(fn => fn())
-
-    console.log('PgBoss started!')
-    hasPgBossBeenStarted = true
+  } catch (error) {
+    console.error('pg-boss failed to start!')
+    console.error(error)
+    pgBossStatus = PgBossStatus.Error
+    rejectPgBossStarted(boss)
+    return
   }
+
+  resolvePgBossStarted(boss)
+
+  console.log('pg-boss started!')
+  pgBossStatus = PgBossStatus.Started
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,17 +1,17 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of PgBoss.
+// Add an escape hatch for advanced configuration of pg-boss.
 const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
-// Allows setup code that runs before PgBoss starts to register their PgBoss functions.
+// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
 let afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }
 
-// Ensure PgBoss can only be started once during a server's lifetime.
+// Ensure pg-boss can only be started once during a server's lifetime.
 let hasPgBossBeenStarted = false
 
 /**
@@ -20,7 +20,7 @@ let hasPgBossBeenStarted = false
  * `boss.start()` will automatically create them.
  * Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#start
  * 
- * After making this call, we can send PgBoss jobs and they will be persisted and acted upon.
+ * After making this call, we can send pg-boss jobs and they will be persisted and acted upon.
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -6,7 +6,7 @@ const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
 // Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-let afterStartCallbacks = []
+const afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -69,9 +69,9 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for `boss.send()` applied to every `submit()` invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5-field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
 export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
   // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
@@ -87,7 +87,7 @@ export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
 
-    // This tells pgBoss to run given worker function when job/payload with given job name is submitted.
+    // This tells pg-boss to run given worker function when job with that name is submitted.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#work
     await boss.work(jobName, jobFn)
 

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -5,7 +5,7 @@ import { SubmittedJob } from '../SubmittedJob.js'
 export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
 
 /**
- * A PgBoss specific SubmittedJob that adds additional PgBoss functionality.
+ * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
   constructor(job, jobId) {
@@ -19,7 +19,7 @@ class PgBossSubmittedJob extends SubmittedJob {
 }
 
 /**
- * This is a class repesenting a job that can be submitted to PgBoss.
+ * This is a class repesenting a job that can be submitted to pg-boss.
  * It is not yet submitted until the caller invokes `submit()` on an instance.
  * The caller can make as many calls to `submit()` as they wish.
  */
@@ -51,9 +51,9 @@ class PgBossJob extends Job {
   }
 
   /**
-   * Submits the job to PgBoss.
+   * Submits the job to pg-boss.
    * @param {object} jobArgs - The job arguments supplied by the user for their perform callback.
-   * @param {object} jobOptions - PgBoss specific options for `boss.send()`, which can override their defaultJobOptions.
+   * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
     const jobId = await boss.send(this.jobName, jobArgs,
@@ -68,12 +68,12 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - PgBoss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
  * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
  */
 export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before PgBoss starts. Therefore, anything that expects PgBoss to be running
+  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
   // should be registered as a callback passed to registerAfterStartCallback.
   registerAfterStartCallback(async () => {
     // As a safety precaution against undefined behavior of registering different

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -85,7 +85,7 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the new cron expression.
+    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
     if (jobSchedule !== null) {
       await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -1,4 +1,4 @@
-import { boss, registerAfterStartCallback } from './pgBoss.js'
+import { pgBossStarted } from './pgBoss.js'
 import { Job } from '../Job.js'
 import { SubmittedJob } from '../SubmittedJob.js'
 
@@ -8,12 +8,12 @@ export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
  * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
-  constructor(job, jobId) {
+  constructor(boss, job, jobId) {
     super(job, jobId)
     this.pgBoss = {
-      async cancel() { return boss.cancel(jobId) },
-      async resume() { return boss.resume(jobId) },
-      async details() { return boss.getJobById(jobId) }
+      cancel: () => boss.cancel(jobId),
+      resume: () => boss.resume(jobId),
+      details: () => boss.getJobById(jobId),
     }
   }
 }
@@ -56,9 +56,10 @@ class PgBossJob extends Job {
    * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
+    const boss = await pgBossStarted
     const jobId = await boss.send(this.jobName, jobArgs,
       { ...this.#defaultJobOptions, ...(this.#startAfter && { startAfter: this.#startAfter }), ...jobOptions })
-    return new PgBossSubmittedJob(this, jobId)
+    return new PgBossSubmittedJob(boss, this, jobId)
   }
 }
 
@@ -70,12 +71,18 @@ class PgBossJob extends Job {
  * @param {fn} jobFn - The user-defined async job callback function.
  * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
-export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
-  // should be registered as a callback passed to registerAfterStartCallback.
-  registerAfterStartCallback(async () => {
+export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
+  // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
+  // template, or else the NodeJS module bootstrapping process will block and fail as it would then depend
+  // on a runtime resolution of the promise in `startServer()`.
+  // Since `pgBossStarted` will resolve in the future, it may appear possible to send pg-boss
+  // a job before we actually have registered the handler via `boss.work()`. However, even if NodeJS does
+  // not execute this callback before any job `submit()` calls, this is not a problem since pg-boss allows you
+  // to submit jobs even if there are no workers registered.
+  // Once they are registered, they will just start on the first job in their queue.
+  pgBossStarted.then(async (boss) => {
     // As a safety precaution against undefined behavior of registering different
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
@@ -85,10 +92,11 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
+    // If the schedule name already exists, it's updated to the provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
-    if (jobSchedule !== null) {
-      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})
+    if (jobSchedule) {
+      const options = { ...defaultJobOptions, ...jobSchedule.options }
+      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.args || null, options)
     }
   })
 

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/simpleJob.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/simpleJob.js
@@ -2,14 +2,14 @@ import { sleep } from '../../utils.js'
 import { Job } from './Job.js'
 import { SubmittedJob } from './SubmittedJob.js'
 
-export const PASSTHROUGH_EXECUTOR_NAME = Symbol('Passthrough')
+export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It is dependency-free, however.
+ * It does not support `schedule`. It is dependency-free, however.
  */
-class PassthroughJob extends Job {
+class SimpleJob extends Job {
   #jobFn
   #delaySeconds
 
@@ -20,7 +20,7 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - The number of seconds to delay invoking the Job function.
    */
   constructor(jobName, jobFn, delaySeconds = 0) {
-    super(jobName, PASSTHROUGH_EXECUTOR_NAME)
+    super(jobName, SIMPLE_EXECUTOR_NAME)
     this.#jobFn = jobFn
     this.#delaySeconds = delaySeconds
   }
@@ -29,18 +29,18 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - Used to delay the processing of the job by some number of seconds.
    */
   delay(delaySeconds) {
-    return new PassthroughJob(this.jobName, this.#jobFn, delaySeconds)
+    return new SimpleJob(this.jobName, this.#jobFn, delaySeconds)
   }
 
   async submit(jobArgs) {
     sleep(this.#delaySeconds * 1000).then(() => this.#jobFn(jobArgs))
     // NOTE: Dumb random ID generator, mainly so we don't have to add `uuid`
     // as a dependency in the server generator for something nobody will likely use.
-    let jobId = (Math.random() + 1).toString(36).substring(7)
+    const jobId = (Math.random() + 1).toString(36).substring(7)
     return new SubmittedJob(this, jobId)
   }
 }
 
 export function createJob({ jobName, jobFn } = {}) {
-  return new PassthroughJob(jobName, jobFn)
+  return new SimpleJob(jobName, jobFn)
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/simpleJob.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/jobs/core/simpleJob.js
@@ -7,7 +7,8 @@ export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It does not support `schedule`. It is dependency-free, however.
+ * It does not support `schedule`. It does not require any extra NPM dependencies
+ * or infrastructure, however.
  */
 class SimpleJob extends Job {
   #jobFn

--- a/waspc/e2e-test/test-outputs/waspJob-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/files.manifest
@@ -19,9 +19,9 @@ waspJob/.wasp/out/server/src/ext-src/waspLogo.png
 waspJob/.wasp/out/server/src/jobs/MySpecialJob.js
 waspJob/.wasp/out/server/src/jobs/core/Job.js
 waspJob/.wasp/out/server/src/jobs/core/SubmittedJob.js
-waspJob/.wasp/out/server/src/jobs/core/passthroughJob.js
 waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
 waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+waspJob/.wasp/out/server/src/jobs/core/simpleJob.js
 waspJob/.wasp/out/server/src/routes/index.js
 waspJob/.wasp/out/server/src/routes/operations/index.js
 waspJob/.wasp/out/server/src/server.js

--- a/waspc/e2e-test/test-outputs/waspJob-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/files.manifest
@@ -19,6 +19,7 @@ waspJob/.wasp/out/server/src/ext-src/waspLogo.png
 waspJob/.wasp/out/server/src/jobs/MySpecialJob.js
 waspJob/.wasp/out/server/src/jobs/core/Job.js
 waspJob/.wasp/out/server/src/jobs/core/SubmittedJob.js
+waspJob/.wasp/out/server/src/jobs/core/allJobs.js
 waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
 waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
 waspJob/.wasp/out/server/src/jobs/core/simpleJob.js

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -123,7 +123,7 @@
             "file",
             "server/src/jobs/MySpecialJob.js"
         ],
-        "7b06f538ad577addec09b634128e27bf61fb2b0317443804544f5a231f389de3"
+        "4639c4c738a9a6a5b0137962ac64252da12aaa01cff7918ba0937e8b375bf9e6"
     ],
     [
         [
@@ -142,23 +142,23 @@
     [
         [
             "file",
-            "server/src/jobs/core/passthroughJob.js"
-        ],
-        "5df690abebd10220346751adcfc157dd66f34a033abe017e34ac4e84287090bf"
-    ],
-    [
-        [
-            "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "23fbb367a1cfe7729798be1b5fc22c4f4ffbda2941944a61057f68f5e43e6184"
+        "9821963d90b39058285343834c70e6f825d3d7696c738fd95539614b5e7d7b94"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "3857d87db368c5014480b1840d29b262cbb431f99d7c102f45a1865878eecff4"
+        "9f04cf045b5d6b6f2bfaa1089e80a3fdc10cf9b8b1cd95da35f1530b0277ba10"
+    ],
+    [
+        [
+            "file",
+            "server/src/jobs/core/simpleJob.js"
+        ],
+        "ac538ab0a437f0acd2056197488ea4c6c6d056d86c34a0a1e36bf80e515c12e5"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -158,7 +158,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "9f04cf045b5d6b6f2bfaa1089e80a3fdc10cf9b8b1cd95da35f1530b0277ba10"
+        "6a58878b76d5086454bc721dc779d0589eab6096913272910f390dc502a34708"
     ],
     [
         [
@@ -186,7 +186,7 @@
             "file",
             "server/src/server.js"
         ],
-        "3570425ae5b581b91b00c46caa6931d0bd7445cb608fbca11d525389d2aff392"
+        "25cee89ea082bef40d13a6ba01718ecaa0933c92991c9d395dc8602215c61255"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -142,6 +142,13 @@
     [
         [
             "file",
+            "server/src/jobs/core/allJobs.js"
+        ],
+        "b5ddc268dfe8f1f7d96d775c1d8d407a647a45ed4937a87da7eb1eb50f9a4674"
+    ],
+    [
+        [
+            "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
         "9821963d90b39058285343834c70e6f825d3d7696c738fd95539614b5e7d7b94"
@@ -179,7 +186,7 @@
             "file",
             "server/src/server.js"
         ],
-        "6ee8aa871c3340f832d2a7fddac32a29a87683699f654bf6ada91377c26ddb2b"
+        "3570425ae5b581b91b00c46caa6931d0bd7445cb608fbca11d525389d2aff392"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -165,7 +165,7 @@
             "file",
             "server/src/jobs/core/simpleJob.js"
         ],
-        "ac538ab0a437f0acd2056197488ea4c6c6d056d86c34a0a1e36bf80e515c12e5"
+        "36fe173d9f5128859196bfd3a661983df2d95eb34d165a469b840982b06cf59b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -151,14 +151,14 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "f87b5143ae3f53d6cf9e6f435a683d07a0663902431f9c98418226857234b25a"
+        "b3fa9bdd0b1409d15c91e22cfc07a12c8d9e7d791ab2b0a35bf0bf3ca439b643"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "7d038e876648dc19f763ee30240e0dc59d95b8098419714d94ca12b7aeb60921"
+        "1a792979f471071c76c4d906fd6b1473dd819151a87ef6696f501346f318e02c"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -123,7 +123,7 @@
             "file",
             "server/src/jobs/MySpecialJob.js"
         ],
-        "36f01c1d688af5eb7eaaec00c920af81dbf2a3d9f54444d94873306e8d10527f"
+        "7b06f538ad577addec09b634128e27bf61fb2b0317443804544f5a231f389de3"
     ],
     [
         [
@@ -151,14 +151,14 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "b6bc8378ba0870623fdf63620ceb60306f45616ef073bb399307784fe10b20c4"
+        "f87b5143ae3f53d6cf9e6f435a683d07a0663902431f9c98418226857234b25a"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "d55605f4699cdba098a7a52f6d4d69e4cd4deabf3234b08634f86fbcf9a31dc8"
+        "7d038e876648dc19f763ee30240e0dc59d95b8098419714d94ca12b7aeb60921"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -158,7 +158,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "1a792979f471071c76c4d906fd6b1473dd819151a87ef6696f501346f318e02c"
+        "3857d87db368c5014480b1840d29b262cbb431f99d7c102f45a1865878eecff4"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -151,7 +151,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "b3fa9bdd0b1409d15c91e22cfc07a12c8d9e7d791ab2b0a35bf0bf3ca439b643"
+        "23fbb367a1cfe7729798be1b5fc22c4f4ffbda2941944a61057f68f5e43e6184"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/MySpecialJob.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/MySpecialJob.js
@@ -1,7 +1,7 @@
 import { createJob } from './core/pgBoss/pgBossJob.js'
 import { foo } from './../ext-src/jobs/bar.js'
 
-export const MySpecialJob = await createJob({
+export const MySpecialJob = createJob({
   jobName: "MySpecialJob",
   jobFn: foo,
   defaultJobOptions: {},

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/MySpecialJob.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/MySpecialJob.js
@@ -1,4 +1,9 @@
 import { createJob } from './core/pgBoss/pgBossJob.js'
 import { foo } from './../ext-src/jobs/bar.js'
 
-export const MySpecialJob = await createJob({ jobName: "MySpecialJob", jobFn: foo, defaultJobOptions: {} })
+export const MySpecialJob = await createJob({
+  jobName: "MySpecialJob",
+  jobFn: foo,
+  defaultJobOptions: {},
+  jobSchedule: null
+})

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/allJobs.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/allJobs.js
@@ -1,0 +1,5 @@
+
+// This module exports all jobs and is imported by the server to ensure
+// any schedules that are not referenced are still loaded by NodeJS.
+
+export { MySpecialJob } from '../MySpecialJob.js'

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,18 +1,41 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of pg-boss.
-const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
-export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
+const boss = createPgBoss()
 
-// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-const afterStartCallbacks = []
-export function registerAfterStartCallback(callback) {
-  afterStartCallbacks.push(callback)
+function createPgBoss() {
+  let pgBossNewOptions = {
+    connectionString: config.databaseUrl,
+  }
+
+  // Add an escape hatch for advanced configuration of pg-boss to overwrite our defaults.
+  if (process.env.PG_BOSS_NEW_OPTIONS) {
+    try {
+      pgBossNewOptions = JSON.parse(process.env.PG_BOSS_NEW_OPTIONS)
+    }
+    catch {
+      console.error("Environment variable PG_BOSS_NEW_OPTIONS was not parsable by JSON.parse()!")
+    }
+  }
+
+  return new PgBoss(pgBossNewOptions)
 }
 
+let resolvePgBossStarted, rejectPgBossStarted
+// Code that wants to access pg-boss must wait until it has been started.
+export const pgBossStarted = new Promise((resolve, reject) => {
+  resolvePgBossStarted = resolve
+  rejectPgBossStarted = reject
+})
+
 // Ensure pg-boss can only be started once during a server's lifetime.
-let hasPgBossBeenStarted = false
+const PgBossStatus = {
+  Unstarted: 'Unstarted',
+  Starting: 'Starting',
+  Started: 'Started',
+  Error: 'Error'
+}
+let pgBossStatus = PgBossStatus.Unstarted
 
 /**
  * Prepares the target PostgreSQL database and begins job monitoring.
@@ -24,15 +47,23 @@ let hasPgBossBeenStarted = false
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {
-  if (!hasPgBossBeenStarted) {
-    console.log('Starting PgBoss...')
+  if (pgBossStatus !== PgBossStatus.Unstarted) { return }
+  pgBossStatus = PgBossStatus.Starting
+  console.log('Starting pg-boss...')
 
-    boss.on('error', error => console.error(error))
+  boss.on('error', error => console.error(error))
+  try {
     await boss.start()
-
-    afterStartCallbacks.forEach(fn => fn())
-
-    console.log('PgBoss started!')
-    hasPgBossBeenStarted = true
+  } catch (error) {
+    console.error('pg-boss failed to start!')
+    console.error(error)
+    pgBossStatus = PgBossStatus.Error
+    rejectPgBossStarted(boss)
+    return
   }
+
+  resolvePgBossStarted(boss)
+
+  console.log('pg-boss started!')
+  pgBossStatus = PgBossStatus.Started
 }

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,17 +1,17 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of PgBoss.
+// Add an escape hatch for advanced configuration of pg-boss.
 const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
-// Allows setup code that runs before PgBoss starts to register their PgBoss functions.
+// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
 let afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }
 
-// Ensure PgBoss can only be started once during a server's lifetime.
+// Ensure pg-boss can only be started once during a server's lifetime.
 let hasPgBossBeenStarted = false
 
 /**
@@ -20,7 +20,7 @@ let hasPgBossBeenStarted = false
  * `boss.start()` will automatically create them.
  * Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#start
  * 
- * After making this call, we can send PgBoss jobs and they will be persisted and acted upon.
+ * After making this call, we can send pg-boss jobs and they will be persisted and acted upon.
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -6,7 +6,7 @@ const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
 // Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-let afterStartCallbacks = []
+const afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -69,9 +69,9 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for `boss.send()` applied to every `submit()` invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5-field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
 export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
   // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
@@ -87,7 +87,7 @@ export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
 
-    // This tells pgBoss to run given worker function when job/payload with given job name is submitted.
+    // This tells pg-boss to run given worker function when job with that name is submitted.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#work
     await boss.work(jobName, jobFn)
 

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -5,7 +5,7 @@ import { SubmittedJob } from '../SubmittedJob.js'
 export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
 
 /**
- * A PgBoss specific SubmittedJob that adds additional PgBoss functionality.
+ * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
   constructor(job, jobId) {
@@ -19,7 +19,7 @@ class PgBossSubmittedJob extends SubmittedJob {
 }
 
 /**
- * This is a class repesenting a job that can be submitted to PgBoss.
+ * This is a class repesenting a job that can be submitted to pg-boss.
  * It is not yet submitted until the caller invokes `submit()` on an instance.
  * The caller can make as many calls to `submit()` as they wish.
  */
@@ -51,9 +51,9 @@ class PgBossJob extends Job {
   }
 
   /**
-   * Submits the job to PgBoss.
+   * Submits the job to pg-boss.
    * @param {object} jobArgs - The job arguments supplied by the user for their perform callback.
-   * @param {object} jobOptions - PgBoss specific options for `boss.send()`, which can override their defaultJobOptions.
+   * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
     const jobId = await boss.send(this.jobName, jobArgs,
@@ -68,12 +68,12 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - PgBoss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
  * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
  */
 export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before PgBoss starts. Therefore, anything that expects PgBoss to be running
+  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
   // should be registered as a callback passed to registerAfterStartCallback.
   registerAfterStartCallback(async () => {
     // As a safety precaution against undefined behavior of registering different

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -85,7 +85,7 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the new cron expression.
+    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
     if (jobSchedule !== null) {
       await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -1,4 +1,4 @@
-import { boss, registerAfterStartCallback } from './pgBoss.js'
+import { pgBossStarted } from './pgBoss.js'
 import { Job } from '../Job.js'
 import { SubmittedJob } from '../SubmittedJob.js'
 
@@ -8,12 +8,12 @@ export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
  * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
-  constructor(job, jobId) {
+  constructor(boss, job, jobId) {
     super(job, jobId)
     this.pgBoss = {
-      async cancel() { return boss.cancel(jobId) },
-      async resume() { return boss.resume(jobId) },
-      async details() { return boss.getJobById(jobId) }
+      cancel: () => boss.cancel(jobId),
+      resume: () => boss.resume(jobId),
+      details: () => boss.getJobById(jobId),
     }
   }
 }
@@ -56,9 +56,10 @@ class PgBossJob extends Job {
    * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
+    const boss = await pgBossStarted
     const jobId = await boss.send(this.jobName, jobArgs,
       { ...this.#defaultJobOptions, ...(this.#startAfter && { startAfter: this.#startAfter }), ...jobOptions })
-    return new PgBossSubmittedJob(this, jobId)
+    return new PgBossSubmittedJob(boss, this, jobId)
   }
 }
 
@@ -70,12 +71,18 @@ class PgBossJob extends Job {
  * @param {fn} jobFn - The user-defined async job callback function.
  * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
-export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
-  // should be registered as a callback passed to registerAfterStartCallback.
-  registerAfterStartCallback(async () => {
+export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
+  // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
+  // template, or else the NodeJS module bootstrapping process will block and fail as it would then depend
+  // on a runtime resolution of the promise in `startServer()`.
+  // Since `pgBossStarted` will resolve in the future, it may appear possible to send pg-boss
+  // a job before we actually have registered the handler via `boss.work()`. However, even if NodeJS does
+  // not execute this callback before any job `submit()` calls, this is not a problem since pg-boss allows you
+  // to submit jobs even if there are no workers registered.
+  // Once they are registered, they will just start on the first job in their queue.
+  pgBossStarted.then(async (boss) => {
     // As a safety precaution against undefined behavior of registering different
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
@@ -85,10 +92,11 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
+    // If the schedule name already exists, it's updated to the provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
-    if (jobSchedule !== null) {
-      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})
+    if (jobSchedule) {
+      const options = { ...defaultJobOptions, ...jobSchedule.options }
+      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.args || null, options)
     }
   })
 

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/simpleJob.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/simpleJob.js
@@ -2,14 +2,14 @@ import { sleep } from '../../utils.js'
 import { Job } from './Job.js'
 import { SubmittedJob } from './SubmittedJob.js'
 
-export const PASSTHROUGH_EXECUTOR_NAME = Symbol('Passthrough')
+export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It is dependency-free, however.
+ * It does not support `schedule`. It is dependency-free, however.
  */
-class PassthroughJob extends Job {
+class SimpleJob extends Job {
   #jobFn
   #delaySeconds
 
@@ -20,7 +20,7 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - The number of seconds to delay invoking the Job function.
    */
   constructor(jobName, jobFn, delaySeconds = 0) {
-    super(jobName, PASSTHROUGH_EXECUTOR_NAME)
+    super(jobName, SIMPLE_EXECUTOR_NAME)
     this.#jobFn = jobFn
     this.#delaySeconds = delaySeconds
   }
@@ -29,18 +29,18 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - Used to delay the processing of the job by some number of seconds.
    */
   delay(delaySeconds) {
-    return new PassthroughJob(this.jobName, this.#jobFn, delaySeconds)
+    return new SimpleJob(this.jobName, this.#jobFn, delaySeconds)
   }
 
   async submit(jobArgs) {
     sleep(this.#delaySeconds * 1000).then(() => this.#jobFn(jobArgs))
     // NOTE: Dumb random ID generator, mainly so we don't have to add `uuid`
     // as a dependency in the server generator for something nobody will likely use.
-    let jobId = (Math.random() + 1).toString(36).substring(7)
+    const jobId = (Math.random() + 1).toString(36).substring(7)
     return new SubmittedJob(this, jobId)
   }
 }
 
 export function createJob({ jobName, jobFn } = {}) {
-  return new PassthroughJob(jobName, jobFn)
+  return new SimpleJob(jobName, jobFn)
 }

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/simpleJob.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/jobs/core/simpleJob.js
@@ -7,7 +7,8 @@ export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It does not support `schedule`. It is dependency-free, however.
+ * It does not support `schedule`. It does not require any extra NPM dependencies
+ * or infrastructure, however.
  */
 class SimpleJob extends Job {
   #jobFn

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/server.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/server.js
@@ -6,7 +6,7 @@ import config from './config.js'
 
 
 import { startPgBoss } from './jobs/core/pgBoss/pgBoss.js'
-import * as allJobs from './jobs/core/allJobs.js'
+import './jobs/core/allJobs.js'
 
 const startServer = async () => {
   await startPgBoss()

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/server.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/server.js
@@ -6,6 +6,7 @@ import config from './config.js'
 
 
 import { startPgBoss } from './jobs/core/pgBoss/pgBoss.js'
+import * as allJobs from './jobs/core/allJobs.js'
 
 const startServer = async () => {
   await startPgBoss()

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/files.manifest
@@ -22,6 +22,7 @@ waspMigrate/.wasp/out/server/src/ext-src/MainPage.js
 waspMigrate/.wasp/out/server/src/ext-src/waspLogo.png
 waspMigrate/.wasp/out/server/src/jobs/core/Job.js
 waspMigrate/.wasp/out/server/src/jobs/core/SubmittedJob.js
+waspMigrate/.wasp/out/server/src/jobs/core/allJobs.js
 waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
 waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
 waspMigrate/.wasp/out/server/src/jobs/core/simpleJob.js

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/files.manifest
@@ -22,9 +22,9 @@ waspMigrate/.wasp/out/server/src/ext-src/MainPage.js
 waspMigrate/.wasp/out/server/src/ext-src/waspLogo.png
 waspMigrate/.wasp/out/server/src/jobs/core/Job.js
 waspMigrate/.wasp/out/server/src/jobs/core/SubmittedJob.js
-waspMigrate/.wasp/out/server/src/jobs/core/passthroughJob.js
 waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
 waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+waspMigrate/.wasp/out/server/src/jobs/core/simpleJob.js
 waspMigrate/.wasp/out/server/src/routes/index.js
 waspMigrate/.wasp/out/server/src/routes/operations/index.js
 waspMigrate/.wasp/out/server/src/server.js

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -151,7 +151,7 @@
             "file",
             "server/src/jobs/core/simpleJob.js"
         ],
-        "ac538ab0a437f0acd2056197488ea4c6c6d056d86c34a0a1e36bf80e515c12e5"
+        "36fe173d9f5128859196bfd3a661983df2d95eb34d165a469b840982b06cf59b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -137,7 +137,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "b3fa9bdd0b1409d15c91e22cfc07a12c8d9e7d791ab2b0a35bf0bf3ca439b643"
+        "23fbb367a1cfe7729798be1b5fc22c4f4ffbda2941944a61057f68f5e43e6184"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "1a792979f471071c76c4d906fd6b1473dd819151a87ef6696f501346f318e02c"
+        "3857d87db368c5014480b1840d29b262cbb431f99d7c102f45a1865878eecff4"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -137,14 +137,14 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "b6bc8378ba0870623fdf63620ceb60306f45616ef073bb399307784fe10b20c4"
+        "f87b5143ae3f53d6cf9e6f435a683d07a0663902431f9c98418226857234b25a"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "d55605f4699cdba098a7a52f6d4d69e4cd4deabf3234b08634f86fbcf9a31dc8"
+        "7d038e876648dc19f763ee30240e0dc59d95b8098419714d94ca12b7aeb60921"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "9f04cf045b5d6b6f2bfaa1089e80a3fdc10cf9b8b1cd95da35f1530b0277ba10"
+        "6a58878b76d5086454bc721dc779d0589eab6096913272910f390dc502a34708"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -128,6 +128,13 @@
     [
         [
             "file",
+            "server/src/jobs/core/allJobs.js"
+        ],
+        "90b1b3012216900efa82fff14911dcbf195fa2e449edb3b24ab80db0065d796f"
+    ],
+    [
+        [
+            "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
         "9821963d90b39058285343834c70e6f825d3d7696c738fd95539614b5e7d7b94"

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -137,14 +137,14 @@
             "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "f87b5143ae3f53d6cf9e6f435a683d07a0663902431f9c98418226857234b25a"
+        "b3fa9bdd0b1409d15c91e22cfc07a12c8d9e7d791ab2b0a35bf0bf3ca439b643"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "7d038e876648dc19f763ee30240e0dc59d95b8098419714d94ca12b7aeb60921"
+        "1a792979f471071c76c4d906fd6b1473dd819151a87ef6696f501346f318e02c"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -128,23 +128,23 @@
     [
         [
             "file",
-            "server/src/jobs/core/passthroughJob.js"
-        ],
-        "5df690abebd10220346751adcfc157dd66f34a033abe017e34ac4e84287090bf"
-    ],
-    [
-        [
-            "file",
             "server/src/jobs/core/pgBoss/pgBoss.js"
         ],
-        "23fbb367a1cfe7729798be1b5fc22c4f4ffbda2941944a61057f68f5e43e6184"
+        "9821963d90b39058285343834c70e6f825d3d7696c738fd95539614b5e7d7b94"
     ],
     [
         [
             "file",
             "server/src/jobs/core/pgBoss/pgBossJob.js"
         ],
-        "3857d87db368c5014480b1840d29b262cbb431f99d7c102f45a1865878eecff4"
+        "9f04cf045b5d6b6f2bfaa1089e80a3fdc10cf9b8b1cd95da35f1530b0277ba10"
+    ],
+    [
+        [
+            "file",
+            "server/src/jobs/core/simpleJob.js"
+        ],
+        "ac538ab0a437f0acd2056197488ea4c6c6d056d86c34a0a1e36bf80e515c12e5"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/allJobs.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/allJobs.js
@@ -1,0 +1,4 @@
+
+// This module exports all jobs and is imported by the server to ensure
+// any schedules that are not referenced are still loaded by NodeJS.
+

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,18 +1,41 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of pg-boss.
-const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
-export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
+const boss = createPgBoss()
 
-// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-const afterStartCallbacks = []
-export function registerAfterStartCallback(callback) {
-  afterStartCallbacks.push(callback)
+function createPgBoss() {
+  let pgBossNewOptions = {
+    connectionString: config.databaseUrl,
+  }
+
+  // Add an escape hatch for advanced configuration of pg-boss to overwrite our defaults.
+  if (process.env.PG_BOSS_NEW_OPTIONS) {
+    try {
+      pgBossNewOptions = JSON.parse(process.env.PG_BOSS_NEW_OPTIONS)
+    }
+    catch {
+      console.error("Environment variable PG_BOSS_NEW_OPTIONS was not parsable by JSON.parse()!")
+    }
+  }
+
+  return new PgBoss(pgBossNewOptions)
 }
 
+let resolvePgBossStarted, rejectPgBossStarted
+// Code that wants to access pg-boss must wait until it has been started.
+export const pgBossStarted = new Promise((resolve, reject) => {
+  resolvePgBossStarted = resolve
+  rejectPgBossStarted = reject
+})
+
 // Ensure pg-boss can only be started once during a server's lifetime.
-let hasPgBossBeenStarted = false
+const PgBossStatus = {
+  Unstarted: 'Unstarted',
+  Starting: 'Starting',
+  Started: 'Started',
+  Error: 'Error'
+}
+let pgBossStatus = PgBossStatus.Unstarted
 
 /**
  * Prepares the target PostgreSQL database and begins job monitoring.
@@ -24,15 +47,23 @@ let hasPgBossBeenStarted = false
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {
-  if (!hasPgBossBeenStarted) {
-    console.log('Starting PgBoss...')
+  if (pgBossStatus !== PgBossStatus.Unstarted) { return }
+  pgBossStatus = PgBossStatus.Starting
+  console.log('Starting pg-boss...')
 
-    boss.on('error', error => console.error(error))
+  boss.on('error', error => console.error(error))
+  try {
     await boss.start()
-
-    afterStartCallbacks.forEach(fn => fn())
-
-    console.log('PgBoss started!')
-    hasPgBossBeenStarted = true
+  } catch (error) {
+    console.error('pg-boss failed to start!')
+    console.error(error)
+    pgBossStatus = PgBossStatus.Error
+    rejectPgBossStarted(boss)
+    return
   }
+
+  resolvePgBossStarted(boss)
+
+  console.log('pg-boss started!')
+  pgBossStatus = PgBossStatus.Started
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -1,17 +1,17 @@
 import PgBoss from 'pg-boss'
 import config from '../../../config.js'
 
-// Add an escape hatch for advanced configuration of PgBoss.
+// Add an escape hatch for advanced configuration of pg-boss.
 const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
-// Allows setup code that runs before PgBoss starts to register their PgBoss functions.
+// Allows setup code that runs before pg-boss starts to register their pg-boss functions.
 let afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }
 
-// Ensure PgBoss can only be started once during a server's lifetime.
+// Ensure pg-boss can only be started once during a server's lifetime.
 let hasPgBossBeenStarted = false
 
 /**
@@ -20,7 +20,7 @@ let hasPgBossBeenStarted = false
  * `boss.start()` will automatically create them.
  * Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#start
  * 
- * After making this call, we can send PgBoss jobs and they will be persisted and acted upon.
+ * After making this call, we can send pg-boss jobs and they will be persisted and acted upon.
  * This should only be called once during a server's lifetime.
  */
 export async function startPgBoss() {

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBoss.js
@@ -6,7 +6,7 @@ const pgBossNewOptions = process.env.PG_BOSS_NEW_OPTIONS || {}
 export const boss = new PgBoss({ connectionString: config.databaseUrl, ...pgBossNewOptions })
 
 // Allows setup code that runs before pg-boss starts to register their pg-boss functions.
-let afterStartCallbacks = []
+const afterStartCallbacks = []
 export function registerAfterStartCallback(callback) {
   afterStartCallbacks.push(callback)
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -69,9 +69,9 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for `boss.send()` applied to every `submit()` invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5-field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
 export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
   // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
@@ -87,7 +87,7 @@ export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
 
-    // This tells pgBoss to run given worker function when job/payload with given job name is submitted.
+    // This tells pg-boss to run given worker function when job with that name is submitted.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#work
     await boss.work(jobName, jobFn)
 

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -5,7 +5,7 @@ import { SubmittedJob } from '../SubmittedJob.js'
 export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
 
 /**
- * A PgBoss specific SubmittedJob that adds additional PgBoss functionality.
+ * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
   constructor(job, jobId) {
@@ -19,7 +19,7 @@ class PgBossSubmittedJob extends SubmittedJob {
 }
 
 /**
- * This is a class repesenting a job that can be submitted to PgBoss.
+ * This is a class repesenting a job that can be submitted to pg-boss.
  * It is not yet submitted until the caller invokes `submit()` on an instance.
  * The caller can make as many calls to `submit()` as they wish.
  */
@@ -51,9 +51,9 @@ class PgBossJob extends Job {
   }
 
   /**
-   * Submits the job to PgBoss.
+   * Submits the job to pg-boss.
    * @param {object} jobArgs - The job arguments supplied by the user for their perform callback.
-   * @param {object} jobOptions - PgBoss specific options for `boss.send()`, which can override their defaultJobOptions.
+   * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
     const jobId = await boss.send(this.jobName, jobArgs,
@@ -68,12 +68,12 @@ class PgBossJob extends Job {
  * functions, we will override the previous calls.
  * @param {string} jobName - The user-defined job name in their .wasp file.
  * @param {fn} jobFn - The user-defined async job callback function.
- * @param {object} defaultJobOptions - PgBoss specific options for boss.send() applied to every submit() invocation,
+ * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
  * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
  */
 export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before PgBoss starts. Therefore, anything that expects PgBoss to be running
+  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
   // should be registered as a callback passed to registerAfterStartCallback.
   registerAfterStartCallback(async () => {
     // As a safety precaution against undefined behavior of registering different

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -85,7 +85,7 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the new cron expression.
+    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
     if (jobSchedule !== null) {
       await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/pgBoss/pgBossJob.js
@@ -1,4 +1,4 @@
-import { boss, registerAfterStartCallback } from './pgBoss.js'
+import { pgBossStarted } from './pgBoss.js'
 import { Job } from '../Job.js'
 import { SubmittedJob } from '../SubmittedJob.js'
 
@@ -8,12 +8,12 @@ export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')
  * A pg-boss specific SubmittedJob that adds additional pg-boss functionality.
  */
 class PgBossSubmittedJob extends SubmittedJob {
-  constructor(job, jobId) {
+  constructor(boss, job, jobId) {
     super(job, jobId)
     this.pgBoss = {
-      async cancel() { return boss.cancel(jobId) },
-      async resume() { return boss.resume(jobId) },
-      async details() { return boss.getJobById(jobId) }
+      cancel: () => boss.cancel(jobId),
+      resume: () => boss.resume(jobId),
+      details: () => boss.getJobById(jobId),
     }
   }
 }
@@ -56,9 +56,10 @@ class PgBossJob extends Job {
    * @param {object} jobOptions - pg-boss specific options for `boss.send()`, which can override their defaultJobOptions.
    */
   async submit(jobArgs, jobOptions) {
+    const boss = await pgBossStarted
     const jobId = await boss.send(this.jobName, jobArgs,
       { ...this.#defaultJobOptions, ...(this.#startAfter && { startAfter: this.#startAfter }), ...jobOptions })
-    return new PgBossSubmittedJob(this, jobId)
+    return new PgBossSubmittedJob(boss, this, jobId)
   }
 }
 
@@ -70,12 +71,18 @@ class PgBossJob extends Job {
  * @param {fn} jobFn - The user-defined async job callback function.
  * @param {object} defaultJobOptions - pg-boss specific options for boss.send() applied to every submit() invocation,
  *                                     which can overriden in that call.
- * @param {object} jobSchedule [Optional] - The cron string and arguments/options when invoking the job.
+ * @param {object} jobSchedule [Optional] - The 5 field cron string, job function JSON arg, and `boss.send()` options when invoking the job.
  */
-export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
-  // Note: createJob runs before pg-boss starts. Therefore, anything that expects pg-boss to be running
-  // should be registered as a callback passed to registerAfterStartCallback.
-  registerAfterStartCallback(async () => {
+export function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule } = {}) {
+  // NOTE(shayne): We are not awaiting `pgBossStarted` here since we need to return an instance to the job
+  // template, or else the NodeJS module bootstrapping process will block and fail as it would then depend
+  // on a runtime resolution of the promise in `startServer()`.
+  // Since `pgBossStarted` will resolve in the future, it may appear possible to send pg-boss
+  // a job before we actually have registered the handler via `boss.work()`. However, even if NodeJS does
+  // not execute this callback before any job `submit()` calls, this is not a problem since pg-boss allows you
+  // to submit jobs even if there are no workers registered.
+  // Once they are registered, they will just start on the first job in their queue.
+  pgBossStarted.then(async (boss) => {
     // As a safety precaution against undefined behavior of registering different
     // functions for the same job name, remove all registered functions first.
     await boss.offWork(jobName)
@@ -85,10 +92,11 @@ export async function createJob({ jobName, jobFn, defaultJobOptions, jobSchedule
     await boss.work(jobName, jobFn)
 
     // If a job schedule is provided, we should schedule the recurring job.
-    // If the schedule name already exists, it's updated to the newly provided cron expression, arguments, and options.
+    // If the schedule name already exists, it's updated to the provided cron expression, arguments, and options.
     // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling
-    if (jobSchedule !== null) {
-      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.performFnArg || null, jobSchedule.options || {})
+    if (jobSchedule) {
+      const options = { ...defaultJobOptions, ...jobSchedule.options }
+      await boss.schedule(jobName, jobSchedule.cron, jobSchedule.args || null, options)
     }
   })
 

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/simpleJob.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/simpleJob.js
@@ -2,14 +2,14 @@ import { sleep } from '../../utils.js'
 import { Job } from './Job.js'
 import { SubmittedJob } from './SubmittedJob.js'
 
-export const PASSTHROUGH_EXECUTOR_NAME = Symbol('Passthrough')
+export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It is dependency-free, however.
+ * It does not support `schedule`. It is dependency-free, however.
  */
-class PassthroughJob extends Job {
+class SimpleJob extends Job {
   #jobFn
   #delaySeconds
 
@@ -20,7 +20,7 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - The number of seconds to delay invoking the Job function.
    */
   constructor(jobName, jobFn, delaySeconds = 0) {
-    super(jobName, PASSTHROUGH_EXECUTOR_NAME)
+    super(jobName, SIMPLE_EXECUTOR_NAME)
     this.#jobFn = jobFn
     this.#delaySeconds = delaySeconds
   }
@@ -29,18 +29,18 @@ class PassthroughJob extends Job {
    * @param {int} delaySeconds - Used to delay the processing of the job by some number of seconds.
    */
   delay(delaySeconds) {
-    return new PassthroughJob(this.jobName, this.#jobFn, delaySeconds)
+    return new SimpleJob(this.jobName, this.#jobFn, delaySeconds)
   }
 
   async submit(jobArgs) {
     sleep(this.#delaySeconds * 1000).then(() => this.#jobFn(jobArgs))
     // NOTE: Dumb random ID generator, mainly so we don't have to add `uuid`
     // as a dependency in the server generator for something nobody will likely use.
-    let jobId = (Math.random() + 1).toString(36).substring(7)
+    const jobId = (Math.random() + 1).toString(36).substring(7)
     return new SubmittedJob(this, jobId)
   }
 }
 
 export function createJob({ jobName, jobFn } = {}) {
-  return new PassthroughJob(jobName, jobFn)
+  return new SimpleJob(jobName, jobFn)
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/simpleJob.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/jobs/core/simpleJob.js
@@ -7,7 +7,8 @@ export const SIMPLE_EXECUTOR_NAME = Symbol('Simple')
 /**
  * A simple job mainly intended for testing. It will not submit work to any
  * job executor, but instead will simply invoke the underlying perform function.
- * It does not support `schedule`. It is dependency-free, however.
+ * It does not support `schedule`. It does not require any extra NPM dependencies
+ * or infrastructure, however.
  */
 class SimpleJob extends Job {
   #jobFn

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -118,7 +118,7 @@ job mySpecialJob {
     options: {=json { "retryLimit": 1 } json=}
   },
   schedule: {
-    cron: "*/1 * * * *",
+    cron: "*/5 * * * *",
     performFnArg: {=json { "foo": "bar" } json=},
     options: {=json { "retryLimit": 0 } json=}
   }

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -115,11 +115,11 @@ job mySpecialJob {
   executor: PgBoss,
   perform: {
     fn: import { foo } from "@ext/jobs/bar.js",
-    options: {=json { "retryLimit": 1 } json=}
+    executorOptions: {=json { "retryLimit": 1 } json=}
   },
   schedule: {
     cron: "*/5 * * * *",
-    performFnArg: {=json { "foo": "bar" } json=},
-    options: {=json { "retryLimit": 0 } json=}
+    args: {=json { "foo": "bar" } json=},
+    executorOptions: {=json { "retryLimit": 0 } json=}
   }
 }

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -115,11 +115,15 @@ job mySpecialJob {
   executor: PgBoss,
   perform: {
     fn: import { foo } from "@ext/jobs/bar.js",
-    executorOptions: {=json { "retryLimit": 1 } json=}
+    executorOptions: {
+      pgBoss: {=json { "retryLimit": 1 } json=}
+    }
   },
   schedule: {
     cron: "*/5 * * * *",
     args: {=json { "foo": "bar" } json=},
-    executorOptions: {=json { "retryLimit": 0 } json=}
+    executorOptions: {
+      pgBoss: {=json { "retryLimit": 0 } json=}
+    }
   }
 }

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -118,12 +118,19 @@ job mySpecialJob {
     executorOptions: {
       pgBoss: {=json { "retryLimit": 1 } json=}
     }
+  }
+}
+
+job mySpecialScheduledJob {
+  executor: PgBoss,
+  perform: {
+    fn: import { foo } from "@ext/jobs/bar.js"
   },
   schedule: {
-    cron: "*/5 * * * *",
+    cron: "*/2 * * * *",
     args: {=json { "foo": "bar" } json=},
     executorOptions: {
-      pgBoss: {=json { "retryLimit": 0 } json=}
+      pgBoss: {=json { "retryLimit": 2 } json=}
     }
   }
 }

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -116,5 +116,10 @@ job mySpecialJob {
   perform: {
     fn: import { foo } from "@ext/jobs/bar.js",
     options: {=json { "retryLimit": 1 } json=}
+  },
+  schedule: {
+    cron: "*/1 * * * *",
+    performFnArg: {=json { "foo": "bar" } json=},
+    options: {=json { "retryLimit": 0 } json=}
   }
 }

--- a/waspc/src/Wasp/AppSpec/JSON.hs
+++ b/waspc/src/Wasp/AppSpec/JSON.hs
@@ -9,7 +9,7 @@ where
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Text as Aeson.Text
-import qualified Data.Aeson.Types as AesonTypes
+import qualified Data.Aeson.Types as Aeson.Types
 import Data.Data (Data)
 import qualified Data.Text.Lazy as TextL
 
@@ -26,7 +26,7 @@ instance Aeson.FromJSON JSON where
   parseJSON val = return $ JSON val
 
 emptyObject :: JSON
-emptyObject = JSON AesonTypes.emptyObject
+emptyObject = JSON Aeson.Types.emptyObject
 
 nullValue :: JSON
-nullValue = JSON AesonTypes.Null
+nullValue = JSON Aeson.Types.Null

--- a/waspc/src/Wasp/AppSpec/JSON.hs
+++ b/waspc/src/Wasp/AppSpec/JSON.hs
@@ -3,18 +3,30 @@
 module Wasp.AppSpec.JSON
   ( JSON (..),
     emptyObject,
+    nullValue,
   )
 where
 
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy.UTF8 as ByteStringLazyUTF8
+import qualified Data.Aeson.Text as Aeson.Text
+import qualified Data.Aeson.Types as AesonTypes
 import Data.Data (Data)
+import qualified Data.Text.Lazy as TextL
 
 newtype JSON = JSON Aeson.Value
   deriving (Eq, Data)
 
 instance Show JSON where
-  show (JSON val) = ByteStringLazyUTF8.toString $ Aeson.encode val
+  show (JSON val) = TextL.unpack . Aeson.Text.encodeToLazyText $ val
+
+instance Aeson.ToJSON JSON where
+  toJSON (JSON val) = val
+
+instance Aeson.FromJSON JSON where
+  parseJSON val = return $ JSON val
 
 emptyObject :: JSON
-emptyObject = JSON $ Aeson.object []
+emptyObject = JSON AesonTypes.emptyObject
+
+nullValue :: JSON
+nullValue = JSON AesonTypes.Null

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -6,6 +6,7 @@ module Wasp.AppSpec.Job
     JobExecutor (..),
     Perform (..),
     Schedule (..),
+    ExecutorOptions (..),
     performExecutorOptionsJson,
     scheduleExecutorOptionsJson,
     jobExecutors,

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -7,7 +7,7 @@ module Wasp.AppSpec.Job
     Perform (..),
     Schedule (..),
     performOptions,
-    sheduleOptions,
+    scheduleOptions,
     jobExecutors,
   )
 where
@@ -53,5 +53,5 @@ jobExecutors = enumFrom minBound :: [JobExecutor]
 performOptions :: Perform -> Maybe JSON
 performOptions p = options (p :: Perform)
 
-sheduleOptions :: Schedule -> Maybe JSON
-sheduleOptions s = options (s :: Schedule)
+scheduleOptions :: Schedule -> Maybe JSON
+scheduleOptions s = options (s :: Schedule)

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -26,7 +26,7 @@ data Job = Job
 
 instance IsDecl Job
 
-data JobExecutor = Passthrough | PgBoss
+data JobExecutor = Simple | PgBoss
   deriving (Show, Eq, Data, Ord, Enum, Bounded)
 
 data Perform = Perform
@@ -51,7 +51,7 @@ instance IsDecl Schedule
 -- directly through to the executor when submitting jobs.
 data ExecutorOptions = ExecutorOptions
   { pgBoss :: Maybe JSON,
-    passthrough :: Maybe JSON
+    simple :: Maybe JSON
   }
   deriving (Show, Eq, Data)
 
@@ -70,6 +70,6 @@ scheduleExecutorOptionsJson job =
     Just s -> executorOptionsJson (executor job) (executorOptions (s :: Schedule))
 
 executorOptionsJson :: JobExecutor -> Maybe ExecutorOptions -> Maybe JSON
-executorOptionsJson Passthrough (Just ExecutorOptions {passthrough = Just json}) = Just json
+executorOptionsJson Simple (Just ExecutorOptions {simple = Just json}) = Just json
 executorOptionsJson PgBoss (Just ExecutorOptions {pgBoss = Just json}) = Just json
 executorOptionsJson _ _ = Nothing

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -37,15 +37,18 @@ data Perform = Perform
 
 instance IsDecl Perform
 
+-- Allows jobs to run via some cron schedule.
 data Schedule = Schedule
-  { cron :: String,
-    args :: Maybe JSON,
+  { cron :: String, -- 5 field cron expression, exe: "*/5 * * * *".
+    args :: Maybe JSON, -- Arguments to pass to the job handler function (`Perform.fn`).
     executorOptions :: Maybe ExecutorOptions
   }
   deriving (Show, Eq, Data)
 
 instance IsDecl Schedule
 
+-- These are optional executor-specific JSON options we pass
+-- directly through to the executor when submitting jobs.
 data ExecutorOptions = ExecutorOptions
   { pgBoss :: Maybe JSON,
     passthrough :: Maybe JSON

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -6,8 +6,8 @@ module Wasp.AppSpec.Job
     JobExecutor (..),
     Perform (..),
     Schedule (..),
-    performOptions,
-    scheduleOptions,
+    performExecutorOptions,
+    scheduleExecutorOptions,
     jobExecutors,
   )
 where
@@ -31,7 +31,7 @@ data JobExecutor = Passthrough | PgBoss
 
 data Perform = Perform
   { fn :: ExtImport,
-    options :: Maybe JSON
+    executorOptions :: Maybe JSON
   }
   deriving (Show, Eq, Data)
 
@@ -39,8 +39,8 @@ instance IsDecl Perform
 
 data Schedule = Schedule
   { cron :: String,
-    performFnArg :: Maybe JSON,
-    options :: Maybe JSON
+    args :: Maybe JSON,
+    executorOptions :: Maybe JSON
   }
   deriving (Show, Eq, Data)
 
@@ -50,8 +50,8 @@ jobExecutors :: [JobExecutor]
 jobExecutors = enumFrom minBound :: [JobExecutor]
 
 -- Helpers to disambiguate duplicate field `options`.
-performOptions :: Perform -> Maybe JSON
-performOptions p = options (p :: Perform)
+performExecutorOptions :: Perform -> Maybe JSON
+performExecutorOptions p = executorOptions (p :: Perform)
 
-scheduleOptions :: Schedule -> Maybe JSON
-scheduleOptions s = options (s :: Schedule)
+scheduleExecutorOptions :: Schedule -> Maybe JSON
+scheduleExecutorOptions s = executorOptions (s :: Schedule)

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -65,10 +65,9 @@ performExecutorOptionsJson job =
   executorOptionsJson (executor job) (executorOptions (perform job :: Perform))
 
 scheduleExecutorOptionsJson :: Job -> Maybe JSON
-scheduleExecutorOptionsJson job =
-  case schedule job of
-    Nothing -> Nothing
-    Just s -> executorOptionsJson (executor job) (executorOptions (s :: Schedule))
+scheduleExecutorOptionsJson job = do
+  s <- schedule job
+  executorOptionsJson (executor job) (executorOptions (s :: Schedule))
 
 executorOptionsJson :: JobExecutor -> Maybe ExecutorOptions -> Maybe JSON
 executorOptionsJson Simple (Just ExecutorOptions {simple = Just json}) = Just json

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Wasp.AppSpec.Job
   ( Job (..),
     JobExecutor (..),
     Perform (..),
+    Schedule (..),
+    performOptions,
+    sheduleOptions,
     jobExecutors,
   )
 where
@@ -15,7 +19,8 @@ import Wasp.AppSpec.JSON (JSON (..))
 
 data Job = Job
   { executor :: JobExecutor,
-    perform :: Perform
+    perform :: Perform,
+    schedule :: Maybe Schedule
   }
   deriving (Show, Eq, Data)
 
@@ -32,5 +37,21 @@ data Perform = Perform
 
 instance IsDecl Perform
 
+data Schedule = Schedule
+  { cron :: String,
+    performFnArg :: Maybe JSON,
+    options :: Maybe JSON
+  }
+  deriving (Show, Eq, Data)
+
+instance IsDecl Schedule
+
 jobExecutors :: [JobExecutor]
 jobExecutors = enumFrom minBound :: [JobExecutor]
+
+-- Helpers to disambiguate duplicate field `option`.
+performOptions :: Perform -> Maybe JSON
+performOptions p = options (p :: Perform)
+
+sheduleOptions :: Schedule -> Maybe JSON
+sheduleOptions s = options (s :: Schedule)

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -49,7 +49,7 @@ instance IsDecl Schedule
 jobExecutors :: [JobExecutor]
 jobExecutors = enumFrom minBound :: [JobExecutor]
 
--- Helpers to disambiguate duplicate field `option`.
+-- Helpers to disambiguate duplicate field `options`.
 performOptions :: Perform -> Maybe JSON
 performOptions p = options (p :: Perform)
 

--- a/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
@@ -28,7 +28,7 @@ import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec, getJobs)
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
 import qualified Wasp.AppSpec.JSON as AS.JSON
-import Wasp.AppSpec.Job (Job, JobExecutor (Passthrough, PgBoss), jobExecutors)
+import Wasp.AppSpec.Job (Job, JobExecutor (PgBoss, Simple), jobExecutors)
 import qualified Wasp.AppSpec.Job as J
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
 import Wasp.Generator.ExternalCodeGenerator.Common (GeneratedExternalCodeDir)
@@ -108,7 +108,7 @@ executorJobTemplateInServerTemplatesDir = (jobsDirInServerTemplatesDir SP.</>) .
 
 executorJobTemplateInJobsDir :: JobExecutor -> Path' (Rel JobsDir) File'
 executorJobTemplateInJobsDir PgBoss = [relfile|core/pgBoss/pgBossJob.js|]
-executorJobTemplateInJobsDir Passthrough = [relfile|core/passthroughJob.js|]
+executorJobTemplateInJobsDir Simple = [relfile|core/simpleJob.js|]
 
 -- Path to destination files are the same as in templates dir.
 jobsDirInServerRootDir :: Path' (Rel ServerRootDir) (Dir JobsDir)

--- a/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
@@ -69,12 +69,12 @@ genJob (jobName, job) =
     tmplFile = C.asTmplFile $ jobsDirInServerTemplatesDir SP.</> [relfile|_job.js|]
     dstFile = jobsDirInServerRootDir SP.</> fromJust (parseRelFile $ jobName ++ ".js")
     (jobPerformFnName, jobPerformFnImportStatement) = getJsImportDetailsForExtFnImport relPosixPathFromJobFileToExtSrcDir $ (J.fn . J.perform) job
-    maybeJobPerformOptions = J.performExecutorOptions . J.perform $ job
+    maybeJobPerformOptions = J.performExecutorOptionsJson job
     jobScheduleTmplData s =
       object
         [ "cron" .= J.cron s,
           "args" .= J.args s,
-          "options" .= J.scheduleExecutorOptions s
+          "options" .= fromMaybe AS.JSON.emptyObject (J.scheduleExecutorOptionsJson job)
         ]
     maybeJobSchedule = jobScheduleTmplData <$> J.schedule job
 

--- a/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
@@ -134,6 +134,8 @@ executorJobTemplateInJobsDir Simple = [relfile|core/simpleJob.js|]
 jobsDirInServerRootDir :: Path' (Rel ServerRootDir) (Dir JobsDir)
 jobsDirInServerRootDir = SP.castRel jobsDirInServerTemplatesDir
 
+-- NOTE: Our pg-boss related documentation references this version in URLs.
+-- Please update the docs when this changes (until we solve: https://github.com/wasp-lang/wasp/issues/596).
 pgBossVersionBounds :: SV.VersionBounds
 pgBossVersionBounds = SV.BackwardsCompatibleWith (SV.Version 7 2 1)
 

--- a/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
@@ -42,6 +42,7 @@ import Wasp.Generator.ServerGenerator.Common
     srcDirInServerTemplatesDir,
   )
 import qualified Wasp.Generator.ServerGenerator.Common as C
+import qualified Wasp.SemanticVersion as SV
 
 genJobs :: AppSpec -> Generator [FileDraft]
 genJobs spec = return $ genJob <$> getJobs spec
@@ -55,7 +56,7 @@ genJobs spec = return $ genJob <$> getJobs spec
           maybeJobPerformOptions = J.performOptions . J.perform $ job
           maybeJobSchedule =
             J.schedule job
-              >>= (\s -> return $ object ["cron" .= J.cron s, "performFnArg" .= J.performFnArg s, "options" .= J.sheduleOptions s])
+              >>= (\s -> return $ object ["cron" .= J.cron s, "performFnArg" .= J.performFnArg s, "options" .= J.scheduleOptions s])
        in C.mkTmplFdWithDstAndData
             tmplFile
             (dstFileFromJobName jobName)
@@ -109,11 +110,11 @@ executorJobTemplateInJobsDir Passthrough = [relfile|core/passthroughJob.js|]
 jobsDirInServerRootDir :: Path' (Rel ServerRootDir) (Dir JobsDir)
 jobsDirInServerRootDir = SP.castRel jobsDirInServerTemplatesDir
 
-pgBossVersionBounds :: String
-pgBossVersionBounds = "^7.2.1"
+pgBossVersionBounds :: SV.VersionBounds
+pgBossVersionBounds = SV.BackwardsCompatibleWith (SV.Version 7 2 1)
 
 pgBossDependency :: AS.Dependency.Dependency
-pgBossDependency = AS.Dependency.make ("pg-boss", pgBossVersionBounds)
+pgBossDependency = AS.Dependency.make ("pg-boss", show pgBossVersionBounds)
 
 depsRequiredByJobs :: AppSpec -> [AS.Dependency.Dependency]
 depsRequiredByJobs spec = [pgBossDependency | isPgBossJobExecutorUsed spec]

--- a/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/JobGenerator.hs
@@ -89,7 +89,7 @@ genAllJobImports spec =
         dstFile
         ( Just $
             object
-              ["jobs" .= map buildJobInfo (fst <$> getJobs spec)]
+              ["jobs" .= (buildJobInfo <$> (fst <$> getJobs spec))]
         )
   where
     buildJobInfo :: String -> Aeson.Value

--- a/waspc/test/AnalyzerTest.hs
+++ b/waspc/test/AnalyzerTest.hs
@@ -85,12 +85,16 @@ spec_Analyzer = do
                 "  executor: PgBoss,",
                 "  perform: {",
                 "    fn: import { backgroundJob } from \"@ext/jobs/baz.js\",",
-                "    executorOptions: {=json { \"retryLimit\": 1 } json=}",
+                "    executorOptions: {",
+                "      pgBoss: {=json { \"retryLimit\": 1 } json=}",
+                "    }",
                 "  },",
                 "  schedule: {",
                 "    cron: \"*/5 * * * *\",",
                 "    args: {=json { \"job\": \"args\" } json=},",
-                "    executorOptions: {=json { \"retryLimit\": 0 } json=}",
+                "    executorOptions: {",
+                "      pgBoss: {=json { \"retryLimit\": 0 } json=}",
+                "    }",
                 "  }",
                 "}"
               ]
@@ -208,12 +212,22 @@ spec_Analyzer = do
                   (ExtImportField "backgroundJob")
                   (fromJust $ SP.parseRelFileP "jobs/baz.js")
               )
-              (JSON.JSON <$> Aeson.decode "{\"retryLimit\":1}")
+              ( Just $
+                  Job.ExecutorOptions
+                    { Job.pgBoss = JSON.JSON <$> Aeson.decode "{\"retryLimit\":1}",
+                      Job.simple = Nothing
+                    }
+              )
       let jobSchedule =
             Job.Schedule
               "*/5 * * * *"
               (JSON.JSON <$> Aeson.decode "{\"job\":\"args\"}")
-              (JSON.JSON <$> Aeson.decode "{\"retryLimit\":0}")
+              ( Just $
+                  Job.ExecutorOptions
+                    { Job.pgBoss = JSON.JSON <$> Aeson.decode "{\"retryLimit\":0}",
+                      Job.simple = Nothing
+                    }
+              )
       let expectedJob =
             [ ( "BackgroundJob",
                 Job.Job

--- a/waspc/test/AnalyzerTest.hs
+++ b/waspc/test/AnalyzerTest.hs
@@ -194,18 +194,19 @@ spec_Analyzer = do
             ]
       takeDecls <$> decls `shouldBe` Right expectedAction
 
+      let jobPerform =
+            Job.Perform
+              ( ExtImport
+                  (ExtImportField "backgroundJob")
+                  (fromJust $ SP.parseRelFileP "jobs/baz.js")
+              )
+              Nothing
       let expectedJob =
             [ ( "BackgroundJob",
                 Job.Job
                   { Job.executor = Job.PgBoss,
-                    Job.perform =
-                      Job.Perform
-                        { Job.fn =
-                            ExtImport
-                              (ExtImportField "backgroundJob")
-                              (fromJust $ SP.parseRelFileP "jobs/baz.js"),
-                          Job.options = Nothing
-                        }
+                    Job.perform = jobPerform,
+                    Job.schedule = Nothing
                   }
               )
             ]

--- a/waspc/test/AnalyzerTest.hs
+++ b/waspc/test/AnalyzerTest.hs
@@ -85,12 +85,12 @@ spec_Analyzer = do
                 "  executor: PgBoss,",
                 "  perform: {",
                 "    fn: import { backgroundJob } from \"@ext/jobs/baz.js\",",
-                "    options: {=json { \"retryLimit\": 1 } json=}",
+                "    executorOptions: {=json { \"retryLimit\": 1 } json=}",
                 "  },",
                 "  schedule: {",
                 "    cron: \"*/5 * * * *\",",
-                "    performFnArg: {=json { \"job\": \"args\" } json=},",
-                "    options: {=json { \"retryLimit\": 0 } json=}",
+                "    args: {=json { \"job\": \"args\" } json=},",
+                "    executorOptions: {=json { \"retryLimit\": 0 } json=}",
                 "  }",
                 "}"
               ]

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -542,7 +542,7 @@ import { mySpecialJob } from '@wasp/jobs/mySpecialJob.js'
 - ###### `jobArgs: object` (optional)
 - ###### `options: object` (optional)
 
-Enques a `job` to be executed by an executor, optionally passing in job arguments and options.
+Enqueues a `job` to be executed by an executor, optionally passing in job arguments and options.
 
 ```js
 const submittedJob = await mySpecialJob.submit({ job: "args" })
@@ -575,12 +575,12 @@ There will also be namespaced, job executor-specific objects.
 
 ### ⚠️ Considerations
 
-There are job executor specific considerations to keep in mind when making your selections. We will continue to offer additional job executor options that balance the pros and cons.
+There are job executor-specific considerations to keep in mind when making your selections. We will continue to offer additional job executor options that balance the pros and cons.
 
 #### pg-boss
-- pg-boss is deployed alongside your web server's application, where both are simultaneously operational. Accoridingly, pg-boss and your web server share the same NodeJS event loop, making it unsuitable for CPU-intensive tasks.
+- pg-boss is deployed alongside your web server's application, where both are simultaneously operational. Accordingly, pg-boss and your web-server share the same NodeJS event loop, making it unsuitable for CPU-intensive tasks.
   - Wasp does not support independent, horizontal scaling of pg-boss-only workers or separate processes/threads.
-- The job name/identifier in your `.wasp` file is the same name that will be used in the `name` column of pg-boss tables. If you change this name and it has a `schedule`, it will continue scheduling jobs that will have no handlers associated, and will thus become stale and expire. You can remove the applicable row from `schedule` table in the `pgboss` schema of your database, or start a NodeJS REPL in your server context and run:
+- The job name/identifier in your `.wasp` file is the same name that will be used in the `name` column of pg-boss tables. If you change this name and it has a `schedule`, it will continue scheduling jobs that will have no handlers associated, and will thus become stale and expire. You can remove the applicable row from the `schedule` table in the `pgboss` schema of your database, or start a NodeJS REPL in your server context and run:
   ```js
   let { boss } = await import(`./src/jobs/core/pgBoss/pgBoss.js`)
   boss.unschedule("mySpecialJob")

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -453,9 +453,9 @@ Job executors hande the scheduling, monitoring, and execution of our job functio
 
 #### pg-boss
 
-We have selected [pg-boss](https://github.com/timgit/pg-boss/) as our first job executor to handle the low-volume, basic job queue workloads many web applications have (think sending emails, connecting to external HTTP APIs to perform work, etc.). By using PostgreSQL as it's storage and synchronization mechanism, it allows us to provide many job queue pros without any additional infrastructure or complex management.
+We have selected [pg-boss](https://github.com/timgit/pg-boss/) as our first job executor to handle the low-volume, basic job queue workloads many web applications have (think sending emails, connecting to external HTTP APIs to perform work, etc.). By using PostgreSQL (and [SKIP LOCKED](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/)) as it's storage and synchronization mechanism, it allows us to provide many job queue pros without any additional infrastructure or complex management.
 
-### Basics
+### Basic job definition and usage
 
 To register a `job` in Wasp, simply add a declaration with a reference to an `async` function, like the following:
 
@@ -483,7 +483,7 @@ await mySpecialJob.delay(10).submit({ job: "args" })
 
 And that is it! Your job will be executed by the job executor as if you called `foo({ job: "args" })`.
 
-### Scheduled Jobs
+### Recurring jobs
 
 If you have work that needs to be done on some recurring basis, you can add a `schedule` to your job declaration:
 
@@ -495,68 +495,82 @@ job mySpecialJob {
   },
   schedule: {
     cron: "0 * * * *",
-    performFnArg: {=json { "foo": "bar" } json=}, // optional
+    performFnArg: {=json { "job": "args" } json=}, // optional
     options: {=json { "retryLimit": 2 } json=} // optional
   }
 }
 ```
 
-In this example, you do _not_ need to invoke anything in JavaScript. You can imagine `foo({ "foo": "bar" })` getting automatically scheduled and invoked for you every hour.
+In this example, you do _not_ need to invoke anything in JavaScript. You can imagine `foo({ "job": "args" })` getting automatically scheduled and invoked for you every hour.
 
-### Syntax
+### Fields
 
-#### Wasp files
-- `executor`:
-  - `Passthrough`: a zero-dependency executor used mainly for testing purposes.
-  - `PgBoss`: the recommended executor for low-volume, production use cases.
-- `perform`:
-  - `fn`: an `async` JavaScript function of work to be performed. It can take any number of arguments.
-  - `options` [Optional]: executor specific options.
-    - See the docs for [pg-boss](https://github.com/timgit/pg-boss/blob/master/docs/readme.md#sendname-data-options).
-- `schedule` [Optional]:
-  - `cron`: a 5-placeholder format cron expression string.
-  - `performFnArg` [Optional]: the arguments to pass the perform function when invoked.
-  - `options` [Optional]: executor specific options.
-    - See the docs for [pg-boss](https://github.com/timgit/pg-boss/blob/master/docs/readme.md#sendname-data-options).
+#### `executor: JobExecutor` (required)
+The executor can be either `Passthrough` or `PgBoss`. `Passthrough`is a zero-dependency executor used mainly for testing purposes. `PgBoss` is the recommended executor for low-volume, production use cases.
 
-#### JavaScript API
+####  `perform: dict` (required)
+
+  - ##### `fn: fn` (required)
+  An `async` JavaScript function of work to be performed. It can take any number of arguments.
+  
+  - ##### `options: JSON` (optional)
+  Executor specific options to use when enquing jobs.
+
+  > See the docs for [pg-boss](https://github.com/timgit/pg-boss/blob/master/docs/readme.md#sendname-data-options).
+
+#### `schedule: dict` (optional)
+  
+  - ##### `cron: string`
+  A 5-placeholder format cron expression string. See rationale for minute-level precision [here](https://github.com/timgit/pg-boss/blob/master/docs/readme.md#scheduling).
+  
+  - ##### `performFnArg: JSON` (optional)
+  The arguments to pass the perform function when invoked.
+  
+  - ##### `options: JSON` (optional)
+  Executor specific options to use when enquing jobs.
+
+### JavaScript API
 - Invocation
-  - `import`:
+  - ##### `import`
     ```js
     import { mySpecialJob } from '@wasp/jobs/mySpecialJob.js'
     ```
-  - `submit(args, opts)`:
-    - Enquing a `job` to be executed by an executor, passing in optional job arguments and options.
+  
+  - ##### `submit(args, opts)`
+    Enques a `job` to be executed by an executor, passing in optional job arguments and options.
+
     ```js
     const submittedJob = await mySpecialJob.submit({ job: "args" })
     ```
-  - `delay(delay)` [Optional]:
-    - Delaying the invocation of the job handler. The delay can be one of:
-      - Integer: number of seconds to delay. [Default 0]
-      - String: ISO date string to run at.
-      - Date: Date to run at.
+  
+  - ##### `delay(delay)` (optional)
+    Delaying the invocation of the job handler. The delay can be one of:
+    - Integer: number of seconds to delay. [Default 0]
+    - String: ISO date string to run at.
+    - Date: Date to run at.
+
     ```js
     const submittedJob = await mySpecialJob.delay(10).submit({ job: "args" })
     ```
 - Tracking
   - The return value of `submit()` is an instance of `SubmittedJob`, that minimally contains:
-    - `jobId`: The UUID String ID for the job in that executor.
-    - `jobName`: The name of the job you used in your `.wasp` file.
-    - `executorName`: The name of the job executor.
+    - `jobId`: A getter returning the UUID String ID for the job in that executor.
+    - `jobName`: A getter returning the name of the job you used in your `.wasp` file.
+    - `executorName`: A getter returning the name of the job executor.
   - There will also be namespaced, job executor-specific objects.
     - For pg-boss, you may access: `pgBoss`
       - **NOTE**: no arguments are necessary, as we already applied the jobId in the returned lambda function.
       - `details()`: pg-boss specific job detail information.
-      - `cancel()`: attempts to cancel a job. Returns either `true` on success, or `false` on failure. [Ref](https://github.com/timgit/pg-boss/blob/master/docs/readme.md#cancelid)
-      - `resume()`: attempts to resume a canceled job. Returns either `true` on success, or `false` on failure. [Ref](https://github.com/timgit/pg-boss/blob/master/docs/readme.md#resumeid)
+      - `cancel()`: attempts to cancel a job. [Ref](https://github.com/timgit/pg-boss/blob/master/docs/readme.md#cancelid)
+      - `resume()`: attempts to resume a canceled job. [Ref](https://github.com/timgit/pg-boss/blob/master/docs/readme.md#resumeid)
 
 ### ⚠️ Considerations
 
 There are job executor specific considerations to keep in mind when making your selections. We will continue to offer additional job executor options that balance the pros and cons.
 
 #### pg-boss
-- All work is performed alongside the web server's NodeJS event loop, making it unsuitable for CPU-intensive tasks.
-- Wasp does not support independent, horizontal scaling of pg-boss workers.
+- pg-boss is deployed alongside your web server's application, where both are simultaneously operational. Accoridingly, pg-boss and your web server share the same NodeJS event loop, making it unsuitable for CPU-intensive tasks.
+  - Wasp does not support independent, horizontal scaling of pg-boss-only workers or separate processes/threads.
 - The job identifier in your `.wasp` file is the same name that will be used in the `name` column of pg-boss tables. If you change this name and it has a `schedule`, it will leave an orphaned cron-jobs behind. You can remove the applicable row from `schedule` table in the `pgboss` schema of your database, or start a NodeJS REPL in your server context and run:
   ```js
   let { boss } = await import(`./src/jobs/core/pgBoss/pgBoss.js`)

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -445,30 +445,36 @@ import { isPrismaError, prismaErrorToHttpError } from '@wasp/utils.js'
 
 ## Jobs
 
-If you have tasks that you do not want to handle as part of the normal request-response cycle, make that function a `job` and it will get some "super powers." Jobs will persist between server restarts, can be retried if they fail, and you can even be delayed until the future or have a recurring schedule! Some examples include sending an email, making an HTTP reqeust to some external API, or doing a nightly calculation.
+If you have tasks that you do not want to handle as part of the normal request-response cycle, Wasp allows you to make that function a `job` and it will gain some "superpowers." Jobs will persist between server restarts, can be retried if they fail, and they can even be delayed until the future (or have a recurring schedule)! Some examples where you may want to use a `job` include sending an email, making an HTTP request to some external API, or doing some nightly calculations.
 
 ### Job Executors
 
 Job executors handle the scheduling, monitoring, and execution of our jobs.
 
-Wasp allows you to choose which job executor will be used to execute a specific job that you define, therefore affecting some of the finer details of how jobs will behave and how they can be further configured.
+Wasp allows you to choose which job executor will be used to execute a specific job that you define, which affects some of the finer details of how jobs will behave and how they can be further configured. Each job executor has its pros and cons, which we will explain in more detail below, so you can pick the one that best suits your needs.
 
-Each job executor has its own pros and cons, which we will explain in more details below, so you can pick the one that suits you best.
-
-Currently Wasp supports only one type of job executor, which is `PgBoss`, but in the future it will likely support more.
+Currently, Wasp supports only one type of job executor, which is `PgBoss`, but in the future, it will likely support more.
 
 #### pg-boss
 
-We have selected [pg-boss](https://github.com/timgit/pg-boss/) as our first job executor to handle the low-volume, basic job queue workloads many web applications have. By using PostgreSQL (and [SKIP LOCKED](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/)) as it's storage and synchronization mechanism, it allows us to provide many job queue pros without any additional infrastructure or complex management.
+We have selected [pg-boss](https://github.com/timgit/pg-boss/) as our first job executor to handle the low-volume, basic job queue workloads many web applications have. By using PostgreSQL (and [SKIP LOCKED](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/)) as its storage and synchronization mechanism, it allows us to provide many job queue pros without any additional infrastructure or complex management.
 
-##### pg-boss considerations
-- Wasp starts pg-boss alongside your web server's application, where both are simultaneously operational. Accordingly, pg-boss and your web-server share the same NodeJS event loop, making it unsuitable for CPU-intensive tasks.
-  - Wasp does not support independent, horizontal scaling of pg-boss-only applications, nor starting them as separate workers/processes/threads.
-- The job name/identifier in your `.wasp` file is the same name that will be used in the `name` column of pg-boss tables. If you change a name that had a `schedule` associated with it, pg-boss will continue scheduling those jobs but they will have no handlers associated, and will thus become stale and expire. You can remove the applicable row from the `schedule` table in the `pgboss` schema of your database, or start a NodeJS REPL in your server context and run:
-  ```js
-  let { boss } = await import(`./src/jobs/core/pgBoss/pgBoss.js`)
-  boss.unschedule("mySpecialJob")
-  ```
+<details>
+  <summary>pg-boss details</summary>
+
+  pg-boss provides many useful features, which can be found [here](https://github.com/timgit/pg-boss/blob/7.2.1/README.md).
+
+  When you add pg-boss to a Wasp project, it will automatically add a new schema to your database called `pgboss` with some internal tracking tables, including `job` and `schedule`. pg-boss tables have a `name` column in most tables that will correspond to your `job` identifier. Additionally, these tables maintain arguments, states, return values, retry information, start and expiration times, and other metadata required by pg-boss.
+
+  If you need to customize the creation of the pg-boss instance, you can set an environment variable called `PG_BOSS_NEW_OPTIONS` to a stringified JSON object containing [these initialization parameters](https://github.com/timgit/pg-boss/blob/7.2.1/docs/readme.md#newoptions). **NOTE**: Setting this overwrites all Wasp defaults, so you must include database connection information as well.
+
+  ##### pg-boss considerations
+  - Wasp starts pg-boss alongside your web server's application, where both are simultaneously operational. Accordingly, pg-boss and your web-server share the same NodeJS event loop, making it unsuitable for CPU-intensive tasks.
+    - Wasp does not support independent, horizontal scaling of pg-boss-only applications, nor starting them as separate workers/processes/threads.
+  - The job name/identifier in your `.wasp` file is the same name that will be used in the `name` column of pg-boss tables. If you change a name that had a `schedule` associated with it, pg-boss will continue scheduling those jobs but they will have no handlers associated, and will thus become stale and expire. To resolve this, you can remove the applicable row from the `schedule` table in the `pgboss` schema of your database.
+    - If you remove a `schedule` from a job, you will need to do the above as well.
+
+</details>
 
 ### Basic job definition and usage
 
@@ -478,8 +484,7 @@ To declare a `job` in Wasp, simply add a declaration with a reference to an `asy
 job mySpecialJob {
   executor: PgBoss,
   perform: {
-    fn: import { foo } from "@ext/jobs/bar.js",
-    executorOptions: {=json { "retryLimit": 1 } json=} // optional
+    fn: import { foo } from "@ext/jobs/bar.js"
   }
 }
 ```
@@ -502,21 +507,42 @@ And that is it! Your job will be executed by the job executor as if you called `
 
 If you have work that needs to be done on some recurring basis, you can add a `schedule` to your job declaration:
 
-```css  {6-10} title="main.wasp"
+```css  {6-9} title="main.wasp"
 job mySpecialJob {
   executor: PgBoss,
   perform: {
     fn: import { foo } from "@ext/jobs/bar.js"
   },
   schedule: {
-    cron: "0 * * * *",
-    args: {=json { "job": "args" } json=}, // optional
-    executorOptions: {=json { "retryLimit": 2 } json=} // optional
+    cron: "*/5 * * * *",
+    args: {=json { "job": "args" } json=} // optional
   }
 }
 ```
 
 In this example, you do _not_ need to invoke anything in JavaScript. You can imagine `foo({ "job": "args" })` getting automatically scheduled and invoked for you every hour.
+
+### Fully specified example
+Additionally, both `perform` and `schedule` accept `executorOptions`, which we pass directly to the named job executor when you submit jobs. In this example, the scheduled job will have a `retryLimit` set to 0, as `schedule` overrides any similar property from `perform`.
+
+```css
+job mySpecialJob {
+  executor: PgBoss,
+  perform: {
+    fn: import { foo } from "@ext/jobs/bar.js",
+    executorOptions: {
+      pgBoss: {=json { "retryLimit": 1 } json=}
+    }
+  },
+  schedule: {
+    cron: "*/5 * * * *",
+    args: {=json { "foo": "bar" } json=},
+    executorOptions: {
+      pgBoss: {=json { "retryLimit": 0 } json=}
+    }
+  }
+}
+```
 
 ### Fields
 
@@ -526,12 +552,13 @@ In this example, you do _not_ need to invoke anything in JavaScript. You can ima
 ####  `perform: dict` (required)
 
   - ##### `fn: fn` (required)
-  An `async` JavaScript function of work to be performed. It can optionally take a JSON object as an argument.
+  An `async` JavaScript function of work to be performed. It can optionally take a JSON value as an argument.
   
-  - ##### `executorOptions: JSON` (optional)
-  Executor specific default options to use when submitting jobs. These are passed directly through and you should consult the documentation for the job executor. These can be overriden during invocation with `submit()`.
+  - ##### `executorOptions: dict` (optional)
+  Executor-specific default options to use when submitting jobs. These are passed directly through and you should consult the documentation for the job executor. These can be overridden during invocation with `submit()` or in a `schedule`.
 
-  > See the docs for [pg-boss](https://github.com/timgit/pg-boss/blob/7.2.1/docs/readme.md#sendname-data-options).
+    - ##### `pgBoss: JSON` (optional)
+    See the docs for [pg-boss](https://github.com/timgit/pg-boss/blob/7.2.1/docs/readme.md#sendname-data-options).
 
 #### `schedule: dict` (optional)
   
@@ -539,12 +566,13 @@ In this example, you do _not_ need to invoke anything in JavaScript. You can ima
   A 5-placeholder format cron expression string. See rationale for minute-level precision [here](https://github.com/timgit/pg-boss/blob/7.2.1/docs/readme.md#scheduling).
   
   - ##### `args: JSON` (optional)
-  The arguments to passed the job `perform.fn` function when invoked.
+  The arguments to pass to the `perform.fn` function when invoked.
   
-  - ##### `executorOptions: JSON` (optional)
-  Executor specific options to use when submitting jobs. The `perform.executorOptions` are the default options, and `schedule.executorOptions` can override/extend those.
+  - ##### `executorOptions: dict` (optional)
+  Executor-specific options to use when submitting jobs. These are passed directly through and you should consult the documentation for the job executor. The `perform.executorOptions` are the default options, and `schedule.executorOptions` can override/extend those.
 
-  > See the docs for [pg-boss](https://github.com/timgit/pg-boss/blob/7.2.1/docs/readme.md#sendname-data-options).
+    - ##### `pgBoss: JSON` (optional)
+    See the docs for [pg-boss](https://github.com/timgit/pg-boss/blob/7.2.1/docs/readme.md#sendname-data-options).
 
 ### JavaScript API
 
@@ -556,10 +584,10 @@ import { mySpecialJob } from '@wasp/jobs/mySpecialJob.js'
 ```
 
 ##### `submit(jobArgs, executorOptions)`
-- ###### `jobArgs: object` (optional)
-- ###### `executorOptions: object` (optional)
+- ###### `jobArgs: JSON` (optional)
+- ###### `executorOptions: JSON` (optional)
 
-Submits a `job` to be executed by an executor, optionally passing in a job argument JSON object and executor submit options.
+Submits a `job` to be executed by an executor, optionally passing in a JSON job argument your job handler function will receive, and executor-specific submit options.
 
 ```js
 const submittedJob = await mySpecialJob.submit({ job: "args" })
@@ -574,16 +602,18 @@ Delaying the invocation of the job handler. The delay can be one of:
 - Date: Date to run at.
 
 ```js
-const submittedJob = await mySpecialJob.delay(10).submit({ job: "args" })
+const submittedJob = await mySpecialJob.delay(10).submit({ job: "args" }, { "retryLimit": 2 })
 ```
 
 #### Tracking
-The return value of `submit()` is an instance of `SubmittedJob`, that minimally contains:
+The return value of `submit()` is an instance of `SubmittedJob`, which minimally contains:
 - `jobId`: A getter returning the UUID String ID for the job in that executor.
 - `jobName`: A getter returning the name of the job you used in your `.wasp` file.
-- `executorName`: A getter returning the name of the job executor.
+- `executorName`: A getter returning a Symbol of the name of the job executor.
+  - For pg-boss, you can import a Symbol from: `import { PG_BOSS_EXECUTOR_NAME } from '@wasp/jobs/core/pgBoss/pgBossJob.js'` if you wish to compare against `executorName`.
 
 There will also be namespaced, job executor-specific objects.
+
 - For pg-boss, you may access: `pgBoss`
   - **NOTE**: no arguments are necessary, as we already applied the `jobId` in the available functions.
   - `details()`: pg-boss specific job detail information. [Reference](https://github.com/timgit/pg-boss/blob/7.2.1/docs/readme.md#getjobbyidid)

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -514,7 +514,7 @@ job mySpecialJob {
     fn: import { foo } from "@ext/jobs/bar.js"
   },
   schedule: {
-    cron: "*/5 * * * *",
+    cron: "0 * * * *",
     args: {=json { "job": "args" } json=} // optional
   }
 }

--- a/web/docs/language/syntax.md
+++ b/web/docs/language/syntax.md
@@ -62,15 +62,16 @@ While fundamental types are here to be basic building blocks of a language, and 
       - Tuples can be of size 2, 3 and 4.
 - Domain types ([source of truth](https://github.com/wasp-lang/wasp/blob/main/waspc/src/Wasp/Analyzer/StdTypeDefinitions.hs))
   - Declaration types
-    - **app**
-    - **page**
-    - **route**
-    - **query**
     - **action**
+    - **app**
     - **entity**
+    - **job**
+    - **page**
+    - **query**
+    - **route**
   - Enum types
     - **AuthMethod**
     - **DbSystem**
-
+    - **JobExecutor**
 
 For more details about each of the domain types, both regarding their body types and what they mean, check the [Features](/language/features.md) section.


### PR DESCRIPTION
# Description

Adds cron support to pg-boss Jobs, and adds documentation as well. Here is what the new `schedule` snippet looks like in a `.wasp` file:

```css 
job mySpecialJob {
  executor: PgBoss,
  perform: {
    fn: import { foo } from "@ext/jobs/bar.js",
    executorOptions: {
      pgBoss: {=json { "retryLimit": 1 } json=}
    }
  },
  schedule: {
    cron: "*/5 * * * *",
    args: {=json { "foo": "bar" } json=},
    executorOptions: {
      pgBoss: {=json { "retryLimit": 0 } json=}
    }
  }
}
```

Closes #534 
Closes #538 
Closes #539 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update