### PR TITLE
Make warnings filterable to avoid redundant messages

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build.hs
@@ -60,6 +60,7 @@ buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir bu
         { externalCodeDirPath = waspProjectDir </> Common.extCodeDirInWaspProjectDir,
           isBuild = True,
           sendMessage = cliSendMessage,
+          -- Ignore "DB needs migration warnings" during build, as that is not a required step.
           warningsFilter =
             filter
               ( \case

--- a/waspc/cli/src/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build.hs
@@ -61,7 +61,7 @@ buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir bu
           isBuild = True,
           sendMessage = cliSendMessage,
           -- Ignore "DB needs migration warnings" during build, as that is not a required step.
-          warningsFilter =
+          generatorWarningsFilter =
             filter
               ( \case
                   GeneratorNeedsMigrationWarning _ -> False

--- a/waspc/cli/src/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Wasp.Cli.Command.Build
   ( build,
   )
@@ -22,6 +24,7 @@ import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Cli.Common as Common
 import Wasp.Cli.Message (cliSendMessage)
 import Wasp.CompileOptions (CompileOptions (..))
+import Wasp.Generator.Monad (GeneratorWarning (GeneratorNeedsMigrationWarning))
 import qualified Wasp.Lib
 import qualified Wasp.Message as Msg
 
@@ -56,5 +59,11 @@ buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir bu
       CompileOptions
         { externalCodeDirPath = waspProjectDir </> Common.extCodeDirInWaspProjectDir,
           isBuild = True,
-          sendMessage = cliSendMessage
+          sendMessage = cliSendMessage,
+          warningsFilter =
+            filter
+              ( \case
+                  GeneratorNeedsMigrationWarning _ -> False
+                  _ -> True
+              )
         }

--- a/waspc/cli/src/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Compile.hs
@@ -1,6 +1,7 @@
 module Wasp.Cli.Command.Compile
   ( compileIO,
     compile,
+    compileWithOptions,
     compileIOWithOptions,
     defaultCompileOptions,
   )
@@ -25,12 +26,17 @@ import qualified Wasp.Message as Msg
 compile :: Command ()
 compile = do
   waspProjectDir <- findWaspProjectRootDirFromCwd
+  compileWithOptions $ defaultCompileOptions waspProjectDir
+
+compileWithOptions :: CompileOptions -> Command ()
+compileWithOptions options = do
+  waspProjectDir <- findWaspProjectRootDirFromCwd
   let outDir =
         waspProjectDir </> Common.dotWaspDirInWaspProjectDir
           </> Common.generatedCodeDirInDotWaspDir
 
   cliSendMessageC $ Msg.Start "Compiling wasp code..."
-  compilationResult <- liftIO $ compileIO waspProjectDir outDir
+  compilationResult <- liftIO $ compileIOWithOptions options waspProjectDir outDir
   case compilationResult of
     Left compileError -> throwError $ CommandError "Compilation failed" compileError
     Right () -> cliSendMessageC $ Msg.Success "Code has been successfully compiled, project has been generated."
@@ -66,5 +72,6 @@ defaultCompileOptions waspProjectDir =
   CompileOptions
     { externalCodeDirPath = waspProjectDir </> Common.extCodeDirInWaspProjectDir,
       isBuild = False,
-      sendMessage = cliSendMessage
+      sendMessage = cliSendMessage,
+      warningsFilter = id
     }

--- a/waspc/cli/src/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Compile.hs
@@ -73,5 +73,7 @@ defaultCompileOptions waspProjectDir =
     { externalCodeDirPath = waspProjectDir </> Common.extCodeDirInWaspProjectDir,
       isBuild = False,
       sendMessage = cliSendMessage,
+      -- Allows exclusion of certain warnings for specific commands where they do not make sense.
+      -- For example, warning the DB needs a migration while running `db migrate-dev`.
       warningsFilter = id
     }

--- a/waspc/cli/src/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Compile.hs
@@ -25,6 +25,9 @@ import qualified Wasp.Message as Msg
 
 compile :: Command ()
 compile = do
+  -- TODO: Consider a way to remove the redundancy of finding the project root
+  -- here and in compileWithOptions. One option could be to add this to defaultCompileOptions
+  -- add make externalCodeDirPath a helper function, along with any others we typically need.
   waspProjectDir <- findWaspProjectRootDirFromCwd
   compileWithOptions $ defaultCompileOptions waspProjectDir
 
@@ -73,7 +76,5 @@ defaultCompileOptions waspProjectDir =
     { externalCodeDirPath = waspProjectDir </> Common.extCodeDirInWaspProjectDir,
       isBuild = False,
       sendMessage = cliSendMessage,
-      -- Allows exclusion of certain warnings for specific commands where they do not make sense.
-      -- For example, warning the DB needs a migration while running `db migrate-dev`.
-      warningsFilter = id
+      generatorWarningsFilter = id
     }

--- a/waspc/cli/src/Wasp/Cli/Command/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Db.hs
@@ -15,7 +15,7 @@ import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd)
 import Wasp.Cli.Command.Compile (compileWithOptions, defaultCompileOptions)
 import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Cli.Common as Common
-import Wasp.CompileOptions (CompileOptions (warningsFilter))
+import Wasp.CompileOptions (CompileOptions (generatorWarningsFilter))
 import Wasp.Generator.DbGenerator.Jobs (runStudio)
 import Wasp.Generator.Job.IO (readJobMessagesAndPrintThemPrefixed)
 import Wasp.Generator.Monad (GeneratorWarning (GeneratorNeedsMigrationWarning))
@@ -39,7 +39,7 @@ makeDbCommand cmd = do
       (defaultCompileOptions waspProjectDir)
         { -- Ignore "DB needs migration warnings" during database commands, as that is redundant
           -- for `db migrate-dev` and not helpful for `db studio`.
-          warningsFilter =
+          generatorWarningsFilter =
             filter
               ( \case
                   GeneratorNeedsMigrationWarning _ -> False

--- a/waspc/cli/src/Wasp/Cli/Command/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Db.hs
@@ -37,7 +37,9 @@ makeDbCommand cmd = do
   where
     compileOptions waspProjectDir =
       (defaultCompileOptions waspProjectDir)
-        { warningsFilter =
+        { -- Ignore "DB needs migration warnings" during database commands, as that is redundant
+          -- for `db migrate-dev` and not helpful for `db studio`.
+          warningsFilter =
             filter
               ( \case
                   GeneratorNeedsMigrationWarning _ -> False

--- a/waspc/src/Wasp/CompileOptions.hs
+++ b/waspc/src/Wasp/CompileOptions.hs
@@ -5,6 +5,7 @@ where
 
 import StrongPath (Abs, Dir, Path')
 import Wasp.AppSpec.ExternalCode (SourceExternalCodeDir)
+import Wasp.Generator.Monad (GeneratorWarning)
 import Wasp.Message (SendMessage)
 
 -- TODO(martin): Should these be merged with Wasp data? Is it really a separate thing or not?
@@ -16,5 +17,6 @@ data CompileOptions = CompileOptions
     -- We give the compiler the ability to send messages. The code that
     -- invokes the compiler (such as the CLI) can then implement a way
     -- to display these messages.
-    sendMessage :: SendMessage
+    sendMessage :: SendMessage,
+    warningsFilter :: [GeneratorWarning] -> [GeneratorWarning]
   }

--- a/waspc/src/Wasp/CompileOptions.hs
+++ b/waspc/src/Wasp/CompileOptions.hs
@@ -18,5 +18,9 @@ data CompileOptions = CompileOptions
     -- invokes the compiler (such as the CLI) can then implement a way
     -- to display these messages.
     sendMessage :: SendMessage,
-    warningsFilter :: [GeneratorWarning] -> [GeneratorWarning]
+    -- The generator returns a list of warnings and errors that happen during compilation.
+    -- CLI commands will almost always compile before they execute to ensure the project is up to date.
+    -- This filter function allows callers to ignore certain warnings where they do not make sense.
+    -- For example, showing a compilation warning to run `db migrate-dev` when you are running that command.
+    generatorWarningsFilter :: [GeneratorWarning] -> [GeneratorWarning]
   }

--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -31,7 +31,12 @@ import Wasp.Generator.DbGenerator.Common
   )
 import qualified Wasp.Generator.DbGenerator.Operations as DbOps
 import Wasp.Generator.FileDraft (FileDraft, createCopyDirFileDraft, createTemplateFileDraft)
-import Wasp.Generator.Monad (Generator, GeneratorError (..), GeneratorWarning (GenericGeneratorWarning), logAndThrowGeneratorError)
+import Wasp.Generator.Monad
+  ( Generator,
+    GeneratorError (..),
+    GeneratorWarning (GeneratorNeedsMigrationWarning),
+    logAndThrowGeneratorError,
+  )
 import qualified Wasp.Psl.Ast.Model as Psl.Ast.Model
 import qualified Wasp.Psl.Generator.Model as Psl.Generator.Model
 import Wasp.Util (checksumFromFilePath, hexToString, ifM, (<:>))
@@ -113,7 +118,7 @@ warnIfDbSchemaChangedSinceLastMigration spec projectRootDir = do
     entitiesExist = not . null $ getEntities spec
 
     warnIf :: Bool -> String -> Maybe GeneratorWarning
-    warnIf b msg = if b then Just $ GenericGeneratorWarning msg else Nothing
+    warnIf b msg = if b then Just $ GeneratorNeedsMigrationWarning msg else Nothing
 
 genPrismaClient :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> IO (Maybe GeneratorError)
 genPrismaClient spec projectRootDir = do

--- a/waspc/src/Wasp/Generator/Monad.hs
+++ b/waspc/src/Wasp/Generator/Monad.hs
@@ -45,10 +45,13 @@ data GeneratorError = GenericGeneratorError String
 instance Show GeneratorError where
   show (GenericGeneratorError e) = e
 
-data GeneratorWarning = GenericGeneratorWarning String
+data GeneratorWarning
+  = GenericGeneratorWarning String
+  | GeneratorNeedsMigrationWarning String
 
 instance Show GeneratorWarning where
   show (GenericGeneratorWarning e) = e
+  show (GeneratorNeedsMigrationWarning e) = e
 
 -- Runs the generator and either returns a result, or a list of 1 or more errors.
 -- Results in error if any error was ever logged and thrown (even if caught).

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -16,7 +16,7 @@ import Wasp.Analyzer.AnalyzeError (getErrorMessageAndCtx)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.Valid as ASV
 import Wasp.Common (DbMigrationsDir, WaspProjectDir, dbMigrationsDirInWaspProjectDir)
-import Wasp.CompileOptions (CompileOptions, sendMessage)
+import Wasp.CompileOptions (CompileOptions (warningsFilter), sendMessage)
 import qualified Wasp.CompileOptions as CompileOptions
 import Wasp.Error (showCompilerErrorForTerminal)
 import qualified Wasp.ExternalCode as ExternalCode
@@ -41,7 +41,7 @@ compile waspDir outDir options = do
       case ASV.validateAppSpec appSpec of
         [] -> do
           (generatorWarnings, generatorErrors) <- Generator.writeWebAppCode appSpec outDir (sendMessage options)
-          return (map show generatorWarnings, map show generatorErrors)
+          return (map show $ warningsFilter options generatorWarnings, map show generatorErrors)
         validationErrors -> do
           return ([], map show validationErrors)
 

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -16,7 +16,7 @@ import Wasp.Analyzer.AnalyzeError (getErrorMessageAndCtx)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.Valid as ASV
 import Wasp.Common (DbMigrationsDir, WaspProjectDir, dbMigrationsDirInWaspProjectDir)
-import Wasp.CompileOptions (CompileOptions (warningsFilter), sendMessage)
+import Wasp.CompileOptions (CompileOptions (generatorWarningsFilter), sendMessage)
 import qualified Wasp.CompileOptions as CompileOptions
 import Wasp.Error (showCompilerErrorForTerminal)
 import qualified Wasp.ExternalCode as ExternalCode
@@ -41,7 +41,7 @@ compile waspDir outDir options = do
       case ASV.validateAppSpec appSpec of
         [] -> do
           (generatorWarnings, generatorErrors) <- Generator.writeWebAppCode appSpec outDir (sendMessage options)
-          return (map show $ warningsFilter options generatorWarnings, map show generatorErrors)
+          return (map show $ generatorWarningsFilter options generatorWarnings, map show generatorErrors)
         validationErrors -> do
           return ([], map show validationErrors)
 


### PR DESCRIPTION
# Description

This change allows you to send a filter function as part of the compile options, so you can optionally exclude certain warnings depending on the CLI command being executed. This is helpful with `db migrate-dev`, for example.

The reason this is needed is we do our error/warning checks during compilation, and we compile before we run every command. So if you have not yet migrated, it will warn you during compilation that you need to migrate, even if you are running `db migrate-dev`. In that case we should filter out that warning since it is redundant.

To address the ability to filter, I added a new `GeneratorWarning`. Additionally, I chose _not_ to change the `String` error/warning interface between `Lib.compile` and the CLI world, as that would be a pretty big change and I'm unsure of the benefit of including the warning types past that layer.

Fixes #597 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update