### PR TITLE
Make basic Wasp LSP server

### DIFF
--- a/waspls/.gitignore
+++ b/waspls/.gitignore
@@ -1,0 +1,8 @@
+dist-newstyle
+.hie
+
+*.orig
+*~
+.dir-locals.el
+.projectile
+.vscode

--- a/waspls/.hlint.yaml
+++ b/waspls/.hlint.yaml
@@ -1,0 +1,12 @@
+- arguments:
+  # NOTE: List of extensions below should reflect the list
+  #   of default extensions from package.yaml.
+  - -XOverloadedStrings
+  - -XScopedTypeVariables
+
+- ignore: {name: Use camelCase} # We can decide this on our own.
+- ignore: {name: Eta reduce} # We can decide this on our own.
+- ignore: {name: Use newtype instead of data} # We can decide this on our own.
+- ignore: {name: Use $>} # I find it makes code harder to read if enforced.
+- ignore: {name: Use list comprehension} # We can decide this on our own.
+- ignore: {name: Use ++} # I sometimes prefer concat over ++ due to the nicer formatting / extensibility.

--- a/waspls/CHANGELOG.md
+++ b/waspls/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for waspls
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/waspls/LICENSE
+++ b/waspls/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2022 Wasp Team
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/waspls/README.md
+++ b/waspls/README.md
@@ -12,21 +12,5 @@ adjusting this line in `cabal.project`.
 
 ## Usage
 
-Use in any place an LSP server can be used. Usage:
-
-```
-Usage: waspls [version] [-v|--version] [--log LOG_FILE] [--stdio]
-
-  LSP Server for the Wasp language
-
-Available options:
-  -h,--help                Show this help text
-  -v,--version             Display version
-  --log LOG_FILE           Write log output to this file, if present. If set to
-                           `[OUTPUT]`, log output is sent to the LSP client.
-  --stdio                  Use stdio (this flag is ignored, stdio is always
-                           used)
-
-Available commands:
-  version                  Display version
-```
+Use in any place an LSP server can be used. Run `waspls --help` for usage
+information.

--- a/waspls/README.md
+++ b/waspls/README.md
@@ -1,0 +1,11 @@
+# Waspls
+
+This directory contains source code of the `wasp` language server (aka `waspls`)
+and this README is aimed at the contributors to the project.
+
+## Overview
+
+`waspls` is implemented in Haskell. It depends on `waspc` for parsing and
+analyzing wasp source code. Cabal is currently configured to look in `../waspc`
+for the `waspc` package, so do not move `waspls` out of the `wasp` repo without
+adjusting this line in `cabal.project`.

--- a/waspls/README.md
+++ b/waspls/README.md
@@ -9,3 +9,24 @@ and this README is aimed at the contributors to the project.
 analyzing wasp source code. Cabal is currently configured to look in `../waspc`
 for the `waspc` package, so do not move `waspls` out of the `wasp` repo without
 adjusting this line in `cabal.project`.
+
+## Usage
+
+Use in any place an LSP server can be used. Usage:
+
+```
+Usage: waspls [version] [-v|--version] [--log LOG_FILE] [--stdio]
+
+  LSP Server for the Wasp language
+
+Available options:
+  -h,--help                Show this help text
+  -v,--version             Display version
+  --log LOG_FILE           Write log output to this file, if present. If set to
+                           `[OUTPUT]`, log output is sent to the LSP client.
+  --stdio                  Use stdio (this flag is ignored, stdio is always
+                           used)
+
+Available commands:
+  version                  Display version
+```

--- a/waspls/cabal.project
+++ b/waspls/cabal.project
@@ -1,0 +1,23 @@
+with-compiler: ghc-8.10.7
+
+packages: . ../waspc/
+
+package waspls
+  -- This causes cabal to build modules on all cores, instead of just one,
+  -- therefore reducing our build times.
+  -- NOTE: If this is enabled at the same time as cabal's parallelization on package-level,
+  --   it can have counter-effect of increasing compilation time due to cabal and ghc fighting
+  --   for common resource: cpu threads.
+  --   This is not a problem for us for now since we have only one package in our project.
+  ghc-options: -j
+
+-- This causes cabal to build packages on all cores, instead of just one.
+-- This doesn't help when developing a single local package, but instead helps when
+-- building multiple packages at once, for example external dependencies.
+jobs: $ncpus
+
+-- Ensures that tests print their output to stdout as they execute.
+test-show-details: direct
+
+-- WARNING: Run cabal update if your local package index is older than this date.
+index-state: 2022-03-22T14:16:26Z

--- a/waspls/exe/Main.hs
+++ b/waspls/exe/Main.hs
@@ -1,0 +1,57 @@
+module Main where
+
+import Data.Version (showVersion)
+import Options.Applicative
+import qualified Paths_waspls
+import Wasp.LSP.Server
+
+data Mode = Run | Version
+
+data Options = Options
+  { mode :: Mode,
+    version :: Bool,
+    logFile :: Maybe FilePath
+  }
+
+parseOptions :: Parser Options
+parseOptions = Options <$> parseMode <*> parseVersion <*> optional parseLogFile
+  where
+    parseLogFile =
+      strOption
+        ( long "log"
+            <> help "Write log output to this file, if present"
+            <> action "file"
+            <> metavar "LOG_FILE"
+        )
+
+    parseVersion =
+      switch
+        ( long "version"
+            <> short 'v'
+            <> help "Display version"
+        )
+
+    parseMode = hsubparser versionCommand <|> pure Run
+
+    versionCommand =
+      command
+        "version"
+        (info (pure Version) (fullDesc <> progDesc "Display version"))
+        <> metavar "version"
+
+parseInfo :: ParserInfo Options
+parseInfo =
+  info
+    (helper <*> parseOptions)
+    (progDesc "LSP Server for the Wasp language" <> fullDesc)
+
+main :: IO ()
+main = do
+  options <- execParser parseInfo
+  if version options
+    then printVersion
+    else case mode options of
+      Version -> printVersion
+      Run -> run $ logFile options
+  where
+    printVersion = putStrLn $ showVersion Paths_waspls.version

--- a/waspls/exe/Main.hs
+++ b/waspls/exe/Main.hs
@@ -7,18 +7,19 @@ import qualified Wasp.LSP.Server as LSP
 
 main :: IO ()
 main = do
-  args <- O.execParser parseArgsWithHelp
+  args <- parseArgsOrPrintUsageAndExit
   case command args of
     PrintVersion -> printVersion
     Serve -> LSP.serve $ optionsLogFile $ options args
   where
     printVersion = putStrLn $ showVersion Paths_waspls.version
 
-parseArgsWithHelp :: O.ParserInfo Args
-parseArgsWithHelp =
-  O.info
-    (O.helper <*> parseArgs)
-    (O.progDesc "LSP Server for the Wasp language" <> O.fullDesc)
+parseArgsOrPrintUsageAndExit :: IO Args
+parseArgsOrPrintUsageAndExit =
+  O.execParser $
+    O.info
+      (O.helper <*> parseArgs)
+      (O.progDesc "LSP Server for the Wasp language" <> O.fullDesc)
 
 data Args = Args
   { command :: Command,

--- a/waspls/exe/Main.hs
+++ b/waspls/exe/Main.hs
@@ -5,21 +5,39 @@ import Options.Applicative
 import qualified Paths_waspls
 import Wasp.LSP.Server
 
+main :: IO ()
+main = do
+  options <- execParser parse
+  if version options
+    then printVersion
+    else case mode options of
+      Version -> printVersion
+      Run -> run $ logFile options
+  where
+    printVersion = putStrLn $ showVersion Paths_waspls.version
+
+parse :: ParserInfo Options
+parse =
+  info
+    (helper <*> parseOptions)
+    (progDesc "LSP Server for the Wasp language" <> fullDesc)
+
 data Mode = Run | Version
 
 data Options = Options
   { mode :: Mode,
     version :: Bool,
-    logFile :: Maybe FilePath
+    logFile :: Maybe FilePath,
+    useStdio :: Bool
   }
 
 parseOptions :: Parser Options
-parseOptions = Options <$> parseMode <*> parseVersion <*> optional parseLogFile
+parseOptions = Options <$> parseMode <*> parseVersion <*> optional parseLogFile <*> parseStdio
   where
     parseLogFile =
       strOption
         ( long "log"
-            <> help "Write log output to this file, if present"
+            <> help "Write log output to this file, if present. If set to `[OUTPUT]`, log output is sent to the LSP client."
             <> action "file"
             <> metavar "LOG_FILE"
         )
@@ -31,6 +49,14 @@ parseOptions = Options <$> parseMode <*> parseVersion <*> optional parseLogFile
             <> help "Display version"
         )
 
+    -- vscode passes this option to the language server. waspls always uses stdio,
+    -- so this switch is ignored.
+    parseStdio =
+      switch
+        ( long "stdio"
+            <> help "Use stdio (this flag is ignored, stdio is always used)"
+        )
+
     parseMode = hsubparser versionCommand <|> pure Run
 
     versionCommand =
@@ -38,20 +64,3 @@ parseOptions = Options <$> parseMode <*> parseVersion <*> optional parseLogFile
         "version"
         (info (pure Version) (fullDesc <> progDesc "Display version"))
         <> metavar "version"
-
-parseInfo :: ParserInfo Options
-parseInfo =
-  info
-    (helper <*> parseOptions)
-    (progDesc "LSP Server for the Wasp language" <> fullDesc)
-
-main :: IO ()
-main = do
-  options <- execParser parseInfo
-  if version options
-    then printVersion
-    else case mode options of
-      Version -> printVersion
-      Run -> run $ logFile options
-  where
-    printVersion = putStrLn $ showVersion Paths_waspls.version

--- a/waspls/exe/Main.hs
+++ b/waspls/exe/Main.hs
@@ -37,7 +37,7 @@ parseOptions = Options <$> parseMode <*> parseVersion <*> optional parseLogFile 
     parseLogFile =
       strOption
         ( long "log"
-            <> help "Write log output to this file, if present. If set to `[OUTPUT]`, log output is sent to the LSP client."
+            <> help "Write log output to this file, if present. If not present, no logs are written. If set to `[OUTPUT]`, log output is sent to the LSP client."
             <> action "file"
             <> metavar "LOG_FILE"
         )
@@ -46,7 +46,7 @@ parseOptions = Options <$> parseMode <*> parseVersion <*> optional parseLogFile 
       switch
         ( long "version"
             <> short 'v'
-            <> help "Display version"
+            <> help "Display version and exit"
         )
 
     -- vscode passes this option to the language server. waspls always uses stdio,
@@ -62,5 +62,5 @@ parseOptions = Options <$> parseMode <*> parseVersion <*> optional parseLogFile 
     versionCommand =
       command
         "version"
-        (info (pure Version) (fullDesc <> progDesc "Display version"))
+        (info (pure Version) (fullDesc <> progDesc "Display version and exit"))
         <> metavar "version"

--- a/waspls/hie.yaml
+++ b/waspls/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/waspls/src/Wasp/LSP/Core.hs
+++ b/waspls/src/Wasp/LSP/Core.hs
@@ -1,7 +1,7 @@
 module Wasp.LSP.Core
   ( ServerM,
     Severity (..),
-    State,
+    ServerState,
     ServerConfig,
   )
 where
@@ -15,7 +15,7 @@ import Data.Text (Text)
 import Language.LSP.Server (LspT)
 
 type ServerM =
-  ExceptT (Severity, Text) (StateT State (LspT ServerConfig IO))
+  ExceptT (Severity, Text) (StateT ServerState (LspT ServerConfig IO))
 
 -- | Error severity levels
 data Severity
@@ -40,7 +40,7 @@ instance FromJSON ServerConfig where
       "parsing ServerConfig failed, "
       (typeMismatch "Object" invalid)
 
-data State = State {}
+data ServerState = ServerState {}
 
-instance Default State where
-  def = State {}
+instance Default ServerState where
+  def = ServerState {}

--- a/waspls/src/Wasp/LSP/Core.hs
+++ b/waspls/src/Wasp/LSP/Core.hs
@@ -1,5 +1,5 @@
-module Wasp.LSP.State
-  ( HandlerM,
+module Wasp.LSP.Core
+  ( ServerM,
     Severity (..),
     State,
     ServerConfig,
@@ -14,10 +14,10 @@ import Data.Default (Default (def))
 import Data.Text (Text)
 import Language.LSP.Server (LspT)
 
-type HandlerM =
+type ServerM =
   ExceptT (Severity, Text) (StateT State (LspT ServerConfig IO))
 
--- | Log levels
+-- | Error severity levels
 data Severity
   = -- | Displayed to user as an error
     Error

--- a/waspls/src/Wasp/LSP/Core.hs
+++ b/waspls/src/Wasp/LSP/Core.hs
@@ -18,6 +18,9 @@ import Language.LSP.Server (LspT)
 type ServerM =
   ExceptT ServerError (StateT ServerState (LspT ServerConfig IO))
 
+-- | The type for a language server error. These are separate from diagnostics
+-- and should be reported when the server fails to process a request/notification
+-- for some reason.
 data ServerError = ServerError Severity Text
 
 -- | Error severity levels

--- a/waspls/src/Wasp/LSP/Core.hs
+++ b/waspls/src/Wasp/LSP/Core.hs
@@ -1,5 +1,6 @@
 module Wasp.LSP.Core
   ( ServerM,
+    ServerError (..),
     Severity (..),
     ServerState,
     ServerConfig,
@@ -15,7 +16,9 @@ import Data.Text (Text)
 import Language.LSP.Server (LspT)
 
 type ServerM =
-  ExceptT (Severity, Text) (StateT ServerState (LspT ServerConfig IO))
+  ExceptT ServerError (StateT ServerState (LspT ServerConfig IO))
+
+data ServerError = ServerError Severity Text
 
 -- | Error severity levels
 data Severity

--- a/waspls/src/Wasp/LSP/Handlers.hs
+++ b/waspls/src/Wasp/LSP/Handlers.hs
@@ -14,62 +14,70 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Language.LSP.Server (Handlers, LspT)
 import qualified Language.LSP.Server as LSP
-import Language.LSP.Types
-import Language.LSP.Types.Lens
+import qualified Language.LSP.Types as J
+import qualified Language.LSP.Types.Lens as J
 import Language.LSP.VFS (virtualFileText)
 import qualified Wasp.Analyzer
 import qualified Wasp.Analyzer.AnalyzeError as WE
 import Wasp.Analyzer.Parser (Ctx (Ctx))
 import Wasp.Analyzer.Parser.SourceRegion (getRgnEnd, getRgnStart)
-import Wasp.LSP.State (HandlerM, ServerConfig, Severity (..))
+import Wasp.LSP.Core (ServerConfig, ServerM, Severity (..))
 
 -- LSP notification and request handlers
 
 -- | "Initialized" notification is sent when the client is started. We don't
 -- have anything we need to do at initialization, but this is required to be
 -- implemented.
-initializedHandler :: Handlers HandlerM
+--
+-- The client starts the LSP at its own discretion, but commonly this is done
+-- either when:
+--
+-- - A file of the associated language is opened (in this case `.wasp`)
+-- - A workspace is opened that has a project structure associated with the
+--   language (in this case, a `main.wasp` file in the root folder of the
+--   workspace)
+initializedHandler :: Handlers ServerM
 initializedHandler =
-  LSP.notificationHandler SInitialized $ \_ -> return ()
+  LSP.notificationHandler J.SInitialized $ const (return ())
 
 -- | "TextDocumentDidOpen" is sent by the client when a new document is opened.
--- This handler then runs the `diagnosticsHandler`.
-didOpenHandler :: Handlers HandlerM
+-- `diagnoseWaspFile` is run to analyze the newly opened document.
+didOpenHandler :: Handlers ServerM
 didOpenHandler =
-  LSP.notificationHandler STextDocumentDidOpen $ diagnosticsHandler . extractUri
+  LSP.notificationHandler J.STextDocumentDidOpen $ diagnoseWaspFile . extractUri
 
 -- | "TextDocumentDidChange" is sent by the client when a document is changed
--- (i.e. when the user types/deletes text). This handler then runs the
--- `diagnosticsHandler`.
-didChangeHandler :: Handlers HandlerM
+-- (i.e. when the user types/deletes text). `diagnoseWaspFile` is run to
+-- analyze the changed document.
+didChangeHandler :: Handlers ServerM
 didChangeHandler =
-  LSP.notificationHandler STextDocumentDidChange $ diagnosticsHandler . extractUri
+  LSP.notificationHandler J.STextDocumentDidChange $ diagnoseWaspFile . extractUri
 
--- | "TextDocumentDidSave" is sent by the client when a document is saved. This
--- handler then runs the `diagnosticsHandler`.
-didSaveHandler :: Handlers HandlerM
+-- | "TextDocumentDidSave" is sent by the client when a document is saved.
+-- `diagnoseWaspFile` is run to analyze the new contents of the document.
+didSaveHandler :: Handlers ServerM
 didSaveHandler =
-  LSP.notificationHandler STextDocumentDidSave $ diagnosticsHandler . extractUri
+  LSP.notificationHandler J.STextDocumentDidSave $ diagnoseWaspFile . extractUri
 
--- | Does not directly handle a notification or event, but should be run
+-- | Does not directly handle a notification or event, but should be run when
 -- text document content changes.
 --
 -- It analyzes the document contents and sends any error messages back to the
 -- LSP client. In the future, it will also store information about the analyzed
 -- file in "Wasp.LSP.State.State".
-diagnosticsHandler :: Uri -> HandlerM ()
-diagnosticsHandler _uri = do
-  src <- readVFSFile _uri
+diagnoseWaspFile :: J.Uri -> ServerM ()
+diagnoseWaspFile uri = do
+  src <- readVFSFile uri
   let analyzeResult = Wasp.Analyzer.analyze $ T.unpack src
-  diags <- case analyzeResult of
+  diagnostics <- case analyzeResult of
     -- Valid wasp file, send no diagnostics
-    Right _ -> return $ List []
+    Right _ -> return $ J.List []
     -- Report the error (for now, just one error per analyze is possible)
     Left err -> do
       let (errMsg, errSrc, errRange) = getErrorDiagnostics err
       return $
-        List
-          [ Diagnostic
+        J.List
+          [ J.Diagnostic
               { _range = errRange,
                 _severity = Nothing,
                 _code = Nothing,
@@ -80,44 +88,44 @@ diagnosticsHandler _uri = do
               }
           ]
   liftLSP $
-    LSP.sendNotification STextDocumentPublishDiagnostics $
-      PublishDiagnosticsParams _uri Nothing diags
+    LSP.sendNotification J.STextDocumentPublishDiagnostics $
+      J.PublishDiagnosticsParams uri Nothing diagnostics
   where
-    getErrorDiagnostics :: WE.AnalyzeError -> (Text, Text, Range)
+    getErrorDiagnostics :: WE.AnalyzeError -> (Text, Text, J.Range)
     getErrorDiagnostics err =
       let errSrc = case err of
             WE.ParseError _ -> "parse"
             WE.TypeError _ -> "typecheck"
             WE.EvaluationError _ -> "evaluate"
           (errMsg, errCtx) = WE.getErrorMessageAndCtx err
-       in (T.pack errMsg, errSrc, ctxToRange errCtx)
+       in (T.pack errMsg, errSrc, waspCtxToLspRange errCtx)
 
-    ctxToRange :: Ctx -> Range
-    ctxToRange (Ctx region) =
-      Range
-        { _start = sourcePositionToPosition (getRgnStart region),
+    waspCtxToLspRange :: Ctx -> J.Range
+    waspCtxToLspRange (Ctx region) =
+      J.Range
+        { _start = waspSourcePositionToLspPosition (getRgnStart region),
           -- Increment end character by 1: Wasp uses an inclusive convention for
           -- the end position, but LSP considers end position to not be part of
           -- the range.
-          _end = sourcePositionToPosition (getRgnEnd region) & character +~ (1 :: UInt)
+          _end = waspSourcePositionToLspPosition (getRgnEnd region) & J.character +~ (1 :: J.UInt)
         }
 
-    sourcePositionToPosition (WE.SourcePosition l c) =
-      Position (fromIntegral $ l - 1) (fromIntegral $ c - 1)
+    waspSourcePositionToLspPosition (WE.SourcePosition l c) =
+      J.Position (fromIntegral $ l - 1) (fromIntegral $ c - 1)
 
 -- | Run a LSP function in the "HandlerM" monad.
-liftLSP :: LspT ServerConfig IO a -> HandlerM a
+liftLSP :: LspT ServerConfig IO a -> ServerM a
 liftLSP m = lift (lift m)
 
 -- | Read the contents of a "Uri" in the virtual file system maintained by the
 -- LSP library.
-readVFSFile :: Uri -> HandlerM Text
-readVFSFile _uri = do
-  mVirtualFile <- liftLSP $ LSP.getVirtualFile $ toNormalizedUri _uri
+readVFSFile :: J.Uri -> ServerM Text
+readVFSFile uri = do
+  mVirtualFile <- liftLSP $ LSP.getVirtualFile $ J.toNormalizedUri uri
   case mVirtualFile of
     Just virtualFile -> return $ virtualFileText virtualFile
-    Nothing -> throwE (Error, "Could not find " <> T.pack (show _uri) <> " in VFS.")
+    Nothing -> throwE (Error, "Could not find " <> T.pack (show uri) <> " in VFS.")
 
 -- | Get the "Uri" from an object that has a "TextDocument".
-extractUri :: (HasParams a b, HasTextDocument b c, HasUri c Uri) => a -> Uri
-extractUri = (^. (params . textDocument . uri))
+extractUri :: (J.HasParams a b, J.HasTextDocument b c, J.HasUri c J.Uri) => a -> J.Uri
+extractUri = (^. (J.params . J.textDocument . J.uri))

--- a/waspls/src/Wasp/LSP/Handlers.hs
+++ b/waspls/src/Wasp/LSP/Handlers.hs
@@ -21,7 +21,7 @@ import qualified Wasp.Analyzer
 import qualified Wasp.Analyzer.AnalyzeError as WE
 import Wasp.Analyzer.Parser (Ctx (Ctx))
 import Wasp.Analyzer.Parser.SourceRegion (getRgnEnd, getRgnStart)
-import Wasp.LSP.Core (ServerConfig, ServerM, Severity (..))
+import Wasp.LSP.Core (ServerConfig, ServerError (ServerError), ServerM, Severity (..))
 
 -- LSP notification and request handlers
 
@@ -124,7 +124,7 @@ readVFSFile uri = do
   mVirtualFile <- liftLSP $ LSP.getVirtualFile $ LSP.toNormalizedUri uri
   case mVirtualFile of
     Just virtualFile -> return $ virtualFileText virtualFile
-    Nothing -> throwE (Error, "Could not find " <> T.pack (show uri) <> " in VFS.")
+    Nothing -> throwE $ ServerError Error $ "Could not find " <> T.pack (show uri) <> " in VFS."
 
 -- | Get the "Uri" from an object that has a "TextDocument".
 extractUri :: (LSP.HasParams a b, LSP.HasTextDocument b c, LSP.HasUri c LSP.Uri) => a -> LSP.Uri

--- a/waspls/src/Wasp/LSP/Handlers.hs
+++ b/waspls/src/Wasp/LSP/Handlers.hs
@@ -1,0 +1,118 @@
+module Wasp.LSP.Handlers
+  ( initializedHandler,
+    didOpenHandler,
+    didChangeHandler,
+    didSaveHandler,
+  )
+where
+
+import Control.Lens ((+~), (^.))
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Except (catchE, throwE)
+import Data.Function ((&))
+import Data.Text (Text)
+import qualified Data.Text as T
+import Language.LSP.Server (Handlers, LspT)
+import qualified Language.LSP.Server as LSP
+import Language.LSP.Types
+import Language.LSP.Types.Lens
+import Language.LSP.VFS (virtualFileText)
+import qualified Wasp.Analyzer
+import qualified Wasp.Analyzer.AnalyzeError as WE
+import Wasp.Analyzer.Parser (Ctx (Ctx))
+import Wasp.Analyzer.Parser.SourceRegion (getRgnEnd, getRgnStart)
+import Wasp.LSP.State (HandlerM, ServerConfig, Severity (..), State)
+
+liftLSP :: LspT ServerConfig IO a -> HandlerM a
+liftLSP m = lift (lift m)
+
+readUri :: Uri -> HandlerM Text
+readUri _uri = do
+  mVirtualFile <- liftLSP $ LSP.getVirtualFile $ toNormalizedUri _uri
+  case mVirtualFile of
+    Just virtualFile -> return $ virtualFileText virtualFile
+    Nothing -> throwE (Error, "Could not find " <> T.pack (show _uri) <> " in VFS.")
+
+extractUri :: (HasParams a b, HasTextDocument b c, HasUri c Uri) => a -> Uri
+extractUri = (^. (params . textDocument . uri))
+
+initializedHandler :: Handlers HandlerM
+initializedHandler =
+  LSP.notificationHandler SInitialized $ \_ -> return ()
+
+didOpenHandler :: Handlers HandlerM
+didOpenHandler =
+  LSP.notificationHandler STextDocumentDidOpen $ diagnosticsHandler . extractUri
+
+-- TODO: is performance bad doing this on every change?
+didChangeHandler :: Handlers HandlerM
+didChangeHandler =
+  LSP.notificationHandler STextDocumentDidChange $ diagnosticsHandler . extractUri
+
+didSaveHandler :: Handlers HandlerM
+didSaveHandler =
+  LSP.notificationHandler STextDocumentDidSave $ diagnosticsHandler . extractUri
+
+diagnosticsHandler :: Uri -> HandlerM ()
+diagnosticsHandler _uri = do
+  src <- readUri _uri
+  let analyzeResult = Wasp.Analyzer.analyze $ T.unpack src
+  diags <- case analyzeResult of
+    -- Valid wasp file, send no diagnostics
+    Right _ -> return $ List []
+    -- Report the error (for now, just one error per analyze is possible)
+    Left err -> do
+      let (errMsg, errSrc, errRange) = getErrorDiagnostics err
+      return $
+        List
+          [ Diagnostic
+              { _range = errRange,
+                _severity = Nothing,
+                _code = Nothing,
+                _source = Just errSrc,
+                _message = errMsg,
+                _tags = Nothing,
+                _relatedInformation = Nothing
+              }
+          ]
+  liftLSP $
+    LSP.sendNotification STextDocumentPublishDiagnostics $
+      PublishDiagnosticsParams _uri Nothing diags
+  where
+    getErrorDiagnostics :: WE.AnalyzeError -> (Text, Text, Range)
+    getErrorDiagnostics err =
+      let errSrc = case err of
+            WE.ParseError _ -> "parse"
+            WE.TypeError _ -> "typecheck"
+            WE.EvaluationError _ -> "evaluate"
+          (errMsg, errCtx) = WE.getErrorMessageAndCtx err
+       in (T.pack errMsg, errSrc, ctxToRange errCtx)
+
+    ctxToRange :: Ctx -> Range
+    ctxToRange (Ctx region) =
+      Range
+        { _start = sourcePositionToPosition (getRgnStart region),
+          _end = sourcePositionToPosition (getRgnEnd region) & character +~ (1 :: UInt)
+        }
+
+    sourcePositionToPosition (WE.SourcePosition l c) =
+      Position (fromIntegral $ l - 1) (fromIntegral $ c - 1)
+
+handleErrorWithDefault :: (Either a b -> HandlerM c) -> b -> HandlerM c -> HandlerM c
+handleErrorWithDefault respond _def = flip catchE handler
+  where
+    handler (Log, _message) = do
+      liftLSP $
+        LSP.sendNotification SWindowLogMessage $
+          LogMessageParams {_xtype = MtLog, _message = _message}
+      respond (Right _def)
+    handler (_severity, _message) = do
+      let _xtype = case _severity of
+            Error -> MtError
+            Warning -> MtWarning
+            Info -> MtInfo
+            Log -> MtLog
+      liftLSP $
+        LSP.sendNotification SWindowShowMessage $
+          ShowMessageParams {_xtype = _xtype, _message = _message}
+      respond (Right _def)

--- a/waspls/src/Wasp/LSP/Handlers.hs
+++ b/waspls/src/Wasp/LSP/Handlers.hs
@@ -14,8 +14,8 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Language.LSP.Server (Handlers, LspT)
 import qualified Language.LSP.Server as LSP
-import qualified Language.LSP.Types as J
-import qualified Language.LSP.Types.Lens as J
+import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types.Lens as LSP
 import Language.LSP.VFS (virtualFileText)
 import qualified Wasp.Analyzer
 import qualified Wasp.Analyzer.AnalyzeError as WE
@@ -38,26 +38,26 @@ import Wasp.LSP.Core (ServerConfig, ServerM, Severity (..))
 --   workspace)
 initializedHandler :: Handlers ServerM
 initializedHandler =
-  LSP.notificationHandler J.SInitialized $ const (return ())
+  LSP.notificationHandler LSP.SInitialized $ const (return ())
 
 -- | "TextDocumentDidOpen" is sent by the client when a new document is opened.
 -- `diagnoseWaspFile` is run to analyze the newly opened document.
 didOpenHandler :: Handlers ServerM
 didOpenHandler =
-  LSP.notificationHandler J.STextDocumentDidOpen $ diagnoseWaspFile . extractUri
+  LSP.notificationHandler LSP.STextDocumentDidOpen $ diagnoseWaspFile . extractUri
 
 -- | "TextDocumentDidChange" is sent by the client when a document is changed
 -- (i.e. when the user types/deletes text). `diagnoseWaspFile` is run to
 -- analyze the changed document.
 didChangeHandler :: Handlers ServerM
 didChangeHandler =
-  LSP.notificationHandler J.STextDocumentDidChange $ diagnoseWaspFile . extractUri
+  LSP.notificationHandler LSP.STextDocumentDidChange $ diagnoseWaspFile . extractUri
 
 -- | "TextDocumentDidSave" is sent by the client when a document is saved.
 -- `diagnoseWaspFile` is run to analyze the new contents of the document.
 didSaveHandler :: Handlers ServerM
 didSaveHandler =
-  LSP.notificationHandler J.STextDocumentDidSave $ diagnoseWaspFile . extractUri
+  LSP.notificationHandler LSP.STextDocumentDidSave $ diagnoseWaspFile . extractUri
 
 -- | Does not directly handle a notification or event, but should be run when
 -- text document content changes.
@@ -65,19 +65,19 @@ didSaveHandler =
 -- It analyzes the document contents and sends any error messages back to the
 -- LSP client. In the future, it will also store information about the analyzed
 -- file in "Wasp.LSP.State.State".
-diagnoseWaspFile :: J.Uri -> ServerM ()
+diagnoseWaspFile :: LSP.Uri -> ServerM ()
 diagnoseWaspFile uri = do
   src <- readVFSFile uri
-  let analyzeResult = Wasp.Analyzer.analyze $ T.unpack src
-  diagnostics <- case analyzeResult of
+  let appSpecOrError = Wasp.Analyzer.analyze $ T.unpack src
+  diagnostics <- case appSpecOrError of
     -- Valid wasp file, send no diagnostics
-    Right _ -> return $ J.List []
+    Right _ -> return $ LSP.List []
     -- Report the error (for now, just one error per analyze is possible)
     Left err -> do
-      let (errMsg, errSrc, errRange) = getErrorDiagnostics err
+      let (errMsg, errSrc, errRange) = waspErrorToLspDiagnostic err
       return $
-        J.List
-          [ J.Diagnostic
+        LSP.List
+          [ LSP.Diagnostic
               { _range = errRange,
                 _severity = Nothing,
                 _code = Nothing,
@@ -88,11 +88,11 @@ diagnoseWaspFile uri = do
               }
           ]
   liftLSP $
-    LSP.sendNotification J.STextDocumentPublishDiagnostics $
-      J.PublishDiagnosticsParams uri Nothing diagnostics
+    LSP.sendNotification LSP.STextDocumentPublishDiagnostics $
+      LSP.PublishDiagnosticsParams uri Nothing diagnostics
   where
-    getErrorDiagnostics :: WE.AnalyzeError -> (Text, Text, J.Range)
-    getErrorDiagnostics err =
+    waspErrorToLspDiagnostic :: WE.AnalyzeError -> (Text, Text, LSP.Range)
+    waspErrorToLspDiagnostic err =
       let errSrc = case err of
             WE.ParseError _ -> "parse"
             WE.TypeError _ -> "typecheck"
@@ -100,32 +100,32 @@ diagnoseWaspFile uri = do
           (errMsg, errCtx) = WE.getErrorMessageAndCtx err
        in (T.pack errMsg, errSrc, waspCtxToLspRange errCtx)
 
-    waspCtxToLspRange :: Ctx -> J.Range
+    waspCtxToLspRange :: Ctx -> LSP.Range
     waspCtxToLspRange (Ctx region) =
-      J.Range
+      LSP.Range
         { _start = waspSourcePositionToLspPosition (getRgnStart region),
           -- Increment end character by 1: Wasp uses an inclusive convention for
           -- the end position, but LSP considers end position to not be part of
           -- the range.
-          _end = waspSourcePositionToLspPosition (getRgnEnd region) & J.character +~ (1 :: J.UInt)
+          _end = waspSourcePositionToLspPosition (getRgnEnd region) & LSP.character +~ (1 :: LSP.UInt)
         }
 
     waspSourcePositionToLspPosition (WE.SourcePosition l c) =
-      J.Position (fromIntegral $ l - 1) (fromIntegral $ c - 1)
+      LSP.Position (fromIntegral $ l - 1) (fromIntegral $ c - 1)
 
--- | Run a LSP function in the "HandlerM" monad.
+-- | Run a LSP function in the "ServerM" monad.
 liftLSP :: LspT ServerConfig IO a -> ServerM a
 liftLSP m = lift (lift m)
 
 -- | Read the contents of a "Uri" in the virtual file system maintained by the
 -- LSP library.
-readVFSFile :: J.Uri -> ServerM Text
+readVFSFile :: LSP.Uri -> ServerM Text
 readVFSFile uri = do
-  mVirtualFile <- liftLSP $ LSP.getVirtualFile $ J.toNormalizedUri uri
+  mVirtualFile <- liftLSP $ LSP.getVirtualFile $ LSP.toNormalizedUri uri
   case mVirtualFile of
     Just virtualFile -> return $ virtualFileText virtualFile
     Nothing -> throwE (Error, "Could not find " <> T.pack (show uri) <> " in VFS.")
 
 -- | Get the "Uri" from an object that has a "TextDocument".
-extractUri :: (J.HasParams a b, J.HasTextDocument b c, J.HasUri c J.Uri) => a -> J.Uri
-extractUri = (^. (J.params . J.textDocument . J.uri))
+extractUri :: (LSP.HasParams a b, LSP.HasTextDocument b c, LSP.HasUri c LSP.Uri) => a -> LSP.Uri
+extractUri = (^. (LSP.params . LSP.textDocument . LSP.uri))

--- a/waspls/src/Wasp/LSP/Server.hs
+++ b/waspls/src/Wasp/LSP/Server.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Wasp.LSP.Server
   ( serve,

--- a/waspls/src/Wasp/LSP/Server.hs
+++ b/waspls/src/Wasp/LSP/Server.hs
@@ -74,6 +74,7 @@ setupLspLogger Nothing = pure ()
 setupLspLogger (Just "[OUTPUT]") = LSP.setupLogger Nothing [] System.Log.Logger.DEBUG
 setupLspLogger file = LSP.setupLogger file [] System.Log.Logger.DEBUG
 
+-- | Returns either a JSON parsing error message or the updated "ServerConfig".
 lspServerUpdateConfig :: ServerConfig -> Aeson.Value -> Either Text.Text ServerConfig
 lspServerUpdateConfig _oldConfig json =
   case Aeson.fromJSON json of

--- a/waspls/src/Wasp/LSP/Server.hs
+++ b/waspls/src/Wasp/LSP/Server.hs
@@ -1,0 +1,7 @@
+module Wasp.LSP.Server
+  ( run,
+  )
+where
+
+run :: Maybe FilePath -> IO ()
+run logFile = putStrLn $ "Hello from waspls (logging to " ++ show logFile ++ ")"

--- a/waspls/src/Wasp/LSP/Server.hs
+++ b/waspls/src/Wasp/LSP/Server.hs
@@ -19,7 +19,7 @@ import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP
 import System.Exit (ExitCode (ExitFailure), exitWith)
 import qualified System.Log.Logger
-import Wasp.LSP.Core (ServerConfig, ServerM, ServerState, Severity (..))
+import Wasp.LSP.Core (ServerConfig, ServerError (ServerError), ServerM, ServerState, Severity (..))
 import Wasp.LSP.Handlers
 
 serve :: Maybe FilePath -> IO ()
@@ -40,7 +40,7 @@ serve maybeLogFile = do
               LSP.runLspT env do
                 (e, newState) <- State.runStateT (Except.runExceptT handler) oldState
                 result <- case e of
-                  Left (severity, errMessage) -> sendErrorMessage severity errMessage
+                  Left (ServerError severity errMessage) -> sendErrorMessage severity errMessage
                   Right a -> return a
 
                 return (newState, result)
@@ -117,7 +117,7 @@ syncOptions =
       _willSave = Just False,
       -- Don't send will-save-wait-until notifications to the server.
       _willSaveWaitUntil = Just False,
-      -- Don't send save notifications to the server.
+      -- Send save notifications to the server.
       _save = Just (LSP.InR (LSP.SaveOptions (Just True)))
     }
 

--- a/waspls/src/Wasp/LSP/Server.hs
+++ b/waspls/src/Wasp/LSP/Server.hs
@@ -1,7 +1,107 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+
 module Wasp.LSP.Server
   ( run,
   )
 where
 
+import qualified Control.Concurrent.MVar as MVar
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import qualified Control.Monad.Trans.Except as Except
+import qualified Control.Monad.Trans.State.Strict as State
+import qualified Data.Aeson as Aeson
+import Data.Default (Default (def))
+import qualified Data.Text as Text
+import Language.LSP.Server (Options (..), ServerDefinition (..), type (<~>) (..))
+import qualified Language.LSP.Server as LSP
+import Language.LSP.Types (TextDocumentSyncOptions (..))
+import qualified Language.LSP.Types as J
+import System.Exit (ExitCode (ExitFailure), exitWith)
+import qualified System.Log.Logger
+import Wasp.LSP.Handlers
+import Wasp.LSP.State (HandlerM, ServerConfig, Severity (..), State)
+
 run :: Maybe FilePath -> IO ()
-run logFile = putStrLn $ "Hello from waspls (logging to " ++ show logFile ++ ")"
+run maybeLogFile = do
+  case maybeLogFile of
+    Nothing -> pure ()
+    Just "[OUTPUT]" -> LSP.setupLogger Nothing [] System.Log.Logger.DEBUG
+    file -> LSP.setupLogger file [] System.Log.Logger.DEBUG
+
+  state <- MVar.newMVar (def :: State)
+
+  let opts =
+        def
+          { textDocumentSync = Just syncOptions,
+            completionTriggerCharacters = Just [':']
+          }
+
+  let initialize env _req = return (Right env)
+
+  let onConfigChange _oldConfig json =
+        case Aeson.fromJSON json of
+          Aeson.Success config -> Right config
+          Aeson.Error string -> Left (Text.pack string)
+
+  let handlers =
+        mconcat
+          [ initializedHandler,
+            didOpenHandler,
+            didSaveHandler,
+            didChangeHandler
+          ]
+
+  let interpret env = Iso {forward = runHandler, backward = liftIO}
+        where
+          runHandler :: HandlerM a -> IO a
+          runHandler handler =
+            MVar.modifyMVar state \oldState -> do
+              LSP.runLspT env do
+                (e, newState) <- State.runStateT (Except.runExceptT handler) oldState
+                result <- case e of
+                  Left (Log, _message) -> do
+                    let _xtype = J.MtLog
+
+                    LSP.sendNotification J.SWindowLogMessage $
+                      J.LogMessageParams {_xtype = _xtype, _message = _message}
+                    liftIO (fail (Text.unpack _message))
+                  Left (severity_, _message) -> do
+                    let _xtype = case severity_ of
+                          Error -> J.MtError
+                          Warning -> J.MtWarning
+                          Info -> J.MtInfo
+                          Log -> J.MtLog
+
+                    LSP.sendNotification J.SWindowShowMessage $
+                      J.ShowMessageParams {_xtype = _xtype, _message = _message}
+                    liftIO (fail (Text.unpack _message))
+                  Right a -> do
+                    return a
+
+                return (newState, result)
+
+  exitCode <-
+    LSP.runServer
+      ServerDefinition
+        { defaultConfig = def :: ServerConfig,
+          onConfigurationChange = onConfigChange,
+          doInitialize = initialize,
+          staticHandlers = handlers,
+          interpretHandler = interpret,
+          options = opts
+        }
+
+  case exitCode of
+    0 -> return ()
+    n -> exitWith (ExitFailure n)
+
+syncOptions :: TextDocumentSyncOptions
+syncOptions =
+  TextDocumentSyncOptions
+    { _openClose = Just True,
+      _change = Just J.TdSyncIncremental,
+      _willSave = Just False,
+      _willSaveWaitUntil = Just False,
+      _save = Just (J.InR (J.SaveOptions (Just False)))
+    }

--- a/waspls/src/Wasp/LSP/State.hs
+++ b/waspls/src/Wasp/LSP/State.hs
@@ -1,0 +1,46 @@
+module Wasp.LSP.State
+  ( HandlerM,
+    Severity (..),
+    State,
+    ServerConfig,
+  )
+where
+
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.State.Strict (StateT)
+import Data.Aeson
+import Data.Aeson.Types (prependFailure, typeMismatch)
+import Data.Default (Default (def))
+import Data.Text (Text)
+import Language.LSP.Server (LspT)
+
+type HandlerM =
+  ExceptT (Severity, Text) (StateT State (LspT ServerConfig IO))
+
+-- | Log levels
+data Severity
+  = -- | Displayed to user as an error
+    Error
+  | -- | Displayed to user as a warning
+    Warning
+  | -- | Displayed to user
+    Info
+  | -- | Not displayed to the user
+    Log
+
+data ServerConfig = ServerConfig {}
+
+instance Default ServerConfig where
+  def = ServerConfig {}
+
+instance FromJSON ServerConfig where
+  parseJSON (Object _) = pure ServerConfig
+  parseJSON invalid =
+    prependFailure
+      "parsing ServerConfig failed, "
+      (typeMismatch "Object" invalid)
+
+data State = State {}
+
+instance Default State where
+  def = State {}

--- a/waspls/waspls.cabal
+++ b/waspls/waspls.cabal
@@ -27,6 +27,9 @@ common common-all
   default-extensions:
     OverloadedStrings
     ScopedTypeVariables
+    FlexibleContexts
+    MultiParamTypeClasses
+    DisambiguateRecordFields
 
 common common-exe
   ghc-options:
@@ -36,6 +39,8 @@ library
   import:           common-all
   exposed-modules:
     Wasp.LSP.Server
+    Wasp.LSP.State
+    Wasp.LSP.Handlers
   other-modules:
     Paths_waspls
   hs-source-dirs:
@@ -46,8 +51,12 @@ library
     , lsp-types ^>=1.4.0.1
     , containers ^>=0.6.5.1
     , mtl ^>=2.2.2
+    , transformers ^>=0.5.6.2
     , text ^>=1.2.4.1
     , data-default ^>=0.7.1.1
+    , hslogger ^>=1.3.1.0
+    , aeson ^>=1.5.6
+    , lens ^>=5.1
     , waspc
 
 executable waspls

--- a/waspls/waspls.cabal
+++ b/waspls/waspls.cabal
@@ -1,5 +1,8 @@
 cabal-version:      2.4
 
+-- TODO: It make sense in the future to move this into "waspc" project as a
+-- separate project, but for now it is separated.
+
 name:               waspls
 version:            0.1.0.0
 description:        Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspls#readme>
@@ -39,7 +42,7 @@ library
   import:           common-all
   exposed-modules:
     Wasp.LSP.Server
-    Wasp.LSP.State
+    Wasp.LSP.Core
     Wasp.LSP.Handlers
   other-modules:
     Paths_waspls

--- a/waspls/waspls.cabal
+++ b/waspls/waspls.cabal
@@ -1,0 +1,64 @@
+cabal-version:      2.4
+
+name:               waspls
+version:            0.1.0.0
+description:        Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspls#readme>
+homepage:           https://github.com/wasp-lang/wasp/waspls#readme
+bug-reports:        https://github.com/wasp-lang/wasp/issues
+author:             Wasp Team
+maintainer:         team@wasp-lang.dev
+copyright:          Wasp, Inc.
+license:            MIT
+license-file:       LICENSE
+extra-source-files:
+  README.md
+  CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/wasp-lang/wasp
+
+common common-all
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -optP-Wno-nonportable-include-path
+    -fwrite-ide-info -hiedir=.hie
+  default-extensions:
+    OverloadedStrings
+    ScopedTypeVariables
+
+common common-exe
+  ghc-options:
+    -threaded -rtsopts -with-rtsopts=-N
+
+library
+  import:           common-all
+  exposed-modules:
+    Wasp.LSP.Server
+  other-modules:
+    Paths_waspls
+  hs-source-dirs:
+    src
+  build-depends:
+    , base ^>=4.14.3.0
+    , lsp ^>=1.4.0.0
+    , lsp-types ^>=1.4.0.1
+    , containers ^>=0.6.5.1
+    , mtl ^>=2.2.2
+    , text ^>=1.2.4.1
+    , data-default ^>=0.7.1.1
+    , waspc
+
+executable waspls
+  import:           common-all, common-exe
+  main-is:          Main.hs
+  other-modules:
+    Paths_waspls
+  hs-source-dirs:
+    exe
+  build-depends:
+    , base ^>=4.14.3.0
+    , optparse-applicative ^>=0.17.0.0
+    , waspls
+  default-language: Haskell2010


### PR DESCRIPTION
# Description

Makes a new cabal project `waspls` which is an implementation of an LSP server for the Wasp DSL. The implementation in this pull request will report a single wasp error message per wasp file, updated as frequently as possible (in vscode, every time the developer types).

The new cabal project depends on `waspc` and requires it to be located in the `waspc` directory next to `waspls`. It is already in this location, but it is important that these two projects do not move relative to each other. I'm not sure if this is the correct approach for this dependency; the only other option I found was publishing `waspc` on hackage, but I'm not sure we want that.

Related issues:
- #204 
- #570
- #604 

Resolves #204

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update