### PR TITLE
Fix missing deploying web client entry in docs

### DIFF
--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -92,7 +92,7 @@ heroku logs --tail --app <app-name>
 If you wish to deploy an app leveraging Jobs that use pg-boss as the executor to Heroku, you need to set an additional environment variable called `PG_BOSS_NEW_OPTIONS` to `{"connectionString":"<REGULAR_HEROKU_DATABASE_URL>","ssl":{"rejectUnauthorized":false}}`. This is because pg-boss uses the `pg` extension, which does not seem to connect to Heroku over SSL by default, which Heroku requires. Additionally, Heroku uses a self-signed cert, so we must handle that as well.
 - https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js
 
-# Deploying web client (frontend)
+## Deploying web client (frontend)
 Position yourself in `.wasp/build/web-app` directory (reminder: which you created by running `wasp build` previously):
 ```
 cd .wasp/build/web-app

--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -12,7 +12,7 @@ Right now, deploying of Wasp project is done by generating the code and then dep
 
 In the future, the plan is to have Wasp take care of it completely: you would declaratively define your deployment in .wasp and then just call `wasp deploy` ([github issue](https://github.com/wasp-lang/wasp/issues/169)).
 
-# Generating deployable code
+## Generating deployable code
 ```
 wasp build
 ```
@@ -20,28 +20,28 @@ generates deployable code for the whole app in the `.wasp/build/` directory. Nex
 
 NOTE: You will not be able to build the app if you are using SQLite as a database (which is a default database) -> you will have to [switch to PostgreSQL](/docs/language/features#migrating-from-sqlite-to-postgresql).
 
-# Deploying API server (backend)
+## Deploying API server (backend)
 In `.wasp/build/`, there is a `Dockerfile` describing an image for building the server.
 
 To run server in production, deploy this docker image to your favorite hosting provider, ensure that env vars are correctly set, and that is it.
 
 Below we will explain the required env vars and also provide detailed instructions for deploying to Heroku.
 
-## Env vars
+### Env vars
 
 Server uses following environment variables, so you need to ensure they are set on your hosting provider:
 - `PORT` -> number of port at which it will listen for requests (e.g. `3001`).
 - `DATABASE_URL` -> url to the Postgres database that it should use (e.g. `postgresql://mydbuser:mypass@localhost:5432/nameofmydb`)
 - `JWT_SECRET` -> you need this if you are using Wasp's `auth` feature. Set it to a random string (password), at least 32 characters long.
 
-## Deploying to Heroku
+### Deploying to Heroku
 
 Heroku is completely free under certain limits, so it is ideal for getting started with deploying a Wasp app.
 You will need Heroku account, `heroku` CLI and `docker` CLI installed to follow these instructions.
 
 Make sure you are logged in with `heroku` CLI. You can check if you are logged in with `heroku whoami`, and if you are not, you can log in with `heroku login`.
 
-### Set up a Heroku app (only once per Wasp app)
+#### Set up a Heroku app (only once per Wasp app)
 Unless you already have a heroku app that you want to deploy to, let's create a new Heroku app:
 ```
 heroku create <app-name>
@@ -58,7 +58,7 @@ Heroku will also set `DATABASE_URL` env var for us at this point. If you are usi
 heroku config:set --app <app-name> JWT_SECRET=<random_string_at_least_32_characters_long>
 ```
 
-### Deploy to a Heroku app
+#### Deploy to a Heroku app
 Position yourself in `.wasp/build/` directory (reminder: which you created by running `wasp build` previously):
 ```
 cd .wasp/build
@@ -88,7 +88,7 @@ Additionally, you can check out the logs with:
 heroku logs --tail --app <app-name>
 ```
 
-### Note on pg-boss
+#### Note on pg-boss
 If you wish to deploy an app leveraging Jobs that use pg-boss as the executor to Heroku, you need to set an additional environment variable called `PG_BOSS_NEW_OPTIONS` to `{"connectionString":"<REGULAR_HEROKU_DATABASE_URL>","ssl":{"rejectUnauthorized":false}}`. This is because pg-boss uses the `pg` extension, which does not seem to connect to Heroku over SSL by default, which Heroku requires. Additionally, Heroku uses a self-signed cert, so we must handle that as well.
 - https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js
 
@@ -108,7 +108,7 @@ where <url_to_wasp_backend> is url of the wasp backend that you previously deplo
 This will create `build/` directory, which you can deploy to any static hosting provider.
 Check instructions below for deploying to Netlify.
 
-## Deploying to Netlify
+### Deploying to Netlify
 
 Netlify is a static hosting solution that is free for many use cases.
 You will need Netlify account and `netlify` CLI installed to follow these instructions.


### PR DESCRIPTION
# Description

Made "Deploying web client" markdown header level to the same as others
that are relevant.

Fixes #580 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update