### PR TITLE
Make waspc/todoApp return tasks in consistent order

### DIFF
--- a/waspc/examples/todoApp/ext/queries.js
+++ b/waspc/examples/todoApp/ext/queries.js
@@ -9,7 +9,10 @@ export const getTasks = async (args, context) => {
 
   const Task = context.entities.Task
   const tasks = await Task.findMany(
-    { where: { user: { id: context.user.id } } }
+    {
+      where: { user: { id: context.user.id } },
+      orderBy: { id: 'asc' },
+    }
   )
   return tasks
 }


### PR DESCRIPTION
The todo app in `waspc/todoApp` sorts tasks using the last modified date (I guess this was the default). This causes jumpy UI and makes testing stuff difficult. This PR changes the backend to sort the todo items by their id before returning them