### PR TITLE
Swapping localStorage JWT with Cookies + CSRF

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/api.js
+++ b/waspc/data/Generator/templates/react-app/src/api.js
@@ -3,46 +3,7 @@ import config from './config'
 
 const api = axios.create({
   baseURL: config.apiUrl,
-})
-
-const WASP_APP_AUTH_TOKEN_NAME = "authToken"
-
-let authToken = null
-if (window.localStorage) {
-  authToken = window.localStorage.getItem(WASP_APP_AUTH_TOKEN_NAME)
-}
-
-export const setAuthToken = (token) => {
-  if (typeof token !== 'string') {
-    throw Error(`Token must be a string, but it was: {${typeof token}} ${token}.`)
-  }
-  authToken = token
-  window.localStorage && window.localStorage.setItem(WASP_APP_AUTH_TOKEN_NAME, token)
-}
-
-export const clearAuthToken = () => {
-  authToken = undefined
-  window.localStorage && window.localStorage.removeItem(WASP_APP_AUTH_TOKEN_NAME)
-}
-
-export const clearLocalStorage = () => {
-  authToken = undefined
-
-  window.localStorage && window.localStorage.clear()
-}
-
-api.interceptors.request.use(request => {
-  if (authToken) {
-    request.headers['Authorization'] = `Bearer ${authToken}`
-  }
-  return request
-})
-
-api.interceptors.response.use(undefined, error => {
-  if (error.response?.status === 401) {
-    clearAuthToken()
-  }
-  return Promise.reject(error)
+  withCredentials: true
 })
 
 /**

--- a/waspc/data/Generator/templates/react-app/src/auth/login.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/login.js
@@ -1,13 +1,12 @@
 import config from '../config.js'
 import { removeQueries } from '../operations/resources'
-import api, { setAuthToken, handleApiError } from '../api.js'
+import api, { handleApiError } from '../api.js'
 
 export default async function login(email, password) {
   try {
     const args = { email, password }
-    const response = await api.post(config.apiUrl + '/auth/login', args)
+    await api.post(config.apiUrl + '/auth/login', args)
 
-    setAuthToken(response.data.token)
     // This isn't really neccessary because we remove all private queries after
     // logout, but we do it to be extra safe.
     // 

--- a/waspc/data/Generator/templates/react-app/src/auth/logout.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/logout.js
@@ -1,9 +1,15 @@
-import { clearLocalStorage } from '../api.js'
 import { invalidateAndRemoveQueries } from '../operations/resources'
+import config from '../config.js'
+import api, { handleApiError } from '../api.js'
 
 export default async function logout() {
-  clearLocalStorage()
-  // TODO(filip): We are currently invalidating and removing  all the queries, but
-  // we should remove only the non-public, user-dependent ones.
-  await invalidateAndRemoveQueries()
+  try {
+    await api.post(config.apiUrl + '/auth/logout')
+
+    // TODO(filip): We are currently invalidating and removing  all the queries, but
+    // we should remove only the non-public, user-dependent ones.
+    await invalidateAndRemoveQueries()
+  } catch (error) {
+    handleApiError(error)
+  }
 }

--- a/waspc/data/Generator/templates/react-app/src/auth/useAuth.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/useAuth.js
@@ -11,7 +11,7 @@ async function getMe() {
 
     return response.data
   } catch (error) {
-    if (error.response?.status === 403) {
+    if (error.response?.status === 401 || error.response?.status === 403) {
       return null
     } else {
       handleApiError(error)

--- a/waspc/data/Generator/templates/react-app/src/index.js
+++ b/waspc/data/Generator/templates/react-app/src/index.js
@@ -26,7 +26,7 @@ async function startApp() {
   {=/ doesClientSetupFnExist =}
   initializeQueryClient()
 
-  await setCsrfTokenHeader()
+  await obtainCsrfTokenHeader()
 
   await render()
 
@@ -36,11 +36,12 @@ async function startApp() {
   serviceWorker.unregister()
 }
 
-// NOTE: Since users will likely have the backend running on a different domain than
-// the frontend, we are unable to set the token:
+// NOTE: Since users will possibly have the backend running on a different domain than
+// the frontend, we are unable to set the CSRF token:
 // (a) on the page load, as the index.html is not served by Node, nor
 // (b) via a cookie, since the frontend JS will not be able to access a cross-domain cookie.
-async function setCsrfTokenHeader() {
+// Therefore, we must use an API route to get the CSRF token.
+async function obtainCsrfTokenHeader() {
   try {
     const token = await api.get(config.apiUrl + '/csrf-token')
     if (token.data) {

--- a/waspc/data/Generator/templates/react-app/src/index.js
+++ b/waspc/data/Generator/templates/react-app/src/index.js
@@ -2,6 +2,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { QueryClientProvider } from 'react-query'
+import api, { handleApiError } from './api.js'
+import config from './config.js'
 
 import router from './router'
 import { 
@@ -24,12 +26,29 @@ async function startApp() {
   {=/ doesClientSetupFnExist =}
   initializeQueryClient()
 
+  await setCsrfTokenHeader()
+
   await render()
 
   // If you want your app to work offline and load faster, you can change
   // unregister() to register() below. Note this comes with some pitfalls.
   // Learn more about service workers: https://bit.ly/CRA-PWA
   serviceWorker.unregister()
+}
+
+// NOTE: Since users will likely have the backend running on a different domain than
+// the frontend, we are unable to set the token:
+// (a) on the page load, as the index.html is not served by Node, nor
+// (b) via a cookie, since the frontend JS will not be able to access a cross-domain cookie.
+async function setCsrfTokenHeader() {
+  try {
+    const token = await api.get(config.apiUrl + '/csrf-token')
+    if (token.data) {
+      api.defaults.headers.common['X-CSRF-Token'] = token.data
+    }
+  } catch (error) {
+    handleApiError(error)
+  }
 }
 
 async function render() {

--- a/waspc/data/Generator/templates/server/src/app.js
+++ b/waspc/data/Generator/templates/server/src/app.js
@@ -1,3 +1,4 @@
+{{={= =}=}}
 import express from 'express'
 import cookieParser from 'cookie-parser'
 import logger from 'morgan'
@@ -6,6 +7,10 @@ import helmet from 'helmet'
 
 import HttpError from './core/HttpError.js'
 import indexRouter from './routes/index.js'
+import config from './config.js'
+{=# isAuthEnabled =}
+import { useSession } from './session.js'
+{=/ isAuthEnabled =}
 
 // TODO: Consider extracting most of this logic into createApp(routes, path) function so that
 //   it can be used in unit tests to test each route individually.
@@ -13,11 +18,22 @@ import indexRouter from './routes/index.js'
 const app = express()
 
 app.use(helmet())
-app.use(cors()) // TODO: Consider configuring CORS to be more restrictive, right now it allows all CORS requests.
+app.use(cors({
+  origin: config.frontendUrl,
+  credentials: true
+}));
 app.use(logger('dev'))
 app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(cookieParser())
+
+if (config.trustProxyCount > 0) {
+  app.set('trust proxy', config.trustProxyCount)
+}
+
+{=# isAuthEnabled =}
+useSession(app)
+{=/ isAuthEnabled =}
 
 app.use('/', indexRouter)
 

--- a/waspc/data/Generator/templates/server/src/app.js
+++ b/waspc/data/Generator/templates/server/src/app.js
@@ -27,8 +27,9 @@ app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(cookieParser())
 
-if (config.trustProxyCount > 0) {
-  app.set('trust proxy', config.trustProxyCount)
+if (config.trustProxies) {
+  app.enable('trust proxy')
+  console.log("Trusting proxies")
 }
 
 {=# isAuthEnabled =}

--- a/waspc/data/Generator/templates/server/src/config.js
+++ b/waspc/data/Generator/templates/server/src/config.js
@@ -35,7 +35,7 @@ const config = {
     frontendUrl: undefined,
   },
   development: {
-    trustProxies: toBooleanOrDefault(process.env.TRUST_PROXIES, false),
+    trustProxies: parseBooleanOrDefault(process.env.TRUST_PROXIES, false),
     {=# isAuthEnabled =}
     session: {
       cookie: {
@@ -46,7 +46,7 @@ const config = {
     frontendUrl: process.env.REACT_APP_URL || 'http://localhost:3000',
   },
   production: {
-    trustProxies: toBooleanOrDefault(process.env.TRUST_PROXIES, true),
+    trustProxies: parseBooleanOrDefault(process.env.TRUST_PROXIES, true),
     {=# isAuthEnabled =}
     session: {
       cookie: {
@@ -61,7 +61,7 @@ const config = {
 const resolvedConfig = _.merge(config.all, config[env])
 export default resolvedConfig
 
-function toBooleanOrDefault(str, defaultValue) {
+function parseBooleanOrDefault(str, defaultValue) {
   if (!str) {
     return defaultValue
   }

--- a/waspc/data/Generator/templates/server/src/config.js
+++ b/waspc/data/Generator/templates/server/src/config.js
@@ -13,25 +13,35 @@ const config = {
     env,
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.DATABASE_URL,
+    trustProxyCount: undefined,
     {=# isAuthEnabled =}
-    auth: {
-      jwtSecret: undefined
-    }
+    session: {
+      name: process.env.SESSION_NAME || 'wasp_session',
+      secret: undefined,
+      cookie: {
+        maxAge: parseInt(process.env.SESSION_COOKIE_MAX_AGE) || 7 * 24 * 60 * 60 * 1000, // ms
+      }, 
+    },
     {=/ isAuthEnabled =}
+    frontendUrl: undefined,
   },
   development: {
+    trustProxyCount: parseInt(process.env.TRUST_PROXY_COUNT) || 0,
     {=# isAuthEnabled =}
-    auth: {
-      jwtSecret: 'DEVJWTSECRET'
-    }
+    session: {
+      secret: process.env.SESSION_SECRET || 'sessionSecret',
+    },
     {=/ isAuthEnabled =}
+    frontendUrl: process.env.REACT_APP_URL || 'http://localhost:3000',
   },
   production: {
+    trustProxyCount: parseInt(process.env.TRUST_PROXY_COUNT) || 1,
     {=# isAuthEnabled =}
-    auth: {
-      jwtSecret: process.env.JWT_SECRET
-    }
+    session: {
+      secret: process.env.SESSION_SECRET,
+    },
     {=/ isAuthEnabled =}
+    frontendUrl: process.env.REACT_APP_URL,
   }
 }
 

--- a/waspc/data/Generator/templates/server/src/config.js
+++ b/waspc/data/Generator/templates/server/src/config.js
@@ -13,13 +13,15 @@ const config = {
     env,
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.DATABASE_URL,
+    // This option is sometimes needed when running behind proxies/load balancers.
+    // Ref: https://expressjs.com/en/guide/behind-proxies.html
     trustProxyCount: undefined,
     {=# isAuthEnabled =}
     session: {
       cookie: {
         name: process.env.SESSION_COOKIE_NAME || 'wasp_session',
         secret: undefined,
-        maxAge: parseInt(process.env.SESSION_COOKIE_MAX_AGE) || 7 * 24 * 60 * 60 * 1000, // ms
+        maxAgeMs: parseInt(process.env.SESSION_COOKIE_MAX_AGE) || 7 * 24 * 60 * 60 * 1000, // 1 week in ms
       },
     },
     csrf: {
@@ -56,3 +58,9 @@ const config = {
 
 const resolvedConfig = _.merge(config.all, config[env])
 export default resolvedConfig
+
+export function checkCookieSecretLength(secret) {
+  if (!secret || secret.length < 32) {
+    throw new Error("SESSION_COOKIE_SECRET must be at least 32 characters long in production")
+  }
+}

--- a/waspc/data/Generator/templates/server/src/config.js
+++ b/waspc/data/Generator/templates/server/src/config.js
@@ -58,9 +58,6 @@ const config = {
   }
 }
 
-const resolvedConfig = _.merge(config.all, config[env])
-export default resolvedConfig
-
 function parseBooleanOrDefault(str, defaultValue) {
   if (!str) {
     return defaultValue
@@ -78,8 +75,19 @@ function parseBooleanOrDefault(str, defaultValue) {
   }
 }
 
-export function checkCookieSecretLength(secret) {
+function checkCookieSecretLength(secret) {
   if (!secret || secret.length < 32) {
-    throw new Error("SESSION_COOKIE_SECRET must be at least 32 characters long in production")
+    throw new Error("SESSION_COOKIE_SECRET must be at least 32 characters long")
   }
 }
+
+function performChecks(config) {
+  if (config.env === 'production') {
+    checkCookieSecretLength(config.session.cookie.secret)
+  }
+
+  return config
+}
+
+const resolvedConfig = performChecks(_.merge(config.all, config[env]))
+export default resolvedConfig

--- a/waspc/data/Generator/templates/server/src/config.js
+++ b/waspc/data/Generator/templates/server/src/config.js
@@ -14,8 +14,10 @@ const config = {
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.DATABASE_URL,
     // This option is sometimes needed when running behind proxies/load balancers.
+    // For example, this is required for secure cookies to work on Heroku.
     // Ref: https://expressjs.com/en/guide/behind-proxies.html
-    trustProxyCount: undefined,
+    // For now, we only handle the boolean case.
+    trustProxies: undefined,
     {=# isAuthEnabled =}
     session: {
       cookie: {
@@ -33,7 +35,7 @@ const config = {
     frontendUrl: undefined,
   },
   development: {
-    trustProxyCount: parseInt(process.env.TRUST_PROXY_COUNT) || 0,
+    trustProxies: toBooleanOrDefault(process.env.TRUST_PROXIES, false),
     {=# isAuthEnabled =}
     session: {
       cookie: {
@@ -44,7 +46,7 @@ const config = {
     frontendUrl: process.env.REACT_APP_URL || 'http://localhost:3000',
   },
   production: {
-    trustProxyCount: parseInt(process.env.TRUST_PROXY_COUNT) || 1,
+    trustProxies: toBooleanOrDefault(process.env.TRUST_PROXIES, true),
     {=# isAuthEnabled =}
     session: {
       cookie: {
@@ -58,6 +60,23 @@ const config = {
 
 const resolvedConfig = _.merge(config.all, config[env])
 export default resolvedConfig
+
+function toBooleanOrDefault(str, defaultValue) {
+  if (!str) {
+    return defaultValue
+  }
+
+  switch(str.toLowerCase()) {
+    case "t":
+    case "true":
+      return true
+    case "f":
+    case "false":
+      return false
+    default:
+      return defaultValue
+  }
+}
 
 export function checkCookieSecretLength(secret) {
   if (!secret || secret.length < 32) {

--- a/waspc/data/Generator/templates/server/src/config.js
+++ b/waspc/data/Generator/templates/server/src/config.js
@@ -16,11 +16,16 @@ const config = {
     trustProxyCount: undefined,
     {=# isAuthEnabled =}
     session: {
-      name: process.env.SESSION_NAME || 'wasp_session',
-      secret: undefined,
       cookie: {
+        name: process.env.SESSION_COOKIE_NAME || 'wasp_session',
+        secret: undefined,
         maxAge: parseInt(process.env.SESSION_COOKIE_MAX_AGE) || 7 * 24 * 60 * 60 * 1000, // ms
-      }, 
+      },
+    },
+    csrf: {
+      cookie: {
+        name: process.env.CSRF_COOKIE_NAME || 'wasp_csrf',
+      },
     },
     {=/ isAuthEnabled =}
     frontendUrl: undefined,
@@ -29,7 +34,9 @@ const config = {
     trustProxyCount: parseInt(process.env.TRUST_PROXY_COUNT) || 0,
     {=# isAuthEnabled =}
     session: {
-      secret: process.env.SESSION_SECRET || 'sessionSecret',
+      cookie: {
+        secret: process.env.SESSION_COOKIE_SECRET || 'sessionSecret',
+      },
     },
     {=/ isAuthEnabled =}
     frontendUrl: process.env.REACT_APP_URL || 'http://localhost:3000',
@@ -38,7 +45,9 @@ const config = {
     trustProxyCount: parseInt(process.env.TRUST_PROXY_COUNT) || 1,
     {=# isAuthEnabled =}
     session: {
-      secret: process.env.SESSION_SECRET,
+      cookie: {
+        secret: process.env.SESSION_COOKIE_SECRET,
+      },
     },
     {=/ isAuthEnabled =}
     frontendUrl: process.env.REACT_APP_URL,

--- a/waspc/data/Generator/templates/server/src/core/auth.js
+++ b/waspc/data/Generator/templates/server/src/core/auth.js
@@ -5,15 +5,15 @@ import prisma from '../dbClient.js'
 import { handleRejection } from '../utils.js'
 
 const auth = handleRejection(async (req, res, next) => {
-  const user_id = req.session?.user_id
-  if (!user_id) {
-    // NOTE: for now we let requests without a user_id in the session through and make it operation's
+  const userId = req.session?.userId
+  if (!userId) {
+    // NOTE: for now we let requests without a userId in the session through and make it operation's
     // responsibility to verify whether the request is authenticated or not. In the future
     // we will develop our own system at Wasp-level for that.
     return next()
   }
 
-  const user = await prisma.{= userEntityLower =}.findUnique({ where: { id: user_id } })
+  const user = await prisma.{= userEntityLower =}.findUnique({ where: { id: userId } })
   if (!user) {
     return res.status(401).send()
   }

--- a/waspc/data/Generator/templates/server/src/routes/auth/index.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/index.js
@@ -2,14 +2,15 @@ import express from 'express'
 
 import auth from '../../core/auth.js'
 import login from './login.js'
+import logout from './logout.js'
 import signup from './signup.js'
 import me from './me.js'
 
 const router = express.Router()
 
 router.post('/login', login)
+router.post('/logout', logout)
 router.post('/signup', signup)
 router.get('/me', auth, me)
 
 export default router
-

--- a/waspc/data/Generator/templates/server/src/routes/auth/login.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/login.js
@@ -28,8 +28,9 @@ export default handleRejection(async (req, res) => {
       return res.status(401).send()
   }
 
-  // Save user_id in session for future request use.
-  req.session = { user_id: {= userEntityLower =}.id }
+  // Save userId in session for future request use.
+  // This gets set as a cookie in the response.
+  req.session = { userId: {= userEntityLower =}.id }
 
   return res.status(200).send()
 })

--- a/waspc/data/Generator/templates/server/src/routes/auth/login.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/login.js
@@ -12,7 +12,7 @@ export default handleRejection(async (req, res) => {
 
   // Try to fetch user with the given email.
   const {= userEntityLower =} = await prisma.{= userEntityLower =}.findUnique({ where: { email: args.email.toLowerCase() } })
-  if (!user) {
+  if (!{= userEntityLower =}) {
     return res.status(401).send()
   }
 

--- a/waspc/data/Generator/templates/server/src/routes/auth/login.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/login.js
@@ -2,14 +2,13 @@
 import Prisma from '@prisma/client'
 import SecurePassword from 'secure-password'
 
-import { sign, verifyPassword } from '../../core/auth.js'
+import { verifyPassword } from '../../core/auth.js'
 import { handleRejection } from '../../utils.js'
 
 const prisma = new Prisma.PrismaClient()
 
 export default handleRejection(async (req, res) => {
   const args = req.body || {}
-  const context = {}
 
   // Try to fetch user with the given email.
   const {= userEntityLower =} = await prisma.{= userEntityLower =}.findUnique({ where: { email: args.email.toLowerCase() } })
@@ -29,12 +28,8 @@ export default handleRejection(async (req, res) => {
       return res.status(401).send()
   }
 
-  // Email & password valid - generate token.
-  const token = await sign({= userEntityLower =}.id)
+  // Save user_id in session for future request use.
+  req.session = { user_id: {= userEntityLower =}.id }
 
-  // NOTE(matija): Possible option - instead of explicitly returning token here,
-  // we could add to response header 'Set-Cookie {token}' directive which would then make
-  // browser automatically save cookie with token.
-
-  return res.json({ token })
+  return res.status(200).send()
 })

--- a/waspc/data/Generator/templates/server/src/routes/auth/logout.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/logout.js
@@ -1,0 +1,8 @@
+import { handleRejection } from '../../utils.js'
+
+export default handleRejection(async (req, res) => {
+  // Destroy the session.
+  req.session = null
+
+  return res.status(200).send()
+})

--- a/waspc/data/Generator/templates/server/src/routes/auth/logout.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/logout.js
@@ -2,6 +2,7 @@ import { handleRejection } from '../../utils.js'
 
 export default handleRejection(async (req, res) => {
   // Destroy the session.
+  // This also empties the cookie set in the response.
   req.session = null
 
   return res.status(200).send()

--- a/waspc/data/Generator/templates/server/src/routes/index.js
+++ b/waspc/data/Generator/templates/server/src/routes/index.js
@@ -15,9 +15,11 @@ router.get('/', function (req, res, next) {
 {=# isAuthEnabled =}
 router.use('/auth', auth)
 
-// NOTE: While we have CORS protection enabled in app.js, it is
-// vitally important that this route always be CORS-protected.
+// NOTE: This route, along with all other routes, are CORS-protected and
+// restricted to the frontend URL only, preventing CSRF. This helps prevent malicious sites
+// from getting a valid token that would be compatible with a logged-in user's cookie.
 router.get('/csrf-token', function (req, res) {
+  // Added by csurf middleware and creates a token that is validated against the visitor’s CSRF cookie.
   res.json(req.csrfToken())
 })
 {=/ isAuthEnabled =}

--- a/waspc/data/Generator/templates/server/src/routes/index.js
+++ b/waspc/data/Generator/templates/server/src/routes/index.js
@@ -14,6 +14,12 @@ router.get('/', function (req, res, next) {
 
 {=# isAuthEnabled =}
 router.use('/auth', auth)
+
+// NOTE: While we have CORS protection enabled in app.js, it is
+// vitally important that this route always be CORS-protected.
+router.get('/csrf-token', function (req, res) {
+  res.json(req.csrfToken())
+})
 {=/ isAuthEnabled =}
 router.use('/{= operationsRouteInRootRouter =}', operations)
 

--- a/waspc/data/Generator/templates/server/src/session.js
+++ b/waspc/data/Generator/templates/server/src/session.js
@@ -1,14 +1,14 @@
 import cookieSession from 'cookie-session'
 import csrf from 'csurf'
 
-import config from './config.js'
+import config, { checkCookieSecretLength } from './config.js'
 
 const sessionConfig = {
   name: config.session.cookie.name,
   secret: config.session.cookie.secret,
   httpOnly: true,
   signed: true,
-  maxAge: config.session.cookie.maxAge,
+  maxAge: config.session.cookie.maxAgeMs,
 }
 
 const csrfConfig = {
@@ -20,6 +20,8 @@ const csrfConfig = {
 
 export function useSession(app) {
   if (config.env === 'production') {
+    checkCookieSecretLength(sessionConfig.secret)
+
     sessionConfig.secure = true
     sessionConfig.sameSite = 'none'
     csrfConfig.cookie.secure = true

--- a/waspc/data/Generator/templates/server/src/session.js
+++ b/waspc/data/Generator/templates/server/src/session.js
@@ -1,7 +1,7 @@
 import cookieSession from 'cookie-session'
 import csrf from 'csurf'
 
-import config, { checkCookieSecretLength } from './config.js'
+import config from './config.js'
 
 const sessionConfig = {
   name: config.session.cookie.name,
@@ -20,8 +20,6 @@ const csrfConfig = {
 
 export function useSession(app) {
   if (config.env === 'production') {
-    checkCookieSecretLength(sessionConfig.secret)
-
     sessionConfig.secure = true
     sessionConfig.sameSite = 'none'
     csrfConfig.cookie.secure = true

--- a/waspc/data/Generator/templates/server/src/session.js
+++ b/waspc/data/Generator/templates/server/src/session.js
@@ -4,8 +4,8 @@ import csrf from 'csurf'
 import config from './config.js'
 
 const sessionConfig = {
-  name: config.session.name,
-  secret: config.session.secret,
+  name: config.session.cookie.name,
+  secret: config.session.cookie.secret,
   httpOnly: true,
   signed: true,
   maxAge: config.session.cookie.maxAge,
@@ -13,7 +13,7 @@ const sessionConfig = {
 
 const csrfConfig = {
   cookie: {
-    key: 'wasp_csrf',
+    key: config.csrf.cookie.name,
     httpOnly: true,
   },
 }

--- a/waspc/data/Generator/templates/server/src/session.js
+++ b/waspc/data/Generator/templates/server/src/session.js
@@ -1,0 +1,31 @@
+import cookieSession from 'cookie-session'
+import csrf from 'csurf'
+
+import config from './config.js'
+
+const sessionConfig = {
+  name: config.session.name,
+  secret: config.session.secret,
+  httpOnly: true,
+  signed: true,
+  maxAge: config.session.cookie.maxAge,
+}
+
+const csrfConfig = {
+  cookie: {
+    key: 'wasp_csrf',
+    httpOnly: true,
+  },
+}
+
+export function useSession(app) {
+  if (config.env === 'production') {
+    sessionConfig.secure = true
+    sessionConfig.sameSite = 'none'
+    csrfConfig.cookie.secure = true
+    csrfConfig.cookie.sameSite = 'none'
+  }
+
+  app.use(cookieSession(sessionConfig))
+  app.use(csrf(csrfConfig))
+}

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -130,13 +130,10 @@ npmDepsForWasp spec =
 depsRequiredBySessions :: AppSpec -> [AS.Dependency.Dependency]
 depsRequiredBySessions spec =
   let deps =
-        if isAuthEnabled spec
-          then
-            [ ("cookie-session", "~2.0.0"),
-              ("csurf", "~1.11.0")
-            ]
-          else []
-   in AS.Dependency.make <$> deps
+        [ ("cookie-session", "~2.0.0"),
+          ("csurf", "~1.11.0")
+        ]
+   in AS.Dependency.make <$> if isAuthEnabled spec then deps else []
 
 genNpmrc :: Generator FileDraft
 genNpmrc =

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -29,9 +29,9 @@ import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
-import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
-import qualified Wasp.AppSpec.App.Server as AS.Server
+import qualified Wasp.AppSpec.App.Server as AS.App.Server
 import qualified Wasp.AppSpec.Entity as AS.Entity
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
 import Wasp.AppSpec.Valid (getApp, isAuthEnabled)
@@ -127,6 +127,9 @@ npmDepsForWasp spec =
           ]
     }
 
+-- | NOTE: Auth depends on session support. However, sessions could
+-- theoretically exist without auth being enabled (e.g., flash messages).
+-- At this time it made sense to couple them, but it is not strictly required.
 depsRequiredBySessions :: AppSpec -> [AS.Dependency.Dependency]
 depsRequiredBySessions spec =
   let deps =
@@ -184,7 +187,7 @@ genDbClient spec = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmpl
         then
           object
             [ "isAuthEnabled" .= True,
-              "userEntityUpper" .= (AS.refName (AS.Auth.userEntity $ fromJust maybeAuth) :: String)
+              "userEntityUpper" .= (AS.refName (AS.App.Auth.userEntity $ fromJust maybeAuth) :: String)
             ]
         else object []
 
@@ -203,7 +206,7 @@ genServerJs spec =
             ]
       )
   where
-    maybeSetupJsFunction = AS.Server.setupFn =<< AS.App.server (snd $ getApp spec)
+    maybeSetupJsFunction = AS.App.Server.setupFn =<< AS.App.server (snd $ getApp spec)
     maybeSetupJsFnImportDetails = getJsImportDetailsForExtFnImport relPosixPathFromSrcDirToExtSrcDir <$> maybeSetupJsFunction
     (maybeSetupJsFnImportIdentifier, maybeSetupJsFnImportStmt) =
       (fst <$> maybeSetupJsFnImportDetails, snd <$> maybeSetupJsFnImportDetails)

--- a/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
@@ -24,6 +24,7 @@ genAuth spec = case maybeAuth of
         -- Auth routes
         genAuthRoutesIndex,
         genLoginRoute auth,
+        genLogoutRoute,
         genSignupRoute auth,
         genMeRoute auth
       ]
@@ -81,6 +82,13 @@ genLoginRoute auth = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tm
             [ "userEntityUpper" .= (userEntityName :: String),
               "userEntityLower" .= (Util.toLowerFirst userEntityName :: String)
             ]
+
+genLogoutRoute :: Generator FileDraft
+genLogoutRoute = return $ C.mkTmplFdWithDstAndData tmplFile dstFile Nothing
+  where
+    logoutRouteRelToSrc = [relfile|routes/auth/logout.js|]
+    tmplFile = C.asTmplFile $ [reldir|src|] </> logoutRouteRelToSrc
+    dstFile = C.serverSrcDirInServerRootDir </> C.asServerSrcFile logoutRouteRelToSrc
 
 genSignupRoute :: AS.Auth.Auth -> Generator FileDraft
 genSignupRoute auth = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)

--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -12,6 +12,8 @@ Right now, deploying of Wasp project is done by generating the code and then dep
 
 In the future, the plan is to have Wasp take care of it completely: you would declaratively define your deployment in .wasp and then just call `wasp deploy` ([github issue](https://github.com/wasp-lang/wasp/issues/169)).
 
+NOTE: Both the frontend and the backend need to know the URLs of each other, creating a circular dependency on your first deploy. The deployment process covered below deploys the backend first, followed by the frontend. If you do not know your frontend URL when deploying your backend, that is ok. That environment variable can be set after both are deployed as a last step.
+
 ## Generating deployable code
 ```
 wasp build
@@ -65,6 +67,8 @@ Heroku will also set `DATABASE_URL` env var for us at this point. If you are usi
 heroku config:set --app <app-name> SESSION_COOKIE_SECRET=<random_string_at_least_32_characters_long>
 heroku config:set --app <app-name> REACT_APP_URL=<url_of_where_frontend_will_be_deployed>
 ```
+
+NOTE: If you do not know what your frontend URL is yet, don't worry. You can set `REACT_APP_URL` after you deploy your frontend.
 
 #### Deploy to a Heroku app
 Position yourself in `.wasp/build/` directory (reminder: which you created by running `wasp build` previously):
@@ -129,4 +133,4 @@ netlify deploy
 ```
 and that is it!
 
-Note: Make sure you set this URL as the `REACT_APP_URL` environment variable in Heroku.
+NOTE: Make sure you set this URL as the `REACT_APP_URL` environment variable in Heroku.

--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -30,16 +30,16 @@ Below we will explain the required env vars and also provide detailed instructio
 ### Env vars
 
 Server uses following environment variables, so you need to ensure they are set on your hosting provider:
-- `PORT` -> number of port at which it will listen for requests (e.g. `3001`).
-- `DATABASE_URL` -> url to the Postgres database that it should use (e.g. `postgresql://mydbuser:mypass@localhost:5432/nameofmydb`)
-- `REACT_APP_URL` -> the URL of where the frontend app is running (e.g. `https://<app-name>.netlify.app`), which is used for CORS protection.
-- `SESSION_COOKIE_SECRET` -> you need this if you are using Wasp's `auth` feature, which is used to sign cookies. Set it to a random string, at least 32 characters long.
+- `PORT: int` -> number of port at which it will listen for requests (e.g. `3001`).
+- `DATABASE_URL: string` -> url to the Postgres database that it should use (e.g. `postgresql://mydbuser:mypass@localhost:5432/nameofmydb`).
+- `REACT_APP_URL: string` -> the URL of where the frontend app is running (e.g. `https://<app-name>.netlify.app`), which is used for CORS protection.
+- `SESSION_COOKIE_SECRET: string` -> you need this if you are using Wasp's `auth` feature, which is used to sign cookies. Set it to a random string, at least 32 characters long.
 
 #### Optional env vars
-- `SESSION_COOKIE_NAME` -> name of cookie used to store session data (defaults to `"wasp_session"`).
-- `SESSION_COOKIE_MAX_AGE` -> max age of session cookie (defaults to `7` days).
-- `CSRF_COOKIE_NAME` -> name of cookie used to store csrf double submit pattern secret (defaults to `"wasp_csrf"`).
-- `TRUST_PROXY_COUNT` -> number of proxies for Express app to trust (defaults to `0` for dev, and `1` for prod).
+- `SESSION_COOKIE_NAME: string` -> name of cookie used to store session data (defaults to `"wasp_session"`).
+- `SESSION_COOKIE_MAX_AGE: int` -> max age of session cookie in milliseconds (defaults to one week).
+- `CSRF_COOKIE_NAME: string` -> name of cookie used to store csrf double submit pattern secret (defaults to `"wasp_csrf"`).
+- `TRUST_PROXY_COUNT: int` -> number of proxies for Express app to trust (defaults to `0` for dev, and `1` for prod).
 
 ### Deploying to Heroku
 
@@ -60,9 +60,9 @@ heroku addons:create --app <app-name> heroku-postgresql:hobby-dev
 ```
 Heroku will also set `DATABASE_URL` env var for us at this point. If you are using external database, you will have to set it yourself.
 
-`PORT` env var will also be provided by Heroku, so the only thing left is to set the `SESSION_SECRET` env var and `REACT_APP_URL`:
+`PORT` env var will also be provided by Heroku, so the only thing left is to set the `SESSION_COOKIE_SECRET` env var and `REACT_APP_URL`:
 ```
-heroku config:set --app <app-name> SESSION_SECRET=<random_string_at_least_32_characters_long>
+heroku config:set --app <app-name> SESSION_COOKIE_SECRET=<random_string_at_least_32_characters_long>
 heroku config:set --app <app-name> REACT_APP_URL=<url_of_where_frontend_will_be_deployed>
 ```
 

--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -41,7 +41,7 @@ Server uses following environment variables, so you need to ensure they are set 
 - `SESSION_COOKIE_NAME: string` -> name of cookie used to store session data (defaults to `"wasp_session"`).
 - `SESSION_COOKIE_MAX_AGE: int` -> max age of session cookie in milliseconds (defaults to one week).
 - `CSRF_COOKIE_NAME: string` -> name of cookie used to store csrf double submit pattern secret (defaults to `"wasp_csrf"`).
-- `TRUST_PROXY_COUNT: int` -> number of proxies for Express app to trust (defaults to `0` for dev, and `1` for prod).
+- `TRUST_PROXIES: bool` -> if Express app should trust proxies (defaults to `false` in development, and `true` in production).
 
 ### Deploying to Heroku
 

--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -32,7 +32,14 @@ Below we will explain the required env vars and also provide detailed instructio
 Server uses following environment variables, so you need to ensure they are set on your hosting provider:
 - `PORT` -> number of port at which it will listen for requests (e.g. `3001`).
 - `DATABASE_URL` -> url to the Postgres database that it should use (e.g. `postgresql://mydbuser:mypass@localhost:5432/nameofmydb`)
-- `JWT_SECRET` -> you need this if you are using Wasp's `auth` feature. Set it to a random string (password), at least 32 characters long.
+- `REACT_APP_URL` -> the URL of where the frontend app is running (e.g. `https://<app-name>.netlify.app`), which is used for CORS protection.
+- `SESSION_COOKIE_SECRET` -> you need this if you are using Wasp's `auth` feature, which is used to sign cookies. Set it to a random string, at least 32 characters long.
+
+#### Optional env vars
+- `SESSION_COOKIE_NAME` -> name of cookie used to store session data (defaults to `"wasp_session"`).
+- `SESSION_COOKIE_MAX_AGE` -> max age of session cookie (defaults to `7` days).
+- `CSRF_COOKIE_NAME` -> name of cookie used to store csrf double submit pattern secret (defaults to `"wasp_csrf"`).
+- `TRUST_PROXY_COUNT` -> number of proxies for Express app to trust (defaults to `0` for dev, and `1` for prod).
 
 ### Deploying to Heroku
 
@@ -53,9 +60,10 @@ heroku addons:create --app <app-name> heroku-postgresql:hobby-dev
 ```
 Heroku will also set `DATABASE_URL` env var for us at this point. If you are using external database, you will have to set it yourself.
 
-`PORT` env var will also be provided by Heroku, so the only thing left is to set `JWT_SECRET` env var:
+`PORT` env var will also be provided by Heroku, so the only thing left is to set the `SESSION_SECRET` env var and `REACT_APP_URL`:
 ```
-heroku config:set --app <app-name> JWT_SECRET=<random_string_at_least_32_characters_long>
+heroku config:set --app <app-name> SESSION_SECRET=<random_string_at_least_32_characters_long>
+heroku config:set --app <app-name> REACT_APP_URL=<url_of_where_frontend_will_be_deployed>
 ```
 
 #### Deploy to a Heroku app
@@ -120,3 +128,5 @@ While positioned in `.wasp/build/web-app/` directory, and after you have created
 netlify deploy
 ```
 and that is it!
+
+Note: Make sure you set this URL as the `REACT_APP_URL` environment variable in Heroku.


### PR DESCRIPTION
# Description

This PR changes our entire AuthN strategy, and opens the door for adding new AuthN methods (like Google, etc.). 🥳 

In particular, it:
- removes our use of JWTs and localStorage
- switches us to use cookies
  - one cookie is the CSRF token
  - one cookie (plus its signature) contains our session data, which like our JWT just is `user_id`
  - Note: In the future, we can add database session support, but the `@quixo3/prisma-session-store` is just not reliable enough to use, so we may need to write our own (or test out the vanilla PostgreSQL version).
- adds CSRF support
- secures our CORS setup

Here is the flow of our CSRF setup:
<img width="1396" alt="Screen Shot 2022-06-17 at 12 38 16 PM" src="https://user-images.githubusercontent.com/523636/174347754-d8ca490d-5c8e-4df9-b544-cb5ef80aba06.png">

And here is what the cookies are set to locally in dev:
<img width="1133" alt="Screen Shot 2022-06-17 at 12 37 52 PM" src="https://user-images.githubusercontent.com/523636/174347798-3441e2e7-1b99-4051-a8bd-5ba03da73c52.png">

And here is what the cookies like in prod:
<img width="1345" alt="Screenshot 2022-06-20 083128" src="https://user-images.githubusercontent.com/523636/174602404-4036967e-8cad-470e-a32c-ba013f02f9a5.png">

Here is a demo app (with some env var changes):
- frontend: https://wasp-csrf-demo.netlify.app
- backend (to see cookies): https://wasp-csrf-demo.herokuapp.com

Note that locally, it works fine since cookies do not care about ports. But for prod, on different domains, we must be running over `https` due to`sameSite` settings.

Fixes #573

I will add the e2e tests after a review to reduce the noise.

## Type of change

This is a breaking change only because it requires new environment variables, not because any known code changes are required.

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update