### PR TITLE
E2e tests accepting

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -247,9 +247,15 @@ To run end-to-end tests only, you can do `cabal test e2e-test` (or `/run test:e2
 
 Besides unit tests, we have e2e tests that run `waspc` on a couple of prepared projects, check that they successfully run, and also compare generated code with the expected generated code (golden output).
 
-This means that when you make a change in your code that affects the generated code, e2e tests will fail while showing a diff between the new generated code and the expected (golden) one.
+This means that when you make a change in your code that modifies the generated code, e2e tests will fail while showing a diff between the new generated code and the previous (golden) one.
 This gives you an opportunity to observe these differences and ensure that they are intentional and that you are satisfied with them. If you notice something unexpected or weird, you have an opportunity to fix it.
-Once you are indeed happy with the changes in the generated code, you will want to update the expected (golden) output to the new (current) output, so that tests pass.
+Once you are indeed happy with the changes in the generated code, you will want to update the golden output to the new (current) output, so that tests pass. Basically, you want to say "I am ok with the changes and I accept them as the new state of things.".
+Easiest way to do this is to go to `e2e-test/test-outputs/` dir, delete all the directories ending with `-golden/`, and then re-run e2e tests -> since there are no golden outputs, the new outputs will be used as new golden outputs and that is it. After that you commit that to git and you are done.
+
+Instead of doing this manually, you can also use convenient command from the `./run` script:
+```
+./run test:e2e:accept-all
+```
 
 ## Code analysis
 

--- a/waspc/run
+++ b/waspc/run
@@ -24,6 +24,8 @@ TEST_CMD="cabal test"
 TEST_UNIT_CMD="cabal test waspc-test"
 TEST_CLI_CMD="cabal test cli-test"
 TEST_E2E_CMD="cabal test e2e-test"
+TEST_E2E_DELETE_GOLDENS="rm -r $PROJECT_ROOT/e2e-test/test-outputs/*-golden"
+TEST_E2E_ACCEPT_ALL_CMD="$TEST_E2E_DELETE_GOLDENS && $TEST_E2E_CMD"
 RUN_CMD="cabal run wasp-cli ${ARGS[@]}"
 GHCID_CMD="ghcid --command=cabal repl"
 GHCID_TEST_CMD="ghcid --command=cabal repl"
@@ -66,6 +68,8 @@ print_usage () {
                     "Executes only cli unit tests. Builds the project first if needed."
     print_usage_cmd "test:e2e" \
                     "Executes only e2e tests. Builds the project first if needed."
+    print_usage_cmd "test:e2e:accept-all" \
+                    "Accepts any diffs in the generated code in e2e tests. Does so by deleting current golden output and re-running e2e tests to produce new golden output."
     print_usage_cmd "wasp-cli <args>" \
                     "Runs the wasp executable while forwarding arguments. Builds the project first if needed."
     print_usage_cmd "ghcid" \
@@ -121,6 +125,9 @@ case $COMMAND in
         ;;
     test:e2e)
         echo_and_eval "$TEST_E2E_CMD"
+        ;;
+    test:e2e:accept-all)
+        echo_and_eval "$TEST_E2E_ACCEPT_ALL_CMD"
         ;;
     wasp-cli)
         echo_and_eval "$RUN_CMD"


### PR DESCRIPTION
Added short instructions to README about e2e tests, focused on how to accept that changes in the generated code.

Also added convenient command to `./run` script for accepting the e2e changes.