### PR TITLE
Improvements to deployment docs based on trying to deploy Cursorial's Grabbit Wasp project

### DIFF
--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -51,7 +51,7 @@ genPrismaSchema spec = do
     AS.Db.PostgreSQL -> return ("postgresql", "env(\"DATABASE_URL\")")
     AS.Db.SQLite ->
       if AS.isBuild spec
-        then logAndThrowGeneratorError $ GenericGeneratorError "SQLite (a default database) is not supported in production. To build your Wasp app for production, switch to a different database. Switching to PostgreSQL: https://wasp-lang.dev/docs/language/features/#migrating-from-sqlite-to-postgresql ."
+        then logAndThrowGeneratorError $ GenericGeneratorError "SQLite (a default database) is not supported in production. To build your Wasp app for production, switch to a different database. Switching to PostgreSQL: https://wasp-lang.dev/docs/language/features#migrating-from-sqlite-to-postgresql ."
         else return ("sqlite", "\"file:./dev.db\"")
 
   let templateData =

--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -119,4 +119,6 @@ While positioned in `.wasp/build/web-app/` directory, and after you have created
 ```
 netlify deploy
 ```
-and that is it!
+and carefully follow their instructions (i.e. do you want to create a new app or use existing one, team under which your app will reside, ..., final step to run `netlify deploy --prod`).
+
+That is it!

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -1110,22 +1110,26 @@ Default database is `SQLite`, since it is great for getting started with a new p
 Check below for more details on how to migrate from SQLite to PostgreSQL.
 
 ### PostgreSQL
-When using `PostgreSQL` (`db: { system: PostgreSQL }`), you will need to spin up a postgres database on your own so it runs during development (when running `wasp start` or doing `wasp db ...` commands) and provide Wasp with `DATABASE_URL` environment variable that Wasp will use to connect to it.
+When using `PostgreSQL` as your database (`app: { db: { system: PostgreSQL } }`), you will need to spin up a postgres database on your own so it runs during development (when running `wasp start` or doing `wasp db ...` commands) and you will need to provide Wasp with `DATABASE_URL` environment variable that Wasp will use to connect to it.
 
-One of the easiest ways to do this is by spinning up postgres docker container when you need it with the shell command
+One of the easiest ways to run a PostgreSQL database on your own is by spinning up [postgres docker](https://hub.docker.com/_/postgres) container when you need it with the following shell command:
 ```
 docker run \
   --rm \
   --publish 5432:5432 \
-  -v postgresql-data:/var/lib/postgresql/data \
-  --env POSTGRES_PASSWORD=devpass \
+  -v my-app-data:/var/lib/postgresql/data \
+  --env POSTGRES_PASSWORD=devpass1234 \
   postgres
 ```
-and adding the line
+
+:::note
+The password you provide via `POSTGRES_PASSWORD` is relevant only for the first time when you run that docker command, when database is set up for the first time. Consequent runs will ignore the value of `POSTGRES_PASSWORD` and will just use the password that was initially set. This is just how postgres docker works.
+:::
+
+The easiest way to provide the needed `DATABASE_URL` environment variable is by adding the following line to the [.env](https://wasp-lang.dev/docs/language/features#env) file in the root dir of your Wasp project (if that file doesn't yet exist, create it):
 ```
-DATABASE_URL=postgresql://postgres:devpass@localhost:5432/postgres
+DATABASE_URL=postgresql://postgres:devpass1234@localhost:5432/postgres
 ```
-to the `.env` file in the root directory of your Wasp project.
 
 ### Migrating from SQLite to PostgreSQL
 To run Wasp app in production, you will need to switch from `SQLite` to `PostgreSQL`.


### PR DESCRIPTION
@cursorial , as per your suggestion I tried deploying your Grabbit Wasp project!

While doing that, I encountered some rough spots and added changes to improve those -> they are content of this PR. At the end I did manage to deploy your app to Netlify + Heroku without too much trouble, I think!

Here is a list of stuff I encountered:
- I get error message that I need to use PSQL to deploy app. URL it gives me is broken.
- Instructions on how to set DB to PSQL are not super detailed?
- I am told to add something to .env file, but I never heard about it nor do I have it, so maybe more information there would be nice.
- I failed to change the password in PostgreSQL docker command (from devpass to devpass1234) and get it working, it continues telling me that the password is incorrect, unless I stick with devpass. Why? Am I not setting it correctly? Ok, I figure it out -> so that password is really set up only the first time, when volume is new and db is being created for the first time. After that, that password remains and passing it via `POSTGRES_PASSWORD` has no effect! This is certainly not clear at the moment in the docs.
- On "deploying to netlify" step, mention at the end you will need to fill in some questions from netlify, including that last one `netlify deploy --prod` -> I guess emphasize you need to follow their instructions from that point on.

This is all, the rest worked fine for me!
How was it for you @cursorial , did you experience any additional trouble on the way? Something that could be clearer, nicer, easier, better?

Btw here is deployed Grabbit app: https://wasp-grabbit-test.netlify.app/ ! I will take it down once I close this PR.

TODO: Take down the deployed Grabbit app that I deployed.