### PR TITLE
Now waspc assumes all files to be UTF8 regardless of OS'es default locale

### DIFF
--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -6,6 +6,7 @@ import qualified Control.Exception as E
 import Control.Monad (void)
 import Data.Char (isSpace)
 import Data.Version (showVersion)
+import Main.Utf8 (withUtf8)
 import Paths_waspc (version)
 import System.Environment (getArgs)
 import Wasp.Cli.Command (runCommand)
@@ -26,7 +27,7 @@ import Wasp.Util (indent)
 import qualified Wasp.Util.Terminal as Term
 
 main :: IO ()
-main = (`E.catch` handleInternalErrors) $ do
+main = withUtf8 . (`E.catch` handleInternalErrors) $ do
   args <- getArgs
   let commandCall = case args of
         ["new", projectName] -> Command.Call.New projectName

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -298,6 +298,7 @@ executable wasp-cli
     , async
     , waspc
     , cli-lib
+    , with-utf8 ^>= 1.0.2
   other-modules:
       Paths_waspc
 


### PR DESCRIPTION
This is based on this great article: https://serokell.io/blog/haskell-with-utf8 .

Basically these days we want to assume following:
1. All files on the disk are utf8 (regardless of what is OS's default locale set to)
2. stdin/stderr/stdout, if used for user input/output, use whatever OS has set as default.

Author of article made a library withUtf8 which sets this defaults so, so we are now using that to make our CLI robust!