### PR TITLE
Remove undefined values from query keys

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/queries/index.js
+++ b/waspc/data/Generator/templates/react-app/src/queries/index.js
@@ -9,8 +9,9 @@ export function useQuery(queryFn, queryFnArgs, options) {
     throw new TypeError('queryFn needs to have queryCacheKey property defined.')
   }
 
+  const queryKey = queryFnArgs !== undefined ? [queryFn.queryCacheKey, queryFnArgs] : [queryFn.queryCacheKey]
   return rqUseQuery({
-    queryKey: [queryFn.queryCacheKey, queryFnArgs],
+    queryKey,
     queryFn: () => queryFn(queryFnArgs),
     ...options
   })

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -319,7 +319,7 @@
             "file",
             "web-app/src/queries/index.js"
         ],
-        "8510924f80b32cc0f67ca39fad9d97c4ce5d9695015da3ec8457e91a88868c78"
+        "965368ac8e979667445031addb947baf19055df0df24656c3af4d3abdd86952b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/queries/index.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/queries/index.js
@@ -9,8 +9,9 @@ export function useQuery(queryFn, queryFnArgs, options) {
     throw new TypeError('queryFn needs to have queryCacheKey property defined.')
   }
 
+  const queryKey = queryFnArgs !== undefined ? [queryFn.queryCacheKey, queryFnArgs] : [queryFn.queryCacheKey]
   return rqUseQuery({
-    queryKey: [queryFn.queryCacheKey, queryFnArgs],
+    queryKey,
     queryFn: () => queryFn(queryFnArgs),
     ...options
   })

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -319,7 +319,7 @@
             "file",
             "web-app/src/queries/index.js"
         ],
-        "8510924f80b32cc0f67ca39fad9d97c4ce5d9695015da3ec8457e91a88868c78"
+        "965368ac8e979667445031addb947baf19055df0df24656c3af4d3abdd86952b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/queries/index.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/queries/index.js
@@ -9,8 +9,9 @@ export function useQuery(queryFn, queryFnArgs, options) {
     throw new TypeError('queryFn needs to have queryCacheKey property defined.')
   }
 
+  const queryKey = queryFnArgs !== undefined ? [queryFn.queryCacheKey, queryFnArgs] : [queryFn.queryCacheKey]
   return rqUseQuery({
-    queryKey: [queryFn.queryCacheKey, queryFnArgs],
+    queryKey,
     queryFn: () => queryFn(queryFnArgs),
     ...options
   })

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -340,7 +340,7 @@
             "file",
             "web-app/src/queries/index.js"
         ],
-        "8510924f80b32cc0f67ca39fad9d97c4ce5d9695015da3ec8457e91a88868c78"
+        "965368ac8e979667445031addb947baf19055df0df24656c3af4d3abdd86952b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/queries/index.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/queries/index.js
@@ -9,8 +9,9 @@ export function useQuery(queryFn, queryFnArgs, options) {
     throw new TypeError('queryFn needs to have queryCacheKey property defined.')
   }
 
+  const queryKey = queryFnArgs !== undefined ? [queryFn.queryCacheKey, queryFnArgs] : [queryFn.queryCacheKey]
   return rqUseQuery({
-    queryKey: [queryFn.queryCacheKey, queryFnArgs],
+    queryKey,
     queryFn: () => queryFn(queryFnArgs),
     ...options
   })

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -319,7 +319,7 @@
             "file",
             "web-app/src/queries/index.js"
         ],
-        "8510924f80b32cc0f67ca39fad9d97c4ce5d9695015da3ec8457e91a88868c78"
+        "965368ac8e979667445031addb947baf19055df0df24656c3af4d3abdd86952b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/queries/index.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/queries/index.js
@@ -9,8 +9,9 @@ export function useQuery(queryFn, queryFnArgs, options) {
     throw new TypeError('queryFn needs to have queryCacheKey property defined.')
   }
 
+  const queryKey = queryFnArgs !== undefined ? [queryFn.queryCacheKey, queryFnArgs] : [queryFn.queryCacheKey]
   return rqUseQuery({
-    queryKey: [queryFn.queryCacheKey, queryFnArgs],
+    queryKey,
     queryFn: () => queryFn(queryFnArgs),
     ...options
   })


### PR DESCRIPTION
We had a small bug here. When we call a query without additional arguments, its key includes the value `undefined`. This PR fixes that.
