### PR TITLE
Updated todo app docs - fix #648

### DIFF
--- a/web/docs/tutorials/todo-app/auth.md
+++ b/web/docs/tutorials/todo-app/auth.md
@@ -220,7 +220,7 @@ Next, let's update the queries and actions to forbid access to non-authenticated
 import HttpError from '@wasp/core/HttpError.js'
 
 export const getTasks = async (args, context) => {
-  if (!context.user) { throw new HttpError(403) }
+  if (!context.user) { throw new HttpError(401) }
   return context.entities.Task.findMany(
     { where: { user: { id: context.user.id } } }
   )
@@ -231,7 +231,7 @@ export const getTasks = async (args, context) => {
 import HttpError from '@wasp/core/HttpError.js'
 
 export const createTask = async ({ description }, context) => {
-  if (!context.user) { throw new HttpError(403) }
+  if (!context.user) { throw new HttpError(401) }
   return context.entities.Task.create({
     data: {
       description,
@@ -241,7 +241,7 @@ export const createTask = async ({ description }, context) => {
 }
 
 export const updateTask = async ({ taskId, data }, context) => {
-  if (!context.user) { throw new HttpError(403) }
+  if (!context.user) { throw new HttpError(401) }
   return context.entities.Task.updateMany({
     where: { id: taskId, user: { id: context.user.id } },
     data: { isDone: data.isDone }


### PR DESCRIPTION
# Description
In the documentation for the Todo app: https://wasp-lang.dev/docs/tutorials/todo-app/auth there was a  snippets that return `403` when the user is not logged in.
In this PR I changed that to return `401`

Fixes #648 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update