### PR TITLE
Update examples/todoApp - fix #678

### DIFF
--- a/examples/tutorials/TodoApp/ext/actions.js
+++ b/examples/tutorials/TodoApp/ext/actions.js
@@ -1,7 +1,7 @@
 import HttpError from '@wasp/core/HttpError.js'
 
 export const createTask = async ({ description }, context) => {
-  if (!context.user) { throw new HttpError(403) }
+  if (!context.user) { throw new HttpError(401) }
   return context.entities.Task.create({
     data: {
       description,
@@ -11,7 +11,7 @@ export const createTask = async ({ description }, context) => {
 }
 
 export const updateTask = async ({ taskId, data }, context) => {
-  if (!context.user) { throw new HttpError(403) }
+  if (!context.user) { throw new HttpError(401) }
   return context.entities.Task.updateMany({
     where: { id: taskId, user: { id: context.user.id } },
     data: {

--- a/examples/tutorials/TodoApp/ext/queries.js
+++ b/examples/tutorials/TodoApp/ext/queries.js
@@ -1,7 +1,7 @@
 import HttpError from '@wasp/core/HttpError.js'
 
 export const getTasks = async (args, context) => {
-  if (!context.user) { throw new HttpError(403) }
+  if (!context.user) { throw new HttpError(401) }
   return context.entities.Task.findMany(
     { where: { user: { id: context.user.id } } }
   )

--- a/waspc/examples/todoApp/ext/actions.js
+++ b/waspc/examples/todoApp/ext/actions.js
@@ -3,7 +3,7 @@ import { getSomeResource } from './serverSetup.js'
 
 export const createTask = async (task, context) => {
   if (!context.user) {
-    throw new HttpError(403)
+    throw new HttpError(401)
   }
 
   const Task = context.entities.Task
@@ -22,7 +22,7 @@ export const createTask = async (task, context) => {
 
 export const updateTaskIsDone = async ({ id, isDone }, context) => {
   if (!context.user) {
-    throw new HttpError(403)
+    throw new HttpError(401)
   }
 
   const Task = context.entities.Task
@@ -34,7 +34,7 @@ export const updateTaskIsDone = async ({ id, isDone }, context) => {
 
 export const deleteCompletedTasks = async (args, context) => {
   if (!context.user) {
-    throw new HttpError(403)
+    throw new HttpError(401)
   }
 
   const Task = context.entities.Task
@@ -45,7 +45,7 @@ export const deleteCompletedTasks = async (args, context) => {
 
 export const toggleAllTasks = async (args, context) => {
   if (!context.user) {
-    throw new HttpError(403)
+    throw new HttpError(401)
   }
 
   const whereIsDone = isDone => ({ isDone, user: { id: context.user.id } })

--- a/waspc/examples/todoApp/ext/queries.js
+++ b/waspc/examples/todoApp/ext/queries.js
@@ -2,7 +2,7 @@ import HttpError from '@wasp/core/HttpError.js'
 
 export const getTasks = async (args, context) => {
   if (!context.user) {
-    throw new HttpError(403)
+    throw new HttpError(401)
   }
   console.log('user who made the query: ', context.user)
   console.log('TEST_ENV_VAR', process.env.TEST_ENV_VAR)
@@ -23,7 +23,7 @@ export const getNumTasks = async (args, context) => {
 
 export const getTask = async ({ id }, context) => {
   if (!context.user) {
-    throw new HttpError(403)
+    throw new HttpError(401)
   }
 
   const Task = context.entities.Task
@@ -34,7 +34,7 @@ export const getTask = async ({ id }, context) => {
     throw new HttpError(404)
   }
   if (task.user.id !== context.user.id) {
-    throw new HttpError(403)
+    throw new HttpError(401)
   }
 
   return task

--- a/waspc/examples/todoApp/ext/queries.js
+++ b/waspc/examples/todoApp/ext/queries.js
@@ -33,8 +33,10 @@ export const getTask = async ({ id }, context) => {
   if (!task) {
     throw new HttpError(404)
   }
+  // 404 is used to 'hide' the current existence of a forbidden target resource as a security measure
+  // for vulnerabilities like IDOR
   if (task.user.id !== context.user.id) {
-    throw new HttpError(401)
+    throw new HttpError(404)
   }
 
   return task


### PR DESCRIPTION
# Description
In the documentation for the Todo app: https://wasp-lang.dev/docs/tutorials/todo-app/auth there was a snippets that return `401` when the user is not logged in. But the todoApp code is still uses `403`
This PR fixes that issue

Fixes #678 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update