### PR TITLE
feat: separate env vars for server and client

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -122,7 +122,8 @@ createNewProject' (ProjectName projectName) = do
     gitignoreFileContent =
       unlines
         [ "/.wasp/",
-          "/.env"
+          "/.env.server",
+          "/.env.client"
         ]
 
     waspignoreFileInExtCodeDir :: Path' (Rel SourceExternalCodeDir) File'

--- a/waspc/src/Wasp/AppSpec.hs
+++ b/waspc/src/Wasp/AppSpec.hs
@@ -44,7 +44,8 @@ data AppSpec = AppSpec
     migrationsDir :: Maybe (Path' Abs (Dir DbMigrationsDir)),
     -- | Absolute path to the .env file in wasp project source. It contains env variables to be
     -- provided to the server only during the development.
-    dotEnvFile :: Maybe (Path' Abs File'),
+    dotEnvServerFile :: Maybe (Path' Abs File'),
+    dotEnvClientFile :: Maybe (Path' Abs File'),
     -- | If true, it means project is being compiled for production/deployment -> it is being "built".
     -- If false, it means project is being compiled for development purposes (e.g. "wasp start").
     isBuild :: Bool

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -66,7 +66,7 @@ genServer spec =
 
 genDotEnv :: AppSpec -> Generator [FileDraft]
 genDotEnv spec = return $
-  case AS.dotEnvFile spec of
+  case AS.dotEnvServerFile spec of
     Just srcFilePath
       | not $ AS.isBuild spec ->
           [ createCopyFileDraft

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -9,7 +9,9 @@ import Data.List (intercalate)
 import Data.Maybe (fromMaybe, isJust)
 import StrongPath
   ( Dir,
+    File',
     Path,
+    Path',
     Posix,
     Rel,
     reldir,
@@ -49,6 +51,21 @@ genWebApp spec = do
     <++> genPublicDir spec
     <++> genSrcDir spec
     <++> genExternalCodeDir WebAppExternalCodeGenerator.generatorStrategy (AS.externalCodeFiles spec)
+    <++> genDotEnv spec
+
+genDotEnv :: AppSpec -> Generator [FileDraft]
+genDotEnv spec = return $
+  case AS.dotEnvClientFile spec of
+    Just srcFilePath
+      | not $ AS.isBuild spec ->
+          [ createCopyFileDraft
+              (C.webAppRootDirInProjectRootDir </> dotEnvInWebAppRootDir)
+              srcFilePath
+          ]
+    _ -> []
+
+dotEnvInWebAppRootDir :: Path' (Rel C.WebAppRootDir) File'
+dotEnvInWebAppRootDir = [relfile|.env|]
 
 genReadme :: Generator FileDraft
 genReadme = return $ C.mkTmplFd $ C.asTmplFile [relfile|README.md|]

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -66,7 +66,8 @@ analyzeWaspProject waspDir options = do
         Right decls -> do
           externalCodeFiles <-
             ExternalCode.readFiles (CompileOptions.externalCodeDirPath options)
-          maybeDotEnvFile <- findDotEnvFile waspDir
+          maybeDotEnvServerFile <- findDotEnvServer waspDir
+          maybeDotEnvClientFile <- findDotEnvClient waspDir
           maybeMigrationsDir <- findMigrationsDir waspDir
           return $
             Right
@@ -75,7 +76,8 @@ analyzeWaspProject waspDir options = do
                   AS.externalCodeFiles = externalCodeFiles,
                   AS.externalCodeDirPath = CompileOptions.externalCodeDirPath options,
                   AS.migrationsDir = maybeMigrationsDir,
-                  AS.dotEnvFile = maybeDotEnvFile,
+                  AS.dotEnvServerFile = maybeDotEnvServerFile,
+                  AS.dotEnvClientFile = maybeDotEnvClientFile,
                   AS.isBuild = CompileOptions.isBuild options
                 }
 
@@ -88,11 +90,17 @@ findWaspFile waspDir = do
       ".wasp" `isSuffixOf` SP.toFilePath path
         && (length (SP.toFilePath path) > length (".wasp" :: String))
 
-findDotEnvFile :: Path' Abs (Dir WaspProjectDir) -> IO (Maybe (Path' Abs File'))
-findDotEnvFile waspDir = do
-  let dotEnvAbsPath = waspDir SP.</> [relfile|.env|]
-  dotEnvExists <- doesFileExist (SP.toFilePath dotEnvAbsPath)
-  return $ if dotEnvExists then Just dotEnvAbsPath else Nothing
+findDotEnvServer :: Path' Abs (Dir WaspProjectDir) -> IO (Maybe (Path' Abs File'))
+findDotEnvServer waspDir = do
+  let dotEnvServerAbsPath = waspDir SP.</> [relfile|.env.server|]
+  dotEnvServerExists <- doesFileExist (SP.toFilePath dotEnvServerAbsPath)
+  return $ if dotEnvServerExists then Just dotEnvServerAbsPath else Nothing
+
+findDotEnvClient :: Path' Abs (Dir WaspProjectDir) -> IO (Maybe (Path' Abs File'))
+findDotEnvClient waspDir = do
+  let dotEnvClientAbsPath = waspDir SP.</> [relfile|.env.client|]
+  dotEnvClientExists <- doesFileExist (SP.toFilePath dotEnvClientAbsPath)
+  return $ if dotEnvClientExists then Just dotEnvClientAbsPath else Nothing
 
 findMigrationsDir ::
   Path' Abs (Dir WaspProjectDir) ->

--- a/waspc/test/AppSpec/ValidTest.hs
+++ b/waspc/test/AppSpec/ValidTest.hs
@@ -147,7 +147,8 @@ spec_AppSpecValid = do
           AS.externalCodeFiles = [],
           AS.isBuild = False,
           AS.migrationsDir = Nothing,
-          AS.dotEnvFile = Nothing
+          AS.dotEnvServerFile = Nothing,
+          AS.dotEnvClientFile = Nothing
         }
 
     basicPage =

--- a/waspc/test/Generator/WebAppGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGeneratorTest.hs
@@ -40,7 +40,8 @@ spec_WebAppGenerator = do
             AS.externalCodeFiles = [],
             AS.isBuild = False,
             AS.migrationsDir = Nothing,
-            AS.dotEnvFile = Nothing
+            AS.dotEnvServerFile = Nothing,
+            AS.dotEnvClientFile = Nothing
           }
 
   describe "genWebApp" $ do


### PR DESCRIPTION
# Description

Adds support for `.env` vars for frontend app. To enable this, Wasp user can add `.env.client` file which will be passed to web app as `.env` file.

**⚠️ Breaking change**: Existing Wasp users have to manually update env filename at wasp root dir from `.env` to `.env.server`.

Fixes #675 

Draft status of this PR will be removed once the following is completed:
- [ ] Check all examples for `env-sample` file and update accordingly. By now found at https://github.com/wasp-lang/wasp/blob/main/waspc/examples/todoApp/sample.env
- [ ] Update docs at https://github.com/wasp-lang/wasp/blob/main/web/docs/language/features.md#env

## Type of change

Please select the option(s) that is more relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update