### PR TITLE
Proposing a new branching and merging model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,10 @@
 name: CI
 
 on:
-  push: { branches: [main] }
+  push:
+    branches:
+      - main
+      - release
   pull_request: { }
   create: { tags: [v*] }
   schedule:

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -13,7 +13,7 @@ If you would like to make your first contribution, here is a handy checklist we 
 - [ ] Join [Discord](https://discord.gg/rzdnErX) and say hi :)!
 - [ ] Pick an issue [labeled with "good first issue"](https://github.com/wasp-lang/wasp/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and let us know you would like to work on it - ideally immediatelly propose a plan of action and ask questions.
       If you can't find a suitable issue for you, reach out to us on Discord and we can try to find smth for you together.
-- [ ] Make a PR and have it accepted! Check [Typical workflow](#typical-development-workflow) for guidance, and consult [Codebase overview](#codebase-overview) for more details on how Wasp compiler works internally.
+- [ ] Make a PR targeting `main` and have it accepted! Check [Typical workflow](#typical-development-workflow) for guidance, and consult [Codebase overview](#codebase-overview) for more details on how Wasp compiler works internally.
 
 
 ## Quick overview
@@ -316,6 +316,21 @@ NOTE: When you run it for the first time it might take a while (~10 minutes) for
 ## Commit message conventions
 We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) convention when creating commits.
 
+## Branching and merging strategy
+This repo contains both the source code that makes up a Wasp release (under `waspc`), as well as our website containing documentation and blog posts (under `web`). In order to facilitate the development of Wasp code while still allowing for website updates or hotfixes of the current release, we have decided on the following minimal branching strategy.
+
+All Wasp development should be done on feature branches. They form the basis of PRs that will target one of the two following branches:
+
+- `main`: this branch contains all the actively developed new features and corresponding documentation updates. Some of these things may not yet be released, but anything merged into `main` should be in a release-ready state.
+  - This is the default branch to target for any Wasp feature branches.
+- `release`: this branch contains the source code of current/latest Wasp release, as well as the documentation and blog posts currently visible on the website.
+  - When we do a full release, we first backmerge `release` into `main` to pick up any diverging changes (see below). We then merge `main` into `release` to get all the new changes. We can now create a new Wasp release as well as deploy the website from the `release` branch.
+  - How can `release` diverge from `main`?
+    - If you have a website-only update (like a blog post or documentation fix) that does _not_ depend on a Wasp release, you may open your PR against `release`.
+    - If there is a hotfix required for the _current_ Wasp release, you may open your PR against `release`.
+
+NOTE: The term "backmerge" here just refers to a normal git merge, but in the opposite or backwards direction to the normal merge flow. Our normal flow is from `main` -> `release`, but we should backport any direct-to-`release` commits via a backmerge from `release` -> `main`.
+
 ## Deployment / CI
 We use Github Actions for CI.
 
@@ -335,13 +350,16 @@ If it happens just once every so it is probably nothing to worry about. If it ha
 ### Typical Release Process
 - Update ChangeLog.md with release notes and open an PR for feedback.
 - After approval, squash and merge PR for ChangeLog.md into `main`.
-- Make sure you are on `main` and up to date locally :D and then run `./new-release 0.x.y.z`.
+- Update your local repository state to have all remote changes.
+- Backmerge `release` into `main`.
+- Merge `main` into `release`.
+- Make sure you are on `release` and then run `./new-release 0.x.y.z`.
   - This will automatically create a new commit for updating the version in waspc.cabal, tag it, and push it all.
 - Wait for CI to finish & succeed for the new tag.
   - This will automatically create a new draft release.
 - Find new draft release here: https://github.com/wasp-lang/wasp/releases and edit it with your release notes.
 - Publish the draft release when ready.
-- Publish new [docs](/web#deployment).
+- Publish new [docs](/web#deployment) from the `release` branch as well.
 - Announce new release in Discord.
 
 ## Documentation

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -324,15 +324,16 @@ All Wasp development should be done on feature branches. They form the basis of 
 - `main`: this branch contains all the actively developed new features and corresponding documentation updates. Some of these things may not yet be released, but anything merged into `main` should be in a release-ready state.
   - This is the default branch to target for any Wasp feature branches.
 - `release`: this branch contains the source code of current/latest Wasp release, as well as the documentation and blog posts currently published and therefore visible on the website.
-  - When we do a full release, we first backmerge `release` into `main` to pick up any diverging changes (see below). We then merge `main` into `release` to get all the new changes. We can now create a new Wasp release as well as deploy the website from the `release` branch.
+  - When doing a full release, which means making a new release based on what we have currently on `main`, we do the following:
+    1. Update `main` branch by merging `release` into it. There might be conflicts but they shouldn't be too hard to fix. Once `main` is updated, you can create a new waspc release from it, as well as deploy the website from it.
+    2. Update `release` branch to this new `main` by merging `main` into it. There will be no conflicts since we already resolved all of them in the previous step.
+
 How do I know where I want to target my PR, to `release` or `main`?
   - If you have a change that you want to publish right now or very soon, certainly earlier than waiting till `main` is ready for publishing, then you want to target `release`. This could be website content update, new blog post, documentation (hot)fix, compiler hotfix that we need to release quickly via a new patch version, ... .
   - If you have a change that is not urgent and can wait until the next "normal" Wasp release is published, then target `main`. These are new features, refactorings, docs accompanying new features, ... .
   - TLDR;
     - `release` is for changes to the already published stuff (the present).
     - `main` is for changes to the to-be-published stuff (the future).
-
-NOTE: The term "backmerge" here just refers to a normal git merge, but in the opposite or backwards direction to the normal merge flow. Our normal flow is from `main` -> `release`, but we should backport any direct-to-`release` commits via a backmerge from `release` -> `main`.
 
 ## Deployment / CI
 We use Github Actions for CI.
@@ -354,7 +355,7 @@ If it happens just once every so it is probably nothing to worry about. If it ha
 - Update ChangeLog.md with release notes and open an PR for feedback.
 - After approval, squash and merge PR for ChangeLog.md into `main`.
 - Update your local repository state to have all remote changes.
-- Backmerge `release` into `main`.
+- Merge `release` into `main`.
 - Merge `main` into `release`.
 - Make sure you are on `release` and then run `./new-release 0.x.y.z`.
   - This will automatically create a new commit for updating the version in waspc.cabal, tag it, and push it all.

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -354,9 +354,9 @@ If it happens just once every so it is probably nothing to worry about. If it ha
 ### Typical Release Process
 - Update ChangeLog.md with release notes and open an PR for feedback.
 - After approval, squash and merge PR for ChangeLog.md into `main`.
-- Update your local repository state to have all remote changes.
-- Merge `release` into `main`.
-- Merge `main` into `release`.
+- Update your local repository state to have all remote changes (`git fetch`).
+- Update `main` to contain changes from `release` by running `git merge release` while on the `main` branch. Resolve any conflicts.
+- Fast-forward `release` to this new, updated `main` by running `git merge main` while on the `release` branch.
 - Make sure you are on `release` and then run `./new-release 0.x.y.z`.
   - This will automatically create a new commit for updating the version in waspc.cabal, tag it, and push it all.
 - Wait for CI to finish & succeed for the new tag.

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -13,7 +13,7 @@ If you would like to make your first contribution, here is a handy checklist we 
 - [ ] Join [Discord](https://discord.gg/rzdnErX) and say hi :)!
 - [ ] Pick an issue [labeled with "good first issue"](https://github.com/wasp-lang/wasp/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and let us know you would like to work on it - ideally immediatelly propose a plan of action and ask questions.
       If you can't find a suitable issue for you, reach out to us on Discord and we can try to find smth for you together.
-- [ ] Make a PR targeting `main` and have it accepted! Check [Typical workflow](#typical-development-workflow) for guidance, and consult [Codebase overview](#codebase-overview) for more details on how Wasp compiler works internally.
+- [ ] Make a PR targeting `main` and have it accepted! Check [Typical workflow](#typical-development-workflow) and [Branching and merging strategy](#branching-and-merging-strategy) for guidance, and consult [Codebase overview](#codebase-overview) for more details on how Wasp compiler works internally.
 
 
 ## Quick overview

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -323,11 +323,14 @@ All Wasp development should be done on feature branches. They form the basis of 
 
 - `main`: this branch contains all the actively developed new features and corresponding documentation updates. Some of these things may not yet be released, but anything merged into `main` should be in a release-ready state.
   - This is the default branch to target for any Wasp feature branches.
-- `release`: this branch contains the source code of current/latest Wasp release, as well as the documentation and blog posts currently visible on the website.
+- `release`: this branch contains the source code of current/latest Wasp release, as well as the documentation and blog posts currently published and therefore visible on the website.
   - When we do a full release, we first backmerge `release` into `main` to pick up any diverging changes (see below). We then merge `main` into `release` to get all the new changes. We can now create a new Wasp release as well as deploy the website from the `release` branch.
-  - How can `release` diverge from `main`?
-    - If you have a website-only update (like a blog post or documentation fix) that does _not_ depend on a Wasp release, you may open your PR against `release`.
-    - If there is a hotfix required for the _current_ Wasp release, you may open your PR against `release`.
+How do I know where I want to target my PR, to `release` or `main`?
+  - If you have a change that you want to publish right now or very soon, certainly earlier than waiting till `main` is ready for publishing, then you want to target `release`. This could be website content update, new blog post, documentation (hot)fix, compiler hotfix that we need to release quickly via a new patch version, ... .
+  - If you have a change that is not urgent and can wait until the next "normal" Wasp release is published, then target `main`. These are new features, refactorings, docs accompanying new features, ... .
+  - TLDR;
+    - `release` is for changes to the already published stuff (the present).
+    - `main` is for changes to the to-be-published stuff (the future).
 
 NOTE: The term "backmerge" here just refers to a normal git merge, but in the opposite or backwards direction to the normal merge flow. Our normal flow is from `main` -> `release`, but we should backport any direct-to-`release` commits via a backmerge from `release` -> `main`.
 

--- a/web/README.md
+++ b/web/README.md
@@ -28,7 +28,9 @@ To run this version of code and check that it works correctly, run `npm run serv
 
 ### Deployment
 
-We are deploying to GitHub pages, and that can easily be done with the following command:
+We are deploying to GitHub pages, and that can easily be done with the following command.
+
+First, ensure you are on the `release` branch. Next, run:
 
 ```
 $ GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy


### PR DESCRIPTION
# Description

This PR updates our READMEs to detail a proposed update to our branching and merging model that @Martinsos and I chatted about today. The current "deploy everything from `main`" model suffers from:
- Inability to deploy website content independent of changes already in `main`.
  - This means we must delay merging code with corresponding doc updates into `main` if we want to be able to publish a new blog post before we cut a new release, for example, as otherwise, our docs won't match the current Wasp release.
- We don't have a good way to handle hotfixes.
  - Many times, `main` may have breaking changes staged to go out next. If we had to make a hotfix for the current release we could not use `main` since building a new release from there could break the current release.

This model will likely have to evolve over time. For example, we probably want to be able to merge hotfixes into multiple prior releases, not just the current. But this idea should improve our current setup in the meantime.

What does everyone think? I am especially curious if there are better ways to handle the divergence of `release` and `main`.

_UPDATE: The more I think about it, the more I think a [gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) model may make sense for us long-term. We could make our releases branches we could then prepare more methodically and keep around to easily hotfix as well. Note, this is not part of this idea and I know it deviates from the popular trunk based used by many SaaS apps today, but I think our ultimate ideal flow is necessarily different._

# TODOs to roll this out:
- [ ] create a new branch `release` from `main`
- [ ] retarget all website-only PRs from `main` to `release`
- [ ] test a website deploy from the `release` branch
- [x] test the git backmerge process from `release` into `main` and how that impacts future merges from `main` to `release` and the history locally (Martin + Shayne did)
- [ ] add CI to `release`? ensure it all still plays nicely with tags like `v`
- [ ] test the Wasp release process to use `release` instead of `main`
