### PR TITLE
Add support for kebab-case in project name (#590)

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -18,14 +18,16 @@ import Wasp.Cli.Command (Command, CommandError (..))
 import qualified Wasp.Cli.Command.Common as Command.Common
 import qualified Wasp.Cli.Common as Common
 import qualified Wasp.Data
-import Wasp.Util (indent)
+import Wasp.Util (indent, projectNameToAppIdentifier)
 import qualified Wasp.Util.Terminal as Term
 
 newtype ProjectName = ProjectName {_projectName :: String}
 
+newtype AppIdentifier = AppIdentifier {_appIdentifier :: String}
+
 createNewProject :: String -> Command ()
 createNewProject name
-  | isValidWaspIdentifier name = createNewProject' (ProjectName name)
+  | isValidWaspIdentifier appIdentifier = createNewProject' (ProjectName name) (AppIdentifier appIdentifier)
   | otherwise =
       throwError $
         CommandError "Project creation failed" $
@@ -36,9 +38,11 @@ createNewProject name
               indent 2 "- It can contain only letters, numbers, or underscores.",
               indent 2 "- It can't be a Wasp keyword."
             ]
+  where
+    appIdentifier = projectNameToAppIdentifier name
 
-createNewProject' :: ProjectName -> Command ()
-createNewProject' (ProjectName projectName) = do
+createNewProject' :: ProjectName -> AppIdentifier -> Command ()
+createNewProject' (ProjectName projectName) (AppIdentifier appIdentifier) = do
   absCwd <- liftIO getCurrentDirectory
   waspProjectDir <- case SP.parseAbsDir $ absCwd FP.</> projectName of
     Left err ->
@@ -106,7 +110,7 @@ createNewProject' (ProjectName projectName) = do
 
     mainWaspFileContent =
       unlines
-        [ "app %s {" `printf` projectName,
+        [ "app %s {" `printf` appIdentifier,
           "  title: \"%s\"" `printf` projectName,
           "}",
           "",

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -29,24 +29,24 @@ data ProjectInfo = ProjectInfo
 -- Takes a project name String
 -- Returns either the ProjectInfo type that contains both the Project name
 -- and the App name (which might be the same), or an error describing why the name is invalid
-parseProjectNameIntoProjectInfo :: String -> Either String ProjectInfo
-parseProjectNameIntoProjectInfo name
-  | isValidWaspIdentifier appIdentifier = Right (ProjectInfo name appIdentifier)
+parseProjectInfo :: String -> Either String ProjectInfo
+parseProjectInfo name
+  | isValidWaspIdentifier appName = Right (ProjectInfo name appName)
   | otherwise =
       Left $
         intercalate
           "\n"
-          [ "The project's name is not of a valid format!",
+          [ "The project's name is not in the valid format!",
             indent 2 "- It can start with a letter or an underscore.",
-            indent 2 "- It can contain only letters, numbers, dash, or underscores.",
+            indent 2 "- It can contain only letters, numbers, dashes, or underscores.",
             indent 2 "- It can't be a Wasp keyword."
           ]
   where
-    appIdentifier = kebabToCamelCase name
+    appName = kebabToCamelCase name
 
 createNewProject :: String -> Command ()
 createNewProject name =
-  case parseProjectNameIntoProjectInfo name of
+  case parseProjectInfo name of
     Right projectInfo -> createNewProject' projectInfo
     Left parsedError ->
       throwError $

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -26,16 +26,17 @@ data ProjectInfo = ProjectInfo
     _appName :: String
   }
 
+-- Takes a project name String
 -- Returns either the ProjectInfo type that contains both the Project name
 -- and the App name (which might be the same), or an error describing why the name is invalid
-parseProjectInfo :: String -> Either String ProjectInfo
-parseProjectInfo name
+parseProjectNameIntoProjectInfo :: String -> Either String ProjectInfo
+parseProjectNameIntoProjectInfo name
   | isValidWaspIdentifier appIdentifier = Right (ProjectInfo name appIdentifier)
   | otherwise =
       Left $
         intercalate
           "\n"
-          [ "The project's name must be a valid Wasp identifier:",
+          [ "The project's name is not of a valid format!",
             indent 2 "- It can start with a letter or an underscore.",
             indent 2 "- It can contain only letters, numbers, dash, or underscores.",
             indent 2 "- It can't be a Wasp keyword."
@@ -45,8 +46,8 @@ parseProjectInfo name
 
 createNewProject :: String -> Command ()
 createNewProject name =
-  case parseProjectInfo name of
-    Right projectName -> createNewProject' projectName
+  case parseProjectNameIntoProjectInfo name of
+    Right projectInfo -> createNewProject' projectInfo
     Left parsedError ->
       throwError $
         CommandError "Project creation failed" parsedError

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -18,31 +18,41 @@ import Wasp.Cli.Command (Command, CommandError (..))
 import qualified Wasp.Cli.Command.Common as Command.Common
 import qualified Wasp.Cli.Common as Common
 import qualified Wasp.Data
-import Wasp.Util (indent, projectNameToAppIdentifier)
+import Wasp.Util (indent, kebabToCamelCase)
 import qualified Wasp.Util.Terminal as Term
 
-newtype ProjectName = ProjectName {_projectName :: String}
+data ProjectInfo = ProjectInfo
+  { _projectName :: String,
+    _appName :: String
+  }
 
-newtype AppIdentifier = AppIdentifier {_appIdentifier :: String}
+-- Returns either the ProjectInfo type that contains both the Project name
+-- and the App name (which might be the same), or an error describing why the name is invalid
+parseProjectInfo :: String -> Either String ProjectInfo
+parseProjectInfo name
+  | isValidWaspIdentifier appIdentifier = Right (ProjectInfo name appIdentifier)
+  | otherwise =
+      Left $
+        intercalate
+          "\n"
+          [ "The project's name must be a valid Wasp identifier:",
+            indent 2 "- It can start with a letter or an underscore.",
+            indent 2 "- It can contain only letters, numbers, dash, or underscores.",
+            indent 2 "- It can't be a Wasp keyword."
+          ]
+  where
+    appIdentifier = kebabToCamelCase name
 
 createNewProject :: String -> Command ()
-createNewProject name
-  | isValidWaspIdentifier appIdentifier = createNewProject' (ProjectName name) (AppIdentifier appIdentifier)
-  | otherwise =
+createNewProject name =
+  case parseProjectInfo name of
+    Right projectName -> createNewProject' projectName
+    Left parsedError ->
       throwError $
-        CommandError "Project creation failed" $
-          intercalate
-            "\n"
-            [ "The project's name must be a valid Wasp identifier:",
-              indent 2 "- It can start with a letter or an underscore.",
-              indent 2 "- It can contain only letters, numbers, or underscores.",
-              indent 2 "- It can't be a Wasp keyword."
-            ]
-  where
-    appIdentifier = projectNameToAppIdentifier name
+        CommandError "Project creation failed" parsedError
 
-createNewProject' :: ProjectName -> AppIdentifier -> Command ()
-createNewProject' (ProjectName projectName) (AppIdentifier appIdentifier) = do
+createNewProject' :: ProjectInfo -> Command ()
+createNewProject' (ProjectInfo projectName appName) = do
   absCwd <- liftIO getCurrentDirectory
   waspProjectDir <- case SP.parseAbsDir $ absCwd FP.</> projectName of
     Left err ->
@@ -110,7 +120,7 @@ createNewProject' (ProjectName projectName) (AppIdentifier appIdentifier) = do
 
     mainWaspFileContent =
       unlines
-        [ "app %s {" `printf` appIdentifier,
+        [ "app %s {" `printf` appName,
           "  title: \"%s\"" `printf` projectName,
           "}",
           "",

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -63,7 +63,7 @@ kebabToCamelCase = concat . capitalizeAllWordsExceptForTheFirstOne . wordsBy (==
   where
     capitalizeAllWordsExceptForTheFirstOne :: [String] -> [String]
     capitalizeAllWordsExceptForTheFirstOne [] = []
-    capitalizeAllWordsExceptForTheFirstOne (kebabHead : kebabTail) = kebabHead : map toUpperFirst kebabTail
+    capitalizeAllWordsExceptForTheFirstOne (firstWord : otherWords) = firstWord : map toUpperFirst otherWords
 
 -- | Applies given function to the first element of the list.
 --   If list is empty, returns empty list.

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -28,6 +28,7 @@ module Wasp.Util
     fromMaybeM,
     orIfNothing,
     orIfNothingM,
+    projectNameToAppIdentifier,
   )
 where
 
@@ -39,7 +40,7 @@ import qualified Data.ByteString.UTF8 as BSU
 import Data.Char (isSpace, isUpper, toLower, toUpper)
 import qualified Data.HashMap.Strict as M
 import Data.List (intercalate)
-import Data.List.Split (splitOn)
+import Data.List.Split (splitOn, wordsBy)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -56,6 +57,13 @@ camelToKebabCase camel@(camelHead : camelTail) = kebabHead : kebabTail
         (\(a, b) -> (if isCamelHump (a, b) then ['-'] else []) ++ [toLower b])
         (zip camel camelTail)
     isCamelHump (a, b) = (not . isUpper) a && isUpper b
+
+projectNameToAppIdentifier :: String -> String
+projectNameToAppIdentifier = concat . capitalizeWords . wordsBy (== '-')
+  where
+    capitalizeWords :: [String] -> [String]
+    capitalizeWords [] = []
+    capitalizeWords (kebabHead : kebabTail) = kebabHead : map toUpperFirst kebabTail
 
 -- | Applies given function to the first element of the list.
 --   If list is empty, returns empty list.

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -28,7 +28,7 @@ module Wasp.Util
     fromMaybeM,
     orIfNothing,
     orIfNothingM,
-    projectNameToAppIdentifier,
+    kebabToCamelCase,
   )
 where
 
@@ -58,12 +58,12 @@ camelToKebabCase camel@(camelHead : camelTail) = kebabHead : kebabTail
         (zip camel camelTail)
     isCamelHump (a, b) = (not . isUpper) a && isUpper b
 
-projectNameToAppIdentifier :: String -> String
-projectNameToAppIdentifier = concat . capitalizeWords . wordsBy (== '-')
+kebabToCamelCase :: String -> String
+kebabToCamelCase = concat . capitalizeAllWordsExceptForTheFirstOne . wordsBy (== '-')
   where
-    capitalizeWords :: [String] -> [String]
-    capitalizeWords [] = []
-    capitalizeWords (kebabHead : kebabTail) = kebabHead : map toUpperFirst kebabTail
+    capitalizeAllWordsExceptForTheFirstOne :: [String] -> [String]
+    capitalizeAllWordsExceptForTheFirstOne [] = []
+    capitalizeAllWordsExceptForTheFirstOne (kebabHead : kebabTail) = kebabHead : map toUpperFirst kebabTail
 
 -- | Applies given function to the first element of the list.
 --   If list is empty, returns empty list.

--- a/waspc/test/UtilTest.hs
+++ b/waspc/test/UtilTest.hs
@@ -18,16 +18,20 @@ spec_camelToKebabCase = do
     camel ~> kebab = it (camel ++ " -> " ++ kebab) $ do
       camelToKebabCase camel `shouldBe` kebab
 
-spec_projectNameToAppIdentifier :: Spec
-spec_projectNameToAppIdentifier = do
+spec_kebabToCamelCase :: Spec
+spec_kebabToCamelCase = do
   "foobar" ~> "foobar"
   "s3" ~> "s3"
   "foo-bar-bar" ~> "fooBarBar"
   "todo-App" ~> "todoApp"
   "TODO-app" ~> "TODOApp"
+  "s3-folder" ~> "s3Folder"
+  "foo---bar-baz" ~> "fooBarBaz"
+  "-foo-" ~> "foo"
+  "" ~> ""
   where
     kebab ~> camel = it (kebab ++ " -> " ++ camel) $ do
-      projectNameToAppIdentifier kebab `shouldBe` camel
+      kebabToCamelCase kebab `shouldBe` camel
 
 spec_onFirst :: Spec
 spec_onFirst = do

--- a/waspc/test/UtilTest.hs
+++ b/waspc/test/UtilTest.hs
@@ -18,6 +18,17 @@ spec_camelToKebabCase = do
     camel ~> kebab = it (camel ++ " -> " ++ kebab) $ do
       camelToKebabCase camel `shouldBe` kebab
 
+spec_projectNameToAppIdentifier :: Spec
+spec_projectNameToAppIdentifier = do
+  "foobar" ~> "foobar"
+  "s3" ~> "s3"
+  "foo-bar-bar" ~> "fooBarBar"
+  "todo-App" ~> "todoApp"
+  "TODO-app" ~> "TODOApp"
+  where
+    kebab ~> camel = it (kebab ++ " -> " ++ camel) $ do
+      projectNameToAppIdentifier kebab `shouldBe` camel
+
 spec_onFirst :: Spec
 spec_onFirst = do
   it "Returns empty list for empty list" $ do

--- a/waspc/test/UtilTest.hs
+++ b/waspc/test/UtilTest.hs
@@ -28,6 +28,8 @@ spec_kebabToCamelCase = do
   "s3-folder" ~> "s3Folder"
   "foo---bar-baz" ~> "fooBarBaz"
   "-foo-" ~> "foo"
+  "-" ~> ""
+  "--" ~> ""
   "" ~> ""
   where
     kebab ~> camel = it (kebab ++ " -> " ++ camel) $ do


### PR DESCRIPTION
# Description

Relaxing the project name constraint by allowing `-` in a project name. I tried to implement what suggested in #590.

Fixes #590

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update