### PR TITLE
Fixes `sodium-native` bug to support Heroku deploys

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -34,6 +34,9 @@ You can now offer your users the ability to sign in with Google! Enabling it is 
 
 Stay tuned, as more external auth methods will be added in the future. Let us know what you'd like to see support for next!
 
+### Bug fixes
+- Works around a `sodium-native` bug (used by a Wasp dependency, `secure-password`) that prevented Heroku deployments by downgrading it from v3.4.1 to v3.3.0 via a `package.json` override. Ref: https://github.com/sodium-friends/sodium-native/issues/160
+
 ---
 
 ## v0.5.2.1 (2022/07/14)

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -35,7 +35,7 @@ You can now offer your users the ability to sign in with Google! Enabling it is 
 Stay tuned, as more external auth methods will be added in the future. Let us know what you'd like to see support for next!
 
 ### Bug fixes
-- Works around a `sodium-native` bug (used by a Wasp dependency, `secure-password`) that prevented Heroku deployments by downgrading it from v3.4.1 to v3.3.0 via a `package.json` override. Ref: https://github.com/sodium-friends/sodium-native/issues/160
+- Works around a `sodium-native` bug (used by a Wasp dependency, `secure-password`) that caused signup/login runtime issues with Heroku deployments by downgrading it from v3.4.1 to v3.3.0 via a `package.json` override. Ref: https://github.com/sodium-friends/sodium-native/issues/160
 
 ---
 

--- a/waspc/data/Generator/templates/server/package.json
+++ b/waspc/data/Generator/templates/server/package.json
@@ -17,6 +17,13 @@
     "delay": "1000"
   },
   "engineStrict": true,
+  "overrides": {
+    {=# overrides =}
+    "{= packageName =}": {
+      "{= dependencyName =}": "{= dependencyVersion =}"
+    }{=^ last =},{=/ last =}
+    {=/ overrides =}
+  },
   "engines": {
     "node": "{=& nodeVersionRange =}",
     "npm": "{=& npmVersionRange =}"

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -46,7 +46,7 @@
             "file",
             "server/package.json"
         ],
-        "afdc0ba105f159e64bedc05ce1944d2e0d37b1b872e2ec89b10ea225755a17e4"
+        "484019a3c68c9b70f7c741d0b3277c244c9574c49440e9802a87bbe45d34f1c8"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
@@ -28,6 +28,11 @@
   "nodemonConfig": {
     "delay": "1000"
   },
+  "overrides": {
+    "secure-password": {
+      "sodium-native": "3.3.0"
+    }
+  },
   "private": true,
   "scripts": {
     "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -46,7 +46,7 @@
             "file",
             "server/package.json"
         ],
-        "afdc0ba105f159e64bedc05ce1944d2e0d37b1b872e2ec89b10ea225755a17e4"
+        "484019a3c68c9b70f7c741d0b3277c244c9574c49440e9802a87bbe45d34f1c8"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
@@ -28,6 +28,11 @@
   "nodemonConfig": {
     "delay": "1000"
   },
+  "overrides": {
+    "secure-password": {
+      "sodium-native": "3.3.0"
+    }
+  },
   "private": true,
   "scripts": {
     "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -46,7 +46,7 @@
             "file",
             "server/package.json"
         ],
-        "bc2b8d05177f4de8960719a67db4555240ea2fce89d29d172bf3719549d775ec"
+        "2c950c67a115882cfa103e65b7778b39eff9a10cd1085464600d19c558901296"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/package.json
@@ -29,6 +29,11 @@
   "nodemonConfig": {
     "delay": "1000"
   },
+  "overrides": {
+    "secure-password": {
+      "sodium-native": "3.3.0"
+    }
+  },
   "private": true,
   "scripts": {
     "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -46,7 +46,7 @@
             "file",
             "server/package.json"
         ],
-        "78b6ad0758092db407827acf2605c521af1ebf5700a4aba03cd8a8f5fd8f092f"
+        "99a22e6f44c7166a5958e628ac0e404f41440232de3dff6f77c2ddb59ef58b78"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
@@ -28,6 +28,11 @@
   "nodemonConfig": {
     "delay": "1000"
   },
+  "overrides": {
+    "secure-password": {
+      "sodium-native": "3.3.0"
+    }
+  },
   "private": true,
   "scripts": {
     "db-migrate-dev": "prisma migrate dev --schema=../db/schema.prisma",

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -283,6 +283,6 @@ getPackageJsonOverrides = map buildOverrideData (designateLastElement overrides)
 
     designateLastElement :: [(String, String, String)] -> [(String, String, String, Bool)]
     designateLastElement [] = []
-    designateLastElement [(x1, x2, x3)] = [(x1, x2, x3, True)]
     designateLastElement l =
-      map (\(x1, x2, x3) -> (x1, x2, x3, False)) (init l) ++ map (\(x1, x2, x3) -> (x1, x2, x3, True)) [last l]
+      map (\(x1, x2, x3) -> (x1, x2, x3, False)) (init l)
+        ++ map (\(x1, x2, x3) -> (x1, x2, x3, True)) [last l]

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -120,7 +120,7 @@ npmDepsForWasp spec =
             ("morgan", "~1.10.0"),
             ("@prisma/client", show prismaVersion),
             ("jsonwebtoken", "^8.5.1"),
-            -- NOTE: "secure-password" has a package.json override of "sodium-native".
+            -- NOTE: secure-password has a package.json override for sodium-native.
             ("secure-password", "^4.0.0"),
             ("dotenv", "16.0.2"),
             ("helmet", "^6.0.0"),
@@ -266,7 +266,9 @@ getPackageJsonOverrides = map buildOverrideData (designateLastElement overrides)
   where
     overrides :: [(String, String, String)]
     overrides =
-      [ ("secure-password", "sodium-native", "3.3.0")
+      [ -- sodium-native > 3.3.0 broke deploying on Heroku.
+        -- Ref: https://github.com/sodium-friends/sodium-native/issues/160
+        ("secure-password", "sodium-native", "3.3.0")
       ]
 
     -- NOTE: We must designate the last element so the JSON template can omit the final comma.


### PR DESCRIPTION
# Description

This change adds support for `"overrides"` in our `package.json` file, and specifically fixes a `sodium-native` bug that is preventing users from deploying to Heroku right now.

Refs:
- https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides
- https://github.com/sodium-friends/sodium-native/issues/160

Fixes #719 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update