### PR TITLE
Put contrasting box around blog intro / CTA part, to distinguish it visually from the content

### DIFF
--- a/web/blog/components/InBlogCta.js
+++ b/web/blog/components/InBlogCta.js
@@ -8,7 +8,7 @@ const Divider = () => (
 )
 
 const InBlogCta = () => (
-    <p>
+    <p className='in-blog-cta-link-container'>
         <Link className='in-blog-cta--link' 
             to='https://e44cy1h4s0q.typeform.com/to/ycUzQa5A'>
             We are in Alpha (try it out)!

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -51,6 +51,13 @@
 
 /* NOTE(matija): this is used within a blog post (e.g. seed round 
  * announcement). */
+
+.in-blog-cta-link-container {
+  border: solid var(--ifm-link-color);
+  padding: 2px;
+  text-align: center;
+}
+
 .in-blog-cta--link {
   color: var(--ifm-color-primary);
   font-weight: bold;

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -135,6 +135,12 @@
   font-size: 0.9rem;
 }
 
+@media only screen and (max-width: 600px) {
+  .in-blog-cta--link {display: block;}
+  .in-blog-cta--divider{display: none;}
+}
+
+
 @media screen and (max-width: 996px) {
   .row .col {
     padding-top: var(--ifm-col-spacing-vertical);


### PR DESCRIPTION
# Description

Improved the CTA bar by adding a box around it to distinguish it and added media queries to make it look clean on small screens.

<img src="https://i.imgur.com/b1oeUsh.gif" alt="Screen recording gif demonstrating changes made">

Fixes #462

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update