### PR TITLE
Add login step to signup and update docs

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/auth/signup.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/signup.js
@@ -1,9 +1,11 @@
 import config from '../config.js'
 import api, { handleApiError } from '../api.js'
+import login from './login.js'
 
 export default async function signup(userFields) {
   try {
     await api.post(config.apiUrl + '/auth/signup', userFields)
+    await login(userFields.username, userFields.password)
   } catch (error) {
     handleApiError(error)
   }

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -909,7 +909,7 @@ Login is a regular action and can be used directly from the frontend.
 
 
 ### `signup()`
-An action for signing in in the user.
+An action for signing in the user. The user is automatically logged in.
 ```js
 signup(userFields)
 ```


### PR DESCRIPTION
# Description

`Right now, if you call signup(), you will not be logged in, you still have to call login(). This has to be made clear in the documentation, or we should make it automatic to be logged in after doing signup().
`

In this PR I am making it so that the user is automatically logged in after doing signup.

Fixes #151 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update