### PR TITLE
Fixes login issue for uppercase usernames

### DIFF
--- a/waspc/data/Generator/templates/server/src/routes/auth/login.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/login.js
@@ -12,7 +12,7 @@ export default handleRejection(async (req, res) => {
   const context = {}
 
   // Try to fetch user with the given username.
-  const user = await prisma.{= userEntityLower =}.findUnique({ where: { username: args.username.toLowerCase() } })
+  const user = await prisma.{= userEntityLower =}.findUnique({ where: { username: args.username } })
   if (!user) {
     return res.status(401).send()
   }

--- a/waspc/examples/todoApp/.gitignore
+++ b/waspc/examples/todoApp/.gitignore
@@ -1,2 +1,4 @@
 /.wasp/
 .env
+.env.server
+.env.client

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -827,7 +827,7 @@ Default value is "/".
 ### Username and Password
 
 `usernameAndPassword` authentication method makes it possible to signup/login into the app by using a username and password.
-This method requires that `userEntity` specified in `auth` contains `username: string` and `password: string` fields.
+This method requires that `userEntity` specified in `auth` contains `username: string` and `password: string` fields. `username`s are stored in a case-sensitive manner.
 
 We provide basic validations out of the box, which you can customize as shown below. Default validations are:
 - `username`: non-empty


### PR DESCRIPTION
# Description

Previously, we used "email" as the login identifier, and it was lowercased. Now, we just have a "username" String. This change removes the normalization of case and instead stores in a case-sensitive manner.

In the future, we could consider adding the option to check for usernames in a case-insensitive way. If you think this is a possible idea, I can create an issue for it.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update