### PR TITLE
Remove rudandant aboslute API URLs

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/auth/login.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/login.js
@@ -5,7 +5,7 @@ import api, { setAuthToken, handleApiError } from '../api.js'
 export default async function login(username, password) {
   try {
     const args = { username, password }
-    const response = await api.post(config.apiUrl + '/auth/login', args)
+    const response = await api.post('/auth/login', args)
 
     setAuthToken(response.data.token)
     // This isn't really neccessary because we remove all private queries after

--- a/waspc/data/Generator/templates/react-app/src/auth/login.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/login.js
@@ -1,4 +1,3 @@
-import config from '../config.js'
 import { removeQueries } from '../operations/resources'
 import api, { setAuthToken, handleApiError } from '../api.js'
 

--- a/waspc/data/Generator/templates/react-app/src/auth/signup.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/signup.js
@@ -3,7 +3,7 @@ import api, { handleApiError } from '../api.js'
 
 export default async function signup(userFields) {
   try {
-    await api.post(config.apiUrl + '/auth/signup', userFields)
+    await api.post('/auth/signup', userFields)
   } catch (error) {
     handleApiError(error)
   }

--- a/waspc/data/Generator/templates/react-app/src/auth/signup.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/signup.js
@@ -1,4 +1,3 @@
-import config from '../config.js'
 import api, { handleApiError } from '../api.js'
 
 export default async function signup(userFields) {

--- a/waspc/data/Generator/templates/react-app/src/auth/useAuth.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/useAuth.js
@@ -7,7 +7,7 @@ export default function useAuth(queryFnArgs, config)  {
 }
 async function getMe() {
   try {
-    const response = await api.get(config.apiUrl + '/auth/me')
+    const response = await api.get('/auth/me')
 
     return response.data
   } catch (error) {

--- a/waspc/data/Generator/templates/react-app/src/auth/useAuth.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/useAuth.js
@@ -1,5 +1,4 @@
 import { useQuery } from '../queries'
-import config from '../config.js'
 import api, { handleApiError } from '../api.js'
 
 export default function useAuth(queryFnArgs, config)  {

--- a/waspc/data/Generator/templates/react-app/src/operations/index.js
+++ b/waspc/data/Generator/templates/react-app/src/operations/index.js
@@ -3,7 +3,7 @@ import config from '../config.js'
 
 export async function callOperation(operationRoute, args) {
   try {
-    const response = await api.post(config.apiUrl + '/' + operationRoute, args)
+    const response = await api.post(`/${operationRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)

--- a/waspc/data/Generator/templates/react-app/src/operations/index.js
+++ b/waspc/data/Generator/templates/react-app/src/operations/index.js
@@ -1,5 +1,4 @@
 import api, { handleApiError } from '../api.js'
-import config from '../config.js'
 
 export async function callOperation(operationRoute, args) {
   try {

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -305,7 +305,7 @@
             "file",
             "web-app/src/operations/index.js"
         ],
-        "4eea48fce8a16a41ee86925955c197752d91e8e067d47bcc795c32b450d1c81a"
+        "6ab717db2304b6134073aa71144b213b86f8d68a106549da06e193d18683dd87"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/operations/index.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/operations/index.js
@@ -1,9 +1,8 @@
 import api, { handleApiError } from '../api.js'
-import config from '../config.js'
 
 export async function callOperation(operationRoute, args) {
   try {
-    const response = await api.post(config.apiUrl + '/' + operationRoute, args)
+    const response = await api.post(`/${operationRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -305,7 +305,7 @@
             "file",
             "web-app/src/operations/index.js"
         ],
-        "4eea48fce8a16a41ee86925955c197752d91e8e067d47bcc795c32b450d1c81a"
+        "6ab717db2304b6134073aa71144b213b86f8d68a106549da06e193d18683dd87"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/operations/index.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/operations/index.js
@@ -1,9 +1,8 @@
 import api, { handleApiError } from '../api.js'
-import config from '../config.js'
 
 export async function callOperation(operationRoute, args) {
   try {
-    const response = await api.post(config.apiUrl + '/' + operationRoute, args)
+    const response = await api.post(`/${operationRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -326,7 +326,7 @@
             "file",
             "web-app/src/operations/index.js"
         ],
-        "4eea48fce8a16a41ee86925955c197752d91e8e067d47bcc795c32b450d1c81a"
+        "6ab717db2304b6134073aa71144b213b86f8d68a106549da06e193d18683dd87"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/operations/index.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/operations/index.js
@@ -1,9 +1,8 @@
 import api, { handleApiError } from '../api.js'
-import config from '../config.js'
 
 export async function callOperation(operationRoute, args) {
   try {
-    const response = await api.post(config.apiUrl + '/' + operationRoute, args)
+    const response = await api.post(`/${operationRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -305,7 +305,7 @@
             "file",
             "web-app/src/operations/index.js"
         ],
-        "4eea48fce8a16a41ee86925955c197752d91e8e067d47bcc795c32b450d1c81a"
+        "6ab717db2304b6134073aa71144b213b86f8d68a106549da06e193d18683dd87"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/operations/index.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/operations/index.js
@@ -1,9 +1,8 @@
 import api, { handleApiError } from '../api.js'
-import config from '../config.js'
 
 export async function callOperation(operationRoute, args) {
   try {
-    const response = await api.post(config.apiUrl + '/' + operationRoute, args)
+    const response = await api.post(`/${operationRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)


### PR DESCRIPTION
I've noticed this while reviewing #749 . Specifying the `baseURL` twice (once in the global config and the other time in each API call) leads to weird/inconsistent behaivor.

For example, setting `REACT_APP_API_URL` to the string `"something"` and doing `api.get(config.apiUrl + '/auth/me')` performs a call to `http://localhost:3001/something/something/auth/me`. You can read [Axios's docs](https://axios-http.com/docs/req_config) if you want to know why.