### PR TITLE
Fix compiler warnings in tests

### DIFF
--- a/waspc/test/AppSpec/ValidTest.hs
+++ b/waspc/test/AppSpec/ValidTest.hs
@@ -153,7 +153,8 @@ spec_AppSpecValid = do
           AS.isBuild = False,
           AS.migrationsDir = Nothing,
           AS.dotEnvServerFile = Nothing,
-          AS.dotEnvClientFile = Nothing
+          AS.dotEnvClientFile = Nothing,
+          AS.userDockerfileContents = Nothing
         }
 
     basicPage =

--- a/waspc/test/Generator/WebAppGeneratorTest.hs
+++ b/waspc/test/Generator/WebAppGeneratorTest.hs
@@ -41,7 +41,8 @@ spec_WebAppGenerator = do
             AS.isBuild = False,
             AS.migrationsDir = Nothing,
             AS.dotEnvServerFile = Nothing,
-            AS.dotEnvClientFile = Nothing
+            AS.dotEnvClientFile = Nothing,
+            AS.userDockerfileContents = Nothing
           }
 
   describe "genWebApp" $ do


### PR DESCRIPTION
# Description
This PR fixes the warnings that `WebAppGeneratorTest` and `ValidTest` report during compilation. You can see them by executing `cabal test waspc-test` in the waspc directory.

Fixes #759 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update