### PR TITLE
Update Wasp CLI bash completion list

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
@@ -26,7 +26,7 @@ bashCompletion = do
     ["db", cmdPrefix] -> listMatchingCommands cmdPrefix dbSubCommands
     _ -> liftIO . putStrLn $ ""
   where
-    commands = ["new", "version", "start", "db", "clean", "build", "telemetry", "deps"]
+    commands = ["new", "version", "waspls", "start", "db", "clean", "build", "telemetry", "deps", "info"]
     dbSubCommands = ["migrate-dev", "studio"]
     listMatchingCommands :: String -> [String] -> Command ()
     listMatchingCommands cmdPrefix cmdList = listCommands $ filter (cmdPrefix `isPrefixOf`) cmdList

--- a/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
@@ -26,7 +26,7 @@ bashCompletion = do
     ["db", cmdPrefix] -> listMatchingCommands cmdPrefix dbSubCommands
     _ -> liftIO . putStrLn $ ""
   where
-    commands = ["new", "version", "waspls", "start", "db", "clean", "build", "telemetry", "deps", "info"]
+    commands = ["new", "version", "waspls", "start", "db", "clean", "build", "telemetry", "deps", "info", "completion", "completion:generate"]
     dbSubCommands = ["migrate-dev", "studio"]
     listMatchingCommands :: String -> [String] -> Command ()
     listMatchingCommands cmdPrefix cmdList = listCommands $ filter (cmdPrefix `isPrefixOf`) cmdList


### PR DESCRIPTION
# Description

This PR updates the Wasp CLI bash completion list to reflect the current commands in the Wasp CLI.

Fixes #754

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update