### PR TITLE
Allow user to specify ports via CLI

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build.hs
@@ -80,5 +80,7 @@ buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir bu
               ( \case
                   GeneratorNeedsMigrationWarning _ -> False
                   _ -> True
-              )
+              ),
+          clientPort = Nothing,
+          serverPort = Nothing
         }

--- a/waspc/cli/src/Wasp/Cli/Command/Call.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Call.hs
@@ -2,7 +2,7 @@ module Wasp.Cli.Command.Call where
 
 data Call
   = New String -- project name
-  | Start
+  | Start [String] -- start args
   | Clean
   | Compile
   | Db [String] -- db args

--- a/waspc/cli/src/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Compile.hs
@@ -119,5 +119,7 @@ defaultCompileOptions waspProjectDir =
       externalSharedCodeDirPath = waspProjectDir </> Common.extSharedCodeDirInWaspProjectDir,
       isBuild = False,
       sendMessage = cliSendMessage,
-      generatorWarningsFilter = id
+      generatorWarningsFilter = id,
+      clientPort = Nothing,
+      serverPort = Nothing
     }

--- a/waspc/cli/src/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start.hs
@@ -8,6 +8,7 @@ import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar (MVar, newMVar, tryTakeMVar)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
+import Data.Maybe (isNothing)
 import StrongPath ((</>))
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Common (findWaspProjectRootDirFromCwd)
@@ -21,8 +22,9 @@ import qualified Wasp.Message as Msg
 
 -- | Does initial compile of wasp code and then runs the generated project.
 -- It also listens for any file changes and recompiles and restarts generated project accordingly.
-start :: Command ()
-start = do
+-- start :: Maybe String -> Maybe String -> Command ()
+start :: Maybe Int -> Maybe Int -> Command ()
+start clientPort serverPort = do
   waspRoot <- findWaspProjectRootDirFromCwd
   let outDir = waspRoot </> Common.dotWaspDirInWaspProjectDir </> Common.generatedCodeDirInDotWaspDir
 

--- a/waspc/src/Wasp/CompileOptions.hs
+++ b/waspc/src/Wasp/CompileOptions.hs
@@ -24,5 +24,9 @@ data CompileOptions = CompileOptions
     -- CLI commands will almost always compile before they execute to ensure the project is up to date.
     -- This filter function allows callers to ignore certain warnings where they do not make sense.
     -- For example, showing a compilation warning to run `db migrate-dev` when you are running that command.
-    generatorWarningsFilter :: [GeneratorWarning] -> [GeneratorWarning]
+    generatorWarningsFilter :: [GeneratorWarning] -> [GeneratorWarning],
+    -- The user can specify client and server ports when running the command `wasp start`from the cli.
+    -- These will override any ports specified by existing .env files during compilation.
+    clientPort :: Maybe Int,
+    serverPort :: Maybe Int
   }


### PR DESCRIPTION
# Description

This PR  allows the user to specify ports via CLI, smth like `wasp start --web-client-port=8000 --api-server-port=4000`. 

Fixes #730 

## Type of change

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update