### PR TITLE
made the example links point to the release branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "wasp",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/web/docs/examples.md
+++ b/web/docs/examples.md
@@ -3,8 +3,8 @@ title: Examples
 ---
 
 Todo App:
- - source code: https://github.com/wasp-lang/wasp/tree/main/examples/tutorials/TodoApp .
+ - source code: https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp
 
 Real World App (clone of Medium):
- - source code: https://github.com/wasp-lang/wasp/tree/main/examples/realworld .
+ - source code: https://github.com/wasp-lang/wasp/tree/release/examples/realworld
  - hosted at: https://wasp-rwa.netlify.app/ .

--- a/web/docs/examples.md
+++ b/web/docs/examples.md
@@ -7,4 +7,4 @@ Todo App:
 
 Real World App (clone of Medium):
  - source code: https://github.com/wasp-lang/wasp/tree/release/examples/realworld
- - hosted at: https://wasp-rwa.netlify.app/ .
+ - hosted at: https://wasp-rwa.netlify.app/


### PR DESCRIPTION
# Description

I made the example links point to the `release` branch.

Fixes #728 


