### PR TITLE
Feat: Validate wasp version from spec

### DIFF
--- a/examples/realworld/main.wasp
+++ b/examples/realworld/main.wasp
@@ -1,6 +1,6 @@
 app Conduit {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
 
   title: "Conduit",

--- a/examples/realworld/main.wasp
+++ b/examples/realworld/main.wasp
@@ -1,4 +1,8 @@
 app Conduit {
+  wasp: {
+    version: "^0.6.0.0"
+  },
+
   title: "Conduit",
   
   head: [

--- a/examples/thoughts/main.wasp
+++ b/examples/thoughts/main.wasp
@@ -1,4 +1,7 @@
 app Thoughts {
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "Thoughts",
   db: { system: PostgreSQL },
   auth: {

--- a/examples/thoughts/main.wasp
+++ b/examples/thoughts/main.wasp
@@ -1,6 +1,6 @@
 app Thoughts {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "Thoughts",
   db: { system: PostgreSQL },

--- a/examples/tutorials/ItWaspsOnMyMachine/main.wasp
+++ b/examples/tutorials/ItWaspsOnMyMachine/main.wasp
@@ -1,6 +1,6 @@
 app ItWaspsOnMyMachine {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
 
   title: "It Wasps On My Machine",

--- a/examples/tutorials/ItWaspsOnMyMachine/main.wasp
+++ b/examples/tutorials/ItWaspsOnMyMachine/main.wasp
@@ -1,4 +1,8 @@
 app ItWaspsOnMyMachine {
+  wasp: {
+    version: "^0.6.0.0"
+  },
+
   title: "It Wasps On My Machine",
 
   head: [

--- a/examples/tutorials/TodoApp/main.wasp
+++ b/examples/tutorials/TodoApp/main.wasp
@@ -1,4 +1,8 @@
 app TodoApp {
+  wasp: {
+    version: "^0.6.0.0"
+  },
+
   title: "Todo app",
 
   auth: {

--- a/examples/tutorials/TodoApp/main.wasp
+++ b/examples/tutorials/TodoApp/main.wasp
@@ -1,6 +1,6 @@
 app TodoApp {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
 
   title: "Todo app",

--- a/examples/waspello/main.wasp
+++ b/examples/waspello/main.wasp
@@ -1,6 +1,6 @@
 app trello {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
 
   title: "trello",

--- a/examples/waspello/main.wasp
+++ b/examples/waspello/main.wasp
@@ -1,4 +1,8 @@
 app trello {
+  wasp: {
+    version: "^0.6.0.0"
+  },
+
   title: "trello",
 
   db: {

--- a/examples/waspleau/main.wasp
+++ b/examples/waspleau/main.wasp
@@ -1,6 +1,6 @@
 app waspleau {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
 
   title: "Waspleau",

--- a/examples/waspleau/main.wasp
+++ b/examples/waspleau/main.wasp
@@ -1,4 +1,8 @@
 app waspleau {
+  wasp: {
+    version: "^0.6.0.0"
+  },
+
   title: "Waspleau",
 
   server: {

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -6,6 +6,8 @@ where
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.List (intercalate)
+import qualified Data.Version
+import qualified Paths_waspc
 import StrongPath (Abs, Dir, File', Path', Rel, reldir, relfile, (</>))
 import qualified StrongPath as SP
 import System.Directory (createDirectory, getCurrentDirectory)
@@ -20,8 +22,6 @@ import qualified Wasp.Cli.Common as Common
 import qualified Wasp.Data
 import Wasp.Util (indent, kebabToCamelCase)
 import qualified Wasp.Util.Terminal as Term
-import qualified Data.Version
-import qualified Paths_waspc
 
 data ProjectInfo = ProjectInfo
   { _projectName :: String,

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -20,6 +20,8 @@ import qualified Wasp.Cli.Common as Common
 import qualified Wasp.Data
 import Wasp.Util (indent, kebabToCamelCase)
 import qualified Wasp.Util.Terminal as Term
+import qualified Data.Version
+import qualified Paths_waspc
 
 data ProjectInfo = ProjectInfo
   { _projectName :: String,
@@ -122,6 +124,9 @@ createNewProject' (ProjectInfo projectName appName) = do
     mainWaspFileContent =
       unlines
         [ "app %s {" `printf` appName,
+          "  wasp: {",
+          "    version: \"^%s\"" `printf` Data.Version.showVersion Paths_waspc.version,
+          "  },",
           "  title: \"%s\"" `printf` projectName,
           "}",
           "",

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -6,8 +6,6 @@ where
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.List (intercalate)
-import qualified Data.Version
-import qualified Paths_waspc
 import StrongPath (Abs, Dir, File', Path', Rel, reldir, relfile, (</>))
 import qualified StrongPath as SP
 import System.Directory (createDirectory, getCurrentDirectory)
@@ -22,6 +20,7 @@ import qualified Wasp.Cli.Common as Common
 import qualified Wasp.Data
 import Wasp.Util (indent, kebabToCamelCase)
 import qualified Wasp.Util.Terminal as Term
+import qualified Wasp.Version as WV
 
 data ProjectInfo = ProjectInfo
   { _projectName :: String,
@@ -125,7 +124,7 @@ createNewProject' (ProjectInfo projectName appName) = do
       unlines
         [ "app %s {" `printf` appName,
           "  wasp: {",
-          "    version: \"^%s\"" `printf` Data.Version.showVersion Paths_waspc.version,
+          "    version: \"^%s\"" `printf` show WV.waspVersion,
           "  },",
           "  title: \"%s\"" `printf` projectName,
           "}",

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
@@ -1,7 +1,7 @@
 app waspBuild {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "waspBuild"
 }

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
@@ -1,5 +1,8 @@
 app waspBuild {
   db: { system: PostgreSQL },
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "waspBuild"
 }
 

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
@@ -1,6 +1,6 @@
 app waspCompile {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "waspCompile"
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
@@ -1,4 +1,7 @@
 app waspCompile {
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "waspCompile"
 }
 

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
@@ -1,7 +1,7 @@
 app waspJob {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "waspJob"
 }

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
@@ -1,5 +1,8 @@
 app waspJob {
   db: { system: PostgreSQL },
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "waspJob"
 }
 

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
@@ -1,6 +1,6 @@
 app waspMigrate {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "waspMigrate"
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
@@ -1,4 +1,7 @@
 app waspMigrate {
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "waspMigrate"
 }
 

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
@@ -1,4 +1,7 @@
 app waspNew {
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "waspNew"
 }
 

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
@@ -1,6 +1,6 @@
 app waspNew {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "waspNew"
 }

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -1,4 +1,7 @@
 app todoApp {
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "ToDo App",
   head: [
     "<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap\" />"

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -1,6 +1,6 @@
 app todoApp {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "ToDo App",
   head: [

--- a/waspc/src/Wasp/AppSpec/App.hs
+++ b/waspc/src/Wasp/AppSpec/App.hs
@@ -9,9 +9,11 @@ import Wasp.AppSpec.App.Db (Db)
 import Wasp.AppSpec.App.Dependency (Dependency)
 import Wasp.AppSpec.App.Server (Server)
 import Wasp.AppSpec.Core.Decl (IsDecl)
+import Wasp.AppSpec.App.Wasp (Wasp)
 
 data App = App
-  { title :: String,
+  { wasp :: Wasp,
+    title :: String,
     head :: Maybe [String],
     auth :: Maybe Auth,
     server :: Maybe Server,

--- a/waspc/src/Wasp/AppSpec/App.hs
+++ b/waspc/src/Wasp/AppSpec/App.hs
@@ -8,8 +8,8 @@ import Wasp.AppSpec.App.Client (Client)
 import Wasp.AppSpec.App.Db (Db)
 import Wasp.AppSpec.App.Dependency (Dependency)
 import Wasp.AppSpec.App.Server (Server)
-import Wasp.AppSpec.Core.Decl (IsDecl)
 import Wasp.AppSpec.App.Wasp (Wasp)
+import Wasp.AppSpec.Core.Decl (IsDecl)
 
 data App = App
   { wasp :: Wasp,

--- a/waspc/src/Wasp/AppSpec/App/Wasp.hs
+++ b/waspc/src/Wasp/AppSpec/App/Wasp.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Wasp.AppSpec.App.Wasp (Wasp (..)) where
+
+import Data.Data (Data)
+import Wasp.AppSpec.Core.Decl (IsDecl)
+
+data Wasp = Wasp
+  { version :: String
+  }
+  deriving (Show, Eq, Data)
+
+instance IsDecl Wasp

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -8,8 +8,14 @@ module Wasp.AppSpec.Valid
   )
 where
 
+import Control.Monad (unless)
 import Data.List (find)
 import Data.Maybe (isJust)
+import qualified Data.Version as DV
+import GHC.Natural (naturalFromInteger)
+import qualified Paths_waspc
+import Text.Read (readMaybe)
+import Text.Regex.TDFA ((=~))
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import Wasp.AppSpec.App (App)
@@ -23,13 +29,7 @@ import qualified Wasp.AppSpec.Entity as Entity
 import qualified Wasp.AppSpec.Entity.Field as Entity.Field
 import qualified Wasp.AppSpec.Page as Page
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
-import Text.Regex.TDFA ((=~))
 import qualified Wasp.SemanticVersion as SV
-import GHC.Natural (naturalFromInteger)
-import qualified Paths_waspc
-import qualified Data.Version as DV
-import Control.Monad (unless)
-import Text.Read (readMaybe)
 
 data ValidationError = GenericValidationError String
   deriving (Show, Eq)

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -59,9 +59,7 @@ validateExactlyOneAppExists spec =
           "You have more than one 'app' declaration in your Wasp app. You have " ++ show (length apps) ++ "."
 
 validateWasp :: AppSpec -> [ValidationError]
-validateWasp spec = validateWaspVersion specWaspVersionStr
-  where
-    specWaspVersionStr = Wasp.version $ App.wasp (snd $ getApp spec)
+validateWasp = validateWaspVersion . Wasp.version . App.wasp . snd . getApp
 
 validateWaspVersion :: String -> [ValidationError]
 validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -69,6 +69,8 @@ validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do
     )
     $ Left $ incompatibleVersionError currentWaspVersion specWaspVersionRange
   where
+    -- TODO: Use version range parser from SemanticVersion when it is fully implemented.
+
     parseWaspVersionRange :: String -> Either ValidationError SV.Range
     parseWaspVersionRange waspVersionRangeStr = do
       let (_ :: String, _ :: String, _ :: String, waspVersionRangeDigits :: [String]) =

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -92,10 +92,9 @@ validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do
           ]
 
     currentWaspVersion :: SV.Version
-    currentWaspVersion = SV.Version (intToNat major) (intToNat minor) (intToNat patch)
+    currentWaspVersion = SV.Version (toEnum major) (toEnum minor) (toEnum patch)
       where
         DV.Version [major, minor, patch] _ = Paths_waspc.version
-        intToNat = naturalFromInteger . toInteger
 
     eitherUnitToErrorList :: Either e () -> [e]
     eitherUnitToErrorList (Left e) = [e]

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -72,7 +72,7 @@ validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do
     parseWaspVersionRange :: String -> Either ValidationError SV.Range
     parseWaspVersionRange waspVersionRangeStr = do
       let (_ :: String, _ :: String, _ :: String, waspVersionRangeDigits :: [String]) =
-            waspVersionRangeStr =~ ("\\^([0-9]+).([0-9]+).([0-9]+)$" :: String)
+            waspVersionRangeStr =~ ("\\`\\^([0-9]+)\\.([0-9]+)\\.([0-9]+)\\'" :: String)
 
       waspSpecVersion <- case mapM readMaybe waspVersionRangeDigits of
         Just [major, minor, patch] -> Right $ SV.Version major minor patch

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -71,6 +71,9 @@ validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do
 
     parseWaspVersionRange :: String -> Either ValidationError SV.Range
     parseWaspVersionRange waspVersionRangeStr = do
+      -- Only ^x.y.z is allowed here because it was the easiest solution to start
+      -- with at the moment. In the future, we plan to allow any SemVer
+      -- definition.
       let (_ :: String, _ :: String, _ :: String, waspVersionRangeDigits :: [String]) =
             waspVersionRangeStr =~ ("\\`\\^([0-9]+)\\.([0-9]+)\\.([0-9]+)\\'" :: String)
 

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -62,10 +62,8 @@ validateWasp = validateWaspVersion . Wasp.version . App.wasp . snd . getApp
 validateWaspVersion :: String -> [ValidationError]
 validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do
   specWaspVersionRange <- parseWaspVersionRange specWaspVersionStr
-  unless
-    ( SV.isVersionInRange WV.waspVersion specWaspVersionRange
-    )
-    $ Left $ incompatibleVersionError WV.waspVersion specWaspVersionRange
+  unless (SV.isVersionInRange WV.waspVersion specWaspVersionRange) $
+    Left $ incompatibleVersionError WV.waspVersion specWaspVersionRange
   where
     -- TODO: Use version range parser from SemanticVersion when it is fully implemented.
 

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -11,9 +11,6 @@ where
 import Control.Monad (unless)
 import Data.List (find)
 import Data.Maybe (isJust)
-import qualified Data.Version as DV
-import GHC.Natural (naturalFromInteger)
-import qualified Paths_waspc
 import Text.Read (readMaybe)
 import Text.Regex.TDFA ((=~))
 import Wasp.AppSpec (AppSpec)
@@ -30,6 +27,7 @@ import qualified Wasp.AppSpec.Entity.Field as Entity.Field
 import qualified Wasp.AppSpec.Page as Page
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
 import qualified Wasp.SemanticVersion as SV
+import qualified Wasp.Version as WV
 
 data ValidationError = GenericValidationError String
   deriving (Show, Eq)
@@ -65,9 +63,9 @@ validateWaspVersion :: String -> [ValidationError]
 validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do
   specWaspVersionRange <- parseWaspVersionRange specWaspVersionStr
   unless
-    ( SV.isVersionInRange currentWaspVersion specWaspVersionRange
+    ( SV.isVersionInRange WV.waspVersion specWaspVersionRange
     )
-    $ Left $ incompatibleVersionError currentWaspVersion specWaspVersionRange
+    $ Left $ incompatibleVersionError WV.waspVersion specWaspVersionRange
   where
     -- TODO: Use version range parser from SemanticVersion when it is fully implemented.
 
@@ -90,11 +88,6 @@ validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do
             "You are running Wasp " ++ show actualVersion ++ ".",
             "This app requires Wasp " ++ show expectedVersionRange ++ "."
           ]
-
-    currentWaspVersion :: SV.Version
-    currentWaspVersion = SV.Version (toEnum major) (toEnum minor) (toEnum patch)
-      where
-        DV.Version [major, minor, patch] _ = Paths_waspc.version
 
     eitherUnitToErrorList :: Either e () -> [e]
     eitherUnitToErrorList (Left e) = [e]

--- a/waspc/src/Wasp/Version.hs
+++ b/waspc/src/Wasp/Version.hs
@@ -1,0 +1,10 @@
+module Wasp.Version (waspVersion) where
+
+import qualified Data.Version as DV
+import qualified Paths_waspc
+import qualified Wasp.SemanticVersion as SV
+
+waspVersion :: SV.Version
+waspVersion = SV.Version (toEnum major) (toEnum minor) (toEnum patch)
+  where
+    DV.Version [major, minor, patch] _ = Paths_waspc.version

--- a/waspc/test/AnalyzerTest.hs
+++ b/waspc/test/AnalyzerTest.hs
@@ -19,6 +19,7 @@ import qualified Wasp.AppSpec.App.Client as Client
 import qualified Wasp.AppSpec.App.Db as Db
 import qualified Wasp.AppSpec.App.Dependency as Dependency
 import qualified Wasp.AppSpec.App.Server as Server
+import qualified Wasp.AppSpec.App.Wasp as Wasp
 import Wasp.AppSpec.Core.Ref (Ref (..))
 import Wasp.AppSpec.Entity (Entity)
 import qualified Wasp.AppSpec.Entity as Entity
@@ -30,6 +31,8 @@ import qualified Wasp.AppSpec.Query as Query
 import Wasp.AppSpec.Route (Route)
 import qualified Wasp.AppSpec.Route as Route
 import qualified Wasp.Psl.Ast.Model as PslModel
+import Data.Version (showVersion)
+import qualified Paths_waspc
 
 spec_Analyzer :: Spec
 spec_Analyzer = do
@@ -38,6 +41,9 @@ spec_Analyzer = do
       let source =
             unlines
               [ "app Todo {",
+                "  wasp: {",
+                "    version: \"^" ++ showVersion Paths_waspc.version ++ "\",",
+                "  },",
                 "  title: \"Todo App\",",
                 "  head: [\"foo\", \"bar\"],",
                 "  auth: {",
@@ -108,7 +114,8 @@ spec_Analyzer = do
       let expectedApps =
             [ ( "Todo",
                 App.App
-                  { App.title = "Todo App",
+                  { App.wasp = Wasp.Wasp {Wasp.version = "^" ++ showVersion Paths_waspc.version},
+                    App.title = "Todo App",
                     App.head = Just ["foo", "bar"],
                     App.auth =
                       Just

--- a/waspc/test/AnalyzerTest.hs
+++ b/waspc/test/AnalyzerTest.hs
@@ -7,8 +7,6 @@ import qualified Data.Aeson as Aeson
 import Data.Either (isRight)
 import Data.List (intercalate)
 import Data.Maybe (fromJust)
-import Data.Version (showVersion)
-import qualified Paths_waspc
 import qualified StrongPath as SP
 import Test.Tasty.Hspec
 import Wasp.Analyzer
@@ -33,6 +31,7 @@ import qualified Wasp.AppSpec.Query as Query
 import Wasp.AppSpec.Route (Route)
 import qualified Wasp.AppSpec.Route as Route
 import qualified Wasp.Psl.Ast.Model as PslModel
+import qualified Wasp.Version as WV
 
 spec_Analyzer :: Spec
 spec_Analyzer = do
@@ -42,7 +41,7 @@ spec_Analyzer = do
             unlines
               [ "app Todo {",
                 "  wasp: {",
-                "    version: \"^" ++ showVersion Paths_waspc.version ++ "\",",
+                "    version: \"^" ++ show WV.waspVersion ++ "\",",
                 "  },",
                 "  title: \"Todo App\",",
                 "  head: [\"foo\", \"bar\"],",
@@ -114,7 +113,7 @@ spec_Analyzer = do
       let expectedApps =
             [ ( "Todo",
                 App.App
-                  { App.wasp = Wasp.Wasp {Wasp.version = "^" ++ showVersion Paths_waspc.version},
+                  { App.wasp = Wasp.Wasp {Wasp.version = "^" ++ show WV.waspVersion},
                     App.title = "Todo App",
                     App.head = Just ["foo", "bar"],
                     App.auth =

--- a/waspc/test/AnalyzerTest.hs
+++ b/waspc/test/AnalyzerTest.hs
@@ -7,6 +7,8 @@ import qualified Data.Aeson as Aeson
 import Data.Either (isRight)
 import Data.List (intercalate)
 import Data.Maybe (fromJust)
+import Data.Version (showVersion)
+import qualified Paths_waspc
 import qualified StrongPath as SP
 import Test.Tasty.Hspec
 import Wasp.Analyzer
@@ -31,8 +33,6 @@ import qualified Wasp.AppSpec.Query as Query
 import Wasp.AppSpec.Route (Route)
 import qualified Wasp.AppSpec.Route as Route
 import qualified Wasp.Psl.Ast.Model as PslModel
-import Data.Version (showVersion)
-import qualified Paths_waspc
 
 spec_Analyzer :: Spec
 spec_Analyzer = do

--- a/waspc/test/AppSpec/ValidTest.hs
+++ b/waspc/test/AppSpec/ValidTest.hs
@@ -82,9 +82,9 @@ spec_AppSpecValid = do
             )
             `shouldBe` [ ASV.GenericValidationError $
                            unwords
-                             [ "Your Wasp version does not match the app's requirements."
-                             , "You are running Wasp " ++ DV.showVersion Paths_waspc.version ++ "."
-                             , "This app requires Wasp ^" ++ DV.showVersion incompatibleWaspVersion ++ "."
+                             [ "Your Wasp version does not match the app's requirements.",
+                               "You are running Wasp " ++ DV.showVersion Paths_waspc.version ++ ".",
+                               "This app requires Wasp ^" ++ DV.showVersion incompatibleWaspVersion ++ "."
                              ]
                        ]
 
@@ -181,10 +181,10 @@ spec_AppSpecValid = do
 
     basicApp =
       AS.App.App
-        { AS.App.wasp = AS.Wasp.Wasp
-          {
-            AS.Wasp.version = "^" ++ DV.showVersion Paths_waspc.version
-          },
+        { AS.App.wasp =
+            AS.Wasp.Wasp
+              { AS.Wasp.version = "^" ++ DV.showVersion Paths_waspc.version
+              },
           AS.App.title = "Test App",
           AS.App.db = Nothing,
           AS.App.server = Nothing,

--- a/waspc/test/AppSpec/ValidTest.hs
+++ b/waspc/test/AppSpec/ValidTest.hs
@@ -60,14 +60,14 @@ spec_AppSpecValid = do
                 }
             )
             `shouldBe` [ ASV.GenericValidationError
-                           "Wasp version should be in the format ^0.major.minor.patch"
+                           "Wasp version should be in the format ^major.minor.patch"
                        ]
 
         it "returns an error if 'waspVersion' is not compatible" $ do
-          let incompatibleWaspVersion = DV.makeVersion (alpha : nextMajor : remaining)
+          let incompatibleWaspVersion = DV.makeVersion (nextMajor : remaining)
                 where
                   nextMajor = major + 1
-                  DV.Version (alpha : major : remaining) _ = Paths_waspc.version
+                  DV.Version (major : remaining) _ = Paths_waspc.version
 
           let basicAppWithIncompatibleWaspVersion =
                 basicApp {AS.App.wasp = AS.Wasp.Wasp {AS.Wasp.version = "^" ++ DV.showVersion incompatibleWaspVersion}}

--- a/waspc/test/AppSpec/ValidTest.hs
+++ b/waspc/test/AppSpec/ValidTest.hs
@@ -3,9 +3,7 @@
 module AppSpec.ValidTest where
 
 import Data.Maybe (fromJust)
-import qualified Data.Version as DV
 import Fixtures (systemSPRoot)
-import qualified Paths_waspc
 import qualified StrongPath as SP
 import Test.Tasty.Hspec
 import qualified Wasp.AppSpec as AS
@@ -19,6 +17,8 @@ import qualified Wasp.AppSpec.ExtImport as AS.ExtImport
 import qualified Wasp.AppSpec.Page as AS.Page
 import qualified Wasp.AppSpec.Valid as ASV
 import qualified Wasp.Psl.Ast.Model as PslM
+import qualified Wasp.SemanticVersion as SV
+import qualified Wasp.Version as WV
 
 spec_AppSpecValid :: Spec
 spec_AppSpecValid = do
@@ -66,17 +66,14 @@ spec_AppSpecValid = do
                        ]
 
         it "returns an error if 'waspVersion' is not compatible" $ do
-          let incompatibleWaspVersion = DV.makeVersion (nextMajor : remaining)
-                where
-                  nextMajor = major + 1
-                  DV.Version (major : remaining) _ = Paths_waspc.version
+          let incompatibleWaspVersion = WV.waspVersion {SV.major = SV.major WV.waspVersion + 1}
 
-          ASV.validateAppSpec (basicAppSpecWithVersionRange $ "^" ++ DV.showVersion incompatibleWaspVersion)
+          ASV.validateAppSpec (basicAppSpecWithVersionRange $ "^" ++ show incompatibleWaspVersion)
             `shouldBe` [ ASV.GenericValidationError $
                            unwords
                              [ "Your Wasp version does not match the app's requirements.",
-                               "You are running Wasp " ++ DV.showVersion Paths_waspc.version ++ ".",
-                               "This app requires Wasp ^" ++ DV.showVersion incompatibleWaspVersion ++ "."
+                               "You are running Wasp " ++ show WV.waspVersion ++ ".",
+                               "This app requires Wasp ^" ++ show incompatibleWaspVersion ++ "."
                              ]
                        ]
 
@@ -175,7 +172,7 @@ spec_AppSpecValid = do
       AS.App.App
         { AS.App.wasp =
             AS.Wasp.Wasp
-              { AS.Wasp.version = "^" ++ DV.showVersion Paths_waspc.version
+              { AS.Wasp.version = "^" ++ show WV.waspVersion
               },
           AS.App.title = "Test App",
           AS.App.db = Nothing,

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.6.0.0
+version:        0.6.0
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -180,6 +180,7 @@ library
     Wasp.AppSpec.App.Db
     Wasp.AppSpec.App.Dependency
     Wasp.AppSpec.App.Server
+    Wasp.AppSpec.App.Wasp
     Wasp.AppSpec.Core.Decl
     Wasp.AppSpec.Core.Ref
     Wasp.AppSpec.Entity

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -260,6 +260,7 @@ library
     Wasp.Generator.NpmDependencies
     Wasp.Generator.NpmInstall
     Wasp.Message
+    Wasp.Version
 
 library waspls
   import: common-all

--- a/web/blog/2022-09-05-dev-excuses-app-tutrial.md
+++ b/web/blog/2022-09-05-dev-excuses-app-tutrial.md
@@ -80,6 +80,10 @@ Now your default browser should open up with a simple predefined text message. T
 
 // Main declaration, defines a new web app.
 app ItWaspsOnMyMachine {
+  // Wasp compiler configuration
+  wasp: {
+    version: "^0.6.0.0"
+  },
 
   // Used as a browser tab title.                                  
   title: "It Wasps On My Machine",

--- a/web/blog/2022-09-05-dev-excuses-app-tutrial.md
+++ b/web/blog/2022-09-05-dev-excuses-app-tutrial.md
@@ -82,7 +82,7 @@ Now your default browser should open up with a simple predefined text message. T
 app ItWaspsOnMyMachine {
   // Wasp compiler configuration
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
 
   // Used as a browser tab title.                                  

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -9,6 +9,9 @@ It serves as a starting point and defines global properties of your app.
 
 ```css
 app todoApp {
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "ToDo App",
   head: [  // optional
     "<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap\" />"
@@ -17,6 +20,11 @@ app todoApp {
 ```
 
 ### Fields
+
+#### `wasp: dict` (required)
+Wasp compiler configuration.
+Check [`app.wasp`](/docs/language/features#compiler-configuration) for more
+details.
 
 #### `title: string` (required)
 Title of your app. It will be displayed in the browser tab, next to the favicon.
@@ -1172,6 +1180,30 @@ entity SocialLogin {=psl
   @@unique([provider, providerId, userId])
 psl=}
 ```
+
+## Compiler configuration
+
+You can configure Wasp's compiler using the `wasp` field inside the `app`
+declaration.
+
+```c
+app MyApp {
+  wasp: {
+    version: "^0.6.0.0"
+  },
+  // ...
+}
+```
+
+`app.wasp` is a dictionary with the following fields:
+
+#### `version: string` (required)
+
+`version` declares the compatible Wasp versions for the app. It is specified
+in a SemVer format.
+
+**Note**: For now, `version` only supports the format `^0.major.minor.patch`. This
+will be extended in the future to support full Semantic Versioning.
 
 ## Client configuration
 

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -10,7 +10,7 @@ It serves as a starting point and defines global properties of your app.
 ```css
 app todoApp {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "ToDo App",
   head: [  // optional
@@ -1189,7 +1189,7 @@ declaration.
 ```c
 app MyApp {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   // ...
 }

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -1202,7 +1202,7 @@ app MyApp {
 `version` declares the compatible Wasp versions for the app. It is specified
 in a SemVer format.
 
-**Note**: For now, `version` only supports the format `^0.major.minor.patch`. This
+**Note**: For now, `version` only supports the format `^x.y.z`. This
 will be extended in the future to support full Semantic Versioning.
 
 ## Client configuration

--- a/web/docs/language/overview.md
+++ b/web/docs/language/overview.md
@@ -26,6 +26,10 @@ TodoApp/
 
 ```css title="main.wasp"
 app todoApp {
+  wasp: {
+    version: "^0.6.0.0"
+  },
+
   title: "ToDo App"
 }
 

--- a/web/docs/language/overview.md
+++ b/web/docs/language/overview.md
@@ -27,7 +27,7 @@ TodoApp/
 ```css title="main.wasp"
 app todoApp {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
 
   title: "ToDo App"

--- a/web/docs/tutorials/todo-app/auth.md
+++ b/web/docs/tutorials/todo-app/auth.md
@@ -39,7 +39,7 @@ Next, we want to tell Wasp that we want full-stack [authentication](language/fea
 ```c {4-11} title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   
   title: "Todo app",

--- a/web/docs/tutorials/todo-app/auth.md
+++ b/web/docs/tutorials/todo-app/auth.md
@@ -38,6 +38,10 @@ Next, we want to tell Wasp that we want full-stack [authentication](language/fea
 
 ```c {4-11} title="main.wasp"
 app TodoApp {
+  wasp: {
+    version: "^0.6.0.0"
+  },
+  
   title: "Todo app",
 
   auth: {

--- a/web/docs/tutorials/todo-app/creating-new-project.md
+++ b/web/docs/tutorials/todo-app/creating-new-project.md
@@ -52,7 +52,7 @@ Let's start with the `main.wasp` file, which introduces 3 new concepts:
 ```c title="main.wasp"
 app TodoApp { // Main declaration, defines a new web app.
   wasp: {
-    version: "^0.6.0.0"
+    version: "^0.6.0"
   },
   title: "Todo app" // Used as a browser tab title.
 }

--- a/web/docs/tutorials/todo-app/creating-new-project.md
+++ b/web/docs/tutorials/todo-app/creating-new-project.md
@@ -51,6 +51,9 @@ Let's start with the `main.wasp` file, which introduces 3 new concepts:
 
 ```c title="main.wasp"
 app TodoApp { // Main declaration, defines a new web app.
+  wasp: {
+    version: "^0.6.0.0"
+  },
   title: "Todo app" // Used as a browser tab title.
 }
 


### PR DESCRIPTION
# Description

This PR adds validation of the specific Wasp version required to build an app. This was done by adding the field `wasp.version` to `app` in the app's specification, and validating it in the `validateAppSpec` function of `AppSpec.Valid`.

- The only valid format for `app.wasp.version` for now is `^0.major.minor.version` (check the linked issue for the discussion).
- The error message when the current version is invalid is similar to the Node version mismatch message, as suggested by @sodic .
- The `CreateNewApp` module was changed so that the `wasp new` command adds the `app.wasp.version` field to the generated spec file.
- Tests were added for this feature.
-  E2E tests were modified for the changes.
- The documentation was extended to include the new `app.wasp` dictionary field and the `app.wasp.version` string field.

#### New changes after review

- waspc's version was changed to use regular SemVer: `0.6.0.0` -> `0.6.0` 

Fixes #578 

> *Note*
> I'm not too good with Haskell yet, but I refactored my code multiple times to make it better.
> I'll be happy to refactor the code if you can guide me on where it can improve. Thank you and sorry for the inconvenience.

## Type of change

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update