### PR TITLE
Updates node/npm to current LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Run tests
         run: cabal test

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -4,6 +4,7 @@
 
 ### BREAKING CHANGES
 - Updates Create React App from version 4.0.3 to 5.0.1. This brings many improvements as well as downstream library updates. It also has a list of possible breaking changes: https://github.com/facebook/create-react-app/blob/main/CHANGELOG.md
+- Updates required Node LTS version from version 16 to version 18. This Node ecosystem change happened on 2022-10-25: https://github.com/nodejs/Release
 
 ### [NEW FEATURE] Dockerfile customization
 

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "102dded28312bbe81553d71eb878ed4f7766fda51503e08e75ffd9931ff1a8bb"
+        "c11eaf8c89e4dd4321444e4951f0047b2f1c4784c84edb027e06185359472781"
     ],
     [
         [
@@ -46,7 +46,7 @@
             "file",
             "server/package.json"
         ],
-        "484019a3c68c9b70f7c741d0b3277c244c9574c49440e9802a87bbe45d34f1c8"
+        "d432e3560976f10d3282e33a83fec546838df6346ca168015ea878251a442a24"
     ],
     [
         [
@@ -207,7 +207,7 @@
             "file",
             "web-app/package.json"
         ],
-        "dcfb537ea41be61f8c435716c1ecf6af3ca372aaabc7abc44c96a72e5eac2bf3"
+        "228080234154d37b357013646aff651c65a415e3870054929f2fd2cc66af0f8c"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/Dockerfile
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS node
+FROM node:18-alpine AS node
 
 
 FROM node AS base

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
@@ -21,8 +21,8 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^16.0.0",
-    "npm": "^8.0.0"
+    "node": "^18.12.0",
+    "npm": "^8.19.2"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {},
   "engineStrict": true,
   "engines": {
-    "node": "^16.0.0",
-    "npm": "^8.0.0"
+    "node": "^18.12.0",
+    "npm": "^8.19.2"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "102dded28312bbe81553d71eb878ed4f7766fda51503e08e75ffd9931ff1a8bb"
+        "c11eaf8c89e4dd4321444e4951f0047b2f1c4784c84edb027e06185359472781"
     ],
     [
         [
@@ -46,7 +46,7 @@
             "file",
             "server/package.json"
         ],
-        "484019a3c68c9b70f7c741d0b3277c244c9574c49440e9802a87bbe45d34f1c8"
+        "d432e3560976f10d3282e33a83fec546838df6346ca168015ea878251a442a24"
     ],
     [
         [
@@ -207,7 +207,7 @@
             "file",
             "web-app/package.json"
         ],
-        "78971dc36bacf3ea3270a10315ff3bd36b75db0d244b82a62d15f366695fe97e"
+        "f2fa10158fbdff6cea6339d1620515d9c10d56c5db43f9b061c4e74e83e405b0"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/Dockerfile
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS node
+FROM node:18-alpine AS node
 
 
 FROM node AS base

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
@@ -21,8 +21,8 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^16.0.0",
-    "npm": "^8.0.0"
+    "node": "^18.12.0",
+    "npm": "^8.19.2"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {},
   "engineStrict": true,
   "engines": {
-    "node": "^16.0.0",
-    "npm": "^8.0.0"
+    "node": "^18.12.0",
+    "npm": "^8.19.2"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "102dded28312bbe81553d71eb878ed4f7766fda51503e08e75ffd9931ff1a8bb"
+        "c11eaf8c89e4dd4321444e4951f0047b2f1c4784c84edb027e06185359472781"
     ],
     [
         [
@@ -46,7 +46,7 @@
             "file",
             "server/package.json"
         ],
-        "2c950c67a115882cfa103e65b7778b39eff9a10cd1085464600d19c558901296"
+        "d3c44720d99f9e1856bb068a1e508f5d5ebf344114797e7094d08bdb845a1e58"
     ],
     [
         [
@@ -221,7 +221,7 @@
             "file",
             "web-app/package.json"
         ],
-        "87b09290ebeb7cb704d567860100954e1aa76d74353013d03ebb77d38e2beaea"
+        "ef46ceee543774353403dc2e725387bed4e82158dbb54afb795ed684c81c9908"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/Dockerfile
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS node
+FROM node:18-alpine AS node
 
 
 FROM node AS base

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/package.json
@@ -22,8 +22,8 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^16.0.0",
-    "npm": "^8.0.0"
+    "node": "^18.12.0",
+    "npm": "^8.19.2"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {},
   "engineStrict": true,
   "engines": {
-    "node": "^16.0.0",
-    "npm": "^8.0.0"
+    "node": "^18.12.0",
+    "npm": "^8.19.2"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "0134f44513be86f913897e47699114aaa1f1b497152cabe93755b992957b95e6"
+        "5199be314e1006eca5bbd649f1330d2fc508f15ecbcf33d508763b15aa304923"
     ],
     [
         [
@@ -46,7 +46,7 @@
             "file",
             "server/package.json"
         ],
-        "99a22e6f44c7166a5958e628ac0e404f41440232de3dff6f77c2ddb59ef58b78"
+        "a3dffd7f32f53e942ffc29be86b41374ed5fd421293c336d9bb57ffc795caa5e"
     ],
     [
         [
@@ -207,7 +207,7 @@
             "file",
             "web-app/package.json"
         ],
-        "757531fc8904820a41a00c5bd513d26cf3fbe89aac62d6a4fc8b85c58de80aae"
+        "d85f92e70846628060835b637c590a1ea40d881c2abbd530a2850dd9ad5aae87"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/Dockerfile
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS node
+FROM node:18-alpine AS node
 
 
 FROM node AS base

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
@@ -21,8 +21,8 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^16.0.0",
-    "npm": "^8.0.0"
+    "node": "^18.12.0",
+    "npm": "^8.19.2"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {},
   "engineStrict": true,
   "engines": {
-    "node": "^16.0.0",
-    "npm": "^8.0.0"
+    "node": "^18.12.0",
+    "npm": "^8.19.2"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/src/Wasp/Generator/Common.hs
+++ b/waspc/src/Wasp/Generator/Common.hs
@@ -24,13 +24,13 @@ nodeVersionRange :: SV.Range
 nodeVersionRange = SV.Range [SV.backwardsCompatibleWith latestNodeLTSVersion]
 
 latestNodeLTSVersion :: SV.Version
-latestNodeLTSVersion = SV.Version 16 0 0
+latestNodeLTSVersion = SV.Version 18 12 0
 
 -- | Range of npm versions that Wasp and generated projects work correctly with.
 npmVersionRange :: SV.Range
 npmVersionRange = SV.Range [SV.backwardsCompatibleWith latestLTSVersion]
   where
-    latestLTSVersion = SV.Version 8 0 0 -- Goes with node 16 (but also higher versions too)
+    latestLTSVersion = SV.Version 8 19 2 -- Goes with node 18 (but also higher versions too).
 
 prismaVersion :: SV.Version
 prismaVersion = SV.Version 3 15 2

--- a/web/docs/getting-started.md
+++ b/web/docs/getting-started.md
@@ -12,8 +12,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 ## 1. Requirements
 
 You need to have `node` (and `npm`) installed on your machine and available in `PATH`.
-- `node`: 16.x.x
-- `npm`: 8.x.x
+- `node`: ^18.12.0
+- `npm`: ^8.19.2
 
 You can check `node` and `npm` versions by running:
 ```shell-session
@@ -33,12 +33,12 @@ We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing your Node.j
 
   Then, install a version of node that you need, e.g.:
   ```shell-session
-  nvm install 16
+  nvm install 18
   ```
 
   Finally, whenever you need to ensure specific version of node is used, run e.g.
   ```shell-session
-  nvm use 16
+  nvm use 18
   ```
   to set the node version for current shell session.
 


### PR DESCRIPTION
# Description

Updates node from v16 to the current LTS v18. Updates npm as well. Relevant links:
- https://nodejs.org/en/
- https://nodejs.org/en/download/releases/
- https://github.com/nodejs/Release
- https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#nodejs-18-changelog

Fixes #768

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update