### PR TITLE
[Issue/789] Fix: broken contact link for certain pages

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -93,7 +93,7 @@ module.exports = {
             },
             {
               label: 'Contact',
-              href: 'docs/contact'
+              href: '/docs/contact'
             }
           ],
         },


### PR DESCRIPTION
# Description
This fix updates the documentation
- Updated `to:` field in docusaurus' config file to always redirect to `/docs/contact` 
Fixes # ([issue](#789))

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update