### PR TITLE
Fix typo in docs

### DIFF
--- a/web/docs/language/syntax.md
+++ b/web/docs/language/syntax.md
@@ -41,7 +41,7 @@ All the other types in Wasp language (primitive types (`string`, `number`), comp
 ## Complete list of Wasp types
 Wasp's type system can be divided into two main categories of types: **fundamental types** and **domain types**.
 
-While fundamental types are here to be basic building blocks of a language, and are very similar to what you would see in other popular lanuages, domain types are what makes Wasp special, as they model the concepts of a web app like `page`, `route` and similar.
+While fundamental types are here to be basic building blocks of a language, and are very similar to what you would see in other popular languages, domain types are what makes Wasp special, as they model the concepts of a web app like `page`, `route` and similar.
 
 - Fundamental types ([source of truth](https://github.com/wasp-lang/wasp/blob/main/waspc/src/Wasp/Analyzer/Type.hs))
   - Primitive types

--- a/web/docs/tutorials/todo-app/auth.md
+++ b/web/docs/tutorials/todo-app/auth.md
@@ -49,7 +49,7 @@ app TodoApp {
     userEntity: User,
     methods: {
       usernameAndPassword: {} // We also support Google, with more on the way!
-    }
+    },
     onAuthFailedRedirectTo: "/login" // We'll see how this is used a bit later
   }
 }


### PR DESCRIPTION
# Description

Fix minor typo's on tutorial's code and language section docs. Hopefully, when someone choose to copy the entire tutorial's code they don't see an unexpected error caused by the typo.

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update