### PR TITLE
Fix database setup after NPM install

### DIFF
--- a/waspc/src/Wasp/Generator/Setup.hs
+++ b/waspc/src/Wasp/Generator/Setup.hs
@@ -17,26 +17,23 @@ import qualified Wasp.Util.Terminal as Term
 
 runSetup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> Msg.SendMessage -> IO ([GeneratorWarning], [GeneratorError])
 runSetup spec dstDir sendMessage = do
-  errorOrMaybeFullStackDeps <- isNpmInstallNeeded spec dstDir
-  case errorOrMaybeFullStackDeps of
+  ensureNpmInstall spec dstDir sendMessage >>= \case
+    npmInstallResults@(_, []) -> (npmInstallResults <>) <$> setUpDatabase spec dstDir sendMessage
+    npmInstallResults -> return npmInstallResults
+
+ensureNpmInstall :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> Msg.SendMessage -> IO ([GeneratorWarning], [GeneratorError])
+ensureNpmInstall spec dstDir sendMessage = do
+  isNpmInstallNeeded spec dstDir >>= \case
     Left errorMessage -> return ([], [GenericGeneratorError errorMessage])
-    Right maybeFullStackDeps -> do
-      case maybeFullStackDeps of
-        Nothing -> return ([], [])
-        Just fullStackDeps -> do
-          sendMessage $ Msg.Start "Starting npm install..."
-          (Left (npmInstallWarnings, npmInstallErrors)) <-
-            installNpmDependenciesWithInstallRecord fullStackDeps dstDir
-              `race` reportInstallationProgress reportInstallationProgressMessages
-          if null npmInstallErrors
-            then do
-              sendMessage $ Msg.Success "Successfully completed npm install."
-              sendMessage $ Msg.Start "Setting up database..."
-              (dbGeneratorWarnings, dbGeneratorErrors) <- DbGenerator.postWriteDbGeneratorActions spec dstDir
-              when (null dbGeneratorErrors) (sendMessage $ Msg.Success "Database successfully set up.")
-              return (npmInstallWarnings ++ dbGeneratorWarnings, dbGeneratorErrors)
-            else do
-              return (npmInstallWarnings, npmInstallErrors)
+    Right maybeFullStackDeps -> case maybeFullStackDeps of
+      Nothing -> return ([], [])
+      Just fullStackDeps -> do
+        sendMessage $ Msg.Start "Starting npm install..."
+        (Left (npmInstallWarnings, npmInstallErrors)) <-
+          installNpmDependenciesWithInstallRecord fullStackDeps dstDir
+            `race` reportInstallationProgress reportInstallationProgressMessages
+        when (null npmInstallErrors) (sendMessage $ Msg.Success "Successfully completed npm install.")
+        return (npmInstallWarnings, npmInstallErrors)
   where
     reportInstallationProgress :: [String] -> IO ()
     reportInstallationProgress messages = do
@@ -47,14 +44,21 @@ runSetup spec dstDir sendMessage = do
 
     reportInstallationProgressMessages =
       [ "Still installing npm dependencies!",
-        "Installation going great - we will get there soon!",
-        "Installation is taking a bit longer, but we will get there!",
+        "Installation going great - we'll get there soon!",
+        "The installation is taking a while, but we'll get there!",
         "Yup, still not done installing.",
-        "We are getting closer and closer, soon it will all be installed!",
-        "You still waiting for installation to finish? You should! We got too far to give up now!",
-        "You waited so patiently, wait just a bit more (for installation to finish)..."
+        "We're getting closer and closer, everything will be installed soon!",
+        "Still waiting for the installation to finish? You should! We got too far to give up now!",
+        "You've been waiting so patiently, just wait a little longer (for the installation to finish)..."
       ]
 
     secToMicroSec = (* 1000000)
 
     hasLessThan2Elems = null . drop 1
+
+setUpDatabase :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> Msg.SendMessage -> IO ([GeneratorWarning], [GeneratorError])
+setUpDatabase spec dstDir sendMessage = do
+  sendMessage $ Msg.Start "Setting up database..."
+  (dbGeneratorWarnings, dbGeneratorErrors) <- DbGenerator.postWriteDbGeneratorActions spec dstDir
+  when (null dbGeneratorErrors) (sendMessage $ Msg.Success "Database successfully set up.")
+  return (dbGeneratorWarnings, dbGeneratorErrors)

--- a/waspc/src/Wasp/Generator/Setup.hs
+++ b/waspc/src/Wasp/Generator/Setup.hs
@@ -17,12 +17,12 @@ import qualified Wasp.Util.Terminal as Term
 
 runSetup :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> Msg.SendMessage -> IO ([GeneratorWarning], [GeneratorError])
 runSetup spec dstDir sendMessage = do
-  ensureNpmInstall spec dstDir sendMessage >>= \case
+  runNpmInstallIfNeeded spec dstDir sendMessage >>= \case
     npmInstallResults@(_, []) -> (npmInstallResults <>) <$> setUpDatabase spec dstDir sendMessage
     npmInstallResults -> return npmInstallResults
 
-ensureNpmInstall :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> Msg.SendMessage -> IO ([GeneratorWarning], [GeneratorError])
-ensureNpmInstall spec dstDir sendMessage = do
+runNpmInstallIfNeeded :: AppSpec -> Path' Abs (Dir ProjectRootDir) -> Msg.SendMessage -> IO ([GeneratorWarning], [GeneratorError])
+runNpmInstallIfNeeded spec dstDir sendMessage = do
   isNpmInstallNeeded spec dstDir >>= \case
     Left errorMessage -> return ([], [GenericGeneratorError errorMessage])
     Right maybeFullStackDeps -> case maybeFullStackDeps of


### PR DESCRIPTION
Fixes the issue introduced by https://github.com/wasp-lang/wasp/commit/d5d2c53d7e43087d0308dd3f788555ce4d69e267.

We mistakenly stopped running the database setup when the installation wasn't necessary, now we're running it again.