### PR TITLE
Fix links in examples to point to release branch

### DIFF
--- a/web/blog/2021-03-02-wasp-alpha.md
+++ b/web/blog/2021-03-02-wasp-alpha.md
@@ -76,7 +76,7 @@ entity User {=psl
 psl=}
 ```
 
-Check [here](https://github.com/wasp-lang/wasp/blob/main/examples/tutorials/TodoApp/main.wasp) for the complete example.
+Check [here](https://github.com/wasp-lang/wasp/blob/release/examples/tutorials/TodoApp/main.wasp) for the complete example.
 
 ## Why a language (DSL), aren’t frameworks solving this already?
 

--- a/web/blog/2021-12-02-waspello.md
+++ b/web/blog/2021-12-02-waspello.md
@@ -13,7 +13,7 @@ import ImgWithCaption from './components/ImgWithCaption'
 ![Enter Waspello](../static/img/waspello-screenshot.png)
 
 <p align="center">
-    <Link to={'https://waspello.netlify.app/'}>Try Waspello here!</Link> | <Link to={'https://github.com/wasp-lang/wasp/blob/main/examples/waspello/main.wasp'}>See the code</Link>
+    <Link to={'https://waspello.netlify.app/'}>Try Waspello here!</Link> | <Link to={'https://github.com/wasp-lang/wasp/blob/release/examples/waspello/main.wasp'}>See the code</Link>
 </p>
 
 We've built a Trello clone using Wasp! Read on to learn how it went and how you can contribute. 
@@ -127,7 +127,7 @@ export const getListsAndCards = async (args, context) => {
 ```
 This is just a regular Node.js function, there are no limits on what you can return! All the stuff provided by Wasp (user data, Prisma SDK for a specific entity) comes in a `context` variable.
 
-The code for actions is very similar (we just need to use `action` keyword instead of `query`) so I won't repeat it here. You can check out the code for `updateCard` action [here](https://github.com/wasp-lang/wasp/blob/main/examples/waspello/main.wasp#L103).
+The code for actions is very similar (we just need to use `action` keyword instead of `query`) so I won't repeat it here. You can check out the code for `updateCard` action [here](https://github.com/wasp-lang/wasp/blob/release/examples/waspello/main.wasp#L103).
 
 #### Pages, routing & components
 To display all the nice data we have, we'll use React components. There are no limits to how you can use React components within Wasp, the only one is that each `page` has its root component:

--- a/web/blog/2022-01-27-waspleau.md
+++ b/web/blog/2022-01-27-waspleau.md
@@ -14,7 +14,7 @@ import ImgWithCaption from './components/ImgWithCaption'
 ![Hello, Waspleau](../static/img/waspleau-screenshot.png)
 
 <p align="center">
-  <Link to={'https://waspleau.netlify.app/'}>See Waspleau here!</Link> | <Link to={'https://github.com/wasp-lang/wasp/blob/main/examples/waspleau'}>See the code</Link>
+  <Link to={'https://waspleau.netlify.app/'}>See Waspleau here!</Link> | <Link to={'https://github.com/wasp-lang/wasp/blob/release/examples/waspleau'}>See the code</Link>
 </p>
 
 We've built a dashboard powered by a job queue using Wasp!
@@ -124,7 +124,7 @@ const workerFunction = async (opts) => {
 export const githubWorker = { name: 'GitHub API', fn: workerFunction, schedule: '*/10 * * * *' }
 ```
 
-_Note: Please see the [actual serverSetup.js file](https://github.com/wasp-lang/wasp/blob/main/examples/waspleau/src/server/serverSetup.js) for how we use this abstraction in practice._
+_Note: Please see the [actual serverSetup.js file](https://github.com/wasp-lang/wasp/blob/release/examples/waspleau/src/server/serverSetup.js) for how we use this abstraction in practice._
 
 ### Server → client
 
@@ -165,7 +165,7 @@ const { data: dashboardData, isFetching, error } = useQuery(refreshDashboardData
 
 ## Congratulations, let’s dance!
 
-Whew, we did it! If you’d like to deploy your own customized version of this dashboard, please clone [our repo](https://github.com/wasp-lang/wasp) and check out the Waspleau example [README.md](https://github.com/wasp-lang/wasp/blob/main/examples/waspleau/README.md) for tips on getting started. You can also [check out our docs](https://wasp-lang.dev/docs) to dive deeper into anything.
+Whew, we did it! If you’d like to deploy your own customized version of this dashboard, please clone [our repo](https://github.com/wasp-lang/wasp) and check out the Waspleau example [README.md](https://github.com/wasp-lang/wasp/blob/release/examples/waspleau/README.md) for tips on getting started. You can also [check out our docs](https://wasp-lang.dev/docs) to dive deeper into anything.
 
 ![Rickroll](../static/img/waspleau-rickroll.gif)
 

--- a/web/blog/2022-06-15-jobs-feature-announcement.md
+++ b/web/blog/2022-06-15-jobs-feature-announcement.md
@@ -144,7 +144,7 @@ For those interested, check out the [full diff here](https://github.com/wasp-lan
 
 ## Looks neat! What’s next?
 
-First off, please check out our docs for Jobs: [https://wasp-lang.dev/docs/language/features#jobs](https://wasp-lang.dev/docs/language/features#jobs) There, you will find all the info you need to start using them. Next, if you want to see the code for this example in full, you can find it here: [https://github.com/wasp-lang/wasp/tree/main/examples/waspleau](https://github.com/wasp-lang/wasp/tree/main/examples/waspleau)
+First off, please check out our docs for Jobs: [https://wasp-lang.dev/docs/language/features#jobs](https://wasp-lang.dev/docs/language/features#jobs) There, you will find all the info you need to start using them. Next, if you want to see the code for this example in full, you can find it here: [https://github.com/wasp-lang/wasp/tree/release/examples/waspleau](https://github.com/wasp-lang/wasp/tree/release/examples/waspleau)
 
 In the future, we plan to add more job executors, including support for polyglot workers (imagine running your Python ML function from Wasp!). We are also open to any other ideas on how jobs can become more useful to you (like client-side access to server-side jobs, or client-side jobs using similar abstractions?). Let us know what you think!
 

--- a/web/blog/2022-09-05-dev-excuses-app-tutrial.md
+++ b/web/blog/2022-09-05-dev-excuses-app-tutrial.md
@@ -23,7 +23,7 @@ We’ll use Michele Gerarduzzi’s [open-source project](https://github.com/mich
 - Building an app shouldn’t take more than 15 minutes.
 - Use modern web dev technologies (NodeJS + React)
 
-As a result – we’ll get a simple and fun pet project. You can find the complete codebase [here](https://github.com/wasp-lang/wasp/tree/main/examples/tutorials/ItWaspsOnMyMachine). 
+As a result – we’ll get a simple and fun pet project. You can find the complete codebase [here](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/ItWaspsOnMyMachine). 
 
 ![Final result](../static/img/final-excuse-app.png)
 

--- a/web/docs/examples.md
+++ b/web/docs/examples.md
@@ -3,8 +3,8 @@ title: Examples
 ---
 
 Todo App:
- - source code: https://github.com/wasp-lang/wasp/tree/main/examples/tutorials/TodoApp .
+ - source code: https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp .
 
 Real World App (clone of Medium):
- - source code: https://github.com/wasp-lang/wasp/tree/main/examples/realworld .
+ - source code: https://github.com/wasp-lang/wasp/tree/release/examples/realworld .
  - hosted at: https://wasp-rwa.netlify.app/ .

--- a/web/docs/tutorials/dev-excuses-app.md
+++ b/web/docs/tutorials/dev-excuses-app.md
@@ -18,7 +18,7 @@ We’ll use Michele Gerarduzzi’s [open-source project](https://github.com/mich
 - Building an app shouldn’t take more than 15 minutes.
 - Use modern web dev technologies (NodeJS + React)
 
-As a result – we’ll get a simple and fun pet project. You can find the complete codebase [here](https://github.com/wasp-lang/wasp/tree/main/examples/tutorials/ItWaspsOnMyMachine). 
+As a result – we’ll get a simple and fun pet project. You can find the complete codebase [here](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/ItWaspsOnMyMachine). 
 
 <img alt="Final result"
      src={useBaseUrl('img/dev-excuses-live-preview.gif')}

--- a/web/docs/tutorials/todo-app.md
+++ b/web/docs/tutorials/todo-app.md
@@ -22,7 +22,7 @@ This tutorial will take you step by step through the most important features of 
 
 If you get stuck at any point (or just want to chat), reach out to us on [Discord](https://discord.gg/rzdnErX) and we will help you!
 
-You can check out the complete code of the app we are about to build with Wasp [here](https://github.com/wasp-lang/wasp/tree/main/examples/tutorials/TodoApp).
+You can check out the complete code of the app we are about to build with Wasp [here](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp).
 
 :::tip
 If you are interested at any moment in what is Wasp actually generating in the background, take a look at `.wasp/out/` directory in your project.

--- a/web/docs/tutorials/todo-app/08-the-end.md
+++ b/web/docs/tutorials/todo-app/08-the-end.md
@@ -12,7 +12,7 @@ We did it! For all those that followed the instructions closely and created "Bui
      style={{ border: '1px solid black' }}
 />
 
-You can check out the whole code of the app that we just built [here](https://github.com/wasp-lang/wasp/tree/main/examples/tutorials/TodoApp).
+You can check out the whole code of the app that we just built [here](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp).
 
 If you are interested in what is Wasp actually generating in the background, you can check the `.wasp/out/` directory in your project.
 


### PR DESCRIPTION
Fixes #728 

Procedure (`cd` into `wasp/web`):
```
fd --exec sed -i -e 's|main/examples|release/examples|g'
```
Verifiied with:
```
grep main/examples -R * .* -r
```
And tested some of the links.