### PR TITLE
Fix Google login button height for use with Tailwind

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/auth/buttons/Google.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/buttons/Google.js
@@ -6,10 +6,9 @@ export const googleSignInUrl = `${config.apiUrl}/auth/external/google/login`
 // which sets `height: auto` for `img`.
 export function GoogleSignInButton(props) {
   return (
-    <a {...props.a} href={googleSignInUrl}>
+    <a href={googleSignInUrl}>
       <img alt="Sign in with Google"
-        style={{ height: 40 }}
-        {...props.img}
+        style={{ height: props.height || 40 }}
         src="/images/btn_google_signin_dark_normal_web@2x.png" />
     </a>
   )

--- a/waspc/data/Generator/templates/react-app/src/auth/buttons/Google.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/buttons/Google.js
@@ -4,8 +4,11 @@ export const googleSignInUrl = `${config.apiUrl}/auth/external/google/login`
 
 export function GoogleSignInButton(props) {
   return (
-    <a href={googleSignInUrl}>
-      <img alt="Sign in with Google" height={props?.height || 40} src="/images/btn_google_signin_dark_normal_web@2x.png" />
+    <a {...props.a} href={googleSignInUrl}>
+      <img alt="Sign in with Google"
+        style={{ height: 40 }}
+        {...props.img}
+        src="/images/btn_google_signin_dark_normal_web@2x.png" />
     </a>
   )
 }

--- a/waspc/data/Generator/templates/react-app/src/auth/buttons/Google.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/buttons/Google.js
@@ -2,6 +2,8 @@ import config from '../../config.js'
 
 export const googleSignInUrl = `${config.apiUrl}/auth/external/google/login`
 
+// Note: Using `style` instead of `height` to work with Tailwind,
+// which sets `height: auto` for `img`.
 export function GoogleSignInButton(props) {
   return (
     <a {...props.a} href={googleSignInUrl}>

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -1188,8 +1188,7 @@ const Login = () => {
 export default Login
 ```
 
-You can set the height of the button by setting a prop (e.g., `<Google height={25}/>`), which defaults to 40px.
-
+You can change properties of the image or link by setting a scoped property (either `a` or `img`). For example, to change the height of the button (which defaults to 40px) set a `style` prop on the `img`, like so: `<GoogleSignInButton img={{ style: { height: 30 } }} />`. It uses `style` instead of `height` by default to be compatible with Tailwind, which sets `height: auto` for `img`.
 
 ### `externalAuthEntity`
 Anytime an authentication method is used that relies on an external authorization provider, for example, Google, we require an `externalAuthEntity` specified in `auth` that contains at least the following highlighted fields:

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -1188,7 +1188,7 @@ const Login = () => {
 export default Login
 ```
 
-You can change properties of the image or link by setting a scoped property (either `a` or `img`). For example, to change the height of the button (which defaults to 40px) set a `style` prop on the `img`, like so: `<GoogleSignInButton img={{ style: { height: 30 } }} />`. It uses `style` instead of `height` by default to be compatible with Tailwind, which sets `height: auto` for `img`.
+You can adjust the height of the button by setting a prop (e.g., `<Google height={25}/>`), which defaults to 40px. NOTE: Under the covers it uses `style` instead of `height` to be compatible with Tailwind, which sets `height: auto` for `img` in the Tailwind `base` directive. If you need more customization, you can create your own custom component using the `googleSignInUrl`.
 
 ### `externalAuthEntity`
 Anytime an authentication method is used that relies on an external authorization provider, for example, Google, we require an `externalAuthEntity` specified in `auth` that contains at least the following highlighted fields:

--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -1188,7 +1188,7 @@ const Login = () => {
 export default Login
 ```
 
-You can adjust the height of the button by setting a prop (e.g., `<Google height={25}/>`), which defaults to 40px. NOTE: Under the covers it uses `style` instead of `height` to be compatible with Tailwind, which sets `height: auto` for `img` in the Tailwind `base` directive. If you need more customization, you can create your own custom component using the `googleSignInUrl`.
+You can adjust the height of the button by setting a `height` prop (e.g., `<GoogleSignInButton height={25}/>`), which defaults to 40px. NOTE: Under the covers it uses `img.style` instead of `img.height` to be compatible with Tailwind, which sets `height: auto` for `img` in the Tailwind `base` directive. If you need more customization, you can create your own custom component using the `googleSignInUrl`.
 
 ### `externalAuthEntity`
 Anytime an authentication method is used that relies on an external authorization provider, for example, Google, we require an `externalAuthEntity` specified in `auth` that contains at least the following highlighted fields:


### PR DESCRIPTION
# Description

Fixes the Google login button when using Tailwind. Before, we were setting `img.height`. However, in Tailwind's `base` directive it sets `img { height: auto }`.

This change sets the height using `img.style` on the button to work with Tailwind (and without). It is backward compatible with existing code setting the `height` prop on our component.

Some reference about why the do it here: https://github.com/tailwindlabs/tailwindcss/pull/7742#issuecomment-1061332148

Fixes #837 

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update