### PR TITLE
Remove Haskell from Github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.wasp linguist-language=JavaScript
+*.haskell linguist-detectable=false
 
 /examples/* linguist-documentation


### PR DESCRIPTION
# Description

Removes Haskell from the list of languages, making JS the primary repo language. 

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update