### PR TITLE
WIP: Make Queries use `GET`

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/actions/core.js
+++ b/waspc/data/Generator/templates/react-app/src/actions/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callAction } from '../operations'
 import {
   registerActionInProgress,
   registerActionDone,
@@ -11,7 +11,7 @@ export function createAction(actionRoute, entitiesUsed) {
       // The `return await` is not redundant here. If we removed the await, the
       // `finally` block would execute before the action finishes, prematurely
       // registering the action as done.
-      return await callOperation(actionRoute, args)
+      return await callAction(actionRoute, args)
     } finally {
       await registerActionDone(entitiesUsed, specificOptimisticUpdateDefinitions)
     }

--- a/waspc/data/Generator/templates/react-app/src/operations/index.js
+++ b/waspc/data/Generator/templates/react-app/src/operations/index.js
@@ -11,7 +11,9 @@ export async function callAction(actionRoute, args) {
 
 export async function callQuery(queryRoute, args) {
   try {
-    const response = await api.get(`/${queryRoute}`, { params: args })
+    // TODO: This is to help us preserve the types of the args.
+    // In future, we should get type info from users via wasp file.
+    const response = await api.get(`/${queryRoute}`, { params: { args: JSON.stringify(args) } })
     return response.data
   } catch (error) {
     handleApiError(error)

--- a/waspc/data/Generator/templates/react-app/src/operations/index.js
+++ b/waspc/data/Generator/templates/react-app/src/operations/index.js
@@ -1,11 +1,19 @@
 import api, { handleApiError } from '../api.js'
 
-export async function callOperation(operationRoute, args) {
+export async function callAction(actionRoute, args) {
   try {
-    const response = await api.post(`/${operationRoute}`, args)
+    const response = await api.post(`/${actionRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)
   }
 }
 
+export async function callQuery(queryRoute, args) {
+  try {
+    const response = await api.get(`/${queryRoute}`, { params: args })
+    return response.data
+  } catch (error) {
+    handleApiError(error)
+  }
+}

--- a/waspc/data/Generator/templates/react-app/src/queries/core.js
+++ b/waspc/data/Generator/templates/react-app/src/queries/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callQuery } from '../operations'
 import {
   addResourcesUsedByQuery,
   getActiveOptimisticUpdates,
@@ -6,7 +6,7 @@ import {
 
 export function createQuery(queryRoute, entitiesUsed) {
   async function query(queryKey, queryArgs) {
-    const serverResult = await callOperation(queryRoute, queryArgs)
+    const serverResult = await callQuery(queryRoute, queryArgs)
     return getActiveOptimisticUpdates(queryKey).reduce(
       (result, update) => update(result), 
       serverResult,

--- a/waspc/data/Generator/templates/server/src/app.js
+++ b/waspc/data/Generator/templates/server/src/app.js
@@ -35,8 +35,7 @@ app.use((err, req, res, next) => {
     return res.status(err.statusCode).json({ message: err.message, data: err.data })
   }
 
-  console.error(err);
-  return res.status(500).json({message: "An internal server error occurred."})
+  return next(err)
 })
 
 export default app

--- a/waspc/data/Generator/templates/server/src/app.js
+++ b/waspc/data/Generator/templates/server/src/app.js
@@ -35,7 +35,8 @@ app.use((err, req, res, next) => {
     return res.status(err.statusCode).json({ message: err.message, data: err.data })
   }
 
-  return next(err)
+  console.error(err);
+  return res.status(500).json({message: "An internal server error occurred."})
 })
 
 export default app

--- a/waspc/data/Generator/templates/server/src/queries/_query.js
+++ b/waspc/data/Generator/templates/server/src/queries/_query.js
@@ -3,7 +3,7 @@ import prisma from '../dbClient.js'
 
 {=& jsFnImportStatement =}
 
-{=! TODO: This template is exactly the same at the moment as one for queries,
+{=! TODO: This template is exactly the same at the moment as one for actions,
           consider in the future if it is worth removing this duplication. =}
 
 export default async (args, context) => {

--- a/waspc/data/Generator/templates/server/src/routes/operations/_query.js
+++ b/waspc/data/Generator/templates/server/src/routes/operations/_query.js
@@ -4,14 +4,15 @@ import { handleRejection } from '../../utils.js'
 import {= operationName =} from "{= operationImportPath =}"
 
 export default handleRejection(async (req, res) => {
-  {=! TODO: When generating express route for query, generated code would be most human-like if we
-    generated GET route that uses query arguments.
-    However, for that, we need to know the types of the arguments so we can cast/parse them.
-    Also, there is limit on URI length, which could be problem if users want to send some bigger
-    JSON objects or smth.
-    So for now we are just going with POST that has JSON in the body -> generated code is not
-    as human-like as it should be though. =}
-  const args = req.body || {}
+  const args = req.query || {}
+
+  // TODO: Have a flag for if we should autoconvert numbers.
+  // Just doing some testing right now.
+  if (true) {
+    if (req.query.id) {
+      req.query.id = parseInt(req.query.id);
+    }
+  }
 
   const context = {
     {=# userEntityLower =}

--- a/waspc/data/Generator/templates/server/src/routes/operations/_query.js
+++ b/waspc/data/Generator/templates/server/src/routes/operations/_query.js
@@ -4,15 +4,7 @@ import { handleRejection } from '../../utils.js'
 import {= operationName =} from "{= operationImportPath =}"
 
 export default handleRejection(async (req, res) => {
-  const args = req.query || {}
-
-  // TODO: Have a flag for if we should autoconvert numbers.
-  // Just doing some testing right now.
-  if (true) {
-    if (req.query.id) {
-      req.query.id = parseInt(req.query.id);
-    }
-  }
+  const args = JSON.parse(req?.query?.args || '{}')
 
   const context = {
     {=# userEntityLower =}

--- a/waspc/data/Generator/templates/server/src/routes/operations/index.js
+++ b/waspc/data/Generator/templates/server/src/routes/operations/index.js
@@ -12,7 +12,12 @@ import {= importIdentifier =} from '{= importPath =}'
 const router = express.Router()
 
 {=# operationRoutes =}
+{=# isQuery =}
+router.get('{= routePath =}', {=# isUsingAuth =} auth, {=/ isUsingAuth =} {= importIdentifier =})
+{=/ isQuery =}
+{=^ isQuery =}
 router.post('{= routePath =}', {=# isUsingAuth =} auth, {=/ isUsingAuth =} {= importIdentifier =})
+{=/ isQuery =}
 {=/ operationRoutes =}
 
 export default router

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -235,7 +235,7 @@
             "file",
             "web-app/src/actions/core.js"
         ],
-        "5c4dcdec74fb014a8edbb3d240bcbbfc829e201bce64132598b444db14a2bd45"
+        "0472a8567c9d8b0239088b4606900e26b0b67cb4de501d53702f327f84af4add"
     ],
     [
         [
@@ -305,7 +305,7 @@
             "file",
             "web-app/src/operations/index.js"
         ],
-        "6ab717db2304b6134073aa71144b213b86f8d68a106549da06e193d18683dd87"
+        "e5bdced98b11da592e569144bde7ee89a60cc8b6d6d14f0f01bba8f45b90404c"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "web-app/src/queries/core.js"
         ],
-        "2daf5b414722204281d65e954ce862a6fc586e8907b202800694909d23957c5e"
+        "53a78b05c5ea5a7230b568ac5aaa97d2ee56baa2d70c5074ef3a4e8d678f2f21"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/actions/core.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/actions/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callAction } from '../operations'
 import {
   registerActionInProgress,
   registerActionDone,
@@ -11,7 +11,7 @@ export function createAction(actionRoute, entitiesUsed) {
       // The `return await` is not redundant here. If we removed the await, the
       // `finally` block would execute before the action finishes, prematurely
       // registering the action as done.
-      return await callOperation(actionRoute, args)
+      return await callAction(actionRoute, args)
     } finally {
       await registerActionDone(entitiesUsed, specificOptimisticUpdateDefinitions)
     }

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/operations/index.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/operations/index.js
@@ -1,11 +1,21 @@
 import api, { handleApiError } from '../api.js'
 
-export async function callOperation(operationRoute, args) {
+export async function callAction(actionRoute, args) {
   try {
-    const response = await api.post(`/${operationRoute}`, args)
+    const response = await api.post(`/${actionRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)
   }
 }
 
+export async function callQuery(queryRoute, args) {
+  try {
+    // TODO: This is to help us preserve the types of the args.
+    // In future, we should get type info from users via wasp file.
+    const response = await api.get(`/${queryRoute}`, { params: { args: JSON.stringify(args) } })
+    return response.data
+  } catch (error) {
+    handleApiError(error)
+  }
+}

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/queries/core.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/queries/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callQuery } from '../operations'
 import {
   addResourcesUsedByQuery,
   getActiveOptimisticUpdates,
@@ -6,7 +6,7 @@ import {
 
 export function createQuery(queryRoute, entitiesUsed) {
   async function query(queryKey, queryArgs) {
-    const serverResult = await callOperation(queryRoute, queryArgs)
+    const serverResult = await callQuery(queryRoute, queryArgs)
     return getActiveOptimisticUpdates(queryKey).reduce(
       (result, update) => update(result), 
       serverResult,

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -235,7 +235,7 @@
             "file",
             "web-app/src/actions/core.js"
         ],
-        "5c4dcdec74fb014a8edbb3d240bcbbfc829e201bce64132598b444db14a2bd45"
+        "0472a8567c9d8b0239088b4606900e26b0b67cb4de501d53702f327f84af4add"
     ],
     [
         [
@@ -305,7 +305,7 @@
             "file",
             "web-app/src/operations/index.js"
         ],
-        "6ab717db2304b6134073aa71144b213b86f8d68a106549da06e193d18683dd87"
+        "e5bdced98b11da592e569144bde7ee89a60cc8b6d6d14f0f01bba8f45b90404c"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "web-app/src/queries/core.js"
         ],
-        "2daf5b414722204281d65e954ce862a6fc586e8907b202800694909d23957c5e"
+        "53a78b05c5ea5a7230b568ac5aaa97d2ee56baa2d70c5074ef3a4e8d678f2f21"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/actions/core.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/actions/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callAction } from '../operations'
 import {
   registerActionInProgress,
   registerActionDone,
@@ -11,7 +11,7 @@ export function createAction(actionRoute, entitiesUsed) {
       // The `return await` is not redundant here. If we removed the await, the
       // `finally` block would execute before the action finishes, prematurely
       // registering the action as done.
-      return await callOperation(actionRoute, args)
+      return await callAction(actionRoute, args)
     } finally {
       await registerActionDone(entitiesUsed, specificOptimisticUpdateDefinitions)
     }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/operations/index.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/operations/index.js
@@ -1,11 +1,21 @@
 import api, { handleApiError } from '../api.js'
 
-export async function callOperation(operationRoute, args) {
+export async function callAction(actionRoute, args) {
   try {
-    const response = await api.post(`/${operationRoute}`, args)
+    const response = await api.post(`/${actionRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)
   }
 }
 
+export async function callQuery(queryRoute, args) {
+  try {
+    // TODO: This is to help us preserve the types of the args.
+    // In future, we should get type info from users via wasp file.
+    const response = await api.get(`/${queryRoute}`, { params: { args: JSON.stringify(args) } })
+    return response.data
+  } catch (error) {
+    handleApiError(error)
+  }
+}

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/queries/core.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/queries/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callQuery } from '../operations'
 import {
   addResourcesUsedByQuery,
   getActiveOptimisticUpdates,
@@ -6,7 +6,7 @@ import {
 
 export function createQuery(queryRoute, entitiesUsed) {
   async function query(queryKey, queryArgs) {
-    const serverResult = await callOperation(queryRoute, queryArgs)
+    const serverResult = await callQuery(queryRoute, queryArgs)
     return getActiveOptimisticUpdates(queryKey).reduce(
       (result, update) => update(result), 
       serverResult,

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -249,7 +249,7 @@
             "file",
             "web-app/src/actions/core.js"
         ],
-        "5c4dcdec74fb014a8edbb3d240bcbbfc829e201bce64132598b444db14a2bd45"
+        "0472a8567c9d8b0239088b4606900e26b0b67cb4de501d53702f327f84af4add"
     ],
     [
         [
@@ -319,7 +319,7 @@
             "file",
             "web-app/src/operations/index.js"
         ],
-        "6ab717db2304b6134073aa71144b213b86f8d68a106549da06e193d18683dd87"
+        "e5bdced98b11da592e569144bde7ee89a60cc8b6d6d14f0f01bba8f45b90404c"
     ],
     [
         [
@@ -347,7 +347,7 @@
             "file",
             "web-app/src/queries/core.js"
         ],
-        "2daf5b414722204281d65e954ce862a6fc586e8907b202800694909d23957c5e"
+        "53a78b05c5ea5a7230b568ac5aaa97d2ee56baa2d70c5074ef3a4e8d678f2f21"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/actions/core.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/actions/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callAction } from '../operations'
 import {
   registerActionInProgress,
   registerActionDone,
@@ -11,7 +11,7 @@ export function createAction(actionRoute, entitiesUsed) {
       // The `return await` is not redundant here. If we removed the await, the
       // `finally` block would execute before the action finishes, prematurely
       // registering the action as done.
-      return await callOperation(actionRoute, args)
+      return await callAction(actionRoute, args)
     } finally {
       await registerActionDone(entitiesUsed, specificOptimisticUpdateDefinitions)
     }

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/operations/index.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/operations/index.js
@@ -1,11 +1,21 @@
 import api, { handleApiError } from '../api.js'
 
-export async function callOperation(operationRoute, args) {
+export async function callAction(actionRoute, args) {
   try {
-    const response = await api.post(`/${operationRoute}`, args)
+    const response = await api.post(`/${actionRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)
   }
 }
 
+export async function callQuery(queryRoute, args) {
+  try {
+    // TODO: This is to help us preserve the types of the args.
+    // In future, we should get type info from users via wasp file.
+    const response = await api.get(`/${queryRoute}`, { params: { args: JSON.stringify(args) } })
+    return response.data
+  } catch (error) {
+    handleApiError(error)
+  }
+}

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/queries/core.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/queries/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callQuery } from '../operations'
 import {
   addResourcesUsedByQuery,
   getActiveOptimisticUpdates,
@@ -6,7 +6,7 @@ import {
 
 export function createQuery(queryRoute, entitiesUsed) {
   async function query(queryKey, queryArgs) {
-    const serverResult = await callOperation(queryRoute, queryArgs)
+    const serverResult = await callQuery(queryRoute, queryArgs)
     return getActiveOptimisticUpdates(queryKey).reduce(
       (result, update) => update(result), 
       serverResult,

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -235,7 +235,7 @@
             "file",
             "web-app/src/actions/core.js"
         ],
-        "5c4dcdec74fb014a8edbb3d240bcbbfc829e201bce64132598b444db14a2bd45"
+        "0472a8567c9d8b0239088b4606900e26b0b67cb4de501d53702f327f84af4add"
     ],
     [
         [
@@ -305,7 +305,7 @@
             "file",
             "web-app/src/operations/index.js"
         ],
-        "6ab717db2304b6134073aa71144b213b86f8d68a106549da06e193d18683dd87"
+        "e5bdced98b11da592e569144bde7ee89a60cc8b6d6d14f0f01bba8f45b90404c"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "web-app/src/queries/core.js"
         ],
-        "2daf5b414722204281d65e954ce862a6fc586e8907b202800694909d23957c5e"
+        "53a78b05c5ea5a7230b568ac5aaa97d2ee56baa2d70c5074ef3a4e8d678f2f21"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/actions/core.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/actions/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callAction } from '../operations'
 import {
   registerActionInProgress,
   registerActionDone,
@@ -11,7 +11,7 @@ export function createAction(actionRoute, entitiesUsed) {
       // The `return await` is not redundant here. If we removed the await, the
       // `finally` block would execute before the action finishes, prematurely
       // registering the action as done.
-      return await callOperation(actionRoute, args)
+      return await callAction(actionRoute, args)
     } finally {
       await registerActionDone(entitiesUsed, specificOptimisticUpdateDefinitions)
     }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/operations/index.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/operations/index.js
@@ -1,11 +1,21 @@
 import api, { handleApiError } from '../api.js'
 
-export async function callOperation(operationRoute, args) {
+export async function callAction(actionRoute, args) {
   try {
-    const response = await api.post(`/${operationRoute}`, args)
+    const response = await api.post(`/${actionRoute}`, args)
     return response.data
   } catch (error) {
     handleApiError(error)
   }
 }
 
+export async function callQuery(queryRoute, args) {
+  try {
+    // TODO: This is to help us preserve the types of the args.
+    // In future, we should get type info from users via wasp file.
+    const response = await api.get(`/${queryRoute}`, { params: { args: JSON.stringify(args) } })
+    return response.data
+  } catch (error) {
+    handleApiError(error)
+  }
+}

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/queries/core.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/queries/core.js
@@ -1,4 +1,4 @@
-import { callOperation } from '../operations'
+import { callQuery } from '../operations'
 import {
   addResourcesUsedByQuery,
   getActiveOptimisticUpdates,
@@ -6,7 +6,7 @@ import {
 
 export function createQuery(queryRoute, entitiesUsed) {
   async function query(queryKey, queryArgs) {
-    const serverResult = await callOperation(queryRoute, queryArgs)
+    const serverResult = await callQuery(queryRoute, queryArgs)
     return getActiveOptimisticUpdates(queryKey).reduce(
       (result, update) => update(result), 
       serverResult,

--- a/waspc/src/Wasp/Generator/ServerGenerator/OperationsRoutesG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/OperationsRoutesG.hs
@@ -110,12 +110,15 @@ genOperationsRouter spec
                          )
                    ),
               "routePath" .= ("/" ++ operationRouteInOperationsRouter operation),
-              "isUsingAuth" .= isAuthEnabledForOperation operation
+              "isUsingAuth" .= isAuthEnabledForOperation operation,
+              "isQuery" .= isQuery operation
             ]
 
     isAuthEnabledGlobally = isAuthEnabled spec
     isAuthEnabledForOperation operation = fromMaybe isAuthEnabledGlobally (AS.Operation.getAuth operation)
     isAuthSpecifiedForOperation operation = isJust $ AS.Operation.getAuth operation
+    isQuery (AS.Operation.QueryOp _ _) = True
+    isQuery (AS.Operation.ActionOp _ _) = False
 
 operationRouteInOperationsRouter :: AS.Operation.Operation -> String
 operationRouteInOperationsRouter = U.camelToKebabCase . AS.Operation.getName


### PR DESCRIPTION
# Description

This PR is open mainly for the discussion around shifting Queries from `POST` to `GET`. The approach in this PR does move us in the "right direction" of using`GET` for their semantically correct operations. However, because Wasp lacks the input arg type info, if we simply made them URL params they would all come out on the server as strings. That would not be ideal since it would (a) be a breaking change, and (b) the user would have to do a ton of type conversions in their query functions. The approach taken here mirrors that of `POST` before- namely, serializing JSON as an `arg`. This is not ideal/traditional REST-style, however. :/

The main question is: do we wait on this until we allow users to specify the route and param types for Queries, or is this already a useful step in the right direction we want to take on, knowing it still may "look weird" to devs.

Before:
```
Request URL: http://localhost:3001/operations/get-task
Request Method: POST
Request Payload:
{"id":23}
```

After:
```
Request URL: http://localhost:3001/operations/get-task?args=%7B%22id%22:23%7D
Request Method: GET
```

Let's discuss! :D 

Fixes #445 

## Type of change

Please select the option(s) that is more relevant.

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update