### PR TITLE
Fixes leaking server errors to client

### DIFF
--- a/waspc/data/Generator/templates/server/src/app.js
+++ b/waspc/data/Generator/templates/server/src/app.js
@@ -35,7 +35,8 @@ app.use((err, req, res, next) => {
     return res.status(err.statusCode).json({ message: err.message, data: err.data })
   }
 
-  return next(err)
+  console.error(err);
+  return res.status(500).json({message: "An internal server error occurred."})
 })
 
 export default app


### PR DESCRIPTION
# Description

Currently, if we have any uncaught errors on the server, we are sending those down to the client. This is not great. Example:
<img width="1469" alt="Screenshot 2022-12-21 105752" src="https://user-images.githubusercontent.com/523636/208948479-11ef8722-2f1a-49ad-8ff6-354e36f9dbfe.png">

This PR updates our custom error handler to return a 500 if it is not an `instanceof HttpError`. There was no existing downstream handler/transformer I could find.

Aside: The only places I noticed where we do anything related is:
- Transforming Prisma errors: https://github.com/wasp-lang/wasp/blob/adcb15a41c376baaed1c2c508256214b3fcd2e88/waspc/data/Generator/templates/server/src/utils.js
- Transforming client errors: https://github.com/wasp-lang/wasp/blob/01642db6fac74e6348891bcf8303d0c076b8f192/waspc/data/Generator/templates/react-app/src/api.js

This fix transforms it into:
<img width="1664" alt="Screenshot 2022-12-21 105904" src="https://user-images.githubusercontent.com/523636/208949027-e398261c-4c30-4ade-9054-ea7e5427875e.png">

Fixes #65

## Type of change

Please select the option(s) that is more relevant.

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update