### PR TITLE
[CI]: Downgrade Ubuntu to 20.04 for build, upgrade deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,11 +59,11 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout the repo
-        uses: actions/checkout@v2.6.0
+        uses: actions/checkout@v2
 
       - name: Set up Haskell
         id: setup-haskell-cabal
-        uses: haskell/actions/setup@v1.1.4
+        uses: haskell/actions/setup@v1.1
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
@@ -74,7 +74,7 @@ jobs:
           cabal --version
 
       - name: Cache
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v2
         with:
           path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           # TODO: Right now, actions/cache updates cache only if cache was not fe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,11 +59,11 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Haskell
         id: setup-haskell-cabal
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
@@ -74,7 +74,7 @@ jobs:
           cabal --version
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           # TODO: Right now, actions/cache updates cache only if cache was not fe
@@ -104,7 +104,7 @@ jobs:
         run: cabal build all
 
       - name: Set up Node
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,11 @@ jobs:
           - "3.6.2.0"
         os:
           # Using Ubuntu 20.04 due to recent GLIBC_2.34 version mismatch errors for
-          # users and other services. Can return to `ubuntu-latest` when
-          # enough time has elapsed. Still looking into musl static binaries.
+          # users and other services. The strategy here is to pick a slightly older LTS
+          # version of Ubuntu to build on so glibc is not too new. glibc has great backward
+          # compatibility though, so older builds will run on new OSs (but not vice versa).
+          # We can return to `ubuntu-latest` when enough time has elapsed.
+          # Still looking into musl static binaries.
           # Ref: https://github.com/wasp-lang/wasp/issues/650
           - ubuntu-20.04
           - macos-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel actions in progress of same workflow and same branch
-        uses: styfle/cancel-workflow-action@0.9.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 
@@ -59,11 +59,11 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.6.0
 
       - name: Set up Haskell
         id: setup-haskell-cabal
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v1.1.4
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
@@ -74,7 +74,7 @@ jobs:
           cabal --version
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.7
         with:
           path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           # TODO: Right now, actions/cache updates cache only if cache was not fe
@@ -104,7 +104,7 @@ jobs:
         run: cabal build all
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v2.5.1
         with:
           node-version: '18'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.0
         with:
           access_token: ${{ github.token }}
+          node-version: '18'
 
   build:
     name: Build Wasp
@@ -90,8 +91,8 @@ jobs:
           #   fails multiple times while others don't, its cache will likely get evicted,
           #   making it even slower to test and fix (uffff).
           #   When they fix this, we should remove ${{ github.run_id }} from the end of the key.
-          key: wasp-build-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('waspc/waspc.cabal') }}-${{ hashFiles('waspc/cabal.project') }}-${{ github.run_id }}
-          restore-keys: wasp-build-${{ runner.os }}-${{ matrix.ghc }}-
+          key: wasp-build-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('waspc/waspc.cabal') }}-${{ hashFiles('waspc/cabal.project') }}-${{ github.run_id }}
+          restore-keys: wasp-build-${{ matrix.os }}-${{ matrix.ghc }}-
 
       - name: Check Haskell code formatting
         if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,13 +23,12 @@ defaults:
 jobs:
   cancel:
     name: Cancel redundant actions already in progress
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel actions in progress of same workflow and same branch
         uses: styfle/cancel-workflow-action@0.9.0
         with:
           access_token: ${{ github.token }}
-          node-version: '18'
 
   build:
     name: Build Wasp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ defaults:
 jobs:
   cancel:
     name: Cancel redundant actions already in progress
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel actions in progress of same workflow and same branch
         uses: styfle/cancel-workflow-action@0.9.0
@@ -40,7 +40,11 @@ jobs:
         cabal:
           - "3.6.2.0"
         os:
-          - ubuntu-latest
+          # Using Ubuntu 20.04 due to recent GLIBC_2.34 version mismatch errors for
+          # users and other services. Can return to `ubuntu-latest` when
+          # enough time has elapsed. Still looking into musl static binaries.
+          # Ref: https://github.com/wasp-lang/wasp/issues/650
+          - ubuntu-20.04
           - macos-latest
           - windows-latest
 
@@ -90,7 +94,7 @@ jobs:
           restore-keys: wasp-build-${{ runner.os }}-${{ matrix.ghc }}-
 
       - name: Check Haskell code formatting
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: ./run ormolu:check
 
       - name: Build external dependencies 
@@ -112,7 +116,7 @@ jobs:
         run: cabal test
 
       - name: Create binary package (Unix)
-        if: startsWith(github.ref, 'refs/tags/v') && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest')
+        if: startsWith(github.ref, 'refs/tags/v') && (matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest')
         run: |
           OS_NAME=`case "${{ runner.os }}" in Linux) echo "linux";; macOS) echo "macos";; *) exit 1;; esac`
           mkdir artifacts
@@ -120,7 +124,7 @@ jobs:
 
       - name: Create Github release
         uses: ncipollo/release-action@v1
-        if: startsWith(github.ref, 'refs/tags/v') && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest')
+        if: startsWith(github.ref, 'refs/tags/v') && (matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest')
         with:
           draft: true
           allowUpdates: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Set up Haskell
         id: setup-haskell-cabal
-        uses: haskell/actions/setup@v1.1
+        uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}


### PR DESCRIPTION
# Description

We have been seeing an uptick in user and service errors around GLIBC_2.34. This is because our CI file was using `ubuntu-latest`, and recently GitHub updated what version that points to: https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

While a static binary using musl is the ideal long-term solution, it is fairly complex and a bit off the beaten path. At this stage, just reverting our build behavior back to pre-0.7.x Wasp version style, when things "just worked", should fix our current GLIBC issue (as they are almost always backward compatible). NOTE: This was also how we used to build in Oct, so it should "just work" as before.

Additionally, I noticed we were getting many warnings in our current runs related to deprecation warnings. I updated all our deps to latest and they are now gone. 🥳 

Example of existing warnings this PR removes by upgrading deps:
<img width="911" alt="Screenshot 2022-12-22 141130" src="https://user-images.githubusercontent.com/523636/209209345-65c04d67-dc21-4727-8ec7-3b245349a79a.png">
