### PR TITLE
Type operation input argument

### DIFF
--- a/waspc/data/Generator/templates/server/src/actions/types.ts
+++ b/waspc/data/Generator/templates/server/src/actions/types.ts
@@ -17,7 +17,7 @@ import {
 } from '../types'
 
 {=# operations =}
-export type {= typeName =}<Input = unknown, Output = unknown> = 
+export type {= typeName =}<Input = never, Output = unknown> = 
   {=# usesAuth =}
   AuthenticatedAction<
   {=/ usesAuth =}

--- a/waspc/data/Generator/templates/server/src/actions/types.ts
+++ b/waspc/data/Generator/templates/server/src/actions/types.ts
@@ -17,7 +17,7 @@ import {
 } from '../types'
 
 {=# operations =}
-export type {= typeName =}<Output = unknown> = 
+export type {= typeName =}<Input = unknown, Output = unknown> = 
   {=# usesAuth =}
   AuthenticatedAction<
   {=/ usesAuth =}
@@ -29,6 +29,7 @@ export type {= typeName =}<Output = unknown> =
       {=.=},
     {=/ entities =}
     ],
+    Input,
     Output
   >
 

--- a/waspc/data/Generator/templates/server/src/queries/types.ts
+++ b/waspc/data/Generator/templates/server/src/queries/types.ts
@@ -17,7 +17,7 @@ import {
 } from '../types'
 
 {=# operations =}
-export type {= typeName =}<Output = unknown> = 
+export type {= typeName =}<Input = unknown, Output = unknown> = 
   {=# usesAuth =}
   AuthenticatedQuery<
   {=/ usesAuth =}
@@ -29,6 +29,7 @@ export type {= typeName =}<Output = unknown> =
       {=.=},
     {=/ entities =}
     ],
+    Input,
     Output
   >
 

--- a/waspc/data/Generator/templates/server/src/queries/types.ts
+++ b/waspc/data/Generator/templates/server/src/queries/types.ts
@@ -17,7 +17,7 @@ import {
 } from '../types'
 
 {=# operations =}
-export type {= typeName =}<Input = unknown, Output = unknown> = 
+export type {= typeName =}<Input = never, Output = unknown> = 
   {=# usesAuth =}
   AuthenticatedQuery<
   {=/ usesAuth =}

--- a/waspc/data/Generator/templates/server/src/types/index.ts
+++ b/waspc/data/Generator/templates/server/src/types/index.ts
@@ -5,24 +5,24 @@ import {
   {=# entities =}
   type {= name =},
   {=/ entities =}
- } from "../entities"
+} from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
 {=# isAuthEnabled =}
-export type AuthenticatedQuery<Entities extends WaspEntity[] = [], Result = unknown> = 
-  AuthenticatedOperation<Entities, Result>
+export type AuthenticatedQuery<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = 
+  AuthenticatedOperation<Entities, Input, Result>
 
-export type AuthenticatedAction<Entities extends WaspEntity[] = [], Result = unknown> = 
-  AuthenticatedOperation<Entities, Result>
+export type AuthenticatedAction<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = 
+  AuthenticatedOperation<Entities, Input, Result>
 
-type AuthenticatedOperation<Entities extends WaspEntity[], Result> = (
-  args: any,
+type AuthenticatedOperation<Entities extends WaspEntity[], Input, Result> = (
+  args: Input,
   context: {
-      user: {= userViewName =},
-      entities: EntityMap<Entities>,
+    user: {= userViewName =},
+    entities: EntityMap<Entities>,
   },
 ) => Promise<Result>
 
@@ -33,10 +33,10 @@ type AuthenticatedOperation<Entities extends WaspEntity[], Result> = (
 type {= userViewName =} = Omit<{= userEntityName =}, 'password'>
 {=/ isAuthEnabled =}
 
-type Operation<Entities extends WaspEntity[], Result> = (
-  args: any,
+type Operation<Entities extends WaspEntity[], Input, Result> = (
+  args: Input,
   context: {
-      entities: EntityMap<Entities>,
+    entities: EntityMap<Entities>,
   },
 ) => Promise<Result>
 

--- a/waspc/data/Generator/templates/server/src/types/index.ts
+++ b/waspc/data/Generator/templates/server/src/types/index.ts
@@ -7,24 +7,24 @@ import {
   {=/ entities =}
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
-export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
 {=# isAuthEnabled =}
-export type AuthenticatedQuery<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = 
-  AuthenticatedOperation<Entities, Input, Result>
+export type AuthenticatedQuery<Entities extends WaspEntity[], Input, Output> = 
+  AuthenticatedOperation<Entities, Input, Output>
 
-export type AuthenticatedAction<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = 
-  AuthenticatedOperation<Entities, Input, Result>
+export type AuthenticatedAction<Entities extends WaspEntity[], Input, Output> = 
+  AuthenticatedOperation<Entities, Input, Output>
 
-type AuthenticatedOperation<Entities extends WaspEntity[], Input, Result> = (
+type AuthenticatedOperation<Entities extends WaspEntity[], Input, Output> = (
   args: Input,
   context: {
     user: {= userViewName =},
     entities: EntityMap<Entities>,
   },
-) => Promise<Result>
+) => Promise<Output>
 
 // TODO: This type must match the logic in core/auth.js (if we remove the
 // password field from the object there, we must do the same here). Ideally,
@@ -33,12 +33,12 @@ type AuthenticatedOperation<Entities extends WaspEntity[], Input, Result> = (
 type {= userViewName =} = Omit<{= userEntityName =}, 'password'>
 {=/ isAuthEnabled =}
 
-type Operation<Entities extends WaspEntity[], Input, Result> = (
+type Operation<Entities extends WaspEntity[], Input, Output> = (
   args: Input,
   context: {
     entities: EntityMap<Entities>,
   },
-) => Promise<Result>
+) => Promise<Output>
 
 type PrismaDelegateFor<EntityName extends string> =
   {=# entities =}

--- a/waspc/data/Generator/templates/server/src/types/index.ts
+++ b/waspc/data/Generator/templates/server/src/types/index.ts
@@ -7,15 +7,15 @@ import {
   {=/ entities =}
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
 {=# isAuthEnabled =}
-export type AuthenticatedQuery<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = 
+export type AuthenticatedQuery<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = 
   AuthenticatedOperation<Entities, Input, Result>
 
-export type AuthenticatedAction<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = 
+export type AuthenticatedAction<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = 
   AuthenticatedOperation<Entities, Input, Result>
 
 type AuthenticatedOperation<Entities extends WaspEntity[], Input, Result> = (

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "5e097ef2cf636d2b481c303987aaabeb5276900a6dcbd0fd6fa031c95616058b"
+        "af9ddf419cbec09ca32c5cd9188d92e1d4523b10bd4541fa7ca9321bd81e4f50"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "98e901d8cb64ea7d82df373f0e79b289523e77318311e382eaf847bed3e7aaed"
+        "1ceae306b5223ff954f1fc3a594275b1e184a6ff8b6080df147b5b5cae1593ea"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "af9ddf419cbec09ca32c5cd9188d92e1d4523b10bd4541fa7ca9321bd81e4f50"
+        "98e901d8cb64ea7d82df373f0e79b289523e77318311e382eaf847bed3e7aaed"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/types/index.ts
@@ -1,17 +1,17 @@
 import prisma from "../dbClient.js"
 import { 
   type WaspEntity,
- } from "../entities"
+} from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
 
-type Operation<Entities extends WaspEntity[], Result> = (
-  args: any,
+type Operation<Entities extends WaspEntity[], Input, Result> = (
+  args: Input,
   context: {
-      entities: EntityMap<Entities>,
+    entities: EntityMap<Entities>,
   },
 ) => Promise<Result>
 

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/types/index.ts
@@ -3,17 +3,17 @@ import {
   type WaspEntity,
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
-export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
 
-type Operation<Entities extends WaspEntity[], Input, Result> = (
+type Operation<Entities extends WaspEntity[], Input, Output> = (
   args: Input,
   context: {
     entities: EntityMap<Entities>,
   },
-) => Promise<Result>
+) => Promise<Output>
 
 type PrismaDelegateFor<EntityName extends string> =
   never

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/types/index.ts
@@ -3,9 +3,9 @@ import {
   type WaspEntity,
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
 
 type Operation<Entities extends WaspEntity[], Input, Result> = (

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "5e097ef2cf636d2b481c303987aaabeb5276900a6dcbd0fd6fa031c95616058b"
+        "af9ddf419cbec09ca32c5cd9188d92e1d4523b10bd4541fa7ca9321bd81e4f50"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "98e901d8cb64ea7d82df373f0e79b289523e77318311e382eaf847bed3e7aaed"
+        "1ceae306b5223ff954f1fc3a594275b1e184a6ff8b6080df147b5b5cae1593ea"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "af9ddf419cbec09ca32c5cd9188d92e1d4523b10bd4541fa7ca9321bd81e4f50"
+        "98e901d8cb64ea7d82df373f0e79b289523e77318311e382eaf847bed3e7aaed"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/types/index.ts
@@ -1,17 +1,17 @@
 import prisma from "../dbClient.js"
 import { 
   type WaspEntity,
- } from "../entities"
+} from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
 
-type Operation<Entities extends WaspEntity[], Result> = (
-  args: any,
+type Operation<Entities extends WaspEntity[], Input, Result> = (
+  args: Input,
   context: {
-      entities: EntityMap<Entities>,
+    entities: EntityMap<Entities>,
   },
 ) => Promise<Result>
 

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/types/index.ts
@@ -3,17 +3,17 @@ import {
   type WaspEntity,
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
-export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
 
-type Operation<Entities extends WaspEntity[], Input, Result> = (
+type Operation<Entities extends WaspEntity[], Input, Output> = (
   args: Input,
   context: {
     entities: EntityMap<Entities>,
   },
-) => Promise<Result>
+) => Promise<Output>
 
 type PrismaDelegateFor<EntityName extends string> =
   never

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/types/index.ts
@@ -3,9 +3,9 @@ import {
   type WaspEntity,
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
 
 type Operation<Entities extends WaspEntity[], Input, Result> = (

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -193,7 +193,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "5e097ef2cf636d2b481c303987aaabeb5276900a6dcbd0fd6fa031c95616058b"
+        "af9ddf419cbec09ca32c5cd9188d92e1d4523b10bd4541fa7ca9321bd81e4f50"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -193,7 +193,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "98e901d8cb64ea7d82df373f0e79b289523e77318311e382eaf847bed3e7aaed"
+        "1ceae306b5223ff954f1fc3a594275b1e184a6ff8b6080df147b5b5cae1593ea"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -193,7 +193,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "af9ddf419cbec09ca32c5cd9188d92e1d4523b10bd4541fa7ca9321bd81e4f50"
+        "98e901d8cb64ea7d82df373f0e79b289523e77318311e382eaf847bed3e7aaed"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/types/index.ts
@@ -1,17 +1,17 @@
 import prisma from "../dbClient.js"
 import { 
   type WaspEntity,
- } from "../entities"
+} from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
 
-type Operation<Entities extends WaspEntity[], Result> = (
-  args: any,
+type Operation<Entities extends WaspEntity[], Input, Result> = (
+  args: Input,
   context: {
-      entities: EntityMap<Entities>,
+    entities: EntityMap<Entities>,
   },
 ) => Promise<Result>
 

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/types/index.ts
@@ -3,17 +3,17 @@ import {
   type WaspEntity,
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
-export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
 
-type Operation<Entities extends WaspEntity[], Input, Result> = (
+type Operation<Entities extends WaspEntity[], Input, Output> = (
   args: Input,
   context: {
     entities: EntityMap<Entities>,
   },
-) => Promise<Result>
+) => Promise<Output>
 
 type PrismaDelegateFor<EntityName extends string> =
   never

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/types/index.ts
@@ -3,9 +3,9 @@ import {
   type WaspEntity,
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
 
 type Operation<Entities extends WaspEntity[], Input, Result> = (

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "a80fb680be7a69b4fb4dbec771f19e1b3b2f0a9959b581a5f89477fcdf2beeb8"
+        "f21d66f3733439b5cff24bc31d615db8bc25c2802b373226c5f631198cfe8f61"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "3105fd2e1e6d8dc5481b7f4db21290571e945eb2610cd945cee86254b0e92c6c"
+        "a80fb680be7a69b4fb4dbec771f19e1b3b2f0a9959b581a5f89477fcdf2beeb8"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/types/index.ts"
         ],
-        "f21d66f3733439b5cff24bc31d615db8bc25c2802b373226c5f631198cfe8f61"
+        "24142aeb37094133054a7901388009ddde740a39fee9334932c58880d191a589"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/types/index.ts
@@ -4,9 +4,9 @@ import {
   type Task,
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
 
 
 type Operation<Entities extends WaspEntity[], Input, Result> = (

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/types/index.ts
@@ -2,17 +2,17 @@ import prisma from "../dbClient.js"
 import { 
   type WaspEntity,
   type Task,
- } from "../entities"
+} from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Query<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
-export type Action<Entities extends WaspEntity[] = [], Result = unknown> = Operation<Entities, Result>
+export type Action<Entities extends WaspEntity[] = [], Input = unknown, Result = unknown> = Operation<Entities, Input, Result>
 
 
-type Operation<Entities extends WaspEntity[], Result> = (
-  args: any,
+type Operation<Entities extends WaspEntity[], Input, Result> = (
+  args: Input,
   context: {
-      entities: EntityMap<Entities>,
+    entities: EntityMap<Entities>,
   },
 ) => Promise<Result>
 

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/types/index.ts
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/types/index.ts
@@ -4,17 +4,17 @@ import {
   type Task,
 } from "../entities"
 
-export type Query<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Query<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
-export type Action<Entities extends WaspEntity[] = [], Input = never, Result = unknown> = Operation<Entities, Input, Result>
+export type Action<Entities extends WaspEntity[], Input, Output> = Operation<Entities, Input, Output>
 
 
-type Operation<Entities extends WaspEntity[], Input, Result> = (
+type Operation<Entities extends WaspEntity[], Input, Output> = (
   args: Input,
   context: {
     entities: EntityMap<Entities>,
   },
-) => Promise<Result>
+) => Promise<Output>
 
 type PrismaDelegateFor<EntityName extends string> =
   EntityName extends "Task" ? typeof prisma.task :

--- a/waspc/examples/todoApp/src/server/actions.ts
+++ b/waspc/examples/todoApp/src/server/actions.ts
@@ -9,7 +9,7 @@ import {
   UpdateTaskIsDone
 } from '@wasp/actions/types'
 
-export const createTask: CreateTask = async (task, context) => {
+export const createTask: CreateTask<Pick<Task, 'description'>> = async (task, context) => {
   if (!context.user) {
     throw new HttpError(401)
   }
@@ -28,7 +28,7 @@ export const createTask: CreateTask = async (task, context) => {
   })
 }
 
-export const updateTaskIsDone: UpdateTaskIsDone = async ({ id, isDone }, context) => {
+export const updateTaskIsDone: UpdateTaskIsDone<Pick<Task, 'id' | 'isDone'>> = async ({ id, isDone }, context) => {
   if (!context.user) {
     throw new HttpError(401)
   }
@@ -44,7 +44,7 @@ export const updateTaskIsDone: UpdateTaskIsDone = async ({ id, isDone }, context
   })
 }
 
-export const deleteCompletedTasks: DeleteCompletedTasks = async (args, context) => {
+export const deleteCompletedTasks: DeleteCompletedTasks = async (_args, context) => {
   if (!context.user) {
     throw new HttpError(401)
   }
@@ -55,13 +55,16 @@ export const deleteCompletedTasks: DeleteCompletedTasks = async (args, context) 
   })
 }
 
-export const toggleAllTasks: ToggleAllTasks = async (args, context) => {
+export const toggleAllTasks: ToggleAllTasks = async (_args, context) => {
   if (!context.user) {
     throw new HttpError(401)
   }
 
-  const whereIsDone = isDone => ({ isDone, user: { id: context.user.id } })
-  const Task = context.entities.Task
+  const whereIsDone = (isDone: boolean) => ({
+    isDone,
+    user: { id: context.user.id },
+  });
+  const Task = context.entities.Task;
   const notDoneTasksCount = await Task.count({ where: whereIsDone(false) })
 
   if (notDoneTasksCount > 0) {

--- a/waspc/examples/todoApp/src/server/queries.ts
+++ b/waspc/examples/todoApp/src/server/queries.ts
@@ -6,7 +6,7 @@ import {
   GetTasks
 } from '@wasp/queries/types'
 
-export const getTasks: GetTasks<Task[]> = async (args, context) => {
+export const getTasks: GetTasks = async (_args, context) => {
   if (!context.user) {
     throw new HttpError(401)
   }
@@ -23,11 +23,11 @@ export const getTasks: GetTasks<Task[]> = async (args, context) => {
   return tasks
 }
 
-export const getNumTasks: GetNumTasks<number> = async (args, context) => {
+export const getNumTasks: GetNumTasks = async (_args, context) => {
   return context.entities.Task.count()
 }
 
-export const getTask: GetTask<Task> = async ({ id }, context) => {
+export const getTask: GetTask<Pick<Task, 'id'>> = async ({ id }, context) => {
   if (!context.user) {
     throw new HttpError(401)
   }

--- a/waspc/examples/todoApp/src/server/queries.ts
+++ b/waspc/examples/todoApp/src/server/queries.ts
@@ -27,7 +27,7 @@ export const getNumTasks: GetNumTasks = async (_args, context) => {
   return context.entities.Task.count()
 }
 
-export const getTask: GetTask<Pick<Task, 'id'>> = async ({ id }, context) => {
+export const getTask: GetTask<Pick<Task, 'id'>> = async (where, context) => {
   if (!context.user) {
     throw new HttpError(401)
   }
@@ -35,7 +35,7 @@ export const getTask: GetTask<Pick<Task, 'id'>> = async ({ id }, context) => {
   const Task = context.entities.Task
   // NOTE(matija): we can't call findUnique() with the specific user, so we have to fetch user first
   // and then manually check.
-  const task = await Task.findUnique({ where: { id }, include: { user: true } })
+  const task = await Task.findUnique({ where, include: { user: true } })
   if (!task) {
     throw new HttpError(404)
   }


### PR DESCRIPTION
Fixes [#975](https://github.com/wasp-lang/wasp/issues/975).

This types the input of `Query`, `Action`, `Operation`, `AuthenticatedQuery`, `AuthenticatedAction`, `AuthenticatedOperation`, and generated queries and actions.

```ts
type Operation<Entities extends WaspEntity[], Input, Result> = (
    args: Input,
    context: {
        entities: EntityMap<Entities>,
    },
}) => Promise<Result>;
```

Users can now specify the type of the input of an operation.

```ts
//                                         resolves to `Pick<Task, 'id'>`
//                                                       ↓
export const getTask: GetTask<Pick<Task, 'id'>> = async (where, context) => {
  return Task.findUnique({ where, include: { user: true } });
};
```

The order of type variables breaks all user-defined operations that have an explicit `Result` type that doesn't match `Input`.

```ts
// before:
export type GetFoo<Result> = // ...
export const getBarFoo: GetFoo<Foo> = async ({ bar: Bar }, context) => // ...

// after:
export type GetFoo<Input, Result> = // ...
//                        now `Input` :D     not `Foo` :(
//                             ↓             ↓
export const getBarFoo: GetFoo<Foo> = async (bar /* : Bar */, context) => // ...
```

We could make this backwards compatible by adding `Input` to the end of the type variable list, but it doesn't belong there.

I will edit the change log after initial feedback :)