### PR TITLE
Set index-state in dev-tool.project to match cabal.project

### DIFF
--- a/waspc/dev-tool.project
+++ b/waspc/dev-tool.project
@@ -10,3 +10,6 @@ constraints:
   stan ==0.0.1.0,
   hlint ==3.3.6,
   prune-juice ==0.7
+
+-- See cabal.project.
+index-state: 2022-03-22T14:16:26Z


### PR DESCRIPTION
### Description

Fixes CI. There was a `happy` build issue that was stopping CI builds today:

```
Run ./run ormolu:check
Running: cabal --project-file=/home/runner/work/wasp/wasp/waspc/dev-tool.project install ormolu --installdir=/home/runner/work/wasp/wasp/waspc/.bin --install-method=copy --overwrite-policy=always && /home/runner/work/wasp/wasp/waspc/.bin/ormolu --color always --check-idempotence --mode check $(git ls-files '*.hs' '*.hs-boot') 

Resolving dependencies...
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - happy-1.20.1 (exe:happy) (requires download & build)
 - ghc-lib-parser-9.2.5.20221107 (lib) (requires download & build)
 - ormolu-0.4.0.0 (lib) (requires download & build)
 - ormolu-0.4.0.0 (exe:ormolu) (requires download & build)
Downloading  happy-1.20.1
Downloaded   happy-1.20.1
Downloading  ghc-lib-parser-9.2.5.20221107
Starting     happy-1.20.1 (exe:happy)
Downloaded   ghc-lib-parser-9.2.5.20221107
Downloading  ormolu-0.4.0.0
Downloaded   ormolu-0.4.0.0
Building     happy-1.20.1 (exe:happy)

Failed to build exe:happy from happy-1.20.1.
Build log (
/home/runner/.cabal/logs/ghc-8.10.7/happy-1.20.1-e-happy-85f385be9be27da2c14fff0498a9e6f81fe1a5387e646ad6b924a08f8930f4dd.log
):
Configuring executable 'happy' for happy-1.20.1..
Preprocessing executable 'happy' for happy-1.20.1..
cabal: Failed to build exe:happy from happy-1.20.1 (which is required by
exe:ormolu from ormolu-0.4.0.0). See the build log above for details.

cabal-3.6.2.0: The program 'happy' is required but it could not be found

Error: Process completed with exit code 1.
```

This fixes it by setting our `index-state` of `dev-tool.project` to match `cabal.project`.

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [x] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
