### PR TITLE
Fixes a locked file error on latest Macs

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## v0.8.1
 
+### Bug fixes
+- Fixes a file lock error that kills CLI when changing entities with `wasp start` running on newer Macs.
+
 ### `wasp deploy` CLI command added
 We have made it much easier to deploy your Wasp apps via a new CLI command, `wasp deploy`. 🚀 This release adds support for Fly.io, but we hope to add more hosting providers soon!
 

--- a/waspc/src/Wasp/Util/IO.hs
+++ b/waspc/src/Wasp/Util/IO.hs
@@ -7,6 +7,7 @@ module Wasp.Util.IO
     deleteFileIfExists,
     doesFileExist,
     readFile,
+    readFileStrict,
     writeFile,
     removeFile,
   )
@@ -14,6 +15,8 @@ where
 
 import Control.Monad (filterM, when)
 import Control.Monad.Extra (whenM)
+import Data.Text (Text)
+import qualified Data.Text.IO as T.IO
 import StrongPath (Abs, Dir, Dir', File, Path', Rel, basename, parseRelDir, parseRelFile, toFilePath, (</>))
 import qualified StrongPath as SP
 import qualified System.Directory as SD
@@ -89,6 +92,9 @@ doesFileExist = SD.doesFileExist . SP.fromAbsFile
 
 readFile :: Path' Abs (File f) -> IO String
 readFile = P.readFile . SP.fromAbsFile
+
+readFileStrict :: Path' Abs (File f) -> IO Text
+readFileStrict = T.IO.readFile . SP.toFilePath
 
 writeFile :: Path' Abs (File f) -> String -> IO ()
 writeFile = P.writeFile . SP.fromAbsFile


### PR DESCRIPTION
### Description

Fixes a locked file error on latest macOS when trying to read from and write to a Prisma checksum file.

Fixes #999

Targeting `filip-frontend-entities` as that branch updated some of this logic and will soon be merged.

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [x] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [x] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
