### PR TITLE
Relaxes npm version to be any version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,9 +64,11 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v3
 
+      # TODO: This is a temporary workaround for the failing GHCup installation on Ubuntu 20.04.
+      # The fix will be propagated in a few days, so we can remove this workaround then.
+      # https://github.com/actions/runner-images/issues/7061
       - name: Workaround runner image issue
         if: matrix.os == 'ubuntu-20.04'
-        # https://github.com/actions/runner-images/issues/7061
         run: sudo chown -R $USER /usr/local/.ghcup
 
       - name: Set up Haskell
@@ -118,7 +120,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12'
+          node-version: '18'
 
       - name: On MacOS, skip e2e tests with Docker since it is not installed
         if: matrix.os == 'macos-latest'

--- a/waspc/data/Generator/templates/react-app/package.json
+++ b/waspc/data/Generator/templates/react-app/package.json
@@ -16,8 +16,7 @@
   },
   "engineStrict": true,
   "engines": {
-      "node": "{=& nodeVersionRange =}",
-      "npm": "{=& npmVersionRange =}"
+      "node": "{=& nodeVersionRange =}"
   },
   "browserslist": {
     "production": [

--- a/waspc/data/Generator/templates/server/package.json
+++ b/waspc/data/Generator/templates/server/package.json
@@ -27,8 +27,7 @@
     {=/ overrides =}
   },
   "engines": {
-    "node": "{=& nodeVersionRange =}",
-    "npm": "{=& npmVersionRange =}"
+    "node": "{=& nodeVersionRange =}"
   },
   {=& depsChunk =},
   {=& devDepsChunk =}

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -53,7 +53,7 @@
             "file",
             "server/package.json"
         ],
-        "9a2b6514f984dc7815733e448b42eda73f6d8cbe74934bd116a26c9b34b95a6b"
+        "944ae7609fb9b3ff6f84ea9212e2f82b4fe70f716f31685fee9cc3cf232f67da"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "web-app/package.json"
         ],
-        "36e7bbd6d57392eee0d75dfd534cc390d02a8b7f63b24952bc73fa07d59d2228"
+        "89690c80f0daed510b6d561345f3035d2b9f078188f9b875c3e6b88bdd6807d3"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -53,7 +53,7 @@
             "file",
             "server/package.json"
         ],
-        "a25c784008e936018cc8f5fe0a35fdd6dfc86d7762fcad40bed04e6af294b87f"
+        "9a2b6514f984dc7815733e448b42eda73f6d8cbe74934bd116a26c9b34b95a6b"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "web-app/package.json"
         ],
-        "68c241389188ef0e6ec2397c89914d62e5a8f458543d08bfefeff49655e87c43"
+        "36e7bbd6d57392eee0d75dfd534cc390d02a8b7f63b24952bc73fa07d59d2228"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
@@ -24,7 +24,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^18.12.0",
-    "npm": "^8.19.2"
+    "npm": "*"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/package.json
@@ -23,8 +23,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "*"
+    "node": "^18.12.0"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
@@ -28,8 +28,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "*"
+    "node": "^18.12.0"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
@@ -29,7 +29,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^18.12.0",
-    "npm": "^8.19.2"
+    "npm": "*"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -53,7 +53,7 @@
             "file",
             "server/package.json"
         ],
-        "9a2b6514f984dc7815733e448b42eda73f6d8cbe74934bd116a26c9b34b95a6b"
+        "944ae7609fb9b3ff6f84ea9212e2f82b4fe70f716f31685fee9cc3cf232f67da"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "web-app/package.json"
         ],
-        "93711f6c8ec0f9032ca74e75708e966c3dde1f59d4ba29b7fcfe59c618f99703"
+        "05fab99540aa45be16b9e18807608563af2015fa3d65e40ffe43f1d71721a004"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -53,7 +53,7 @@
             "file",
             "server/package.json"
         ],
-        "a25c784008e936018cc8f5fe0a35fdd6dfc86d7762fcad40bed04e6af294b87f"
+        "9a2b6514f984dc7815733e448b42eda73f6d8cbe74934bd116a26c9b34b95a6b"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "web-app/package.json"
         ],
-        "56ead359017cdbb350a4e609af2fa75a0411642cfb1734a6e8d6e53991bd54b3"
+        "93711f6c8ec0f9032ca74e75708e966c3dde1f59d4ba29b7fcfe59c618f99703"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
@@ -24,7 +24,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^18.12.0",
-    "npm": "^8.19.2"
+    "npm": "*"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/package.json
@@ -23,8 +23,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "*"
+    "node": "^18.12.0"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
@@ -28,8 +28,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "*"
+    "node": "^18.12.0"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
@@ -29,7 +29,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^18.12.0",
-    "npm": "^8.19.2"
+    "npm": "*"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -53,7 +53,7 @@
             "file",
             "server/package.json"
         ],
-        "522cb04643a3062418b54fe7dcf58c4c36b2439ccefe71047bc81fd04c2b4757"
+        "80da89a8fb7b4e8859890f6ae7c2840cdfe45724c4fb4ac1e287e6546e6ac874"
     ],
     [
         [
@@ -242,7 +242,7 @@
             "file",
             "web-app/package.json"
         ],
-        "855d82b845cc7b96898013f78c0f5eff9a8b9b03a0c39536be69f9dfbc551da5"
+        "3d88e4a159a8c0d14dde4d64101706955290714eec9d935b2782b57b63e4c264"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -53,7 +53,7 @@
             "file",
             "server/package.json"
         ],
-        "80da89a8fb7b4e8859890f6ae7c2840cdfe45724c4fb4ac1e287e6546e6ac874"
+        "3e6985d644af90e8a9329298fd3ffd50235526abebe1b63b5bb300b396745ee7"
     ],
     [
         [
@@ -242,7 +242,7 @@
             "file",
             "web-app/package.json"
         ],
-        "3d88e4a159a8c0d14dde4d64101706955290714eec9d935b2782b57b63e4c264"
+        "53dc579c28cab9ae137cb8da8b1b72de185157898cfe062020aaa31868bc9982"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/package.json
@@ -25,7 +25,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^18.12.0",
-    "npm": "^8.19.2"
+    "npm": "*"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/package.json
@@ -24,8 +24,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "*"
+    "node": "^18.12.0"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/package.json
@@ -28,8 +28,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "*"
+    "node": "^18.12.0"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/package.json
@@ -29,7 +29,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^18.12.0",
-    "npm": "^8.19.2"
+    "npm": "*"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -53,7 +53,7 @@
             "file",
             "server/package.json"
         ],
-        "ad7d8801cce632509f54a706cd2b3fffaf1aa6e58e1332af675e298ab3e88865"
+        "d5df9887d57283d8c3dfff1613affa4c06f26f2c9ab60feeef0d79773bb519e4"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "web-app/package.json"
         ],
-        "3d9133836cf4849624b03a8ca029542571aac61958adca68c2c28d487bad392e"
+        "fd6941246dd2e2ea8bb82fcb9a4f9b1e4eda69fff0b62f045bf27376477bc647"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -53,7 +53,7 @@
             "file",
             "server/package.json"
         ],
-        "c9ace6d614519e0534c06f2c84af1cf7dfbff5361f2aad5010b8eaf0a84c965c"
+        "ad7d8801cce632509f54a706cd2b3fffaf1aa6e58e1332af675e298ab3e88865"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "web-app/package.json"
         ],
-        "15dac783a05b96e341b491a40368f4cfed4784967ca6a7980583b33d080986fa"
+        "3d9133836cf4849624b03a8ca029542571aac61958adca68c2c28d487bad392e"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
@@ -24,7 +24,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^18.12.0",
-    "npm": "^8.19.2"
+    "npm": "*"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/package.json
@@ -23,8 +23,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "*"
+    "node": "^18.12.0"
   },
   "name": "server",
   "nodemonConfig": {

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
@@ -28,8 +28,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "*"
+    "node": "^18.12.0"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
@@ -29,7 +29,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^18.12.0",
-    "npm": "^8.19.2"
+    "npm": "*"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/waspc/src/Wasp/Generator/Common.hs
+++ b/waspc/src/Wasp/Generator/Common.hs
@@ -24,7 +24,7 @@ nodeVersionRange :: SV.Range
 nodeVersionRange = SV.Range [SV.backwardsCompatibleWith latestNodeLTSVersion]
 
 latestNodeLTSVersion :: SV.Version
-latestNodeLTSVersion = SV.Version 18 14 0
+latestNodeLTSVersion = SV.Version 18 12 0
 
 -- | Range of npm versions that Wasp and generated projects work correctly with.
 npmVersionRange :: SV.Version

--- a/waspc/src/Wasp/Generator/Common.hs
+++ b/waspc/src/Wasp/Generator/Common.hs
@@ -2,7 +2,6 @@ module Wasp.Generator.Common
   ( ProjectRootDir,
     latestMajorNodeVersion,
     nodeVersionRange,
-    npmVersionRange,
     prismaVersion,
   )
 where
@@ -25,10 +24,6 @@ nodeVersionRange = SV.Range [SV.backwardsCompatibleWith latestNodeLTSVersion]
 
 latestNodeLTSVersion :: SV.Version
 latestNodeLTSVersion = SV.Version 18 12 0
-
--- | Range of npm versions that Wasp and generated projects work correctly with.
-npmVersionRange :: SV.Version
-npmVersionRange = SV.AnyVersion
 
 prismaVersion :: SV.Version
 prismaVersion = SV.Version 4 5 0

--- a/waspc/src/Wasp/Generator/Common.hs
+++ b/waspc/src/Wasp/Generator/Common.hs
@@ -24,13 +24,11 @@ nodeVersionRange :: SV.Range
 nodeVersionRange = SV.Range [SV.backwardsCompatibleWith latestNodeLTSVersion]
 
 latestNodeLTSVersion :: SV.Version
-latestNodeLTSVersion = SV.Version 18 12 0
+latestNodeLTSVersion = SV.Version 18 14 0
 
 -- | Range of npm versions that Wasp and generated projects work correctly with.
-npmVersionRange :: SV.Range
-npmVersionRange = SV.Range [SV.backwardsCompatibleWith latestLTSVersion]
-  where
-    latestLTSVersion = SV.Version 8 19 2 -- Goes with node 18 (but also higher versions too).
+npmVersionRange :: SV.Version
+npmVersionRange = SV.AnyVersion
 
 prismaVersion :: SV.Version
 prismaVersion = SV.Version 4 5 0

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -36,7 +36,7 @@ import qualified Wasp.AppSpec.App.Server as AS.App.Server
 import qualified Wasp.AppSpec.Entity as AS.Entity
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
 import Wasp.AppSpec.Valid (getApp, isAuthEnabled)
-import Wasp.Generator.Common (latestMajorNodeVersion, nodeVersionRange, npmVersionRange, prismaVersion)
+import Wasp.Generator.Common (latestMajorNodeVersion, nodeVersionRange, prismaVersion)
 import Wasp.Generator.ExternalCodeGenerator (genExternalCodeDir)
 import Wasp.Generator.ExternalCodeGenerator.Common (GeneratedExternalCodeDir)
 import Wasp.Generator.FileDraft (FileDraft, createCopyFileDraft)
@@ -100,7 +100,6 @@ genPackageJson spec waspDependencies = do
             [ "depsChunk" .= N.getDependenciesPackageJsonEntry combinedDependencies,
               "devDepsChunk" .= N.getDevDependenciesPackageJsonEntry combinedDependencies,
               "nodeVersionRange" .= show nodeVersionRange,
-              "npmVersionRange" .= show npmVersionRange,
               "startProductionScript"
                 .= ( (if hasEntities then "npm run db-migrate-prod && " else "")
                        ++ "NODE_ENV=production npm run build-and-start"

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -26,7 +26,7 @@ import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
 import Wasp.AppSpec.App.Client as AS.App.Client
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
 import Wasp.AppSpec.Valid (getApp)
-import Wasp.Generator.Common (nodeVersionRange, npmVersionRange)
+import Wasp.Generator.Common (nodeVersionRange)
 import qualified Wasp.Generator.ConfigFile as G.CF
 import Wasp.Generator.ExternalCodeGenerator (genExternalCodeDir)
 import Wasp.Generator.ExternalCodeGenerator.Common (GeneratedExternalCodeDir)
@@ -90,8 +90,7 @@ genPackageJson spec waspDependencies = do
             [ "appName" .= (fst (getApp spec) :: String),
               "depsChunk" .= N.getDependenciesPackageJsonEntry combinedDependencies,
               "devDepsChunk" .= N.getDevDependenciesPackageJsonEntry combinedDependencies,
-              "nodeVersionRange" .= show nodeVersionRange,
-              "npmVersionRange" .= show npmVersionRange
+              "nodeVersionRange" .= show nodeVersionRange
             ]
       )
 

--- a/waspc/src/Wasp/SemanticVersion.hs
+++ b/waspc/src/Wasp/SemanticVersion.hs
@@ -25,13 +25,11 @@ data Version
         minor :: Natural,
         patch :: Natural
       }
-  | AnyVersion
   deriving (Eq, Ord)
 
 -- | We rely on this `show` implementation to produce valid semver representation of version.
 instance Show Version where
   show (Version mjr mnr ptc) = printf "%d.%d.%d" mjr mnr ptc
-  show AnyVersion = "*"
 
 data Operator
   = Equal
@@ -111,7 +109,6 @@ nextBreakingChangeVersion version = case version of
   (Version 0 0 x) -> Version 0 0 (succ x)
   (Version 0 x _) -> Version 0 (succ x) 0
   (Version x _ _) -> Version (succ x) 0 0
-  AnyVersion -> AnyVersion
 
 -- Helper methods.
 

--- a/waspc/src/Wasp/SemanticVersion.hs
+++ b/waspc/src/Wasp/SemanticVersion.hs
@@ -19,16 +19,19 @@ import Text.Printf (printf)
 
 -- Implements SemVer (semantic versioning) by following spec from https://github.com/npm/node-semver .
 
-data Version = Version
-  { major :: Natural,
-    minor :: Natural,
-    patch :: Natural
-  }
+data Version
+  = Version
+      { major :: Natural,
+        minor :: Natural,
+        patch :: Natural
+      }
+  | AnyVersion
   deriving (Eq, Ord)
 
 -- | We rely on this `show` implementation to produce valid semver representation of version.
 instance Show Version where
   show (Version mjr mnr ptc) = printf "%d.%d.%d" mjr mnr ptc
+  show AnyVersion = "*"
 
 data Operator
   = Equal
@@ -108,6 +111,7 @@ nextBreakingChangeVersion version = case version of
   (Version 0 0 x) -> Version 0 0 (succ x)
   (Version 0 x _) -> Version 0 (succ x) 0
   (Version x _ _) -> Version (succ x) 0 0
+  AnyVersion -> AnyVersion
 
 -- Helper methods.
 

--- a/web/docs/getting-started.md
+++ b/web/docs/getting-started.md
@@ -14,14 +14,12 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ## 1. Requirements
 
-You need to have `node` (and `npm`) installed on your machine and available in `PATH`.
-- `node`: ^18.12.0
-- `npm`: ^8.19.2
+You need to have `node` (and `npm`) installed on your machine and available in `PATH`. We rely on the latest Node.js LTS version, and currently that's version `v18.14.0`.
 
-You can check `node` and `npm` versions by running:
+You can check the `node` version by running:
 ```shell-session
-node -v
-npm -v
+$ node -v
+v18.14.0
 ```
 
 We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing your Node.js installation version(s).
@@ -111,7 +109,7 @@ If the installer is not working for you or your OS is not supported, you can try
 
 To install from source, you need to clone the [wasp repo](https://github.com/wasp-lang/wasp), install [cabal](https://cabal.readthedocs.io/en/stable/getting-started.html) on your machine and then run `cabal install` from the `waspc/` dir.
 
-If you have never built Wasp before, this might take some time due to `cabal` downloading dependencies for the first time.  
+If you have never built Wasp before, this might take some time due to `cabal` downloading dependencies for the first time.
 
 Check [waspc/](https://github.com/wasp-lang/wasp/tree/main/waspc) for more details on building.
 
@@ -132,7 +130,7 @@ That's it :tada:! You have successfully created and served a new web app at <htt
 
 :::info For Visual Studio Code
 
-If you are using VSCode, install our [Wasp language extension](https://marketplace.visualstudio.com/items?itemName=wasp-lang.wasp). 
+If you are using VSCode, install our [Wasp language extension](https://marketplace.visualstudio.com/items?itemName=wasp-lang.wasp).
 
 The extension brings the following functionality:
 
@@ -149,6 +147,6 @@ The extension brings the following functionality:
 
 **Check out the 🤓 [Todo App tutorial](tutorials/todo-app.md) 🤓 , which will take you through all the core features of Wasp!**
 
-Also, we would be excited to have you **join our community on [Discord](https://discord.gg/rzdnErX)!** Any feedback or questions you have, we are there for you. 
+Also, we would be excited to have you **join our community on [Discord](https://discord.gg/rzdnErX)!** Any feedback or questions you have, we are there for you.
 
 Finally, to stay up to date with updates in Wasp, you can **subscribe to our newsletter: https://wasp-lang.dev/#signup ** . We usually send 1 per month, and Matija does his best to unleash his creativity to make them engaging and fun to read :D!


### PR DESCRIPTION
Removes the constraint on the `npm` version the user need to have installed.

### Background

With the change from Node.js `18.12` to `18.14`, Node.js ships a [different major npm version](https://nodejs.org/en/blog/release/v18.14.0/#updated-npm-to-9-3-1) (version 9). And this breaks the experience for our users who use Node.js 18.14 which is the default that gets installed when running `nvm install 18`. 