### PR TITLE
Updates type for relative import paths

### DIFF
--- a/waspc/src/Wasp/Generator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/JsImport.hs
@@ -1,6 +1,6 @@
 module Wasp.Generator.JsImport
   ( extImportToJsImport,
-    PathFromImportLocationToSrcDir,
+    ImportLocation,
   )
 where
 
@@ -15,12 +15,12 @@ import Wasp.JsImport
     makeJsImport,
   )
 
-type PathFromImportLocationToSrcDir d = Path Posix (Rel ()) (Dir d)
+type ImportLocation = ()
 
 extImportToJsImport ::
   GeneratedSrcDir d =>
   Path Posix (Rel d) (Dir GeneratedExternalCodeDir) ->
-  PathFromImportLocationToSrcDir d ->
+  Path Posix (Rel ImportLocation) (Dir d) ->
   EI.ExtImport ->
   JsImport
 extImportToJsImport pathFromSrcDirToExtCodeDir pathFromImportLocationToSrcDir extImport = makeJsImport importPath importName

--- a/waspc/src/Wasp/Generator/ServerGenerator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/JsImport.hs
@@ -1,9 +1,10 @@
 module Wasp.Generator.ServerGenerator.JsImport where
 
 import Data.Maybe (fromJust)
+import StrongPath (Dir, Path, Posix, Rel)
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec.ExtImport as EI
-import Wasp.Generator.JsImport (PathFromImportLocationToSrcDir)
+import Wasp.Generator.JsImport (ImportLocation)
 import qualified Wasp.Generator.JsImport as GJI
 import Wasp.Generator.ServerGenerator.Common (ServerSrcDir)
 import Wasp.Generator.ServerGenerator.ExternalCodeGenerator (extServerCodeDirInServerSrcDir)
@@ -15,13 +16,13 @@ import Wasp.JsImport
 import qualified Wasp.JsImport as JI
 
 getJsImportStmtAndIdentifier ::
-  PathFromImportLocationToSrcDir ServerSrcDir ->
+  Path Posix (Rel ImportLocation) (Dir ServerSrcDir) ->
   EI.ExtImport ->
   (JsImportStatement, JsImportIdentifier)
 getJsImportStmtAndIdentifier pathFromImportLocationToExtCodeDir = JI.getJsImportStmtAndIdentifier . extImportToJsImport pathFromImportLocationToExtCodeDir
 
 extImportToJsImport ::
-  PathFromImportLocationToSrcDir ServerSrcDir ->
+  Path Posix (Rel ImportLocation) (Dir ServerSrcDir) ->
   EI.ExtImport ->
   JsImport
 extImportToJsImport = GJI.extImportToJsImport serverExtDir

--- a/waspc/src/Wasp/Generator/WebAppGenerator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/JsImport.hs
@@ -1,9 +1,10 @@
 module Wasp.Generator.WebAppGenerator.JsImport where
 
 import Data.Maybe (fromJust)
+import StrongPath (Dir, Path, Posix, Rel)
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec.ExtImport as EI
-import Wasp.Generator.JsImport (PathFromImportLocationToSrcDir)
+import Wasp.Generator.JsImport (ImportLocation)
 import qualified Wasp.Generator.JsImport as GJI
 import Wasp.Generator.WebAppGenerator.Common (WebAppSrcDir)
 import Wasp.Generator.WebAppGenerator.ExternalCodeGenerator (extClientCodeDirInWebAppSrcDir)
@@ -15,13 +16,13 @@ import Wasp.JsImport
 import qualified Wasp.JsImport as JI
 
 getJsImportStmtAndIdentifier ::
-  PathFromImportLocationToSrcDir WebAppSrcDir ->
+  Path Posix (Rel ImportLocation) (Dir WebAppSrcDir) ->
   EI.ExtImport ->
   (JsImportStatement, JsImportIdentifier)
 getJsImportStmtAndIdentifier pathFromImportLocationToSrcDir = JI.getJsImportStmtAndIdentifier . extImportToJsImport pathFromImportLocationToSrcDir
 
 extImportToJsImport ::
-  PathFromImportLocationToSrcDir WebAppSrcDir ->
+  Path Posix (Rel ImportLocation) (Dir WebAppSrcDir) ->
   EI.ExtImport ->
   JsImport
 extImportToJsImport = GJI.extImportToJsImport webAppExtDir


### PR DESCRIPTION
The types read much nicer now, it's clear from `Path Posix (Rel ImportLocation) (Dir WebAppSrcDir)` that we are importing something from `WebAppSrcDir` relative to the import location. 