### PR TITLE
Allow Fly to build locally

### DIFF
--- a/waspc/packages/deploy/src/providers/fly/CommonOptions.ts
+++ b/waspc/packages/deploy/src/providers/fly/CommonOptions.ts
@@ -11,6 +11,6 @@ export interface DbOptions {
 }
 
 export interface LocalBuildOptions {
-	buildServerRemotely: boolean;
-	buildClientRemotely: boolean;
+	buildServerLocally: boolean;
+	buildClientLocally: boolean;
 }

--- a/waspc/packages/deploy/src/providers/fly/CommonOptions.ts
+++ b/waspc/packages/deploy/src/providers/fly/CommonOptions.ts
@@ -3,3 +3,14 @@ export interface CommonOptions {
 	waspProjectDir: string;
 	flyTomlDir?: string;
 }
+
+export interface DbOptions {
+	vmSize: string;
+	initialClusterSize: string;
+	volumeSize: string;
+}
+
+export interface LocalBuildOptions {
+	buildServerRemotely: boolean;
+	buildClientRemotely: boolean;
+}

--- a/waspc/packages/deploy/src/providers/fly/CommonOptions.ts
+++ b/waspc/packages/deploy/src/providers/fly/CommonOptions.ts
@@ -11,6 +11,5 @@ export interface DbOptions {
 }
 
 export interface LocalBuildOptions {
-	buildServerLocally: boolean;
-	buildClientLocally: boolean;
+	buildLocally: boolean;
 }

--- a/waspc/packages/deploy/src/providers/fly/createDb/CreateDbOptions.ts
+++ b/waspc/packages/deploy/src/providers/fly/createDb/CreateDbOptions.ts
@@ -1,7 +1,3 @@
-import { CommonOptions } from '../CommonOptions.js';
+import { CommonOptions, DbOptions } from '../CommonOptions.js';
 
-export interface CreateDbOptions extends CommonOptions {
-  vmSize: string;
-  initialClusterSize: string;
-  volumeSize: string;
-}
+export interface CreateDbOptions extends CommonOptions, DbOptions {}

--- a/waspc/packages/deploy/src/providers/fly/deploy/DeployOptions.ts
+++ b/waspc/packages/deploy/src/providers/fly/deploy/DeployOptions.ts
@@ -1,6 +1,6 @@
-import { CommonOptions } from '../CommonOptions.js';
+import { CommonOptions, LocalBuildOptions } from '../CommonOptions.js';
 
-export interface DeployOptions extends CommonOptions {
+export interface DeployOptions extends CommonOptions, LocalBuildOptions {
 	skipBuild?: boolean;
 	skipClient?: boolean;
 	skipServer?: boolean;

--- a/waspc/packages/deploy/src/providers/fly/deploy/deploy.ts
+++ b/waspc/packages/deploy/src/providers/fly/deploy/deploy.ts
@@ -50,7 +50,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
 		const inferredBaseName = getInferredBasenameFromServerToml(tomlFilePaths);
 		const deploymentInfo = createDeploymentInfo(inferredBaseName, undefined, options, tomlFilePaths);
 		await buildWasp();
-		await deployServer(deploymentInfo, options.buildServerLocally);
+		await deployServer(deploymentInfo, options);
 	}
 
 	if (!clientTomlExistsInProject(tomlFilePaths)) {
@@ -61,11 +61,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
 		const inferredBaseName = getInferredBasenameFromClientToml(tomlFilePaths);
 		const deploymentInfo = createDeploymentInfo(inferredBaseName, undefined, options, tomlFilePaths);
 		await buildWasp();
-		await deployClient(deploymentInfo, options.buildClientLocally);
+		await deployClient(deploymentInfo, options);
 	}
 }
 
-async function deployServer(deploymentInfo: DeploymentInfo, buildServerLocally: boolean) {
+async function deployServer(deploymentInfo: DeploymentInfo, { buildLocally }: DeployOptions) {
 	waspSays('Deploying your server now...');
 
 	cdToServerBuildDir(deploymentInfo.options.waspProjectDir);
@@ -85,7 +85,7 @@ async function deployServer(deploymentInfo: DeploymentInfo, buildServerLocally: 
 	}
 
 	const deployArgs = [
-		buildServerLocally ? '--local-only' : '--remote-only',
+		buildLocally ? '--local-only' : '--remote-only',
 	];
 	await $`flyctl deploy ${deployArgs}`;
 
@@ -97,7 +97,7 @@ async function deployServer(deploymentInfo: DeploymentInfo, buildServerLocally: 
 	waspSays('Server has been deployed!');
 }
 
-async function deployClient(deploymentInfo: DeploymentInfo, buildClientLocally: boolean) {
+async function deployClient(deploymentInfo: DeploymentInfo, { buildLocally }: DeployOptions) {
 	waspSays('Deploying your client now...');
 
 	cdToClientBuildDir(deploymentInfo.options.waspProjectDir);
@@ -119,7 +119,7 @@ async function deployClient(deploymentInfo: DeploymentInfo, buildClientLocally: 
 	fs.writeFileSync('.dockerignore', '');
 
 	const deployArgs = [
-		buildClientLocally ? '--local-only' : '--remote-only',
+		buildLocally ? '--local-only' : '--remote-only',
 	];
 	await $`flyctl deploy ${deployArgs}`;
 

--- a/waspc/packages/deploy/src/providers/fly/index.ts
+++ b/waspc/packages/deploy/src/providers/fly/index.ts
@@ -13,7 +13,7 @@ class FlyCommand extends Command {
 		return this.argument('<basename>', 'base app name to use on Fly.io (must be unique)');
 	}
 	addRegionArgument(): this {
-		return this.argument('<region>', 'deployment region to use on Fly.io');
+		return this.argument('<region>', '3 letter deployment region to use on Fly.io');
 	}
 	addDbOptions(): this {
 		return this.option('--vm-size <vmSize>', 'flyctl postgres create option', 'shared-cpu-1x')
@@ -21,8 +21,7 @@ class FlyCommand extends Command {
 			.option('--volume-size <volumeSize>', 'flyctl postgres create option', '1');
 	}
 	addLocalBuildOption(): this {
-		return this.option('--build-server-locally', 'force the server Docker container to build locally', false)
-			.option('--build-client-locally', 'force the client Docker container to build locally', false);
+		return this.option('--build-locally', 'build Docker containers locally instead of remotely', false);
 	}
 }
 
@@ -51,8 +50,8 @@ export function addFlyCommand(program: Command): void {
 	// NOTE: When we add another provider, consider pulling `--wasp-exe` and `--wasp-project-dir`
 	// up as a global option that every provider can use (if possible).
 	fly.commands.forEach((cmd) => {
-		cmd.requiredOption('--wasp-exe <path>', 'Wasp executable (either on PATH or absolute path)', 'wasp')
-			.requiredOption('--wasp-project-dir <dir>', 'absolute path to Wasp project dir')
+		cmd.addOption(new Option('--wasp-exe <path>', 'Wasp executable (either on PATH or absolute path)').hideHelp().makeOptionMandatory())
+			.addOption(new Option('--wasp-project-dir <dir>', 'absolute path to Wasp project dir').hideHelp().makeOptionMandatory())
 			.option('--fly-toml-dir <dir>', 'absolute path to dir where fly.toml files live')
 			.hook('preAction', ensureFlyReady)
 			.hook('preAction', ensureDirsInCmdAreAbsoluteAndPresent)

--- a/waspc/packages/deploy/src/providers/fly/index.ts
+++ b/waspc/packages/deploy/src/providers/fly/index.ts
@@ -20,6 +20,10 @@ class FlyCommand extends Command {
 			.option('--initial-cluster-size <initialClusterSize>', 'flyctl postgres create option', '1')
 			.option('--volume-size <volumeSize>', 'flyctl postgres create option', '1');
 	}
+	addLocalBuildOption(): this {
+		return this.option('--build-server-remotely', 'force the server Docker container to build on Fly', false)
+			.option('--build-client-remotely', 'force the client Docker container to build on Fly', false);
+	}
 }
 
 const flyLaunchCommand = makeFlyLaunchCommand();
@@ -67,6 +71,7 @@ function makeFlyLaunchCommand(): Command {
 		.addBasenameArgument()
 		.addRegionArgument()
 		.addDbOptions()
+		.addLocalBuildOption()
 		.action(launchFn);
 }
 
@@ -84,6 +89,7 @@ function makeFlyDeployCommand(): Command {
 		.option('--skip-build', 'do not run `wasp build` before deploying')
 		.option('--skip-client', 'do not deploy the web client')
 		.option('--skip-server', 'do not deploy the server')
+		.addLocalBuildOption()
 		.action(deployFn);
 }
 

--- a/waspc/packages/deploy/src/providers/fly/index.ts
+++ b/waspc/packages/deploy/src/providers/fly/index.ts
@@ -21,8 +21,8 @@ class FlyCommand extends Command {
 			.option('--volume-size <volumeSize>', 'flyctl postgres create option', '1');
 	}
 	addLocalBuildOption(): this {
-		return this.option('--build-server-remotely', 'force the server Docker container to build on Fly', false)
-			.option('--build-client-remotely', 'force the client Docker container to build on Fly', false);
+		return this.option('--build-server-locally', 'force the server Docker container to build locally', false)
+			.option('--build-client-locally', 'force the client Docker container to build locally', false);
 	}
 }
 

--- a/waspc/packages/deploy/src/providers/fly/launch/LaunchOptions.ts
+++ b/waspc/packages/deploy/src/providers/fly/launch/LaunchOptions.ts
@@ -1,0 +1,3 @@
+import { CommonOptions, DbOptions, LocalBuildOptions } from '../CommonOptions.js';
+
+export interface LaunchOptions extends CommonOptions, DbOptions, LocalBuildOptions {}

--- a/waspc/packages/deploy/src/providers/fly/launch/launch.ts
+++ b/waspc/packages/deploy/src/providers/fly/launch/launch.ts
@@ -1,5 +1,5 @@
 import { exit } from 'process';
-import { CreateDbOptions } from '../createDb/CreateDbOptions';
+import { LaunchOptions } from './LaunchOptions.js';
 import { DeployOptions } from '../deploy/DeployOptions.js';
 import { getCommandHelp, waspSays } from '../helpers/helpers.js';
 import { setup } from '../setup/setup.js';
@@ -8,7 +8,7 @@ import { deploy } from '../deploy/deploy.js';
 import { clientTomlExistsInProject, getTomlFilePaths, serverTomlExistsInProject } from '../helpers/tomlFileHelpers.js';
 import { createFlyDbCommand, flyDeployCommand, flySetupCommand } from '../index.js';
 
-export async function launch(basename: string, region: string, options: CreateDbOptions): Promise<void> {
+export async function launch(basename: string, region: string, options: LaunchOptions): Promise<void> {
 	waspSays('Launching your Wasp app to Fly.io!');
 
 	const tomlFilePaths = getTomlFilePaths(options);

--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -54,6 +54,10 @@ You may notice after running `setup` you have a `fly-server.toml` and `fly-clien
 
 Finally, we `deploy` which will push your client and server live. We run this single command each time you want to update your app.
 
+:::note
+Fly.io offers support for both locally built Docker containers and remotely built ones. However, for simplicity and reproducability, the CLI defaults to the use of a remote Fly.io builder. If you wish to build locally, you may supply the `--build-server-locally`/`--build-client-locally` option(s) to `wasp deploy fly`.
+:::
+
 If you would like to run arbitrary Fly commands (eg, `flyctl secrets list` for your server app), you can run them like so:
 ```shell
 wasp deploy fly cmd secrets list --context server
@@ -110,7 +114,7 @@ Server uses following environment variables, so you need to ensure they are set 
 Fly.io offers a variety of free services that are perfect for deploying your first Wasp app! You will need a Fly.io account and the [`flyctl` CLI](https://fly.io/docs/hands-on/install-flyctl/).
 
 :::note
-Fly.io offers support for both locally built Docker containers and remotely built ones. However, for simplicity and reproducability, we will force the use of a remote Fly.io builder.
+Fly.io offers support for both locally built Docker containers and remotely built ones. However, for simplicity and reproducability, we will default to the use of a remote Fly.io builder.
 
 Additionally, `fly` is a symlink for `flyctl` on most systems and they can be used interchangeably.
 :::

--- a/web/docs/deploying.md
+++ b/web/docs/deploying.md
@@ -55,7 +55,7 @@ You may notice after running `setup` you have a `fly-server.toml` and `fly-clien
 Finally, we `deploy` which will push your client and server live. We run this single command each time you want to update your app.
 
 :::note
-Fly.io offers support for both locally built Docker containers and remotely built ones. However, for simplicity and reproducability, the CLI defaults to the use of a remote Fly.io builder. If you wish to build locally, you may supply the `--build-server-locally`/`--build-client-locally` option(s) to `wasp deploy fly`.
+Fly.io offers support for both locally built Docker containers and remotely built ones. However, for simplicity and reproducability, the CLI defaults to the use of a remote Fly.io builder. If you wish to build locally, you may supply the `--build-locally` option to `wasp deploy fly launch` or `wasp deploy fly deploy`.
 :::
 
 If you would like to run arbitrary Fly commands (eg, `flyctl secrets list` for your server app), you can run them like so:


### PR DESCRIPTION
### Description

Allows `wasp deploy fly` users to specify if server/client should be built locally (using their own Docker) by optionally passing `--build-locally` to `launch` and/or `deploy`. Before, it would _always_ just run on the Fly builder. This may not be ideal if the build process requires lots of resources/time, and they cannot use the Free Builder for it.

It also fixes up the use of shared options and how those are expressed in the interfaces.

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [x] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
