### PR TITLE
Moves root component inside of `Router`

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/index.js
+++ b/waspc/data/Generator/templates/react-app/src/index.js
@@ -13,9 +13,6 @@ import * as serviceWorker from './serviceWorker'
 {=# setupFn.isDefined =}
 {=& setupFn.importStatement =}
 {=/ setupFn.isDefined =}
-{=# rootComponent.isDefined =}
-{=& rootComponent.importStatement =}
-{=/ rootComponent.isDefined =}
 
 startApp()
 
@@ -37,13 +34,7 @@ async function render() {
   const queryClient = await queryClientInitialized
   ReactDOM.render(
     <QueryClientProvider client={queryClient}>
-      {=# rootComponent.isDefined =}
-      <{= rootComponent.importIdentifier =}>
-      {=/ rootComponent.isDefined =}
       {router}
-      {=# rootComponent.isDefined =}
-      </{= rootComponent.importIdentifier =}>
-      {=/ rootComponent.isDefined =}
     </QueryClientProvider>,
     document.getElementById('root')
   )

--- a/waspc/data/Generator/templates/react-app/src/router.js
+++ b/waspc/data/Generator/templates/react-app/src/router.js
@@ -1,6 +1,9 @@
 {{={= =}=}}
 import React from 'react'
 import { Route, BrowserRouter as Router } from 'react-router-dom'
+{=# rootComponent.isDefined =}
+{=& rootComponent.importStatement =}
+{=/ rootComponent.isDefined =}
 
 {=# isAuthEnabled =}
 import createAuthRequiredPage from "./auth/pages/createAuthRequiredPage.js"
@@ -16,11 +19,15 @@ import OAuthCodeExchange from "./auth/pages/OAuthCodeExchange"
 
 const router = (
   <Router>
-    <div>
+    {=# rootComponent.isDefined =}
+    <{= rootComponent.importIdentifier =}>
+    {=/ rootComponent.isDefined =}
+    {=^ rootComponent.isDefined =}
+    <>
+    {=/ rootComponent.isDefined =}
       {=# routes =}
       <Route exact path="{= urlPath =}" component={ {= targetComponent =} }/>
       {=/ routes =}
-
       {=# isExternalAuthEnabled =}
       {=# externalAuthProviders =}
       {=# authProviderEnabled =}
@@ -30,7 +37,12 @@ const router = (
       {=/ authProviderEnabled =}
       {=/ externalAuthProviders =}
       {=/ isExternalAuthEnabled =}
-    </div>
+    {=# rootComponent.isDefined =}
+    </{= rootComponent.importIdentifier =}>
+    {=/ rootComponent.isDefined =}
+    {=^ rootComponent.isDefined =}
+    </>
+    {=/ rootComponent.isDefined =}
   </Router>
 )
 

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -403,7 +403,7 @@
             "file",
             "web-app/src/router.js"
         ],
-        "62928b69543a870338ab09c2f7493ec7594993bc4f2922052da3c3a9d804e0cd"
+        "70c9237cf961320f04d9736007a8ec3fbc1cd1adfe2cfbc5214cb2d91d57d503"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/router.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/router.js
@@ -7,10 +7,9 @@ import MainPage from './ext-src/MainPage'
 
 const router = (
   <Router>
-    <div>
+    <>
       <Route exact path="/" component={ MainPage }/>
-
-    </div>
+    </>
   </Router>
 )
 

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -403,7 +403,7 @@
             "file",
             "web-app/src/router.js"
         ],
-        "62928b69543a870338ab09c2f7493ec7594993bc4f2922052da3c3a9d804e0cd"
+        "70c9237cf961320f04d9736007a8ec3fbc1cd1adfe2cfbc5214cb2d91d57d503"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/router.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/router.js
@@ -7,10 +7,9 @@ import MainPage from './ext-src/MainPage'
 
 const router = (
   <Router>
-    <div>
+    <>
       <Route exact path="/" component={ MainPage }/>
-
-    </div>
+    </>
   </Router>
 )
 

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -417,7 +417,7 @@
             "file",
             "web-app/src/router.js"
         ],
-        "62928b69543a870338ab09c2f7493ec7594993bc4f2922052da3c3a9d804e0cd"
+        "70c9237cf961320f04d9736007a8ec3fbc1cd1adfe2cfbc5214cb2d91d57d503"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/router.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/router.js
@@ -7,10 +7,9 @@ import MainPage from './ext-src/MainPage'
 
 const router = (
   <Router>
-    <div>
+    <>
       <Route exact path="/" component={ MainPage }/>
-
-    </div>
+    </>
   </Router>
 )
 

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -403,7 +403,7 @@
             "file",
             "web-app/src/router.js"
         ],
-        "62928b69543a870338ab09c2f7493ec7594993bc4f2922052da3c3a9d804e0cd"
+        "70c9237cf961320f04d9736007a8ec3fbc1cd1adfe2cfbc5214cb2d91d57d503"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/router.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/router.js
@@ -7,10 +7,9 @@ import MainPage from './ext-src/MainPage'
 
 const router = (
   <Router>
-    <div>
+    <>
       <Route exact path="/" component={ MainPage }/>
-
-    </div>
+    </>
   </Router>
 )
 

--- a/waspc/examples/todoApp/src/client/App.jsx
+++ b/waspc/examples/todoApp/src/client/App.jsx
@@ -1,8 +1,12 @@
+import { Link } from "react-router-dom";
+
 export function App({ children }) {
     return (
         <div className="p-6">
             <header className="mb-6">
-                <h1 className="text-3xl font-bold">ToDo App</h1>
+                <h1 className="text-3xl font-bold">
+                    <Link to="/">ToDo App</Link>
+                </h1>
             </header>
             {children}
         </div>

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -245,13 +245,11 @@ genIndexJs spec =
       (C.asWebAppFile [relfile|src/index.js|])
       ( Just $
           object
-            [ "setupFn" .= extImportToImportJson relPathToWebAppSrcDir maybeSetupJsFunction,
-              "rootComponent" .= extImportToImportJson relPathToWebAppSrcDir maybeRootComponent
+            [ "setupFn" .= extImportToImportJson relPathToWebAppSrcDir maybeSetupJsFunction
             ]
       )
   where
     maybeSetupJsFunction = AS.App.Client.setupFn =<< AS.App.client (snd $ getApp spec)
-    maybeRootComponent = AS.App.Client.rootComponent =<< AS.App.client (snd $ getApp spec)
 
     relPathToWebAppSrcDir :: Path Posix (Rel importLocation) (Dir C.WebAppSrcDir)
     relPathToWebAppSrcDir = [reldirP|./|]


### PR DESCRIPTION
Fixes #1015

- Moves `rootComponent` inside of `Router` (makes possible to use `<Link>` in `rootComponent`)
- Uses fragment instead of `<div>` when no `rootComponent` is defined (avoids wrapping with extra div)
- Uses `<Link>` in `rootComponent` in example app
- Fixes e2e tests