### PR TITLE
Invalidate queries after oAuth login

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/auth/helpers/user.ts
+++ b/waspc/data/Generator/templates/react-app/src/auth/helpers/user.ts
@@ -1,0 +1,14 @@
+import { setAuthToken } from '../../api.js'
+import { invalidateAndRemoveQueries } from '../../operations/resources'
+
+export async function setupAuth({ token }: { token: string }): Promise<void> {
+    setAuthToken(token)
+    // We need to invalidate queries after login in order to get the correct user
+    // data in the React components (using `useAuth`).
+    // Redirects after login won't work properly without this.
+
+    // TODO(filip): We are currently removing all the queries, but we should
+    // remove only non-public, user-dependent queries - public queries are
+    // expected not to change in respect to the currently logged in user.
+    await invalidateAndRemoveQueries()
+}

--- a/waspc/data/Generator/templates/react-app/src/auth/helpers/user.ts
+++ b/waspc/data/Generator/templates/react-app/src/auth/helpers/user.ts
@@ -1,7 +1,7 @@
 import { setAuthToken } from '../../api.js'
 import { invalidateAndRemoveQueries } from '../../operations/resources'
 
-export async function setupAuth({ token }: { token: string }): Promise<void> {
+export async function initSession(token: string): Promise<void> {
     setAuthToken(token)
     // We need to invalidate queries after login in order to get the correct user
     // data in the React components (using `useAuth`).

--- a/waspc/data/Generator/templates/react-app/src/auth/login.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/login.js
@@ -1,23 +1,12 @@
-import { invalidateAndRemoveQueries } from '../operations/resources'
-import api, { setAuthToken, handleApiError } from '../api.js'
+import api, { handleApiError } from '../api.js'
+import { setupAuth } from './helpers/user'
 
 export default async function login(username, password) {
   try {
     const args = { username, password }
     const response = await api.post('/auth/login', args)
 
-    setAuthToken(response.data.token)
-    // This isn't really neccessary because we remove all private queries after
-    // logout, but we do it to be extra safe.
-    //
-    // For example, in future versions, users might be able to get to an SPA
-    // login page while there's an active session. This code will prevent data
-    // leaks in such cases.
-    //
-    // TODO(filip): We are currently removing all the queries, but we should
-    // remove only non-public, user-dependent queries - public queries are
-    // expected not to change in respect to the currently logged in user.
-    await invalidateAndRemoveQueries()
+    await setupAuth({ token: response.data.token })
   } catch (error) {
     handleApiError(error)
   }

--- a/waspc/data/Generator/templates/react-app/src/auth/login.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/login.js
@@ -1,12 +1,12 @@
 import api, { handleApiError } from '../api.js'
-import { setupAuth } from './helpers/user'
+import { initSession } from './helpers/user'
 
 export default async function login(username, password) {
   try {
     const args = { username, password }
     const response = await api.post('/auth/login', args)
 
-    await setupAuth({ token: response.data.token })
+    await initSession(response.data.token)
   } catch (error) {
     handleApiError(error)
   }

--- a/waspc/data/Generator/templates/react-app/src/auth/pages/OAuthCodeExchange.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/pages/OAuthCodeExchange.js
@@ -3,8 +3,8 @@ import React, { useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 
 import config from '../../config.js'
-import api, { setAuthToken } from '../../api.js'
-import { invalidateAndRemoveQueries } from '../../operations/resources'
+import api from '../../api.js'
+import { setupAuth } from '../helpers/user'
 
 // After a user authenticates via an Oauth 2.0 provider, this is the page that
 // the provider should redirect them to, while providing query string parameters
@@ -38,8 +38,7 @@ async function exchangeCodeForJwtAndRedirect(history, apiServerUrlHandlingOauthR
   const token = await exchangeCodeForJwt(apiServerUrlHandlingOauthRedirect)
 
   if (token !== null) {
-    setAuthToken(token)
-    await invalidateAndRemoveQueries()
+    await setupAuth({ token })
     history.push('{= onAuthSucceededRedirectTo =}')
   } else {
     console.error('Error obtaining JWT token')

--- a/waspc/data/Generator/templates/react-app/src/auth/pages/OAuthCodeExchange.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/pages/OAuthCodeExchange.js
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom'
 
 import config from '../../config.js'
 import api from '../../api.js'
-import { setupAuth } from '../helpers/user'
+import { initSession } from '../helpers/user'
 
 // After a user authenticates via an Oauth 2.0 provider, this is the page that
 // the provider should redirect them to, while providing query string parameters
@@ -38,7 +38,7 @@ async function exchangeCodeForJwtAndRedirect(history, apiServerUrlHandlingOauthR
   const token = await exchangeCodeForJwt(apiServerUrlHandlingOauthRedirect)
 
   if (token !== null) {
-    await setupAuth({ token })
+    await initSession(token)
     history.push('{= onAuthSucceededRedirectTo =}')
   } else {
     console.error('Error obtaining JWT token')

--- a/waspc/data/Generator/templates/react-app/src/auth/pages/OAuthCodeExchange.js
+++ b/waspc/data/Generator/templates/react-app/src/auth/pages/OAuthCodeExchange.js
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router-dom'
 
 import config from '../../config.js'
 import api, { setAuthToken } from '../../api.js'
+import { invalidateAndRemoveQueries } from '../../operations/resources'
 
 // After a user authenticates via an Oauth 2.0 provider, this is the page that
 // the provider should redirect them to, while providing query string parameters
@@ -38,6 +39,7 @@ async function exchangeCodeForJwtAndRedirect(history, apiServerUrlHandlingOauthR
 
   if (token !== null) {
     setAuthToken(token)
+    await invalidateAndRemoveQueries()
     history.push('{= onAuthSucceededRedirectTo =}')
   } else {
     console.error('Error obtaining JWT token')

--- a/waspc/src/Wasp/Generator/WebAppGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/AuthG.hs
@@ -29,7 +29,8 @@ genAuth spec =
           genLogin,
           genLogout,
           genUseAuth,
-          genCreateAuthRequiredPage auth
+          genCreateAuthRequiredPage auth,
+          genUserHelpers
         ]
         <++> genAuthForms auth
     Nothing -> return []
@@ -132,3 +133,6 @@ compileTmplToSamePath tmplFileInTmplSrcDir keyValuePairs =
 
 getOnAuthSucceededRedirectToOrDefault :: AS.Auth.Auth -> String
 getOnAuthSucceededRedirectToOrDefault auth = fromMaybe "/" (AS.Auth.onAuthSucceededRedirectTo auth)
+
+genUserHelpers :: Generator FileDraft
+genUserHelpers = return $ C.mkTmplFd (C.asTmplFile [relfile|src/auth/helpers/user.ts|])


### PR DESCRIPTION
Redirect to `onAuthSucceededRedirectTo` happens before `auth/me` query is invalidated.