### PR TITLE
Fixes tsconfig.json use of extends 

### DIFF
--- a/waspc/data/Generator/templates/react-app/tsconfig.json
+++ b/waspc/data/Generator/templates/react-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "@tsconfig/vite-react/tsconfig.json",
   "compilerOptions": {
-    "extends": "@tsconfig/vite-react/tsconfig.json",
     // Temporary loosen the type checking until we can address all the errors.
     "allowJs": true,
     "strict": false

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -473,7 +473,7 @@
             "file",
             "web-app/tsconfig.json"
         ],
-        "49258557f92e10eddda507885655d22f51d52f6f39e277c2ec1c9d626018c728"
+        "27e39dd3e6155ffccdb1d9cb0cba8db7d9e06e10958bee900340a2d9f17400c8"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "@tsconfig/vite-react/tsconfig.json",
   "compilerOptions": {
-    "extends": "@tsconfig/vite-react/tsconfig.json",
     // Temporary loosen the type checking until we can address all the errors.
     "allowJs": true,
     "strict": false

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -473,7 +473,7 @@
             "file",
             "web-app/tsconfig.json"
         ],
-        "49258557f92e10eddda507885655d22f51d52f6f39e277c2ec1c9d626018c728"
+        "27e39dd3e6155ffccdb1d9cb0cba8db7d9e06e10958bee900340a2d9f17400c8"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "@tsconfig/vite-react/tsconfig.json",
   "compilerOptions": {
-    "extends": "@tsconfig/vite-react/tsconfig.json",
     // Temporary loosen the type checking until we can address all the errors.
     "allowJs": true,
     "strict": false

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -739,7 +739,7 @@
             "file",
             "web-app/tsconfig.json"
         ],
-        "49258557f92e10eddda507885655d22f51d52f6f39e277c2ec1c9d626018c728"
+        "27e39dd3e6155ffccdb1d9cb0cba8db7d9e06e10958bee900340a2d9f17400c8"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "@tsconfig/vite-react/tsconfig.json",
   "compilerOptions": {
-    "extends": "@tsconfig/vite-react/tsconfig.json",
     // Temporary loosen the type checking until we can address all the errors.
     "allowJs": true,
     "strict": false

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -487,7 +487,7 @@
             "file",
             "web-app/tsconfig.json"
         ],
-        "49258557f92e10eddda507885655d22f51d52f6f39e277c2ec1c9d626018c728"
+        "27e39dd3e6155ffccdb1d9cb0cba8db7d9e06e10958bee900340a2d9f17400c8"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "@tsconfig/vite-react/tsconfig.json",
   "compilerOptions": {
-    "extends": "@tsconfig/vite-react/tsconfig.json",
     // Temporary loosen the type checking until we can address all the errors.
     "allowJs": true,
     "strict": false

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -473,7 +473,7 @@
             "file",
             "web-app/tsconfig.json"
         ],
-        "49258557f92e10eddda507885655d22f51d52f6f39e277c2ec1c9d626018c728"
+        "27e39dd3e6155ffccdb1d9cb0cba8db7d9e06e10958bee900340a2d9f17400c8"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "@tsconfig/vite-react/tsconfig.json",
   "compilerOptions": {
-    "extends": "@tsconfig/vite-react/tsconfig.json",
     // Temporary loosen the type checking until we can address all the errors.
     "allowJs": true,
     "strict": false


### PR DESCRIPTION
Our build step is broken, this fixes it.

Updates `tsconfig.json` in the templates and the e2e tests.

It's weird that my editor didn't scream at me that `extends` should be outside of `compilerOptions`.