### PR TITLE
Adds support for FE listening on multiple addresses

### DIFF
--- a/waspc/data/Generator/templates/react-app/vite.config.ts
+++ b/waspc/data/Generator/templates/react-app/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: '0.0.0.0',
   },
   envPrefix: 'REACT_APP_',
   build: {

--- a/waspc/data/Generator/templates/server/src/app.js
+++ b/waspc/data/Generator/templates/server/src/app.js
@@ -16,7 +16,7 @@ const app = express()
 app.use(helmet())
 app.use(cors({
   // TODO: Consider allowing users to provide an ENV variable or function to further configure CORS setup.
-  origin: config.frontendUrl,
+  origin: config.allowedCORSOrigins,
 }))
 app.use(logger('dev'))
 app.use(express.json())

--- a/waspc/data/Generator/templates/server/src/config.js
+++ b/waspc/data/Generator/templates/server/src/config.js
@@ -16,22 +16,38 @@ const config = {
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.{= databaseUrlEnvVar =},
     frontendUrl: undefined,
+    allowedCORSOrigins: [],
     {=# isAuthEnabled =}
     auth: {
       jwtSecret: undefined
     }
     {=/ isAuthEnabled =}
   },
-  development: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000',
+  development: getDevelopmentConfig(),
+  production: getProductionConfig(),
+}
+
+const resolvedConfig = merge(config.all, config[env])
+export default resolvedConfig
+
+function getDevelopmentConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000';
+  return {
+    frontendUrl,
+    allowedCORSOrigins: '*',
     {=# isAuthEnabled =}
     auth: {
       jwtSecret: 'DEVJWTSECRET'
     }
     {=/ isAuthEnabled =}
-  },
-  production: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL),
+  }
+}
+
+function getProductionConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL);
+  return {
+    frontendUrl,
+    allowedCORSOrigins: [frontendUrl],
     {=# isAuthEnabled =}
     auth: {
       jwtSecret: process.env.JWT_SECRET
@@ -39,6 +55,3 @@ const config = {
     {=/ isAuthEnabled =}
   }
 }
-
-const resolvedConfig = merge(config.all, config[env])
-export default resolvedConfig

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -95,14 +95,14 @@
             "file",
             "server/src/app.js"
         ],
-        "1e802078a0c6738f9dc2dc8f1739120d28fdc3d6fdc8029671ec9aed73c8ed72"
+        "f7df4b76a53a92117e0ddca41edd47961cf20ee6f13cc4d252e11c2a293a6e76"
     ],
     [
         [
             "file",
             "server/src/config.js"
         ],
-        "60a63ed453f6a6d8306f7a3660eff80b5f9803b37e5865db66fcae80df918a68"
+        "db65648bfa899b556f499abfde8a4cc6360b01dce88d9318456a8920e6a7d942"
     ],
     [
         [
@@ -487,6 +487,6 @@
             "file",
             "web-app/vite.config.ts"
         ],
-        "ab5c138ab0ab01f5108c2da9a8bf6b673b79115ca97276f6293da8e3bc0a45b1"
+        "56541f643d10dec29609b98dfc0df75d4893a592396be2888e89591efc93bd7c"
     ]
 ]

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/app.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/app.js
@@ -16,7 +16,7 @@ const app = express()
 app.use(helmet())
 app.use(cors({
   // TODO: Consider allowing users to provide an ENV variable or function to further configure CORS setup.
-  origin: config.frontendUrl,
+  origin: config.allowedCORSOrigins,
 }))
 app.use(logger('dev'))
 app.use(express.json())

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/config.js
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/server/src/config.js
@@ -15,14 +15,27 @@ const config = {
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.DATABASE_URL,
     frontendUrl: undefined,
+    allowedCORSOrigins: [],
   },
-  development: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000',
-  },
-  production: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL),
-  }
+  development: getDevelopmentConfig(),
+  production: getProductionConfig(),
 }
 
 const resolvedConfig = merge(config.all, config[env])
 export default resolvedConfig
+
+function getDevelopmentConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000';
+  return {
+    frontendUrl,
+    allowedCORSOrigins: '*',
+  }
+}
+
+function getProductionConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL);
+  return {
+    frontendUrl,
+    allowedCORSOrigins: [frontendUrl],
+  }
+}

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/vite.config.ts
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: '0.0.0.0',
   },
   envPrefix: 'REACT_APP_',
   build: {

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -95,14 +95,14 @@
             "file",
             "server/src/app.js"
         ],
-        "1e802078a0c6738f9dc2dc8f1739120d28fdc3d6fdc8029671ec9aed73c8ed72"
+        "f7df4b76a53a92117e0ddca41edd47961cf20ee6f13cc4d252e11c2a293a6e76"
     ],
     [
         [
             "file",
             "server/src/config.js"
         ],
-        "60a63ed453f6a6d8306f7a3660eff80b5f9803b37e5865db66fcae80df918a68"
+        "db65648bfa899b556f499abfde8a4cc6360b01dce88d9318456a8920e6a7d942"
     ],
     [
         [
@@ -487,6 +487,6 @@
             "file",
             "web-app/vite.config.ts"
         ],
-        "ab5c138ab0ab01f5108c2da9a8bf6b673b79115ca97276f6293da8e3bc0a45b1"
+        "56541f643d10dec29609b98dfc0df75d4893a592396be2888e89591efc93bd7c"
     ]
 ]

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/app.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/app.js
@@ -16,7 +16,7 @@ const app = express()
 app.use(helmet())
 app.use(cors({
   // TODO: Consider allowing users to provide an ENV variable or function to further configure CORS setup.
-  origin: config.frontendUrl,
+  origin: config.allowedCORSOrigins,
 }))
 app.use(logger('dev'))
 app.use(express.json())

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/config.js
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/server/src/config.js
@@ -15,14 +15,27 @@ const config = {
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.DATABASE_URL,
     frontendUrl: undefined,
+    allowedCORSOrigins: [],
   },
-  development: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000',
-  },
-  production: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL),
-  }
+  development: getDevelopmentConfig(),
+  production: getProductionConfig(),
 }
 
 const resolvedConfig = merge(config.all, config[env])
 export default resolvedConfig
+
+function getDevelopmentConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000';
+  return {
+    frontendUrl,
+    allowedCORSOrigins: '*',
+  }
+}
+
+function getProductionConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL);
+  return {
+    frontendUrl,
+    allowedCORSOrigins: [frontendUrl],
+  }
+}

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/vite.config.ts
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: '0.0.0.0',
   },
   envPrefix: 'REACT_APP_',
   build: {

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -116,14 +116,14 @@
             "file",
             "server/src/app.js"
         ],
-        "1e802078a0c6738f9dc2dc8f1739120d28fdc3d6fdc8029671ec9aed73c8ed72"
+        "f7df4b76a53a92117e0ddca41edd47961cf20ee6f13cc4d252e11c2a293a6e76"
     ],
     [
         [
             "file",
             "server/src/config.js"
         ],
-        "99e89fb4d207108caf0afeaf8f364819bac6f6d7c28a0a14b6ae7a4f134aa779"
+        "feb61b839f6ce3c1f49b279fd08275479308089a6f12188b312b64bdf571e6c5"
     ],
     [
         [
@@ -753,6 +753,6 @@
             "file",
             "web-app/vite.config.ts"
         ],
-        "ab5c138ab0ab01f5108c2da9a8bf6b673b79115ca97276f6293da8e3bc0a45b1"
+        "56541f643d10dec29609b98dfc0df75d4893a592396be2888e89591efc93bd7c"
     ]
 ]

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/app.js
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/app.js
@@ -16,7 +16,7 @@ const app = express()
 app.use(helmet())
 app.use(cors({
   // TODO: Consider allowing users to provide an ENV variable or function to further configure CORS setup.
-  origin: config.frontendUrl,
+  origin: config.allowedCORSOrigins,
 }))
 app.use(logger('dev'))
 app.use(express.json())

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/config.js
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/config.js
@@ -15,23 +15,36 @@ const config = {
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.DATABASE_URL,
     frontendUrl: undefined,
+    allowedCORSOrigins: [],
     auth: {
       jwtSecret: undefined
     }
   },
-  development: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000',
+  development: getDevelopmentConfig(),
+  production: getProductionConfig(),
+}
+
+const resolvedConfig = merge(config.all, config[env])
+export default resolvedConfig
+
+function getDevelopmentConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000';
+  return {
+    frontendUrl,
+    allowedCORSOrigins: '*',
     auth: {
       jwtSecret: 'DEVJWTSECRET'
     }
-  },
-  production: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL),
+  }
+}
+
+function getProductionConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL);
+  return {
+    frontendUrl,
+    allowedCORSOrigins: [frontendUrl],
     auth: {
       jwtSecret: process.env.JWT_SECRET
     }
   }
 }
-
-const resolvedConfig = merge(config.all, config[env])
-export default resolvedConfig

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/vite.config.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: '0.0.0.0',
   },
   envPrefix: 'REACT_APP_',
   build: {

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -95,14 +95,14 @@
             "file",
             "server/src/app.js"
         ],
-        "1e802078a0c6738f9dc2dc8f1739120d28fdc3d6fdc8029671ec9aed73c8ed72"
+        "f7df4b76a53a92117e0ddca41edd47961cf20ee6f13cc4d252e11c2a293a6e76"
     ],
     [
         [
             "file",
             "server/src/config.js"
         ],
-        "60a63ed453f6a6d8306f7a3660eff80b5f9803b37e5865db66fcae80df918a68"
+        "db65648bfa899b556f499abfde8a4cc6360b01dce88d9318456a8920e6a7d942"
     ],
     [
         [
@@ -501,6 +501,6 @@
             "file",
             "web-app/vite.config.ts"
         ],
-        "ab5c138ab0ab01f5108c2da9a8bf6b673b79115ca97276f6293da8e3bc0a45b1"
+        "56541f643d10dec29609b98dfc0df75d4893a592396be2888e89591efc93bd7c"
     ]
 ]

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/app.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/app.js
@@ -16,7 +16,7 @@ const app = express()
 app.use(helmet())
 app.use(cors({
   // TODO: Consider allowing users to provide an ENV variable or function to further configure CORS setup.
-  origin: config.frontendUrl,
+  origin: config.allowedCORSOrigins,
 }))
 app.use(logger('dev'))
 app.use(express.json())

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/config.js
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/server/src/config.js
@@ -15,14 +15,27 @@ const config = {
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.DATABASE_URL,
     frontendUrl: undefined,
+    allowedCORSOrigins: [],
   },
-  development: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000',
-  },
-  production: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL),
-  }
+  development: getDevelopmentConfig(),
+  production: getProductionConfig(),
 }
 
 const resolvedConfig = merge(config.all, config[env])
 export default resolvedConfig
+
+function getDevelopmentConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000';
+  return {
+    frontendUrl,
+    allowedCORSOrigins: '*',
+  }
+}
+
+function getProductionConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL);
+  return {
+    frontendUrl,
+    allowedCORSOrigins: [frontendUrl],
+  }
+}

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/vite.config.ts
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: '0.0.0.0',
   },
   envPrefix: 'REACT_APP_',
   build: {

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -95,14 +95,14 @@
             "file",
             "server/src/app.js"
         ],
-        "1e802078a0c6738f9dc2dc8f1739120d28fdc3d6fdc8029671ec9aed73c8ed72"
+        "f7df4b76a53a92117e0ddca41edd47961cf20ee6f13cc4d252e11c2a293a6e76"
     ],
     [
         [
             "file",
             "server/src/config.js"
         ],
-        "60a63ed453f6a6d8306f7a3660eff80b5f9803b37e5865db66fcae80df918a68"
+        "db65648bfa899b556f499abfde8a4cc6360b01dce88d9318456a8920e6a7d942"
     ],
     [
         [
@@ -487,6 +487,6 @@
             "file",
             "web-app/vite.config.ts"
         ],
-        "ab5c138ab0ab01f5108c2da9a8bf6b673b79115ca97276f6293da8e3bc0a45b1"
+        "56541f643d10dec29609b98dfc0df75d4893a592396be2888e89591efc93bd7c"
     ]
 ]

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/app.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/app.js
@@ -16,7 +16,7 @@ const app = express()
 app.use(helmet())
 app.use(cors({
   // TODO: Consider allowing users to provide an ENV variable or function to further configure CORS setup.
-  origin: config.frontendUrl,
+  origin: config.allowedCORSOrigins,
 }))
 app.use(logger('dev'))
 app.use(express.json())

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/config.js
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/server/src/config.js
@@ -15,14 +15,27 @@ const config = {
     port: parseInt(process.env.PORT) || 3001,
     databaseUrl: process.env.DATABASE_URL,
     frontendUrl: undefined,
+    allowedCORSOrigins: [],
   },
-  development: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000',
-  },
-  production: {
-    frontendUrl: stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL),
-  }
+  development: getDevelopmentConfig(),
+  production: getProductionConfig(),
 }
 
 const resolvedConfig = merge(config.all, config[env])
 export default resolvedConfig
+
+function getDevelopmentConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL) || 'http://localhost:3000';
+  return {
+    frontendUrl,
+    allowedCORSOrigins: '*',
+  }
+}
+
+function getProductionConfig() {
+  const frontendUrl = stripTrailingSlash(process.env.WASP_WEB_CLIENT_URL);
+  return {
+    frontendUrl,
+    allowedCORSOrigins: [frontendUrl],
+  }
+}

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/vite.config.ts
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
+    host: '0.0.0.0',
   },
   envPrefix: 'REACT_APP_',
   build: {

--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -1,6 +1,6 @@
 app todoApp {
   wasp: {
-    version: "^0.8.0"
+    version: "^0.9.0"
   },
   title: "ToDo App",
   // head: [],


### PR DESCRIPTION
This PR enables using Wasp in environemtns where the user is not visiting the FE through `localhost:3000` 

It also allows all origins in the CORS rules when in development mode, so the backend will work with requests from both `localhost:3000` or `192.168.1.1:3000`