### PR TITLE
Relax dependency between oauth and usernameAndPassword

### DIFF
--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/createRouter.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/createRouter.ts
@@ -76,7 +76,7 @@ async function findOrCreateUserByExternalAuthAssociation(
   const userAndExternalAuthAssociation = {
     ...userFields,
     {=# isPasswordOnUserEntity =}
-    // TODO: Decouple social from usernameAndPassword oauth.
+    // TODO: Decouple social from usernameAndPassword auth.
     password: uuidv4(),
     {=/ isPasswordOnUserEntity =}
     externalAuthAssociations: {

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/createRouter.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/createRouter.ts
@@ -72,11 +72,13 @@ async function findOrCreateUserByExternalAuthAssociation(
 
   // No external auth association linkage found. Create a new User using details from
   // `getUserFields()`. Additionally, associate the externalAuthAssociations with the new User.
-  // NOTE: For now, we force a random (uuidv4) password string. In the future, we will allow password reset.
   const userFields = await getUserFields()
   const userAndExternalAuthAssociation = {
     ...userFields,
+    {=# isUsernameAndPasswordAuthEnabled =}
+    // TODO: Decouple social from username and password auth.
     password: uuidv4(),
+    {=/ isUsernameAndPasswordAuthEnabled =}
     externalAuthAssociations: {
       create: [{ provider, providerId }]
     }

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/createRouter.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/createRouter.ts
@@ -75,10 +75,10 @@ async function findOrCreateUserByExternalAuthAssociation(
   const userFields = await getUserFields()
   const userAndExternalAuthAssociation = {
     ...userFields,
-    {=# isUsernameAndPasswordAuthEnabled =}
-    // TODO: Decouple social from username and password auth.
+    {=# isPasswordOnUserEntity =}
+    // TODO: Decouple social from usernameAndPassword oauth.
     password: uuidv4(),
-    {=/ isUsernameAndPasswordAuthEnabled =}
+    {=/ isPasswordOnUserEntity =}
     externalAuthAssociations: {
       create: [{ provider, providerId }]
     }

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/defaults.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/defaults.ts
@@ -1,6 +1,12 @@
+{{={= =}=}}
 import { generateAvailableDictionaryUsername } from '../../../core/auth.js'
 
 export async function getUserFieldsFn(_context, _args) {
+  {=# isUsernameAndPasswordAuthEnabled =}
   const username = await generateAvailableDictionaryUsername()
   return { username }
+  {=/ isUsernameAndPasswordAuthEnabled =}
+  {=^ isUsernameAndPasswordAuthEnabled =}
+  return {}
+  {=/ isUsernameAndPasswordAuthEnabled =}
 }

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/defaults.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/defaults.ts
@@ -2,11 +2,11 @@
 import { generateAvailableDictionaryUsername } from '../../../core/auth.js'
 
 export async function getUserFieldsFn(_context, _args) {
-  {=# isUsernameAndPasswordAuthEnabled =}
+  {=# isUsernameOnUserEntity =}
   const username = await generateAvailableDictionaryUsername()
   return { username }
-  {=/ isUsernameAndPasswordAuthEnabled =}
-  {=^ isUsernameAndPasswordAuthEnabled =}
+  {=/ isUsernameOnUserEntity =}
+  {=^ isUsernameOnUserEntity =}
   return {}
-  {=/ isUsernameAndPasswordAuthEnabled =}
+  {=/ isUsernameOnUserEntity =}
 }

--- a/waspc/data/Generator/templates/server/src/core/auth/prismaMiddleware.js
+++ b/waspc/data/Generator/templates/server/src/core/auth/prismaMiddleware.js
@@ -62,17 +62,15 @@ export const registerAuthMiddleware = (prismaClient) => {
 const validateUser = (user, args, action) => {
   user = user || {}
 
-  {=# isUsernameAndPasswordAuthEnabled =}
-  const defaultValidations = [
-    { validates: USERNAME_FIELD, message: 'username must be present', validator: username => !!username },
-    { validates: PASSWORD_FIELD, message: 'password must be present', validator: password => !!password },
-    { validates: PASSWORD_FIELD, message: 'password must be at least 8 characters', validator: password => password.length >= 8 },
-    { validates: PASSWORD_FIELD, message: 'password must contain a number', validator: password => /\d/.test(password) },
-  ]
-  {=/ isUsernameAndPasswordAuthEnabled =}
-  {=^ isUsernameAndPasswordAuthEnabled =}
   const defaultValidations = []
-  {=/ isUsernameAndPasswordAuthEnabled =}
+  {=# isUsernameOnUserEntity =}
+  defaultValidations.push({ validates: USERNAME_FIELD, message: 'username must be present', validator: username => !!username })
+  {=/ isUsernameOnUserEntity =}
+  {=# isPasswordOnUserEntity =}
+  defaultValidations.push({ validates: PASSWORD_FIELD, message: 'password must be present', validator: password => !!password })
+  defaultValidations.push({ validates: PASSWORD_FIELD, message: 'password must be at least 8 characters', validator: password => password.length >= 8 })
+  defaultValidations.push({ validates: PASSWORD_FIELD, message: 'password must contain a number', validator: password => /\d/.test(password) })
+  {=/ isPasswordOnUserEntity =}
 
   const validations = [
     ...(args._waspSkipDefaultValidations ? [] : defaultValidations),

--- a/waspc/data/Generator/templates/server/src/core/auth/prismaMiddleware.js
+++ b/waspc/data/Generator/templates/server/src/core/auth/prismaMiddleware.js
@@ -62,12 +62,17 @@ export const registerAuthMiddleware = (prismaClient) => {
 const validateUser = (user, args, action) => {
   user = user || {}
 
+  {=# isUsernameAndPasswordAuthEnabled =}
   const defaultValidations = [
     { validates: USERNAME_FIELD, message: 'username must be present', validator: username => !!username },
     { validates: PASSWORD_FIELD, message: 'password must be present', validator: password => !!password },
     { validates: PASSWORD_FIELD, message: 'password must be at least 8 characters', validator: password => password.length >= 8 },
     { validates: PASSWORD_FIELD, message: 'password must contain a number', validator: password => /\d/.test(password) },
   ]
+  {=/ isUsernameAndPasswordAuthEnabled =}
+  {=^ isUsernameAndPasswordAuthEnabled =}
+  const defaultValidations = []
+  {=/ isUsernameAndPasswordAuthEnabled =}
 
   const validations = [
     ...(args._waspSkipDefaultValidations ? [] : defaultValidations),

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "server/src/auth/providers/oauth/createRouter.ts"
         ],
-        "3855c4b789d15511d871d35f69a4b2d14b7923516cba5c50eb528aee9254b5c5"
+        "928db99ea6e38c5e42739cd988ef5a282b0b8a0e8970c5010073103eba59dcc9"
     ],
     [
         [
@@ -214,7 +214,7 @@
             "file",
             "server/src/core/auth/prismaMiddleware.js"
         ],
-        "aede440c2297aa5028e5f387e3392228d8249fb4906aeb95364006aeec039aae"
+        "14746535104eaaefeeb0befda6d4472177e367d906c005706f740802f6a57240"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "server/src/auth/providers/oauth/createRouter.ts"
         ],
-        "928db99ea6e38c5e42739cd988ef5a282b0b8a0e8970c5010073103eba59dcc9"
+        "3743bd9f6b01ba355ae9af62637bd66f327615664552869397c1feb025273dad"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/auth/providers/oauth/createRouter.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/auth/providers/oauth/createRouter.ts
@@ -71,10 +71,10 @@ async function findOrCreateUserByExternalAuthAssociation(
 
   // No external auth association linkage found. Create a new User using details from
   // `getUserFields()`. Additionally, associate the externalAuthAssociations with the new User.
-  // NOTE: For now, we force a random (uuidv4) password string. In the future, we will allow password reset.
   const userFields = await getUserFields()
   const userAndExternalAuthAssociation = {
     ...userFields,
+    // TODO: Decouple social from usernameAndPassword oauth.
     password: uuidv4(),
     externalAuthAssociations: {
       create: [{ provider, providerId }]

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/auth/providers/oauth/createRouter.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/auth/providers/oauth/createRouter.ts
@@ -74,7 +74,7 @@ async function findOrCreateUserByExternalAuthAssociation(
   const userFields = await getUserFields()
   const userAndExternalAuthAssociation = {
     ...userFields,
-    // TODO: Decouple social from usernameAndPassword oauth.
+    // TODO: Decouple social from usernameAndPassword auth.
     password: uuidv4(),
     externalAuthAssociations: {
       create: [{ provider, providerId }]

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/core/auth/prismaMiddleware.js
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/core/auth/prismaMiddleware.js
@@ -61,12 +61,11 @@ export const registerAuthMiddleware = (prismaClient) => {
 const validateUser = (user, args, action) => {
   user = user || {}
 
-  const defaultValidations = [
-    { validates: USERNAME_FIELD, message: 'username must be present', validator: username => !!username },
-    { validates: PASSWORD_FIELD, message: 'password must be present', validator: password => !!password },
-    { validates: PASSWORD_FIELD, message: 'password must be at least 8 characters', validator: password => password.length >= 8 },
-    { validates: PASSWORD_FIELD, message: 'password must contain a number', validator: password => /\d/.test(password) },
-  ]
+  const defaultValidations = []
+  defaultValidations.push({ validates: USERNAME_FIELD, message: 'username must be present', validator: username => !!username })
+  defaultValidations.push({ validates: PASSWORD_FIELD, message: 'password must be present', validator: password => !!password })
+  defaultValidations.push({ validates: PASSWORD_FIELD, message: 'password must be at least 8 characters', validator: password => password.length >= 8 })
+  defaultValidations.push({ validates: PASSWORD_FIELD, message: 'password must contain a number', validator: password => /\d/.test(password) })
 
   const validations = [
     ...(args._waspSkipDefaultValidations ? [] : defaultValidations),

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -5,6 +5,7 @@ module Wasp.AppSpec.Valid
     ValidationError (..),
     getApp,
     isAuthEnabled,
+    doesUserEntityContainField,
   )
 where
 
@@ -193,3 +194,11 @@ getDbSystem spec = AS.Db.system =<< AS.App.db (snd $ getApp spec)
 -- | This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).
 isPostgresUsed :: AppSpec -> Bool
 isPostgresUsed = (Just AS.Db.PostgreSQL ==) . getDbSystem
+
+-- | This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).
+doesUserEntityContainField :: AppSpec -> String -> Maybe Bool
+doesUserEntityContainField spec fieldName = do
+  auth <- App.auth (snd $ getApp spec)
+  let (_userEntityName, userEntity) = AS.resolveRef spec (Auth.userEntity auth)
+  let userEntityFields = Entity.getFields userEntity
+  Just $ any (\field -> Entity.Field.fieldName field == fieldName) userEntityFields

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -200,6 +200,6 @@ isPostgresUsed = (Just AS.Db.PostgreSQL ==) . getDbSystem
 doesUserEntityContainField :: AppSpec -> String -> Maybe Bool
 doesUserEntityContainField spec fieldName = do
   auth <- App.auth (snd $ getApp spec)
-  let (_userEntityName, userEntity) = AS.resolveRef spec (Auth.userEntity auth)
+  let userEntity = snd $ AS.resolveRef spec (Auth.userEntity auth)
   let userEntityFields = Entity.getFields userEntity
   Just $ any (\field -> Entity.Field.fieldName field == fieldName) userEntityFields

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -196,6 +196,7 @@ isPostgresUsed :: AppSpec -> Bool
 isPostgresUsed = (Just AS.Db.PostgreSQL ==) . getDbSystem
 
 -- | This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).
+-- If there is no user entity, it returns Nothing.
 doesUserEntityContainField :: AppSpec -> String -> Maybe Bool
 doesUserEntityContainField spec fieldName = do
   auth <- App.auth (snd $ getApp spec)

--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/OAuthAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/OAuthAuthG.hs
@@ -63,10 +63,11 @@ genCreateRouter spec auth = return $ C.mkTmplFdWithData [relfile|src/auth/provid
         [ "userEntityUpper" .= (userEntityName :: String),
           "userEntityLower" .= (Util.toLowerFirst userEntityName :: String),
           "externalAuthEntityLower" .= (Util.toLowerFirst externalAuthEntityName :: String),
-          "isPasswordOnUserEntity" .= (doesUserEntityContainField spec "password" == Just True)
+          "isPasswordOnUserEntity" .= isPasswordOnUserEntity
         ]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
     externalAuthEntityName = maybe "undefined" AS.refName (AS.Auth.externalAuthEntity auth)
+    isPasswordOnUserEntity = doesUserEntityContainField spec "password" == Just True
 
 genTypes :: AS.Auth.Auth -> Generator FileDraft
 genTypes auth = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
@@ -79,7 +80,8 @@ genDefaults :: AS.AppSpec -> Generator FileDraft
 genDefaults spec = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
   where
     tmplFile = C.srcDirInServerTemplatesDir </> [relfile|auth/providers/oauth/defaults.ts|]
-    tmplData = object ["isUsernameOnUserEntity" .= (doesUserEntityContainField spec "username" == Just True)]
+    tmplData = object ["isUsernameOnUserEntity" .= isUsernameOnUserEntity]
+    isUsernameOnUserEntity = doesUserEntityContainField spec "username" == Just True
 
 genOAuthProvider ::
   OAuthAuthProvider ->

--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/OAuthAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/OAuthAuthG.hs
@@ -26,7 +26,7 @@ import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.App.Dependency as App.Dependency
-import Wasp.AppSpec.Valid (getApp)
+import Wasp.AppSpec.Valid (doesUserEntityContainField, getApp)
 import Wasp.Generator.AuthProviders (gitHubAuthProvider, googleAuthProvider)
 import Wasp.Generator.AuthProviders.OAuth (OAuthAuthProvider)
 import qualified Wasp.Generator.AuthProviders.OAuth as OAuth
@@ -38,32 +38,32 @@ import Wasp.Generator.ServerGenerator.JsImport (extImportToImportJson)
 import Wasp.Util ((<++>))
 import qualified Wasp.Util as Util
 
-genOAuthAuth :: AS.Auth.Auth -> Generator [FileDraft]
-genOAuthAuth auth
+genOAuthAuth :: AS.AppSpec -> AS.Auth.Auth -> Generator [FileDraft]
+genOAuthAuth spec auth
   | AS.Auth.isExternalAuthEnabled auth =
-      genOAuthHelpers auth
+      genOAuthHelpers spec auth
         <++> genOAuthProvider googleAuthProvider (AS.Auth.google . AS.Auth.methods $ auth)
         <++> genOAuthProvider gitHubAuthProvider (AS.Auth.gitHub . AS.Auth.methods $ auth)
   | otherwise = return []
 
-genOAuthHelpers :: AS.Auth.Auth -> Generator [FileDraft]
-genOAuthHelpers auth =
+genOAuthHelpers :: AS.AppSpec -> AS.Auth.Auth -> Generator [FileDraft]
+genOAuthHelpers spec auth =
   sequence
-    [ genCreateRouter auth,
+    [ genCreateRouter spec auth,
       genTypes auth,
-      genDefaults auth,
+      genDefaults spec,
       return $ C.mkSrcTmplFd [relfile|auth/providers/oauth/init.ts|]
     ]
 
-genCreateRouter :: AS.Auth.Auth -> Generator FileDraft
-genCreateRouter auth = return $ C.mkTmplFdWithData [relfile|src/auth/providers/oauth/createRouter.ts|] (Just tmplData)
+genCreateRouter :: AS.AppSpec -> AS.Auth.Auth -> Generator FileDraft
+genCreateRouter spec auth = return $ C.mkTmplFdWithData [relfile|src/auth/providers/oauth/createRouter.ts|] (Just tmplData)
   where
     tmplData =
       object
         [ "userEntityUpper" .= (userEntityName :: String),
           "userEntityLower" .= (Util.toLowerFirst userEntityName :: String),
           "externalAuthEntityLower" .= (Util.toLowerFirst externalAuthEntityName :: String),
-          "isUsernameAndPasswordAuthEnabled" .= AS.Auth.isUsernameAndPasswordAuthEnabled auth
+          "isPasswordOnUserEntity" .= (doesUserEntityContainField spec "password" == Just True)
         ]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
     externalAuthEntityName = maybe "undefined" AS.refName (AS.Auth.externalAuthEntity auth)
@@ -75,11 +75,11 @@ genTypes auth = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
     tmplData = object ["userEntityName" .= userEntityName]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
 
-genDefaults :: AS.Auth.Auth -> Generator FileDraft
-genDefaults auth = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
+genDefaults :: AS.AppSpec -> Generator FileDraft
+genDefaults spec = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
   where
     tmplFile = C.srcDirInServerTemplatesDir </> [relfile|auth/providers/oauth/defaults.ts|]
-    tmplData = object ["isUsernameAndPasswordAuthEnabled" .= AS.Auth.isUsernameAndPasswordAuthEnabled auth]
+    tmplData = object ["isUsernameOnUserEntity" .= (doesUserEntityContainField spec "username" == Just True)]
 
 genOAuthProvider ::
   OAuthAuthProvider ->

--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/OAuthAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/OAuthAuthG.hs
@@ -51,8 +51,8 @@ genOAuthHelpers auth =
   sequence
     [ genCreateRouter auth,
       genTypes auth,
-      return $ C.mkSrcTmplFd [relfile|auth/providers/oauth/init.ts|],
-      return $ C.mkSrcTmplFd [relfile|auth/providers/oauth/defaults.ts|]
+      genDefaults auth,
+      return $ C.mkSrcTmplFd [relfile|auth/providers/oauth/init.ts|]
     ]
 
 genCreateRouter :: AS.Auth.Auth -> Generator FileDraft
@@ -62,7 +62,8 @@ genCreateRouter auth = return $ C.mkTmplFdWithData [relfile|src/auth/providers/o
       object
         [ "userEntityUpper" .= (userEntityName :: String),
           "userEntityLower" .= (Util.toLowerFirst userEntityName :: String),
-          "externalAuthEntityLower" .= (Util.toLowerFirst externalAuthEntityName :: String)
+          "externalAuthEntityLower" .= (Util.toLowerFirst externalAuthEntityName :: String),
+          "isUsernameAndPasswordAuthEnabled" .= AS.Auth.isUsernameAndPasswordAuthEnabled auth
         ]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
     externalAuthEntityName = maybe "undefined" AS.refName (AS.Auth.externalAuthEntity auth)
@@ -73,6 +74,12 @@ genTypes auth = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
     tmplFile = C.srcDirInServerTemplatesDir </> [relfile|auth/providers/oauth/types.ts|]
     tmplData = object ["userEntityName" .= userEntityName]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
+
+genDefaults :: AS.Auth.Auth -> Generator FileDraft
+genDefaults auth = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
+  where
+    tmplFile = C.srcDirInServerTemplatesDir </> [relfile|auth/providers/oauth/defaults.ts|]
+    tmplData = object ["isUsernameAndPasswordAuthEnabled" .= AS.Auth.isUsernameAndPasswordAuthEnabled auth]
 
 genOAuthProvider ::
   OAuthAuthProvider ->

--- a/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
@@ -79,7 +79,10 @@ genAuthMiddleware auth = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Jus
 
     tmplData =
       let userEntityName = AS.refName $ AS.Auth.userEntity auth
-       in object ["userEntityUpper" .= (userEntityName :: String)]
+       in object
+            [ "userEntityUpper" .= (userEntityName :: String),
+              "isUsernameAndPasswordAuthEnabled" .= AS.Auth.isUsernameAndPasswordAuthEnabled auth
+            ]
 
 genAuthRoutesIndex :: AS.Auth.Auth -> Generator FileDraft
 genAuthRoutesIndex auth = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)

--- a/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
@@ -79,10 +79,12 @@ genAuthMiddleware spec auth = return $ C.mkTmplFdWithDstAndData tmplFile dstFile
 
     tmplData =
       let userEntityName = AS.refName $ AS.Auth.userEntity auth
+          isPasswordOnUserEntity = doesUserEntityContainField spec "password" == Just True
+          isUsernameOnUserEntity = doesUserEntityContainField spec "username" == Just True
        in object
             [ "userEntityUpper" .= (userEntityName :: String),
-              "isPasswordOnUserEntity" .= (doesUserEntityContainField spec "password" == Just True),
-              "isUsernameOnUserEntity" .= (doesUserEntityContainField spec "username" == Just True)
+              "isPasswordOnUserEntity" .= isPasswordOnUserEntity,
+              "isUsernameOnUserEntity" .= isUsernameOnUserEntity
             ]
 
 genAuthRoutesIndex :: AS.Auth.Auth -> Generator FileDraft

--- a/waspc/test/AppSpec/ValidTest.hs
+++ b/waspc/test/AppSpec/ValidTest.hs
@@ -126,6 +126,11 @@ spec_AppSpecValid = do
             `shouldBe` [ ASV.GenericValidationError
                            "Expected app.auth to be defined since there are Pages with authRequired set to true."
                        ]
+        it "contains expected fields" $ do
+          ASV.doesUserEntityContainField (makeSpec Nothing Nothing) "password" `shouldBe` Nothing
+          ASV.doesUserEntityContainField (makeSpec (Just validAppAuth) Nothing) "username" `shouldBe` Just True
+          ASV.doesUserEntityContainField (makeSpec (Just validAppAuth) Nothing) "password" `shouldBe` Just True
+          ASV.doesUserEntityContainField (makeSpec (Just validAppAuth) Nothing) "missing" `shouldBe` Just False
 
       describe "should validate that when app.auth is using UsernameAndPassword, user entity is of valid shape." $ do
         let makeSpec appAuth userEntity =


### PR DESCRIPTION
### Description

This relaxes the relationship between oauth and usernameAndPassword. Before, we implicitly required the User entity to have username/password fields since we checked/set them. Now, we only do is _if they exist on the User entity_. This should be backwards compatible, but also now allow for oauth to be used with no assumptions on the User entity fields beyond an id (which we can later relax the type of).

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
