### PR TITLE
Adds scaffolding based on giget

### DIFF
--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -38,7 +38,7 @@ main :: IO ()
 main = withUtf8 . (`E.catch` handleInternalErrors) $ do
   args <- getArgs
   let commandCall = case args of
-        ["new", projectName] -> Command.Call.New projectName
+        ("new" : newArgs) -> Command.Call.New newArgs
         ["start"] -> Command.Call.Start
         ["start", "db"] -> Command.Call.StartDb
         ["clean"] -> Command.Call.Clean
@@ -62,7 +62,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
   telemetryThread <- Async.async $ runCommand $ Telemetry.considerSendingData commandCall
 
   case commandCall of
-    Command.Call.New projectName -> runCommand $ createNewProject projectName
+    Command.Call.New newArgs -> runCommand $ createNewProject newArgs
     Command.Call.Start -> runCommand start
     Command.Call.StartDb -> runCommand Command.Start.Db.start
     Command.Call.Clean -> runCommand clean
@@ -104,7 +104,10 @@ printUsage =
               "",
         title "COMMANDS",
         title "  GENERAL",
-        cmd   "    new <project-name>    Creates new Wasp project.",
+        cmd   "    new <name> [args]     Creates a new Wasp project.",
+              "    OPTIONS:",
+              "    --template <template-name>",
+              "",
         cmd   "    version               Prints current version of CLI.",
         cmd   "    waspls                Run Wasp Language Server. Add --help to get more info.",
         cmd   "    completion            Prints help on bash completion.",
@@ -125,6 +128,7 @@ printUsage =
               "",
         title "EXAMPLES",
               "  wasp new MyApp",
+              "  wasp new MyApp --template waspello",
               "  wasp start",
               "  wasp db migrate-dev",
               "",

--- a/waspc/cli/src/Wasp/Cli/Command/Call.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Call.hs
@@ -1,7 +1,7 @@
 module Wasp.Cli.Command.Call where
 
 data Call
-  = New String -- project name
+  = New [String] -- new args
   | Start
   | StartDb
   | Clean

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -3,9 +3,15 @@ module Wasp.Cli.Command.CreateNewProject
   )
 where
 
+import Control.Concurrent (newChan)
+import Control.Monad (when)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
+import Data.Functor ((<&>))
 import Data.List (intercalate)
+import Data.Maybe (isJust)
+import qualified Data.Text as T
+import GHC.IO.Exception (ExitCode (..))
 import Path.IO (copyDirRecur, doesDirExist)
 import StrongPath (Abs, Dir, Path, Path', System, parseAbsDir, reldir, relfile, (</>))
 import StrongPath.Path (toPathAbsDir)
@@ -14,21 +20,26 @@ import qualified System.FilePath as FP
 import Text.Printf (printf)
 import Wasp.Analyzer.Parser (isValidWaspIdentifier)
 import Wasp.Cli.Command (Command, CommandError (..))
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import qualified Wasp.Data as Data
+import qualified Wasp.Generator.Job as J
+import Wasp.Generator.Job.Process (runNodeCommandAsJob)
+import qualified Wasp.Message as Msg
 import Wasp.Project (WaspProjectDir)
-import Wasp.Util (indent, kebabToCamelCase)
+import Wasp.Util (indent, kebabToCamelCase, whenM)
 import qualified Wasp.Util.IO as IOUtil
 import qualified Wasp.Util.Terminal as Term
 import qualified Wasp.Version as WV
 
 data ProjectInfo = ProjectInfo
   { _projectName :: String,
-    _appName :: String
+    _appName :: String,
+    _template :: Maybe String
   }
 
-createNewProject :: String -> Command ()
-createNewProject projectNameCandidate = do
-  projectInfo <- parseProjectInfo projectNameCandidate
+createNewProject :: [String] -> Command ()
+createNewProject newArgs = do
+  projectInfo <- parseProjectInfo newArgs
   createWaspProjectDir projectInfo
   liftIO $ printGettingStartedInstructions $ _projectName projectInfo
   where
@@ -40,12 +51,16 @@ createNewProject projectNameCandidate = do
       putStrLn $ Term.applyStyles [Term.Bold] ("    cd " ++ projectName)
       putStrLn $ Term.applyStyles [Term.Bold] "    wasp start"
 
--- Takes a project name String
--- Returns either the ProjectInfo type that contains both the Project name
--- and the App name (which might be the same), or an error describing why the name is invalid
-parseProjectInfo :: String -> Command ProjectInfo
-parseProjectInfo name
-  | isValidWaspIdentifier appName = return $ ProjectInfo name appName
+parseProjectInfo :: [String] -> Command ProjectInfo
+parseProjectInfo newArgs = case newArgs of
+  [projectName] -> createProjectInfo projectName Nothing
+  [projectName, templateFlag, templateName] | templateFlag `elem` ["--template", "-t"] -> createProjectInfo projectName (Just templateName)
+  [_, templateFlag] | templateFlag `elem` ["--template", "-t"] -> throwProjectCreationError "You must provide a template name."
+  _anyOtherArgs -> throwProjectCreationError "Invalid arguments for 'wasp new' command."
+
+createProjectInfo :: String -> Maybe String -> Command ProjectInfo
+createProjectInfo name template
+  | isValidWaspIdentifier appName = return $ ProjectInfo {_projectName = name, _appName = appName, _template = template}
   | otherwise =
       throwProjectCreationError $
         intercalate
@@ -59,17 +74,26 @@ parseProjectInfo name
     appName = kebabToCamelCase name
 
 createWaspProjectDir :: ProjectInfo -> Command ()
-createWaspProjectDir projectInfo = do
+createWaspProjectDir projectInfo@ProjectInfo {_template = template} = do
   absWaspProjectDir <- getAbsoluteWaspProjectDir projectInfo
   dirExists <- doesDirExist $ toPathAbsDir absWaspProjectDir
-  if dirExists
-    then throwProjectCreationError $ show absWaspProjectDir ++ " is an existing directory"
-    else liftIO $ do
-      initializeProjectFromSkeleton absWaspProjectDir
-      writeMainWaspFile absWaspProjectDir projectInfo
+
+  when
+    dirExists
+    $ throwProjectCreationError
+    $ show absWaspProjectDir ++ " is an existing directory"
+
+  createProjectFromProjectInfo absWaspProjectDir
+  where
+    createProjectFromProjectInfo absWaspProjectDir = do
+      if isJust template
+        then createProjectFromTemplate absWaspProjectDir projectInfo
+        else liftIO $ do
+          initializeProjectFromSkeleton absWaspProjectDir
+          writeMainWaspFile absWaspProjectDir projectInfo
 
 getAbsoluteWaspProjectDir :: ProjectInfo -> Command (Path System Abs (Dir WaspProjectDir))
-getAbsoluteWaspProjectDir (ProjectInfo projectName _) = do
+getAbsoluteWaspProjectDir (ProjectInfo projectName _ _) = do
   absCwd <- liftIO getCurrentDirectory
   case parseAbsDir $ absCwd FP.</> projectName of
     Right sp -> return sp
@@ -85,14 +109,14 @@ initializeProjectFromSkeleton absWaspProjectDir = do
   copyDirRecur (toPathAbsDir absSkeletonDir) (toPathAbsDir absWaspProjectDir)
 
 writeMainWaspFile :: Path System Abs (Dir WaspProjectDir) -> ProjectInfo -> IO ()
-writeMainWaspFile waspProjectDir (ProjectInfo projectName appName) = IOUtil.writeFile absMainWaspFile mainWaspFileContent
+writeMainWaspFile waspProjectDir (ProjectInfo projectName appName _) = IOUtil.writeFile absMainWaspFile mainWaspFileContent
   where
     absMainWaspFile = waspProjectDir </> [relfile|main.wasp|]
     mainWaspFileContent =
       unlines
         [ "app %s {" `printf` appName,
           "  wasp: {",
-          "    version: \"^%s\"" `printf` show WV.waspVersion,
+          "    version: \"%s\"" `printf` waspVersionStr,
           "  },",
           "  title: \"%s\"" `printf` projectName,
           "}",
@@ -102,6 +126,72 @@ writeMainWaspFile waspProjectDir (ProjectInfo projectName appName) = IOUtil.writ
           "  component: import Main from \"@client/MainPage.jsx\"",
           "}"
         ]
+
+createProjectFromTemplate :: Path System Abs (Dir WaspProjectDir) -> ProjectInfo -> Command ()
+createProjectFromTemplate absWaspProjectDir ProjectInfo {_appName = appName, _projectName = projectName, _template = maybeTemplateName} = do
+  cliSendMessageC $ Msg.Start "Creating project from template..."
+
+  dirWhereProjectIsCreated <- getDirWhereProjectIsCreated
+  templatePath <- getPathToRemoteTemplate maybeTemplateName
+
+  let projectDir = projectName
+
+  fetchTemplate templatePath projectDir dirWhereProjectIsCreated
+  ensureTemplateWasFetched
+
+  replacePlaceholdersInWaspFile
+  where
+    getDirWhereProjectIsCreated :: Command (Path System Abs (Dir dir))
+    getDirWhereProjectIsCreated = do
+      (liftIO getCurrentDirectory <&> parseAbsDir) >>= \case
+        Left err -> throwProjectCreationError $ "Failed to parse absolute path to current working directory: " ++ show err
+        Right result -> return result
+
+    getPathToRemoteTemplate :: Maybe String -> Command String
+    getPathToRemoteTemplate = \case
+      Just templateName -> return $ waspTemplatesRepo ++ "/" ++ templateName
+      Nothing -> throwProjectCreationError "Template name is not provided."
+      where
+        -- gh: prefix means Github repo
+        waspTemplatesRepo = "gh:wasp-lang/starters"
+
+    fetchTemplate :: String -> String -> Path System Abs (Dir dir) -> Command ()
+    fetchTemplate templatePath projectDir dirWhereProjectIsCreated = do
+      liftIO executeCmd >>= \case
+        ExitSuccess -> return ()
+        ExitFailure _ -> throwProjectCreationError "Failed to create project from template."
+      where
+        executeCmd = newChan >>= runNodeCommandAsJob dirWhereProjectIsCreated "npx" args J.Cli
+        args = ["giget@latest", templatePath, projectDir]
+
+    -- gitget doesn't fail if the template dir doesn't exist in the repo, so we need to check if the directory exists.
+    ensureTemplateWasFetched :: Command ()
+    ensureTemplateWasFetched = do
+      whenM
+        (liftIO $ IOUtil.isDirectoryEmpty absWaspProjectDir)
+        $ throwProjectCreationError "Are you sure that the template exists? 🤔 Check the list of templates here: https://github.com/wasp-lang/starters"
+
+    replacePlaceholdersInWaspFile :: Command ()
+    replacePlaceholdersInWaspFile = liftIO $ do
+      mainWaspFileContent <- IOUtil.readFileStrict absMainWaspFile
+
+      let replacedContent =
+            foldl
+              (\acc (placeholder, value) -> T.replace (T.pack placeholder) (T.pack value) acc)
+              mainWaspFileContent
+              placeholders
+
+      IOUtil.writeFileFromText absMainWaspFile replacedContent
+      where
+        absMainWaspFile = absWaspProjectDir </> [relfile|main.wasp|]
+        placeholders =
+          [ ("__waspAppName__", appName),
+            ("__waspProjectName__", projectName),
+            ("__waspVersion__", waspVersionStr)
+          ]
+
+waspVersionStr :: String
+waspVersionStr = "^%s" `printf` show WV.waspVersion
 
 throwProjectCreationError :: String -> Command a
 throwProjectCreationError = throwError . CommandError "Project creation failed"

--- a/waspc/src/Wasp/Generator/Job.hs
+++ b/waspc/src/Wasp/Generator/Job.hs
@@ -28,4 +28,4 @@ data JobMessageData
 
 data JobOutputType = Stdout | Stderr deriving (Show, Eq)
 
-data JobType = WebApp | Server | Db deriving (Show, Eq, Ord, Bounded, Enum)
+data JobType = WebApp | Server | Db | Cli deriving (Show, Eq, Ord, Bounded, Enum)

--- a/waspc/src/Wasp/Generator/Job/IO/PrefixedWriter.hs
+++ b/waspc/src/Wasp/Generator/Job/IO/PrefixedWriter.hs
@@ -173,6 +173,7 @@ makeJobMessagePrefix jobMsg =
     J.Server -> T.pack $ Term.applyStyles [Term.Magenta] "Server"
     J.WebApp -> T.pack $ Term.applyStyles [Term.Cyan] "Web app"
     J.Db -> T.pack $ Term.applyStyles [Term.Blue] "Db"
+    J.Cli -> T.pack $ Term.applyStyles [Term.White] "Cli"
     <> ( if getJobMessageOutHandle jobMsg == stderr
            then T.pack $ Term.applyStyles [Term.Yellow] "(stderr)"
            else ""

--- a/waspc/src/Wasp/Generator/NpmInstall.hs
+++ b/waspc/src/Wasp/Generator/NpmInstall.hs
@@ -128,6 +128,7 @@ installNpmDependencies projectDir = do
               J.WebApp -> go (True, isServerDone) chan
               J.Server -> go (isWebAppDone, True) chan
               J.Db -> error "This should never happen. No db job should be active."
+              J.Cli -> error "This should never happen. No cli job should be active."
 
     setupFailedMessage (serverExitCode, webAppExitCode) =
       let serverErrorMessage = case serverExitCode of

--- a/waspc/src/Wasp/Util/IO.hs
+++ b/waspc/src/Wasp/Util/IO.hs
@@ -10,6 +10,8 @@ module Wasp.Util.IO
     readFileStrict,
     writeFile,
     removeFile,
+    isDirectoryEmpty,
+    writeFileFromText,
   )
 where
 
@@ -99,5 +101,13 @@ readFileStrict = T.IO.readFile . SP.toFilePath
 writeFile :: Path' Abs (File f) -> String -> IO ()
 writeFile = P.writeFile . SP.fromAbsFile
 
+writeFileFromText :: Path' Abs (File f) -> Text -> IO ()
+writeFileFromText = T.IO.writeFile . SP.fromAbsFile
+
 removeFile :: Path' Abs (File f) -> IO ()
 removeFile = SD.removeFile . SP.fromAbsFile
+
+isDirectoryEmpty :: Path' Abs (Dir d) -> IO Bool
+isDirectoryEmpty dirPath = do
+  (files, dirs) <- listDirectory dirPath
+  return $ null files && null dirs


### PR DESCRIPTION
Adds the `--template <name>` option to the `wasp new` command which uses [gitget](https://github.com/unjs/giget) under the hood to fetch templates from the https://github.com/wasp-lang/starters repository.

### How it works
1. The `<name>` represents the folder name in the repo.
2. After we fetch the template we replace some placeholders
    - replacing `__waspProjectName__`, `__waspAppName__` with user provided info (like we did with the regular `wasp new` commend)
    - replacing `__waspVersion__` with current version

### Templates
We can add new templates all the time to the repo and users will be able to use them via the Wasp CLI.
