### PR TITLE
Adds input padding for Auth UI

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/auth/forms/Auth.tsx
+++ b/waspc/data/Generator/templates/react-app/src/auth/forms/Auth.tsx
@@ -155,6 +155,8 @@ const FormInput = styled('input', {
 
   paddingTop: '0.375rem',
   paddingBottom: '0.375rem',
+  paddingLeft: '0.75rem',
+  paddingRight: '0.75rem',
 
   marginTop: '0.5rem'
 })


### PR DESCRIPTION
We were missing horizontal padding. I've used the defaults that Tailwind uses.

### Before

<img width="649" alt="Screenshot 2023-04-11 at 18 28 49" src="https://user-images.githubusercontent.com/2223680/231228280-17bc8d17-1b45-46c1-867d-f1f9101bf93d.png">

### After

<img width="798" alt="Screenshot 2023-04-11 at 18 27 37" src="https://user-images.githubusercontent.com/2223680/231228143-7455cfc8-319f-49dd-a61b-2666fb3302e0.png">
