### PR TITLE
Adds building of `examples/todoApp` to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,11 @@ jobs:
       - name: Run tests
         run: cabal test
 
+      - name: Ensure todoApp builds
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
+        run: |
+          ./tools/ensure_todoapp_builds.sh
+
       - name: Create binary package (Unix)
         if: startsWith(github.ref, 'refs/tags/v') && (matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest')
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,8 +131,7 @@ jobs:
 
       - name: Ensure todoApp builds
         if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
-        run: |
-          ./tools/ensure_todoapp_builds.sh
+        run: ./tools/ensure_todoapp_builds.sh
 
       - name: Create binary package (Unix)
         if: startsWith(github.ref, 'refs/tags/v') && (matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest')

--- a/waspc/data/Generator/templates/react-app/src/auth/forms/Auth.tsx
+++ b/waspc/data/Generator/templates/react-app/src/auth/forms/Auth.tsx
@@ -461,7 +461,7 @@ const ResetPasswordForm = (
     event.preventDefault()
 
     if (!token) {
-      setErrorMessage({ title: 'The token is missing from the URL. Please check the link you received in your email.' })
+      setErrorMessage({ 'The token is missing from the URL. Please check the link you received in your email.' })
       return
     }
 

--- a/waspc/data/Generator/templates/react-app/src/auth/forms/Auth.tsx
+++ b/waspc/data/Generator/templates/react-app/src/auth/forms/Auth.tsx
@@ -461,7 +461,7 @@ const ResetPasswordForm = (
     event.preventDefault()
 
     if (!token) {
-      setErrorMessage({ 'The token is missing from the URL. Please check the link you received in your email.' })
+      setErrorMessage({ title: 'The token is missing from the URL. Please check the link you received in your email.' })
       return
     }
 

--- a/waspc/tools/ensure_todoapp_builds.sh
+++ b/waspc/tools/ensure_todoapp_builds.sh
@@ -22,6 +22,6 @@ echo "Ensure client builds"
 cd .wasp/build/web-app
 npm run build
 
-echo "Ensure server builds""
+echo "Ensure server builds"
 cd ../server
 npm run build

--- a/waspc/tools/ensure_todoapp_builds.sh
+++ b/waspc/tools/ensure_todoapp_builds.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+
+# Compiles the todoApp and checks `npm run build` on both client and server.
+
+# Gets the directory of where this script lives.
+dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+echo "Running ensure_todoapp_builds.sh from $dir"
+
+cd "$dir/../examples/todoApp"
+echo "cd into $(pwd)"
+
+# Compile example app.
+WASP_BINARY_PATH="$(cabal list-bin wasp-cli)"
+CABAL_PROJECT_ROOT_PATH="$(cabal list-bin wasp-cli | sed s/\\/dist-newstyle.*//)"
+WASP_COMMAND="waspc_datadir=$CABAL_PROJECT_ROOT_PATH/data $WASP_BINARY_PATH"
+echo "Wasp command: $WASP_COMMAND"
+
+eval "$WASP_COMMAND build"
+
+# Make sure they build.
+echo "Ensure client builds"
+cd .wasp/build/web-app
+npm run build
+
+echo "Ensure server builds""
+cd ../server
+npm run build

--- a/waspc/tools/ensure_todoapp_builds.sh
+++ b/waspc/tools/ensure_todoapp_builds.sh
@@ -1,21 +1,17 @@
 #!/bin/sh -e
 
 # Compiles the todoApp and checks `npm run build` on both client and server.
+# This helps us out in CI since Vite won't typecheck locally. So we want to
+# make sure we don't accidentally add anything that causes `tsc` to error out.
 
 # Gets the directory of where this script lives.
 dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 echo "Running ensure_todoapp_builds.sh from $dir"
 
 cd "$dir/../examples/todoApp"
-echo "cd into $(pwd)"
 
 # Compile example app.
-WASP_BINARY_PATH="$(cabal list-bin wasp-cli)"
-CABAL_PROJECT_ROOT_PATH="$(cabal list-bin wasp-cli | sed s/\\/dist-newstyle.*//)"
-WASP_COMMAND="waspc_datadir=$CABAL_PROJECT_ROOT_PATH/data $WASP_BINARY_PATH"
-echo "Wasp command: $WASP_COMMAND"
-
-eval "$WASP_COMMAND build"
+cabal run wasp-cli build
 
 # Make sure they build.
 echo "Ensure client builds"


### PR DESCRIPTION
### Description

Adds building of `examples/todoApp` to CI. This should help catch any TS errors.

Example of a build failure: https://github.com/wasp-lang/wasp/actions/runs/4734719184/jobs/8404025469 (this was what would have happened on `main` before the fix was made).

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
