### PR TITLE
Fixes Haskell list to JS array utility

### DIFF
--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -130,7 +130,7 @@
             "file",
             "server/src/auth/providers/config/google.ts"
         ],
-        "7fbd4267706f1ce75574392c4b763917b7d574554db6966cacb9bac29abcf3df"
+        "ff060f3cb2437755867b9548dce153bd38b985dc3fc102073bd698d3d7fa23a7"
     ],
     [
         [
@@ -557,7 +557,7 @@
             "file",
             "web-app/src/actions/MySpecialAction.ts"
         ],
-        "5bcc78e0debb14c6af4572fe1c7512e8128f0d66c7bb80bd606cab014e6df8ec"
+        "32410f3702d0f04f19b6c6f84f827dc208eb63b7dce062385e388601ddfc72cf"
     ],
     [
         [
@@ -690,7 +690,7 @@
             "file",
             "web-app/src/auth/useAuth.ts"
         ],
-        "e3cd75c8a68c29a17a9ca5c5c8e86c03229c2323cf62cbaf70519fe8001cefa4"
+        "8d4051f75e47c6bfa1d44ef2ecf252e38988795c1a8b795cdf5ca3c7a1ac065d"
     ],
     [
         [
@@ -788,7 +788,7 @@
             "file",
             "web-app/src/queries/MySpecialQuery.ts"
         ],
-        "cf9bc21326f94f4359c66a373324290d73c6b71ff335210b7fddfa3afaa062d6"
+        "2d1424a21683c9c6a2facbd60ede45a90bc7b4deb04b04c8e0d955a140eb3d9d"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/auth/providers/config/google.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/auth/providers/config/google.ts
@@ -11,7 +11,7 @@ const _waspUserDefinedConfigFn = undefined
 const _waspOAuthConfig: OAuthConfig = {
     clientID: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    scope: ['"profile"'],
+    scope: ['profile'],
 };
 
 const _waspConfig: ProviderConfig = {

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/actions/MySpecialAction.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/actions/MySpecialAction.ts
@@ -3,7 +3,7 @@ import { MySpecialAction } from '../../../server/src/actions/MySpecialAction'
 
 const action = createAction<MySpecialAction>(
   'operations/my-special-action',
-  ['"User"'],
+  ['User'],
 )
 
 export default action

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/auth/useAuth.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/auth/useAuth.ts
@@ -32,7 +32,7 @@ function createUserGetter() {
   addMetadataToQuery(getMe, {
     relativeQueryPath: getMeRelativePath,
     queryRoute: getMeRoute,
-    entitiesUsed: ['"User"'],
+    entitiesUsed: ['User'],
   })
 
   return getMe

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/queries/MySpecialQuery.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/queries/MySpecialQuery.ts
@@ -4,7 +4,7 @@ import { MySpecialQuery } from '../../../server/src/queries/MySpecialQuery'
 
 const query = createQuery<MySpecialQuery>(
   'operations/my-special-query',
-  ['"User"'],
+  ['User'],
 )
 
 export default query

--- a/waspc/src/Wasp/Generator/Common.hs
+++ b/waspc/src/Wasp/Generator/Common.hs
@@ -83,7 +83,7 @@ makeJsonWithEntityData name =
     entityNameToPrismaIdentifier :: String -> String
     entityNameToPrismaIdentifier = toLowerFirst
 
-makeJsArrayFromHaskellList :: Show a => [a] -> String
+makeJsArrayFromHaskellList :: [String] -> String
 makeJsArrayFromHaskellList list = "[" ++ intercalate ", " listOfJsStrings ++ "]"
   where
-    listOfJsStrings = map (\x -> "'" ++ show x ++ "'") list
+    listOfJsStrings = map (\s -> "'" ++ s ++ "'") list

--- a/waspc/test/Generator/CommonTest.hs
+++ b/waspc/test/Generator/CommonTest.hs
@@ -1,0 +1,15 @@
+module Generator.CommonTest where
+
+import Test.Tasty.Hspec
+import Wasp.Generator.Common (makeJsArrayFromHaskellList)
+
+spec_GeneratorCommonTest :: Spec
+spec_GeneratorCommonTest = do
+  describe "makeJsArrayFromHaskellList" $ do
+    it "creates an empty JS array from empty Haskell list" $ do
+      makeJsArrayFromHaskellList []
+        `shouldBe` "[]"
+
+    it "creates an array of strings from Haskell list of strings" $ do
+      makeJsArrayFromHaskellList ["one", "two", "three"]
+        `shouldBe` "['one', 'two', 'three']"

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -471,6 +471,7 @@ test-suite waspc-test
     Generator.WebAppGeneratorTest
     Generator.WriteFileDraftsTest
     Generator.JsImportTest
+    Generator.CommonTest
     Psl.Common.ModelTest
     Psl.Generator.ModelTest
     Psl.Parser.ModelTest


### PR DESCRIPTION
Notice that we have double quotes around User and profile (we generate these JS arrays in Haskell) 
```ts
const query = createQuery<GetUsers>(
  'operations/get-users',
  ['"User"'],
)
```
```ts
const _waspOAuthConfig: OAuthConfig = {
    clientID: process.env.GOOGLE_CLIENT_ID,
    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
    scope: ['"profile"'],
};
```