### PR TITLE
Updates imports for throwInvalidCredentialsError

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## v0.10.3
 
+### Bug fixes
+- Fixed a bug with circular imports in JS code which prevented database seeding from working properly.
+
 ### Express middleware customization
 We now offer the ability to customize Express middleware:
 - globally (impacting all actions, queries, and apis by default)

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/login.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/login.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
-import { verifyPassword } from "../../../core/auth.js";
-import { findUserBy, createAuthToken, ensureValidEmailAndPassword, throwInvalidCredentialsError } from "../../utils.js";
+import { verifyPassword, throwInvalidCredentialsError } from "../../../core/auth.js";
+import { findUserBy, createAuthToken, ensureValidEmailAndPassword } from "../../utils.js";
 
 export function getLoginRoute({
     allowUnverifiedLogin,

--- a/waspc/data/Generator/templates/server/src/auth/providers/local/login.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/local/login.ts
@@ -1,8 +1,8 @@
 {{={= =}=}}
-import { verifyPassword } from '../../../core/auth.js'
+import { verifyPassword, throwInvalidCredentialsError } from '../../../core/auth.js'
 import { handleRejection } from '../../../utils.js'
 
-import { findUserBy, createAuthToken, throwInvalidCredentialsError } from '../../utils.js'
+import { findUserBy, createAuthToken } from '../../utils.js'
 
 export default handleRejection(async (req, res) => {
   const args = req.body || {}

--- a/waspc/data/Generator/templates/server/src/auth/utils.ts
+++ b/waspc/data/Generator/templates/server/src/auth/utils.ts
@@ -206,10 +206,6 @@ function validate(args: unknown, validators: { validates: string, message: strin
 }
 {=/ isEmailAuthEnabled =}
 
-export function throwInvalidCredentialsError(message?: string): void {
-  throw new HttpError(401, 'Invalid credentials', { message })
-}
-
 function rethrowPossiblePrismaError(e: unknown): void {
   if (e instanceof AuthError) {
     throwValidationError(e.message);

--- a/waspc/data/Generator/templates/server/src/core/auth.js
+++ b/waspc/data/Generator/templates/server/src/core/auth.js
@@ -7,7 +7,6 @@ import { randomInt } from 'node:crypto'
 import prisma from '../dbClient.js'
 import { handleRejection } from '../utils.js'
 import config from '../config.js'
-import { throwInvalidCredentialsError } from '../auth/utils.js'
 
 const jwtSign = util.promisify(jwt.sign)
 const jwtVerify = util.promisify(jwt.verify)
@@ -119,6 +118,10 @@ async function findAvailableUsername(potentialUsernames) {
   }
 
   return availableUsernames[0]
+}
+
+export function throwInvalidCredentialsError(message) {
+  throw new HttpError(401, 'Invalid credentials', { message })
 }
 
 export default auth

--- a/waspc/data/Generator/templates/server/src/routes/auth/me.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/me.js
@@ -1,7 +1,7 @@
 {{={= =}=}}
 import { serialize as superjsonSerialize } from 'superjson'
 import { handleRejection } from '../../utils.js'
-import { throwInvalidCredentialsError } from '../../auth/utils.js'
+import { throwInvalidCredentialsError } from '../../core/auth.js'
 
 export default handleRejection(async (req, res) => {
   if (req.{= userEntityLower =}) {

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "server/src/auth/utils.ts"
         ],
-        "cc5c7e899b9e4389999748f19177f8a392098279f19d99875d09986334d173c8"
+        "4b57bc76321dbc5708ae28aeffb6e6402e06517221e2044cf3712b16e124a4ff"
     ],
     [
         [
@@ -207,7 +207,7 @@
             "file",
             "server/src/core/auth.js"
         ],
-        "0ea7ff5b8576c4bd455328a56d60a038c1107eaa2e20cba28437cdfc630ce571"
+        "c825afbf6e6be7c694a99bb3dde2641b20891b7c6e33e798d042e86a6a05ecf1"
     ],
     [
         [
@@ -424,7 +424,7 @@
             "file",
             "server/src/routes/auth/me.js"
         ],
-        "9a9cb533bb94af63caf448f73a0d0fef8902c8f8d1af411bed2570a32da2fab9"
+        "705f77d8970a8367981c9a89601c6d5b12e998c23970ae1735b376dd0826ef10"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/auth/utils.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/auth/utils.ts
@@ -61,10 +61,6 @@ export async function doFakeWork() {
 }
 
 
-export function throwInvalidCredentialsError(message?: string): void {
-  throw new HttpError(401, 'Invalid credentials', { message })
-}
-
 function rethrowPossiblePrismaError(e: unknown): void {
   if (e instanceof AuthError) {
     throwValidationError(e.message);

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/core/auth.js
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/core/auth.js
@@ -6,7 +6,6 @@ import { randomInt } from 'node:crypto'
 import prisma from '../dbClient.js'
 import { handleRejection } from '../utils.js'
 import config from '../config.js'
-import { throwInvalidCredentialsError } from '../auth/utils.js'
 
 const jwtSign = util.promisify(jwt.sign)
 const jwtVerify = util.promisify(jwt.verify)
@@ -118,6 +117,10 @@ async function findAvailableUsername(potentialUsernames) {
   }
 
   return availableUsernames[0]
+}
+
+export function throwInvalidCredentialsError(message) {
+  throw new HttpError(401, 'Invalid credentials', { message })
 }
 
 export default auth

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/routes/auth/me.js
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/routes/auth/me.js
@@ -1,6 +1,6 @@
 import { serialize as superjsonSerialize } from 'superjson'
 import { handleRejection } from '../../utils.js'
-import { throwInvalidCredentialsError } from '../../auth/utils.js'
+import { throwInvalidCredentialsError } from '../../core/auth.js'
 
 export default handleRejection(async (req, res) => {
   if (req.user) {


### PR DESCRIPTION
It fixes the circular dependency issue we had.

This is the simplest solution I could come up with, moving the `throwInvalidCredentialsError` from `auth/utils.ts` to `core/auth.js`. -> this just highlights the need for a cleanup in auth code which we will do soon.

Side note: can we detect circular imports like this automatically? 