### PR TITLE
Hotfixes issues with HttpError import

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.10.4
+
+### Bug fixes
+- Adds missing import for HttpError which prevent auth from working properly.
+
 ## v0.10.3
 
 ### Bug fixes

--- a/waspc/data/Generator/templates/server/src/core/auth.js
+++ b/waspc/data/Generator/templates/server/src/core/auth.js
@@ -6,6 +6,7 @@ import { randomInt } from 'node:crypto'
 
 import prisma from '../dbClient.js'
 import { handleRejection } from '../utils.js'
+import HttpError from '../core/HttpError.js'
 import config from '../config.js'
 
 const jwtSign = util.promisify(jwt.sign)

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
@@ -1,7 +1,7 @@
 app waspBuild {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.10.3"
+    version: "^0.10.4"
   },
   title: "waspBuild"
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
@@ -1,6 +1,6 @@
 app waspCompile {
   wasp: {
-    version: "^0.10.3"
+    version: "^0.10.4"
   },
   title: "waspCompile"
 }

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -207,7 +207,7 @@
             "file",
             "server/src/core/auth.js"
         ],
-        "c825afbf6e6be7c694a99bb3dde2641b20891b7c6e33e798d042e86a6a05ecf1"
+        "89d2e6b1693deb9cc243efd0bf680513d0860475a2655ef487c684eb2574a92f"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/core/auth.js
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/server/src/core/auth.js
@@ -5,6 +5,7 @@ import { randomInt } from 'node:crypto'
 
 import prisma from '../dbClient.js'
 import { handleRejection } from '../utils.js'
+import HttpError from '../core/HttpError.js'
 import config from '../config.js'
 
 const jwtSign = util.promisify(jwt.sign)

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
@@ -1,7 +1,7 @@
 app waspComplexTest {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.10.3"
+    version: "^0.10.4"
   },
   auth: {
     userEntity: User,

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
@@ -1,7 +1,7 @@
 app waspJob {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.10.3"
+    version: "^0.10.4"
   },
   title: "waspJob"
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
@@ -1,6 +1,6 @@
 app waspMigrate {
   wasp: {
-    version: "^0.10.3"
+    version: "^0.10.4"
   },
   title: "waspMigrate"
 }

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
@@ -1,6 +1,6 @@
 app waspNew {
   wasp: {
-    version: "^0.10.3"
+    version: "^0.10.4"
   },
   title: "waspNew"
 }

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.10.3
+version:        0.10.4
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues


### PR DESCRIPTION
[waspc/data/Generator/templates/server/src/core/auth.js](https://github.com/wasp-lang/wasp/pull/1178/files#diff-cef9f57f4821af345822bbbd609521140ec9b3a0bcbc71ec1448ab9b5abd781d) was missing the `HttpError` import (introduced through a different bug fix here: https://github.com/wasp-lang/wasp/pull/1170)