### PR TITLE
Expose correct `User` type on the frontend

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/auth/types.ts
+++ b/waspc/data/Generator/templates/react-app/src/auth/types.ts
@@ -1,0 +1,2 @@
+// todo(filip): turn into a proper import/path
+export { type SanitizedUser as User } from '../../../server/src/_types/' 

--- a/waspc/data/Generator/templates/react-app/src/auth/useAuth.ts
+++ b/waspc/data/Generator/templates/react-app/src/auth/useAuth.ts
@@ -3,9 +3,9 @@ import { deserialize as superjsonDeserialize } from 'superjson'
 import { useQuery } from '../queries'
 import api, { handleApiError } from '../api'
 import { HttpMethod } from '../types'
-// todo(filip): turn into a proper import
-import { type SanitizedUser as User } from '../../../server/src/_types/' 
+import type { User } from './types' 
 import { addMetadataToQuery } from '../queries/core'
+
 
 export const getMe = createUserGetter()
 

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/files.manifest
@@ -102,6 +102,7 @@ waspComplexTest/.wasp/out/web-app/src/auth/helpers/user.ts
 waspComplexTest/.wasp/out/web-app/src/auth/logout.js
 waspComplexTest/.wasp/out/web-app/src/auth/pages/OAuthCodeExchange.jsx
 waspComplexTest/.wasp/out/web-app/src/auth/pages/createAuthRequiredPage.jsx
+waspComplexTest/.wasp/out/web-app/src/auth/types.ts
 waspComplexTest/.wasp/out/web-app/src/auth/useAuth.ts
 waspComplexTest/.wasp/out/web-app/src/config.js
 waspComplexTest/.wasp/out/web-app/src/entities/index.ts

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -709,9 +709,16 @@
     [
         [
             "file",
+            "web-app/src/auth/types.ts"
+        ],
+        "b6572845796b4217c142b855fc72652d5dfd67fd317b0ed5487fa70ba3d92219"
+    ],
+    [
+        [
+            "file",
             "web-app/src/auth/useAuth.ts"
         ],
-        "8d4051f75e47c6bfa1d44ef2ecf252e38988795c1a8b795cdf5ca3c7a1ac065d"
+        "f730cb58a5ebd12285b7568bec34f4e5615261580cff1727e64b5c871d784d62"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/auth/types.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/auth/types.ts
@@ -1,0 +1,2 @@
+// todo(filip): turn into a proper import/path
+export { type SanitizedUser as User } from '../../../server/src/_types/' 

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/auth/useAuth.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/auth/useAuth.ts
@@ -2,9 +2,9 @@ import { deserialize as superjsonDeserialize } from 'superjson'
 import { useQuery } from '../queries'
 import api, { handleApiError } from '../api'
 import { HttpMethod } from '../types'
-// todo(filip): turn into a proper import
-import { type SanitizedUser as User } from '../../../server/src/_types/' 
+import type { User } from './types' 
 import { addMetadataToQuery } from '../queries/core'
+
 
 export const getMe = createUserGetter()
 

--- a/waspc/examples/todoApp/src/client/pages/ProfilePage.tsx
+++ b/waspc/examples/todoApp/src/client/pages/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { User } from '@wasp/entities'
+import { User } from '@wasp/auth/types'
 import api from '@wasp/api'
 
 async function fetchCustomRoute() {

--- a/waspc/src/Wasp/Generator/WebAppGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/AuthG.hs
@@ -26,24 +26,22 @@ import Wasp.Util ((<++>))
 genAuth :: AppSpec -> Generator [FileDraft]
 genAuth spec =
   case maybeAuth of
+    Nothing -> return []
     Just auth ->
       sequence
-        [ genLogout,
+        [ copyTmplFile [relfile|auth/logout.js|],
+          copyTmplFile [relfile|auth/helpers/user.ts|],
+          copyTmplFile [relfile|auth/types.ts|],
           genUseAuth auth,
-          genCreateAuthRequiredPage auth,
-          genUserHelpers
+          genCreateAuthRequiredPage auth
         ]
         <++> genAuthForms auth
         <++> genLocalAuth auth
         <++> genOAuthAuth auth
         <++> genEmailAuth auth
-    Nothing -> return []
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
-
--- | Generates file with logout function to be used by Wasp developer.
-genLogout :: Generator FileDraft
-genLogout = return $ C.mkTmplFd (C.asTmplFile [relfile|src/auth/logout.js|])
+    copyTmplFile = return . C.mkSrcTmplFd
 
 -- | Generates HOC that handles auth for the given page.
 genCreateAuthRequiredPage :: AS.Auth.Auth -> Generator FileDraft
@@ -109,6 +107,3 @@ compileTmplToSamePath tmplFileInTmplSrcDir keyValuePairs =
     C.mkTmplFdWithData
       (asTmplFile $ [reldir|src|] </> tmplFileInTmplSrcDir)
       (object keyValuePairs)
-
-genUserHelpers :: Generator FileDraft
-genUserHelpers = return $ C.mkTmplFd (C.asTmplFile [relfile|src/auth/helpers/user.ts|])


### PR DESCRIPTION
Usage:
```typescript
import { User } from '@wasp/auth/types'

// ...

export const ProfilePage = ({ user }: { user: User }) => {
  // ...
}
```
I didn't change anything in the docs since they don't cover this feature properly anyway. We'll have to do a rewrite of that part.