### PR TITLE
Update react-query docs link

### DIFF
--- a/web/docs/language/features.md
+++ b/web/docs/language/features.md
@@ -1862,9 +1862,9 @@ export default async function mySetupFunction() {
 }
 ```
 
-Make sure to pass in an object expected by the `QueryClient`'s construcor, as
+Make sure to pass in an object expected by the `QueryClient`'s constructor, as
 explained in
-[_react-query_'s docs](https://react-query.tanstack.com/reference/QueryClient).
+[_react-query_'s docs](https://tanstack.com/query/v4/docs/react/reference/QueryClient).
 
 ## Server configuration
 


### PR DESCRIPTION
### Description

Update the link to the Tanstack query and fix the typo. In the `package.json` of `.wasp/out` directory, I noticed that Wasp is using version 4 of React Query, so the link is appropriate.

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
