### PR TITLE
Improve waspc node version checking and error messages

### DIFF
--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -31,8 +31,10 @@ import qualified Wasp.Cli.Command.Telemetry as Telemetry
 import Wasp.Cli.Command.Test (test)
 import Wasp.Cli.Command.Uninstall (uninstall)
 import Wasp.Cli.Command.WaspLS (runWaspLS)
+import Wasp.Cli.Message (cliSendMessage)
 import Wasp.Cli.Terminal (title)
 import qualified Wasp.Generator.Node.Version as NodeVersion
+import qualified Wasp.Message as Message
 import Wasp.Util (indent)
 import qualified Wasp.Util.Terminal as Term
 import Wasp.Version (waspVersion)
@@ -70,7 +72,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
   -- See https://github.com/wasp-lang/wasp/issues/1134#issuecomment-1554065668
   NodeVersion.checkNodeVersion >>= \case
     Left errorMsg -> do
-      putStrLn $ Term.applyStyles [Term.Red] errorMsg
+      cliSendMessage $ Message.Failure "Node requirement not met" errorMsg
       exitFailure
     Right _ -> pure ()
 

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -70,7 +70,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
   -- not needed for every command, but checking for every command was decided
   -- to be more robust than trying to only check for commands that require it.
   -- See https://github.com/wasp-lang/wasp/issues/1134#issuecomment-1554065668
-  NodeVersion.checkNodeVersion >>= \case
+  NodeVersion.getAndCheckNodeVersion >>= \case
     Left errorMsg -> do
       cliSendMessage $ Message.Failure "Node requirement not met" errorMsg
       exitFailure

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -8,6 +8,7 @@ import Data.Char (isSpace)
 import Data.List (intercalate)
 import Main.Utf8 (withUtf8)
 import System.Environment (getArgs)
+import System.Exit (exitFailure)
 import Wasp.Cli.Command (runCommand)
 import Wasp.Cli.Command.BashCompletion (bashCompletion, generateBashCompletionScript, printBashCompletionInstruction)
 import Wasp.Cli.Command.Build (build)
@@ -31,6 +32,7 @@ import Wasp.Cli.Command.Test (test)
 import Wasp.Cli.Command.Uninstall (uninstall)
 import Wasp.Cli.Command.WaspLS (runWaspLS)
 import Wasp.Cli.Terminal (title)
+import qualified Wasp.Generator.Node.Version as NodeVersion
 import Wasp.Util (indent)
 import qualified Wasp.Util.Terminal as Term
 import Wasp.Version (waspVersion)
@@ -61,6 +63,16 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
         _ -> Command.Call.Unknown args
 
   telemetryThread <- Async.async $ runCommand $ Telemetry.considerSendingData commandCall
+
+  -- Before calling any command, check that the node requirement is met. Node is
+  -- not needed for every command, but checking for every command was decided
+  -- to be more robust than trying to only check for commands that require it.
+  -- See https://github.com/wasp-lang/wasp/issues/1134#issuecomment-1554065668
+  NodeVersion.checkNodeVersion >>= \case
+    Left errorMsg -> do
+      putStrLn $ Term.applyStyles [Term.Red] errorMsg
+      exitFailure
+    Right _ -> pure ()
 
   case commandCall of
     Command.Call.New newArgs -> runCommand $ createNewProject newArgs
@@ -95,11 +107,11 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
     handleInternalErrors :: E.ErrorCall -> IO ()
     handleInternalErrors e = putStrLn $ "\nInternal Wasp error (bug in compiler):\n" ++ indent 2 (show e)
 
+{- ORMOLU_DISABLE -}
 printUsage :: IO ()
 printUsage =
   putStrLn $
     unlines
-{- ORMOLU_DISABLE -}
       [ title "USAGE",
               "  wasp <command> [command-args]",
               "",
@@ -165,11 +177,11 @@ dbCli args = case args of
   ["studio"] -> runDbCommand Command.Db.Studio.studio
   _ -> printDbUsage
 
+{- ORMOLU_DISABLE -}
 printDbUsage :: IO ()
 printDbUsage =
   putStrLn $
     unlines
-{- ORMOLU_DISABLE -}
       [ title "USAGE",
               "  wasp db <command> [command-args]",
               "",

--- a/waspc/src/Wasp/Generator/Job/Process.hs
+++ b/waspc/src/Wasp/Generator/Job/Process.hs
@@ -23,7 +23,6 @@ import qualified System.Process as P
 import UnliftIO.Exception (bracket)
 import qualified Wasp.Generator.Job as J
 import qualified Wasp.Generator.Node.Version as NodeVersion
-import qualified Wasp.SemanticVersion as SV
 
 -- TODO:
 --   Switch from Data.Conduit.Process to Data.Conduit.Process.Typed.

--- a/waspc/src/Wasp/Generator/Job/Process.hs
+++ b/waspc/src/Wasp/Generator/Job/Process.hs
@@ -96,7 +96,7 @@ runNodeCommandAsJob = runNodeCommandAsJobWithExtraEnv []
 
 runNodeCommandAsJobWithExtraEnv :: [(String, String)] -> Path' Abs (Dir a) -> String -> [String] -> J.JobType -> J.Job
 runNodeCommandAsJobWithExtraEnv extraEnvVars fromDir command args jobType chan =
-  NodeVersion.checkNodeVersion >>= \case
+  NodeVersion.getAndCheckNodeVersion >>= \case
     Left errorMsg -> exitWithError (ExitFailure 1) (T.pack errorMsg)
     Right _ -> do
       envVars <- getAllEnvVars

--- a/waspc/src/Wasp/Generator/Node/Version.hs
+++ b/waspc/src/Wasp/Generator/Node/Version.hs
@@ -1,5 +1,6 @@
 module Wasp.Generator.Node.Version
-  ( getNodeVersion,
+  ( checkNodeVersion,
+    getNodeVersion,
     nodeVersionRange,
     latestMajorNodeVersion,
     waspNodeRequirementMessage,
@@ -15,6 +16,25 @@ import qualified Text.Regex.TDFA as R
 import qualified Wasp.SemanticVersion as SV
 import Wasp.Util (indent)
 
+-- | Gets the installed node version, if any is installed, and checks that it
+-- meets Wasp's version requirement.
+--
+-- Returns a string representing the error
+-- condition if node's version could not be found or if the version does not
+-- meet the requirements.
+checkNodeVersion :: IO (Either String SV.Version)
+checkNodeVersion =
+  getNodeVersion >>= \case
+    Left errorMsg -> return $ Left errorMsg
+    Right nodeVersion ->
+      if SV.isVersionInRange nodeVersion nodeVersionRange
+        then return $ Right nodeVersion
+        else return $ Left $ makeNodeVersionMismatchMessage nodeVersion
+
+-- | Gets the installed node version, if any is installed, and returns it.
+--
+-- Returns a string representing the error condition if node's version could
+-- not be found.
 getNodeVersion :: IO (Either String SV.Version)
 getNodeVersion = do
   (exitCode, stdout, stderr) <-

--- a/waspc/src/Wasp/Generator/Node/Version.hs
+++ b/waspc/src/Wasp/Generator/Node/Version.hs
@@ -13,6 +13,7 @@ import qualified System.Process as P
 import Text.Read (readMaybe)
 import qualified Text.Regex.TDFA as R
 import qualified Wasp.SemanticVersion as SV
+import Wasp.Util (indent)
 
 getNodeVersion :: IO (Either String SV.Version)
 getNodeVersion = do
@@ -20,16 +21,17 @@ getNodeVersion = do
     P.readProcessWithExitCode "node" ["--version"] ""
       `catchIOError` ( \e ->
                          if isDoesNotExistError e
-                           then return (ExitFailure 1, "", "Command 'node' not found.")
-                           else ioError e
+                           then return (ExitFailure 1, "", nodeNotFoundMessage)
+                           else return (ExitFailure 1, "", nodeUnknownErrorMessage e)
                      )
   return $ case exitCode of
     ExitFailure _ ->
       Left
-        ( "Running 'node --version' failed: "
-            ++ stderr
-            ++ " "
-            ++ waspNodeRequirementMessage
+        ( unlines
+            [ "Running 'node --version' failed: ",
+              indent 2 stderr,
+              waspNodeRequirementMessage
+            ]
         )
     ExitSuccess -> case parseNodeVersion stdout of
       Nothing ->
@@ -49,11 +51,22 @@ parseNodeVersion nodeVersionStr =
       return $ SV.Version mjr mnr ptc
     _ -> Nothing
 
+nodeNotFoundMessage :: String
+nodeNotFoundMessage = "`node` command not found!"
+
+nodeUnknownErrorMessage :: IOError -> String
+nodeUnknownErrorMessage err =
+  unlines
+    [ "An unknown error occured while trying to run `node --version`:",
+      indent 2 $ show err,
+      "If `node` is installed and in PATH, this is most likely a bug in Wasp, please file an issue."
+    ]
+
 waspNodeRequirementMessage :: String
 waspNodeRequirementMessage =
   unwords
-    [ "Wasp requires node " ++ show nodeVersionRange ++ ".",
-      "Check Wasp docs for more details: https://wasp-lang.dev/docs/quick-start#requirements."
+    [ "Wasp requires node " ++ show nodeVersionRange ++ " to be installed and in PATH.",
+       "Check Wasp docs for more details: https://wasp-lang.dev/docs/quick-start#requirements."
     ]
 
 nodeVersionRange :: SV.Range
@@ -72,8 +85,10 @@ latestMajorNodeVersion = latestNodeLTSVersion
 
 makeNodeVersionMismatchMessage :: SV.Version -> String
 makeNodeVersionMismatchMessage nodeVersion =
-  unwords
-    [ "Your node version does not match Wasp's requirements.",
-      "You are running node " ++ show nodeVersion ++ ".",
+  unlines
+    [ unwords
+        [ "Your node version does not meet Wasp's requirements!",
+          "You are running node " ++ show nodeVersion ++ "."
+        ],
       waspNodeRequirementMessage
     ]

--- a/waspc/src/Wasp/Generator/Node/Version.hs
+++ b/waspc/src/Wasp/Generator/Node/Version.hs
@@ -66,7 +66,7 @@ waspNodeRequirementMessage :: String
 waspNodeRequirementMessage =
   unwords
     [ "Wasp requires node " ++ show nodeVersionRange ++ " to be installed and in PATH.",
-       "Check Wasp docs for more details: https://wasp-lang.dev/docs/quick-start#requirements."
+      "Check Wasp docs for more details: https://wasp-lang.dev/docs/quick-start#requirements."
     ]
 
 nodeVersionRange :: SV.Range

--- a/waspc/src/Wasp/Generator/Node/Version.hs
+++ b/waspc/src/Wasp/Generator/Node/Version.hs
@@ -1,5 +1,5 @@
 module Wasp.Generator.Node.Version
-  ( checkNodeVersion,
+  ( getAndCheckNodeVersion,
     getNodeVersion,
     nodeVersionRange,
     latestMajorNodeVersion,
@@ -22,8 +22,8 @@ import Wasp.Util (indent)
 -- Returns a string representing the error
 -- condition if node's version could not be found or if the version does not
 -- meet the requirements.
-checkNodeVersion :: IO (Either String SV.Version)
-checkNodeVersion =
+getAndCheckNodeVersion :: IO (Either String SV.Version)
+getAndCheckNodeVersion =
   getNodeVersion >>= \case
     Left errorMsg -> return $ Left errorMsg
     Right nodeVersion ->
@@ -45,7 +45,7 @@ getNodeVersion = do
       `catchIOError` ( \e ->
                          if isDoesNotExistError e
                            then return $ Left nodeNotFoundMessage
-                           else return $ Left $ nodeUnknownErrorMessage e
+                           else return $ Left $ makeNodeUnknownErrorMessage e
                      )
   return $ case nodeResult of
     Left procErr ->
@@ -84,8 +84,8 @@ parseNodeVersion nodeVersionStr =
 nodeNotFoundMessage :: String
 nodeNotFoundMessage = "`node` command not found!"
 
-nodeUnknownErrorMessage :: IOError -> String
-nodeUnknownErrorMessage err =
+makeNodeUnknownErrorMessage :: IOError -> String
+makeNodeUnknownErrorMessage err =
   unlines
     [ "An unknown error occured while trying to run `node --version`:",
       indent 2 $ show err

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -107,7 +107,7 @@ library
     , exceptions            ^>= 0.10.4
     , split                 ^>= 0.2.3
     , conduit-extra         ^>= 1.3.5
-    , process               ^>= 1.6.13
+    , process               ^>= 1.6.17
     , cryptohash-sha256     ^>= 0.11.102
     , mustache              ^>= 2.3.2
     , parsec                ^>= 3.1.14


### PR DESCRIPTION
### Description

> Describe your PR! If it fixes specific issue, mention it with "Fixes # (issue)".

- [X] Fixes weird IO error when node is missing on MacOS by changing minimum version of `process` (see discussion in #1134)
- [X] Improves error message if more weird IO errors happen when checking node's version
- [X] Improves error messages for node versions
- [X] Make node version check happen earlier and only once per CLI run

Fixes #1134

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [X] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
