### PR TITLE
Fixes new `flyctl launch` behavior

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.10.6
+
+### Bug fixes
+- `wasp deploy fly launch` now supports the latest `flyctl launch` toml file for the web client (which changed their default structure and port).
+
 ## v0.10.5
 
 ### Bug fixes

--- a/waspc/packages/deploy/src/providers/fly/setup/setup.ts
+++ b/waspc/packages/deploy/src/providers/fly/setup/setup.ts
@@ -70,8 +70,9 @@ async function setupClient(deploymentInfo: DeploymentInfo) {
 	// This creates the fly.toml file, but does not attempt to deploy.
 	await $`flyctl launch --no-deploy --name ${deploymentInfo.clientName} --region ${deploymentInfo.region}`;
 
-	// goStatic listens on port 8043 by default, but the default fly.toml assumes port 8080.
-	replaceLineInLocalToml(/internal_port = 8080/g, 'internal_port = 8043');
+	// goStatic listens on port 8043 by default, but the default fly.toml
+	// assumes port 8080 (or 3000, depending on flyctl version).
+	replaceLineInLocalToml(/internal_port = \d+/g, 'internal_port = 8043');
 
 	copyLocalClientTomlToProject(deploymentInfo.tomlFilePaths);
 


### PR DESCRIPTION
### Description

`flyctl` changed the toml file it generates during launch, including the `service_port` from 8080 to 3000. We update the port number of the client for `goStatic` to 8043, and this change broke Fly deploys on the latest version since we were unable to update it correctly.

#### Old Version

```toml
# fly.toml file generated for shayne-old-behavior on 2023-05-18T13:31:28-04:00

app = "shayne-old-behavior"
kill_signal = "SIGINT"
kill_timeout = 5
processes = []

[env]

[experimental]
  auto_rollback = true

[[services]]
  http_checks = []
  internal_port = 8080 👈
  processes = ["app"]
  protocol = "tcp"
  script_checks = []
  [services.concurrency]
    hard_limit = 25
    soft_limit = 20
    type = "connections"

  [[services.ports]]
    force_https = true
    handlers = ["http"]
    port = 80

  [[services.ports]]
    handlers = ["tls", "http"]
    port = 443

  [[services.tcp_checks]]
    grace_period = "1s"
    interval = "15s"
    restart_limit = 0
    timeout = "2s"
```

#### New Version

```toml
# fly.toml app configuration file generated for shayne-new-behavior on 2023-05-18T13:30:59-04:00
#
# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
#

app = "shayne-new-behavior"
primary_region = "mia"

[http_service]
  internal_port = 3000 👈
  force_https = true
  auto_stop_machines = true
  auto_start_machines = true
  min_machines_running = 0
```

There are at least 2 obvious solutions:
1) Regex the crap outta it (like I am, but keep the port flexible now based on this PR)
2) Parse the toml and try to find the property in the "expected places", or just on any key recursively

The latter feels like a lot of work for something the regex should now be able to keep up with. 🤞🏻 

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [x] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [x] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
