### PR TITLE
Prep `main` for  v0.10.6

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -29,7 +29,6 @@ We now offer an interactive way to create a new project. You can run `wasp new` 
 ### Bug fixes
 - Adds missing import for HttpError which prevent auth from working properly.
 
-This should make it much easier to work with apis and to customize your Express app in general.
 ## v0.10.3
 
 ### Bug fixes

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
@@ -1,7 +1,7 @@
 app waspBuild {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.10.5"
+    version: "^0.10.6"
   },
   title: "waspBuild"
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
@@ -1,6 +1,6 @@
 app waspCompile {
   wasp: {
-    version: "^0.10.5"
+    version: "^0.10.6"
   },
   title: "waspCompile"
 }

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
@@ -1,7 +1,7 @@
 app waspComplexTest {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.10.5"
+    version: "^0.10.6"
   },
   auth: {
     userEntity: User,

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
@@ -1,7 +1,7 @@
 app waspJob {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.10.5"
+    version: "^0.10.6"
   },
   title: "waspJob"
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
@@ -1,6 +1,6 @@
 app waspMigrate {
   wasp: {
-    version: "^0.10.5"
+    version: "^0.10.6"
   },
   title: "waspMigrate"
 }

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
@@ -1,6 +1,6 @@
 app waspNew {
   wasp: {
-    version: "^0.10.5"
+    version: "^0.10.6"
   },
   title: "waspNew"
 }

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.10.5
+version:        0.10.6
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues


### PR DESCRIPTION
### Description

Preps `main` for  v0.10.6 with cabal file, changelog, and e2e updates.
