### PR TITLE
move `Wasp/Generator/Node/Version` to `Wasp/Node/Version`

### DIFF
--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -33,8 +33,8 @@ import Wasp.Cli.Command.Uninstall (uninstall)
 import Wasp.Cli.Command.WaspLS (runWaspLS)
 import Wasp.Cli.Message (cliSendMessage)
 import Wasp.Cli.Terminal (title)
-import qualified Wasp.Generator.Node.Version as NodeVersion
 import qualified Wasp.Message as Message
+import qualified Wasp.Node.Version as NodeVersion
 import Wasp.Util (indent)
 import qualified Wasp.Util.Terminal as Term
 import Wasp.Version (waspVersion)

--- a/waspc/src/Wasp/Generator/DockerGenerator.hs
+++ b/waspc/src/Wasp/Generator/DockerGenerator.hs
@@ -28,8 +28,8 @@ import Wasp.Generator.DbGenerator.Common
 import Wasp.Generator.FileDraft (FileDraft (..), createTemplateFileDraft)
 import qualified Wasp.Generator.FileDraft.TemplateFileDraft as TmplFD
 import Wasp.Generator.Monad (Generator, GeneratorError, runGenerator)
-import Wasp.Generator.Node.Version (latestMajorNodeVersion)
 import Wasp.Generator.Templates (TemplatesDir, compileAndRenderTemplate)
+import Wasp.Node.Version (latestMajorNodeVersion)
 import qualified Wasp.SemanticVersion as SV
 import Wasp.Util (getEnvVarDefinition)
 

--- a/waspc/src/Wasp/Generator/Job/Process.hs
+++ b/waspc/src/Wasp/Generator/Job/Process.hs
@@ -22,7 +22,7 @@ import qualified System.Info
 import qualified System.Process as P
 import UnliftIO.Exception (bracket)
 import qualified Wasp.Generator.Job as J
-import qualified Wasp.Generator.Node.Version as NodeVersion
+import qualified Wasp.Node.Version as NodeVersion
 
 -- TODO:
 --   Switch from Data.Conduit.Process to Data.Conduit.Process.Typed.

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -50,7 +50,6 @@ import Wasp.Generator.Common
 import Wasp.Generator.ExternalCodeGenerator (genExternalCodeDir)
 import Wasp.Generator.FileDraft (FileDraft, createTextFileDraft)
 import Wasp.Generator.Monad (Generator)
-import qualified Wasp.Generator.Node.Version as NodeVersion
 import qualified Wasp.Generator.NpmDependencies as N
 import Wasp.Generator.ServerGenerator.ApiRoutesG (genApis)
 import Wasp.Generator.ServerGenerator.Auth.OAuthAuthG (depsRequiredByPassport)
@@ -64,6 +63,7 @@ import Wasp.Generator.ServerGenerator.JobGenerator (depsRequiredByJobs, genJobEx
 import Wasp.Generator.ServerGenerator.JsImport (extImportToImportJson, getAliasedJsImportStmtAndIdentifier)
 import Wasp.Generator.ServerGenerator.OperationsG (genOperations)
 import Wasp.Generator.ServerGenerator.OperationsRoutesG (genOperationsRoutes)
+import qualified Wasp.Node.Version as NodeVersion
 import Wasp.Project.Db (databaseUrlEnvVarName)
 import Wasp.SemanticVersion (major)
 import Wasp.Util (toLowerFirst, (<++>))

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -35,7 +35,6 @@ import qualified Wasp.Generator.ConfigFile as G.CF
 import Wasp.Generator.ExternalCodeGenerator (genExternalCodeDir)
 import Wasp.Generator.FileDraft
 import Wasp.Generator.Monad (Generator)
-import qualified Wasp.Generator.Node.Version as NodeVersion
 import qualified Wasp.Generator.NpmDependencies as N
 import Wasp.Generator.WebAppGenerator.AuthG (genAuth)
 import qualified Wasp.Generator.WebAppGenerator.Common as C
@@ -46,6 +45,7 @@ import Wasp.Generator.WebAppGenerator.ExternalCodeGenerator
 import Wasp.Generator.WebAppGenerator.JsImport (extImportToImportJson)
 import Wasp.Generator.WebAppGenerator.OperationsGenerator (genOperations)
 import Wasp.Generator.WebAppGenerator.RouterGenerator (genRouter)
+import qualified Wasp.Node.Version as NodeVersion
 import qualified Wasp.SemanticVersion as SV
 import Wasp.Util ((<++>))
 

--- a/waspc/src/Wasp/Node/Version.hs
+++ b/waspc/src/Wasp/Node/Version.hs
@@ -1,4 +1,4 @@
-module Wasp.Generator.Node.Version
+module Wasp.Node.Version
   ( getAndCheckNodeVersion,
     getNodeVersion,
     nodeVersionRange,

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -252,7 +252,6 @@ library
     Wasp.Generator.AuthProviders.OAuth
     Wasp.Generator.AuthProviders.Local
     Wasp.Generator.AuthProviders.Email
-    Wasp.Generator.Node.Version
     Wasp.Generator.ServerGenerator
     Wasp.Generator.ServerGenerator.JsImport
     Wasp.Generator.ServerGenerator.ApiRoutesG
@@ -291,6 +290,7 @@ library
     Wasp.Generator.WebAppGenerator.Start
     Wasp.Generator.WebAppGenerator.Test
     Wasp.Generator.WriteFileDrafts
+    Wasp.Node.Version
     Wasp.Project
     Wasp.Project.Analyze
     Wasp.Project.Common


### PR DESCRIPTION
Moves the `Wasp/Generator/Node/Version` to `Wasp/Node/Version` since now modules outside of Generator depend on Node's version.

As discussed in https://github.com/wasp-lang/wasp/pull/1210/files#r1206824035.