### PR TITLE
[waspls] Add dictionary autocomplete + signatures

### DIFF
--- a/waspc/examples/todoApp/todoApp.wasp
+++ b/waspc/examples/todoApp/todoApp.wasp
@@ -42,7 +42,7 @@ app todoApp {
   },
   server: {
     setupFn: import setup from "@server/serverSetup.js",
-    middlewareConfigFn: import { serverMiddlewareFn } from "@server/serverSetup.js"
+    middlewareConfigFn: import { serverMiddlewareFn } from "@server/serverSetup.js",
   },
   client: {
     rootComponent: import { App } from "@client/App.tsx",

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -349,6 +349,7 @@ library waspls
     , text
     , transformers ^>=0.5.6.2
     , utf8-string
+    , unordered-containers
     , waspc
 
 library cli-lib

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -330,6 +330,8 @@ library waspls
     Wasp.LSP.Handlers
     Wasp.LSP.Diagnostic
     Wasp.LSP.Completion
+    Wasp.LSP.Completions.Common
+    Wasp.LSP.Completions.ExprCompletion
     Wasp.LSP.Util
     Wasp.LSP.Syntax
   build-depends:

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -333,6 +333,7 @@ library waspls
     Wasp.LSP.Completions.Common
     Wasp.LSP.Completions.DictKeyCompletion
     Wasp.LSP.Completions.ExprCompletion
+    Wasp.LSP.SignatureHelp
     Wasp.LSP.Syntax
     Wasp.LSP.TypeHint
     Wasp.LSP.Util

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -333,8 +333,9 @@ library waspls
     Wasp.LSP.Completions.Common
     Wasp.LSP.Completions.DictKeyCompletion
     Wasp.LSP.Completions.ExprCompletion
-    Wasp.LSP.Util
     Wasp.LSP.Syntax
+    Wasp.LSP.TypeHint
+    Wasp.LSP.Util
   build-depends:
       base
     , aeson

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -331,6 +331,7 @@ library waspls
     Wasp.LSP.Diagnostic
     Wasp.LSP.Completion
     Wasp.LSP.Completions.Common
+    Wasp.LSP.Completions.DictKeyCompletion
     Wasp.LSP.Completions.ExprCompletion
     Wasp.LSP.Util
     Wasp.LSP.Syntax

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -335,7 +335,7 @@ library waspls
     Wasp.LSP.Completions.ExprCompletion
     Wasp.LSP.SignatureHelp
     Wasp.LSP.Syntax
-    Wasp.LSP.TypeHint
+    Wasp.LSP.TypeInference
     Wasp.LSP.Util
   build-depends:
       base

--- a/waspc/waspls/src/Wasp/LSP/Completion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completion.hs
@@ -10,6 +10,7 @@ import Control.Monad.State.Class (MonadState, gets)
 import qualified Language.LSP.Types as LSP
 import Wasp.Analyzer.Parser.CST.Traverse
 import Wasp.LSP.Completions.Common (CompletionContext (..), CompletionProvider)
+import qualified Wasp.LSP.Completions.DictKeyCompletion as DictKeyCompletion
 import qualified Wasp.LSP.Completions.ExprCompletion as ExprCompletion
 import Wasp.LSP.ServerState (ServerState, cst, currentWaspSource)
 import Wasp.LSP.Syntax (lspPositionToOffset, toOffset)
@@ -39,5 +40,6 @@ getCompletionsAtPosition position = do
 
 completionProviders :: (MonadReader CompletionContext m, MonadLog m) => [CompletionProvider m]
 completionProviders =
-  [ ExprCompletion.getCompletions
+  [ ExprCompletion.getCompletions,
+    DictKeyCompletion.getCompletions
   ]

--- a/waspc/waspls/src/Wasp/LSP/Completion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completion.hs
@@ -10,7 +10,7 @@ import Control.Monad.State.Class (MonadState, gets)
 import Data.List (sortOn)
 import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
-import Wasp.Analyzer.Parser.CST.Traverse
+import Wasp.Analyzer.Parser.CST.Traverse (fromSyntaxForest)
 import Wasp.LSP.Completions.Common (CompletionContext (..), CompletionProvider)
 import qualified Wasp.LSP.Completions.DictKeyCompletion as DictKeyCompletion
 import qualified Wasp.LSP.Completions.ExprCompletion as ExprCompletion
@@ -43,6 +43,8 @@ getCompletionsAtPosition position = do
             completionProviders
       return $ sortOn (^. LSP.label) completionItems
 
+-- | List of all 'CompletionProvider's to use. We break this up into separate
+-- modules because the code for each can be pretty unrelated.
 completionProviders :: (MonadReader CompletionContext m, MonadLog m) => [CompletionProvider m]
 completionProviders =
   [ ExprCompletion.getCompletions,

--- a/waspc/waspls/src/Wasp/LSP/Completion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completion.hs
@@ -3,18 +3,16 @@ module Wasp.LSP.Completion
   )
 where
 
-import Control.Lens ((?~), (^.))
+import Control.Lens ((^.))
 import Control.Monad.Log.Class (MonadLog (logM))
+import Control.Monad.Reader (MonadReader, runReaderT)
 import Control.Monad.State.Class (MonadState, gets)
-import Data.Maybe (maybeToList)
-import qualified Data.Text as Text
 import qualified Language.LSP.Types as LSP
-import qualified Language.LSP.Types.Lens as LSP
-import Wasp.Analyzer.Parser.CST (SyntaxNode)
-import qualified Wasp.Analyzer.Parser.CST as S
 import Wasp.Analyzer.Parser.CST.Traverse
-import Wasp.LSP.ServerState
-import Wasp.LSP.Syntax (findChild, isAtExprPlace, lexemeAt, lspPositionToOffset, showNeighborhood, toOffset)
+import Wasp.LSP.Completions.Common (CompletionContext (..), CompletionProvider)
+import qualified Wasp.LSP.Completions.ExprCompletion as ExprCompletion
+import Wasp.LSP.ServerState (ServerState, cst, currentWaspSource)
+import Wasp.LSP.Syntax (lspPositionToOffset, toOffset)
 
 -- | Get the list of completions at a (line, column) position in the source.
 getCompletionsAtPosition ::
@@ -31,75 +29,15 @@ getCompletionsAtPosition position = do
       let offset = lspPositionToOffset src position
       -- 'location' is a traversal through the syntax tree that points to 'position'
       let location = toOffset offset (fromSyntaxForest syntax)
-      logM $ "[getCompletionsAtPosition] neighborhood=\n" ++ showNeighborhood location
-      exprCompletions <-
-        if isAtExprPlace location
-          then do
-            logM $ "[getCompletionsAtPosition] offset=" ++ show offset ++ " position=" ++ show position ++ " atExpr=True"
-            getExprCompletions src syntax
-          else do
-            logM $ "[getCompletionsAtPosition] offset=" ++ show offset ++ " position=" ++ show position ++ " atExpr=False"
-            return []
-      let completions = exprCompletions
-      return completions
+      logM $ "[getCompletionsAtPosition] position=" ++ show position ++ " offset=" ++ show offset
+      let completionContext = CompletionContext {_src = src, _cst = syntax}
+      -- Run all completion providers and concatenate results
+      concat
+        <$> mapM
+          (\m -> runReaderT (m location) completionContext)
+          completionProviders
 
--- | If the location is at an expression, find declaration names in the file
--- and return them as autocomplete suggestions
---
--- TODO: include completions for enum variants (use standard type defs from waspc)
-getExprCompletions ::
-  (MonadLog m) =>
-  String ->
-  [SyntaxNode] ->
-  m [LSP.CompletionItem]
-getExprCompletions src syntax = do
-  let declNames = findDeclNames src syntax
-  logM $ "[getExprCompletions] declnames=" ++ show declNames
-  return $
-    map
-      ( \(name, typ) ->
-          makeBasicCompletionItem (Text.pack name)
-            & (LSP.kind ?~ LSP.CiVariable)
-            & (LSP.detail ?~ Text.pack (":: " ++ typ ++ " (declaration type)"))
-      )
-      declNames
-
--- | Search through the CST and collect all @(declName, declType)@ pairs.
-findDeclNames :: String -> [SyntaxNode] -> [(String, String)]
-findDeclNames src syntax = traverseForDeclNames $ fromSyntaxForest syntax
-  where
-    traverseForDeclNames :: Traversal -> [(String, String)]
-    traverseForDeclNames t = case kindAt t of
-      S.Program -> maybe [] traverseForDeclNames $ down t
-      S.Decl ->
-        let declNameAndType = maybeToList $ getDeclNameAndType t
-         in declNameAndType ++ maybe [] traverseForDeclNames (right t)
-      _ -> maybe [] traverseForDeclNames $ right t
-    getDeclNameAndType :: Traversal -> Maybe (String, String)
-    getDeclNameAndType t = do
-      nameT <- findChild S.DeclName t
-      typeT <- findChild S.DeclType t
-      return (lexemeAt src nameT, lexemeAt src typeT)
-
--- | Create a completion item containing only a label.
-makeBasicCompletionItem :: Text.Text -> LSP.CompletionItem
-makeBasicCompletionItem name =
-  LSP.CompletionItem
-    { _label = name,
-      _kind = Nothing,
-      _tags = Nothing,
-      _detail = Nothing,
-      _documentation = Nothing,
-      _deprecated = Nothing,
-      _preselect = Nothing,
-      _sortText = Nothing,
-      _filterText = Nothing,
-      _insertText = Nothing,
-      _insertTextFormat = Nothing,
-      _insertTextMode = Nothing,
-      _textEdit = Nothing,
-      _additionalTextEdits = Nothing,
-      _commitCharacters = Nothing,
-      _command = Nothing,
-      _xdata = Nothing
-    }
+completionProviders :: (MonadReader CompletionContext m, MonadLog m) => [CompletionProvider m]
+completionProviders =
+  [ ExprCompletion.getCompletions
+  ]

--- a/waspc/waspls/src/Wasp/LSP/Completion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completion.hs
@@ -15,7 +15,7 @@ import Wasp.LSP.Completions.Common (CompletionContext (..), CompletionProvider)
 import qualified Wasp.LSP.Completions.DictKeyCompletion as DictKeyCompletion
 import qualified Wasp.LSP.Completions.ExprCompletion as ExprCompletion
 import Wasp.LSP.ServerState (ServerState, cst, currentWaspSource)
-import Wasp.LSP.Syntax (lspPositionToOffset, showNeighborhood, toOffset)
+import Wasp.LSP.Syntax (locationAtOffset, lspPositionToOffset, showNeighborhood)
 
 -- | Get the list of completions at a (line, column) position in the source.
 getCompletionsAtPosition ::
@@ -31,7 +31,7 @@ getCompletionsAtPosition position = do
     Just syntax -> do
       let offset = lspPositionToOffset src position
       -- 'location' is a traversal through the syntax tree that points to 'position'
-      let location = toOffset offset (fromSyntaxForest syntax)
+      let location = locationAtOffset offset (fromSyntaxForest syntax)
       logM $ "[getCompletionsAtPosition] position=" ++ show position ++ " offset=" ++ show offset
       logM $ "[getCompletionsAtPosition] neighborhood=\n" ++ showNeighborhood location
       let completionContext = CompletionContext {_src = src, _cst = syntax}

--- a/waspc/waspls/src/Wasp/LSP/Completions/Common.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/Common.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Wasp.LSP.Completions.Common
+  ( CompletionProvider,
+    CompletionContext (..),
+    src,
+    cst,
+    makeBasicCompletionItem,
+  )
+where
+
+import Control.Lens (makeClassy)
+import qualified Data.Text as Text
+import qualified Language.LSP.Types as LSP
+import Wasp.Analyzer.Parser.CST (SyntaxNode)
+import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
+
+-- | A function that providers 'LSP.CompletionItems' at a location
+type CompletionProvider m = Traversal -> m [LSP.CompletionItem]
+
+-- | The context given to 'CompletionProvider's, via @MonadReader CompletionContext@
+data CompletionContext = CompletionContext
+  { _src :: String,
+    _cst :: [SyntaxNode]
+  }
+  deriving (Eq, Show)
+
+makeClassy 'CompletionContext
+
+-- | Create a completion item containing only a label.
+makeBasicCompletionItem :: Text.Text -> LSP.CompletionItem
+makeBasicCompletionItem name =
+  LSP.CompletionItem
+    { _label = name,
+      _kind = Nothing,
+      _tags = Nothing,
+      _detail = Nothing,
+      _documentation = Nothing,
+      _deprecated = Nothing,
+      _preselect = Nothing,
+      _sortText = Nothing,
+      _filterText = Nothing,
+      _insertText = Nothing,
+      _insertTextFormat = Nothing,
+      _insertTextMode = Nothing,
+      _textEdit = Nothing,
+      _additionalTextEdits = Nothing,
+      _commitCharacters = Nothing,
+      _command = Nothing,
+      _xdata = Nothing
+    }

--- a/waspc/waspls/src/Wasp/LSP/Completions/Common.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/Common.hs
@@ -15,10 +15,10 @@ import qualified Language.LSP.Types as LSP
 import Wasp.Analyzer.Parser.CST (SyntaxNode)
 import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
 
--- | A function that providers 'LSP.CompletionItems' at a location
+-- | A function that providers 'LSP.CompletionItems' at a location.
 type CompletionProvider m = Traversal -> m [LSP.CompletionItem]
 
--- | The context given to 'CompletionProvider's, via @MonadReader CompletionContext@
+-- | The context given to 'CompletionProvider's, via @MonadReader CompletionContext@.
 data CompletionContext = CompletionContext
   { _src :: String,
     _cst :: [SyntaxNode]
@@ -27,7 +27,8 @@ data CompletionContext = CompletionContext
 
 makeClassy 'CompletionContext
 
--- | Create a completion item containing only a label.
+-- | Create a completion item containing only a label. Use lenses and 'Control.Lens.(?~)'
+-- to set more fields, if desired.
 makeBasicCompletionItem :: Text.Text -> LSP.CompletionItem
 makeBasicCompletionItem name =
   LSP.CompletionItem

--- a/waspc/waspls/src/Wasp/LSP/Completions/Common.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/Common.hs
@@ -16,9 +16,8 @@ import Wasp.Analyzer.Parser.CST (SyntaxNode)
 import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
 
 -- | A function that providers 'LSP.CompletionItems' at a location.
-type CompletionProvider m = Traversal -> m [LSP.CompletionItem]
+type CompletionProvider m = CompletionContext -> Traversal -> m [LSP.CompletionItem]
 
--- | The context given to 'CompletionProvider's, via @MonadReader CompletionContext@.
 data CompletionContext = CompletionContext
   { _src :: String,
     _cst :: [SyntaxNode]

--- a/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
@@ -3,12 +3,27 @@ module Wasp.LSP.Completions.DictKeyCompletion
   )
 where
 
+import Control.Lens ((?~), (^.))
+import Control.Monad (guard)
 import Control.Monad.Log.Class (MonadLog (logM))
-import Control.Monad.RWS (MonadReader)
+import Control.Monad.Reader.Class (MonadReader, asks)
+import Data.Bifunctor (Bifunctor (second))
+import Data.Foldable (find)
+import qualified Data.HashMap.Strict as M
+import qualified Data.Text as Text
+import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types.Lens as LSP
 import qualified Wasp.Analyzer.Parser.CST as S
 import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
+import qualified Wasp.Analyzer.Parser.CST.Traverse as T
+import qualified Wasp.Analyzer.Parser.Token as Tok
+import Wasp.Analyzer.StdTypeDefinitions (stdTypes)
+import Wasp.Analyzer.Type (Type)
+import qualified Wasp.Analyzer.Type as Type
+import Wasp.Analyzer.TypeDefinitions (DeclType (dtBodyType), getDeclType)
 import Wasp.LSP.Completions.Common (CompletionContext, CompletionProvider, makeBasicCompletionItem)
-import Wasp.LSP.Syntax (allP, anyP, hasLeft, parentIs)
+import qualified Wasp.LSP.Completions.Common as Ctx
+import Wasp.LSP.Syntax (allP, anyP, hasLeft, lexemeAt, parentIs)
 
 getCompletions :: (MonadReader CompletionContext m, MonadLog m) => CompletionProvider m
 getCompletions location =
@@ -18,7 +33,30 @@ getCompletions location =
       return []
     else do
       logM "[DictKeyCompletion] at dict key"
-      return [makeBasicCompletionItem "key"]
+      src <- asks (^. Ctx.src)
+      case getExprPath src location of
+        Just wholePath@(Decl declType : path) -> do
+          case getExpectedType declType path of
+            Nothing -> do
+              logM $ "[DictKeyCompletion] no expected type for path " ++ show wholePath
+              return []
+            Just typ -> do
+              logM $ "[DictKeyCompletion] found an expected type for path " ++ show wholePath
+              let fields = listFieldsOfType typ
+              return $
+                map
+                  ( \(key, keyType) ->
+                      makeBasicCompletionItem (Text.pack $ key ++ ": ")
+                        T.& (LSP.kind ?~ LSP.CiField)
+                        T.& (LSP.detail ?~ Text.pack (":: " ++ show keyType))
+                  )
+                  fields
+        Just wholePath -> do
+          logM $ "[DictKeyCompletion] found expr path without decl " ++ show wholePath
+          return []
+        Nothing -> do
+          logM "[DictKeyCompletion] could not find expr path"
+          return []
 
 -- | Checks whether a position in the CST is where a DictKey would be expected.
 --
@@ -33,3 +71,69 @@ isAtDictKeyPlace =
     [ parentIs S.Dict,
       allP [parentIs S.DictEntry, not . hasLeft S.DictKey]
     ]
+
+data ExprPath
+  = Decl !String
+  | Key !String
+  | List
+  | Tuple !Int
+  deriving (Eq, Show)
+
+getExprPath :: String -> Traversal -> Maybe [ExprPath]
+getExprPath src location = reverse <$> go location
+  where
+    go :: Traversal -> Maybe [ExprPath]
+    go t = case T.up t of
+      Nothing -> Just [] -- Already at the top level
+      Just t' -> case T.kindAt t' of
+        S.Program -> Just []
+        S.Decl -> do
+          typLoc <- find ((== S.DeclType) . T.kindAt) $ T.leftSiblings t
+          let typ = lexemeAt src typLoc
+          (Decl typ :) <$> go t'
+        S.DictEntry -> case find ((== S.DictKey) . T.kindAt) $ T.leftSiblings t of
+          Just keyLoc -> do
+            let key = lexemeAt src keyLoc
+            t'' <- T.up t'
+            guard $ T.kindAt t'' == S.Dict
+            (Key key :) <$> go t''
+          Nothing -> go t'
+        S.List -> (List :) <$> go t'
+        S.Tuple -> do
+          let nExprsBefore = length $ filter ((/= S.Token Tok.Comma) . T.kindAt) $ T.leftSiblings t
+          (Tuple nExprsBefore :) <$> go t'
+        _ -> go t'
+
+listFieldsOfType :: Type -> [(String, Type)]
+listFieldsOfType (Type.DictType fields) = map (second dictEntryType) $ M.toList fields
+listFieldsOfType _ = []
+
+-- | @getExpectedType declType exprPathWithoutDecl@
+getExpectedType :: String -> [ExprPath] -> Maybe Type
+getExpectedType declType originalPath = do
+  topType <- getDeclType declType stdTypes
+  go (dtBodyType topType) originalPath
+  where
+    go :: Type -> [ExprPath] -> Maybe Type
+    go typ [] = Just typ
+    go _ (Decl _ : _) = Nothing
+    go typ (Key key : path) =
+      case typ of
+        Type.DictType fields -> do
+          typ' <- dictEntryType <$> fields M.!? key
+          go typ' path
+        _ -> Nothing
+    go typ (List : path) = case typ of
+      Type.ListType typ' -> go typ' path
+      _ -> Nothing
+    go typ (Tuple idx : path) = case typ of
+      Type.TupleType (a, b, cs) -> case idx of
+        0 -> go a path
+        1 -> go b path
+        n | n <= length cs + 2 -> go (cs !! (n - 2)) path
+        _ -> Nothing
+      _ -> Nothing
+
+dictEntryType :: Type.DictEntryType -> Type
+dictEntryType (Type.DictOptional typ) = typ
+dictEntryType (Type.DictRequired typ) = typ

--- a/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
@@ -105,10 +105,6 @@ getExprPath src location = reverse <$> go location
           (Tuple nExprsBefore :) <$> go t'
         _ -> go t'
 
-listFieldsOfType :: Type -> [(String, Type)]
-listFieldsOfType (Type.DictType fields) = map (second dictEntryType) $ M.toList fields
-listFieldsOfType _ = []
-
 -- | @getExpectedType declType exprPathWithoutDecl@
 getExpectedType :: String -> [ExprPath] -> Maybe Type
 getExpectedType declType originalPath = do
@@ -134,6 +130,12 @@ getExpectedType declType originalPath = do
         n | n <= length cs + 2 -> go (cs !! (n - 2)) path
         _ -> Nothing
       _ -> Nothing
+
+-- | List the (key, valuetype) pairs for a type. Returns an empty list for
+-- everything except a 'Type.DictType'.
+listFieldsOfType :: Type -> [(String, Type)]
+listFieldsOfType (Type.DictType fields) = map (second dictEntryType) $ M.toList fields
+listFieldsOfType _ = []
 
 dictEntryType :: Type.DictEntryType -> Type
 dictEntryType (Type.DictOptional typ) = typ

--- a/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
@@ -19,7 +19,7 @@ import qualified Wasp.Analyzer.Type as Type
 import Wasp.LSP.Completions.Common (CompletionContext, CompletionProvider, makeBasicCompletionItem)
 import qualified Wasp.LSP.Completions.Common as Ctx
 import Wasp.LSP.Syntax (allP, anyP, hasLeft, parentIs)
-import Wasp.LSP.TypeHint (getTypeHint)
+import Wasp.LSP.TypeInference (inferTypeAtLocation)
 
 -- | If the location is at a place where a dictionary key is expected, find
 -- the list of keys that are allowed in the dictionary around the location and
@@ -41,7 +41,7 @@ getCompletions location =
     else do
       logM "[DictKeyCompletion] at dict key"
       src <- asks (^. Ctx.src)
-      case getTypeHint src location of
+      case inferTypeAtLocation src location of
         Nothing -> do
           logM "[DictKeyCompletion] no type hint, can not suggest keys"
           return []

--- a/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
@@ -46,9 +46,10 @@ getCompletions location =
               return $
                 map
                   ( \(key, keyType) ->
-                      makeBasicCompletionItem (Text.pack $ key ++ ": ")
+                      makeBasicCompletionItem (Text.pack key)
                         T.& (LSP.kind ?~ LSP.CiField)
                         T.& (LSP.detail ?~ Text.pack (":: " ++ show keyType))
+                        T.& (LSP.insertText ?~ Text.pack (key ++ ": "))
                   )
                   fields
         Just wholePath -> do

--- a/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
@@ -45,9 +45,9 @@ getCompletions location =
         Nothing -> do
           logM "[DictKeyCompletion] no type hint, can not suggest keys"
           return []
-        Just typ@(Type.DictType _) -> do
+        Just (Type.DictType fieldMap) -> do
           logM "[DictKeyCompletion] found dict type hint"
-          let fields = listFieldsOfType typ
+          let fields = listDictFields fieldMap
           return $
             map
               ( \(key, keyType) ->
@@ -79,6 +79,5 @@ isAtDictKeyPlace =
 
 -- | List the (key, valuetype) pairs for a type. Returns an empty list for
 -- everything except a 'Type.DictType'.
-listFieldsOfType :: Type -> [(String, Type)]
-listFieldsOfType (Type.DictType fields) = map (second Type.dictEntryType) $ M.toList fields
-listFieldsOfType _ = []
+listDictFields :: M.HashMap String Type.DictEntryType -> [(String, Type)]
+listDictFields fieldMap = map (second Type.dictEntryType) $ M.toList fieldMap

--- a/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
@@ -4,11 +4,9 @@ module Wasp.LSP.Completions.DictKeyCompletion
 where
 
 import Control.Lens ((?~), (^.))
-import Control.Monad (guard)
 import Control.Monad.Log.Class (MonadLog (logM))
 import Control.Monad.Reader.Class (MonadReader, asks)
 import Data.Bifunctor (Bifunctor (second))
-import Data.Foldable (find)
 import qualified Data.HashMap.Strict as M
 import qualified Data.Text as Text
 import qualified Language.LSP.Types as LSP
@@ -16,14 +14,12 @@ import qualified Language.LSP.Types.Lens as LSP
 import qualified Wasp.Analyzer.Parser.CST as S
 import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
 import qualified Wasp.Analyzer.Parser.CST.Traverse as T
-import qualified Wasp.Analyzer.Parser.Token as Tok
-import Wasp.Analyzer.StdTypeDefinitions (stdTypes)
 import Wasp.Analyzer.Type (Type)
 import qualified Wasp.Analyzer.Type as Type
-import Wasp.Analyzer.TypeDefinitions (DeclType (dtBodyType), getDeclType)
 import Wasp.LSP.Completions.Common (CompletionContext, CompletionProvider, makeBasicCompletionItem)
 import qualified Wasp.LSP.Completions.Common as Ctx
-import Wasp.LSP.Syntax (allP, anyP, hasLeft, lexemeAt, parentIs)
+import Wasp.LSP.Syntax (allP, anyP, hasLeft, parentIs)
+import Wasp.LSP.TypeHint (getTypeHint)
 
 getCompletions :: (MonadReader CompletionContext m, MonadLog m) => CompletionProvider m
 getCompletions location =
@@ -34,29 +30,24 @@ getCompletions location =
     else do
       logM "[DictKeyCompletion] at dict key"
       src <- asks (^. Ctx.src)
-      case getExprPath src location of
-        Just wholePath@(Decl declType : path) -> do
-          case getExpectedType declType path of
-            Nothing -> do
-              logM $ "[DictKeyCompletion] no expected type for path " ++ show wholePath
-              return []
-            Just typ -> do
-              logM $ "[DictKeyCompletion] found an expected type for path " ++ show wholePath
-              let fields = listFieldsOfType typ
-              return $
-                map
-                  ( \(key, keyType) ->
-                      makeBasicCompletionItem (Text.pack key)
-                        T.& (LSP.kind ?~ LSP.CiField)
-                        T.& (LSP.detail ?~ Text.pack (":: " ++ show keyType))
-                        T.& (LSP.insertText ?~ Text.pack (key ++ ": "))
-                  )
-                  fields
-        Just wholePath -> do
-          logM $ "[DictKeyCompletion] found expr path without decl " ++ show wholePath
-          return []
+      case getTypeHint src location of
         Nothing -> do
-          logM "[DictKeyCompletion] could not find expr path"
+          logM "[DictKeyCompletion] no type hint, can not suggest keys"
+          return []
+        Just typ@(Type.DictType _) -> do
+          logM "[DictKeyCompletion] found dict type hint"
+          let fields = listFieldsOfType typ
+          return $
+            map
+              ( \(key, keyType) ->
+                  makeBasicCompletionItem (Text.pack key)
+                    T.& (LSP.kind ?~ LSP.CiField)
+                    T.& (LSP.detail ?~ Text.pack (":: " ++ show keyType))
+                    T.& (LSP.insertText ?~ Text.pack (key ++ ": "))
+              )
+              fields
+        Just _ -> do
+          logM "[DictKeyCompletion] found non-dict type hint, no keys to suggest"
           return []
 
 -- | Checks whether a position in the CST is where a DictKey would be expected.
@@ -73,70 +64,8 @@ isAtDictKeyPlace =
       allP [parentIs S.DictEntry, not . hasLeft S.DictKey]
     ]
 
-data ExprPath
-  = Decl !String
-  | Key !String
-  | List
-  | Tuple !Int
-  deriving (Eq, Show)
-
-getExprPath :: String -> Traversal -> Maybe [ExprPath]
-getExprPath src location = reverse <$> go location
-  where
-    go :: Traversal -> Maybe [ExprPath]
-    go t = case T.up t of
-      Nothing -> Just [] -- Already at the top level
-      Just t' -> case T.kindAt t' of
-        S.Program -> Just []
-        S.Decl -> do
-          typLoc <- find ((== S.DeclType) . T.kindAt) $ T.leftSiblings t
-          let typ = lexemeAt src typLoc
-          (Decl typ :) <$> go t'
-        S.DictEntry -> case find ((== S.DictKey) . T.kindAt) $ T.leftSiblings t of
-          Just keyLoc -> do
-            let key = lexemeAt src keyLoc
-            t'' <- T.up t'
-            guard $ T.kindAt t'' == S.Dict
-            (Key key :) <$> go t''
-          Nothing -> go t'
-        S.List -> (List :) <$> go t'
-        S.Tuple -> do
-          let nExprsBefore = length $ filter ((/= S.Token Tok.Comma) . T.kindAt) $ T.leftSiblings t
-          (Tuple nExprsBefore :) <$> go t'
-        _ -> go t'
-
--- | @getExpectedType declType exprPathWithoutDecl@
-getExpectedType :: String -> [ExprPath] -> Maybe Type
-getExpectedType declType originalPath = do
-  topType <- getDeclType declType stdTypes
-  go (dtBodyType topType) originalPath
-  where
-    go :: Type -> [ExprPath] -> Maybe Type
-    go typ [] = Just typ
-    go _ (Decl _ : _) = Nothing
-    go typ (Key key : path) =
-      case typ of
-        Type.DictType fields -> do
-          typ' <- dictEntryType <$> fields M.!? key
-          go typ' path
-        _ -> Nothing
-    go typ (List : path) = case typ of
-      Type.ListType typ' -> go typ' path
-      _ -> Nothing
-    go typ (Tuple idx : path) = case typ of
-      Type.TupleType (a, b, cs) -> case idx of
-        0 -> go a path
-        1 -> go b path
-        n | n <= length cs + 2 -> go (cs !! (n - 2)) path
-        _ -> Nothing
-      _ -> Nothing
-
 -- | List the (key, valuetype) pairs for a type. Returns an empty list for
 -- everything except a 'Type.DictType'.
 listFieldsOfType :: Type -> [(String, Type)]
-listFieldsOfType (Type.DictType fields) = map (second dictEntryType) $ M.toList fields
+listFieldsOfType (Type.DictType fields) = map (second Type.dictEntryType) $ M.toList fields
 listFieldsOfType _ = []
-
-dictEntryType :: Type.DictEntryType -> Type
-dictEntryType (Type.DictOptional typ) = typ
-dictEntryType (Type.DictRequired typ) = typ

--- a/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/DictKeyCompletion.hs
@@ -1,0 +1,35 @@
+module Wasp.LSP.Completions.DictKeyCompletion
+  ( getCompletions,
+  )
+where
+
+import Control.Monad.Log.Class (MonadLog (logM))
+import Control.Monad.RWS (MonadReader)
+import qualified Wasp.Analyzer.Parser.CST as S
+import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
+import Wasp.LSP.Completions.Common (CompletionContext, CompletionProvider, makeBasicCompletionItem)
+import Wasp.LSP.Syntax (allP, anyP, hasLeft, parentIs)
+
+getCompletions :: (MonadReader CompletionContext m, MonadLog m) => CompletionProvider m
+getCompletions location =
+  if not $ isAtDictKeyPlace location
+    then do
+      logM "[DictKeyCompletion] not at dict key"
+      return []
+    else do
+      logM "[DictKeyCompletion] at dict key"
+      return [makeBasicCompletionItem "key"]
+
+-- | Checks whether a position in the CST is where a DictKey would be expected.
+--
+-- The rules for this are:
+-- - If parent is a Dict, then yes
+-- - If parent is a DictEntry and there are no DictKeys to the left of this node,
+--   then yes
+-- - Else, no
+isAtDictKeyPlace :: Traversal -> Bool
+isAtDictKeyPlace =
+  anyP
+    [ parentIs S.Dict,
+      allP [parentIs S.DictEntry, not . hasLeft S.DictKey]
+    ]

--- a/waspc/waspls/src/Wasp/LSP/Completions/ExprCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/ExprCompletion.hs
@@ -1,0 +1,60 @@
+module Wasp.LSP.Completions.ExprCompletion
+  ( getCompletions,
+  )
+where
+
+import Control.Lens ((?~), (^.))
+import Control.Monad.Log.Class (MonadLog (logM))
+import Control.Monad.Reader.Class (MonadReader, asks)
+import Data.Maybe (maybeToList)
+import qualified Data.Text as Text
+import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types.Lens as LSP
+import Wasp.Analyzer.Parser.CST (SyntaxNode)
+import qualified Wasp.Analyzer.Parser.CST as S
+import Wasp.Analyzer.Parser.CST.Traverse
+import Wasp.LSP.Completions.Common (CompletionContext, CompletionProvider, makeBasicCompletionItem)
+import qualified Wasp.LSP.Completions.Common as Ctx
+import Wasp.LSP.Syntax (findChild, isAtExprPlace, lexemeAt)
+
+-- | If the location is at an expression, find declaration names in the file
+-- and return them as autocomplete suggestions
+--
+-- TODO: include completions for enum variants (use standard type defs from waspc)
+getCompletions :: (MonadReader CompletionContext m, MonadLog m) => CompletionProvider m
+getCompletions location =
+  if not (isAtExprPlace location)
+    then do
+      logM "[ExprCompletion] not at expression"
+      return []
+    else do
+      logM "[ExprCompletion] at expression"
+      src <- asks (^. Ctx.src)
+      syntax <- asks (^. Ctx.cst)
+      let declNames = findDeclNames src syntax
+      logM $ "[ExprCompletion] declnames=" ++ show declNames
+      return $
+        map
+          ( \(name, typ) ->
+              makeBasicCompletionItem (Text.pack name)
+                & (LSP.kind ?~ LSP.CiVariable)
+                & (LSP.detail ?~ Text.pack (":: " ++ typ ++ " (declaration type)"))
+          )
+          declNames
+
+-- | Search through the CST and collect all @(declName, declType)@ pairs.
+findDeclNames :: String -> [SyntaxNode] -> [(String, String)]
+findDeclNames src syntax = traverseForDeclNames $ fromSyntaxForest syntax
+  where
+    traverseForDeclNames :: Traversal -> [(String, String)]
+    traverseForDeclNames t = case kindAt t of
+      S.Program -> maybe [] traverseForDeclNames $ down t
+      S.Decl ->
+        let declNameAndType = maybeToList $ getDeclNameAndType t
+         in declNameAndType ++ maybe [] traverseForDeclNames (right t)
+      _ -> maybe [] traverseForDeclNames $ right t
+    getDeclNameAndType :: Traversal -> Maybe (String, String)
+    getDeclNameAndType t = do
+      nameT <- findChild S.DeclName t
+      typeT <- findChild S.DeclType t
+      return (lexemeAt src nameT, lexemeAt src typeT)

--- a/waspc/waspls/src/Wasp/LSP/Completions/ExprCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/ExprCompletion.hs
@@ -53,6 +53,9 @@ findDeclNames src syntax = traverseForDeclNames $ fromSyntaxForest syntax
         let declNameAndType = maybeToList $ getDeclNameAndType t
          in declNameAndType ++ maybe [] traverseForDeclNames (right t)
       _ -> maybe [] traverseForDeclNames $ right t
+
+    -- @getDeclNameAndType t@ expects 't' to be at a 'S.Decl' node. It finds the
+    -- lexemes for the 'S.DeclName' and 'S.DeclType'.
     getDeclNameAndType :: Traversal -> Maybe (String, String)
     getDeclNameAndType t = do
       nameT <- findChild S.DeclName t

--- a/waspc/waspls/src/Wasp/LSP/Completions/ExprCompletion.hs
+++ b/waspc/waspls/src/Wasp/LSP/Completions/ExprCompletion.hs
@@ -18,7 +18,7 @@ import qualified Wasp.LSP.Completions.Common as Ctx
 import Wasp.LSP.Syntax (findChild, isAtExprPlace, lexemeAt)
 
 -- | If the location is at an expression, find declaration names in the file
--- and return them as autocomplete suggestions
+-- and return them as completion items.
 --
 -- TODO: include completions for enum variants (use standard type defs from waspc)
 getCompletions :: (MonadReader CompletionContext m, MonadLog m) => CompletionProvider m

--- a/waspc/waspls/src/Wasp/LSP/Handlers.hs
+++ b/waspc/waspls/src/Wasp/LSP/Handlers.hs
@@ -71,7 +71,7 @@ signatureHelpHandler :: Handlers ServerM
 signatureHelpHandler =
   LSP.requestHandler LSP.STextDocumentSignatureHelp $ \request respond -> do
     -- NOTE: lsp-types 1.4.0.1 forgot to add lenses for SignatureHelpParams so
-    -- we have to get the position out the painful way
+    -- we have to get the position out the painful way.
     let LSP.SignatureHelpParams {_position = position} = request ^. LSP.params
     signatureHelp <- getSignatureHelpAtPosition position
     respond $ Right signatureHelp

--- a/waspc/waspls/src/Wasp/LSP/Handlers.hs
+++ b/waspc/waspls/src/Wasp/LSP/Handlers.hs
@@ -4,6 +4,7 @@ module Wasp.LSP.Handlers
     didChangeHandler,
     didSaveHandler,
     completionHandler,
+    signatureHelpHandler,
   )
 where
 
@@ -22,6 +23,7 @@ import Wasp.LSP.Completion (getCompletionsAtPosition)
 import Wasp.LSP.Diagnostic (concreteParseErrorToDiagnostic, waspErrorToDiagnostic)
 import Wasp.LSP.ServerM (ServerError (..), ServerM, Severity (..), gets, liftLSP, modify, throwError)
 import Wasp.LSP.ServerState (cst, currentWaspSource, latestDiagnostics)
+import Wasp.LSP.SignatureHelp (getSignatureHelpAtPosition)
 
 -- LSP notification and request handlers
 
@@ -64,6 +66,15 @@ completionHandler =
   LSP.requestHandler LSP.STextDocumentCompletion $ \request respond -> do
     completions <- getCompletionsAtPosition $ request ^. LSP.params . LSP.position
     respond $ Right $ LSP.InL $ LSP.List completions
+
+signatureHelpHandler :: Handlers ServerM
+signatureHelpHandler =
+  LSP.requestHandler LSP.STextDocumentSignatureHelp $ \request respond -> do
+    -- NOTE: lsp-types 1.4.0.1 forgot to add lenses for SignatureHelpParams so
+    -- we have to get the position out the painful way
+    let LSP.SignatureHelpParams {_position = position} = request ^. LSP.params
+    signatureHelp <- getSignatureHelpAtPosition position
+    respond $ Right signatureHelp
 
 -- | Does not directly handle a notification or event, but should be run when
 -- text document content changes.

--- a/waspc/waspls/src/Wasp/LSP/Server.hs
+++ b/waspc/waspls/src/Wasp/LSP/Server.hs
@@ -20,6 +20,7 @@ import Wasp.LSP.Handlers
 import Wasp.LSP.ServerConfig (ServerConfig)
 import Wasp.LSP.ServerM (ServerError (..), ServerM, Severity (..), runServerM)
 import Wasp.LSP.ServerState (ServerState)
+import Wasp.LSP.SignatureHelp (signatureHelpRetriggerCharacters, signatureHelpTriggerCharacters)
 
 lspServerHandlers :: LSP.Handlers ServerM
 lspServerHandlers =
@@ -102,8 +103,8 @@ lspServerOptions =
   (def :: LSP.Options)
     { LSP.textDocumentSync = Just syncOptions,
       LSP.completionTriggerCharacters = Just [':', ' '],
-      LSP.signatureHelpTriggerCharacters = Just [':', '{', '[', '(', ','],
-      LSP.signatureHelpRetriggerCharacters = Just ['}', ']', ')']
+      LSP.signatureHelpTriggerCharacters = signatureHelpTriggerCharacters,
+      LSP.signatureHelpRetriggerCharacters = signatureHelpRetriggerCharacters
     }
 
 -- | Options to tell the client how to update the server about the state of text

--- a/waspc/waspls/src/Wasp/LSP/Server.hs
+++ b/waspc/waspls/src/Wasp/LSP/Server.hs
@@ -28,7 +28,8 @@ lspServerHandlers =
       didOpenHandler,
       didSaveHandler,
       didChangeHandler,
-      completionHandler
+      completionHandler,
+      signatureHelpHandler
     ]
 
 serve :: Maybe FilePath -> IO ()
@@ -100,7 +101,9 @@ lspServerOptions :: LSP.Options
 lspServerOptions =
   (def :: LSP.Options)
     { LSP.textDocumentSync = Just syncOptions,
-      LSP.completionTriggerCharacters = Just [':']
+      LSP.completionTriggerCharacters = Just [':', ' '],
+      LSP.signatureHelpTriggerCharacters = Just [':', '{', '[', '(', ','],
+      LSP.signatureHelpRetriggerCharacters = Just ['}', ']', ')']
     }
 
 -- | Options to tell the client how to update the server about the state of text

--- a/waspc/waspls/src/Wasp/LSP/SignatureHelp.hs
+++ b/waspc/waspls/src/Wasp/LSP/SignatureHelp.hs
@@ -22,7 +22,7 @@ import Wasp.Analyzer.Parser.CST.Traverse (Traversal, fromSyntaxForest)
 import Wasp.Analyzer.Type (Type)
 import qualified Wasp.Analyzer.Type as Type
 import Wasp.LSP.ServerState (ServerState, cst, currentWaspSource)
-import Wasp.LSP.Syntax (lspPositionToOffset, toOffset)
+import Wasp.LSP.Syntax (locationAtOffset, lspPositionToOffset)
 import Wasp.LSP.TypeInference (ExprKey (Key, List, Tuple), findExprPathAtLocation, findTypeForPath)
 
 -- | Configuration for 'LSP.Options', used in "Wasp.LSP.Server".
@@ -67,7 +67,7 @@ getSignatureHelpAtPosition position = do
       return emptyHelp
     Just syntax -> do
       let offset = lspPositionToOffset src position
-      let location = toOffset offset (fromSyntaxForest syntax)
+      let location = locationAtOffset offset (fromSyntaxForest syntax)
       findSignatureAtLocation src location >>= \case
         Nothing -> do
           logM "[getSignatureHelpAtPosition] no signature found"

--- a/waspc/waspls/src/Wasp/LSP/SignatureHelp.hs
+++ b/waspc/waspls/src/Wasp/LSP/SignatureHelp.hs
@@ -1,0 +1,192 @@
+module Wasp.LSP.SignatureHelp
+  ( getSignatureHelpAtPosition,
+  )
+where
+
+import Control.Lens ((^.))
+import Control.Monad (guard)
+import Control.Monad.Log.Class (MonadLog, logM)
+import Control.Monad.State.Class (MonadState, gets)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
+import qualified Data.HashMap.Strict as M
+import Data.List (intersperse)
+import qualified Data.Text as Text
+import qualified Language.LSP.Types as LSP
+import Wasp.Analyzer.Parser.CST.Traverse (Traversal, fromSyntaxForest)
+import Wasp.Analyzer.Type (Type)
+import qualified Wasp.Analyzer.Type as Type
+import Wasp.LSP.ServerState (ServerState, cst, currentWaspSource)
+import Wasp.LSP.Syntax (lspPositionToOffset, toOffset)
+import Wasp.LSP.TypeHint (ExprPath (Key, List, Tuple), getExprPath, getPathType)
+
+getSignatureHelpAtPosition ::
+  (MonadState ServerState m, MonadLog m) =>
+  LSP.Position ->
+  m LSP.SignatureHelp
+getSignatureHelpAtPosition position = do
+  src <- gets (^. currentWaspSource)
+  gets (^. cst) >>= \case
+    Nothing ->
+      return emptyHelp
+    Just syntax -> do
+      let offset = lspPositionToOffset src position
+      let location = toOffset offset (fromSyntaxForest syntax)
+      getSignatureContext src location >>= \case
+        Nothing -> do
+          logM "[getSignatureHelpAtPosition] no type hint to provide signature for"
+          return emptyHelp
+        Just (JustSignature typ) -> do
+          logM "[getSignatureHelpAtPosition] type hint found; not at argument"
+          let label = showSig $ sigShow typ
+          return $
+            LSP.SignatureHelp
+              { _signatures =
+                  LSP.List
+                    [ LSP.SignatureInformation
+                        { _parameters = Nothing,
+                          _activeParameter = Nothing,
+                          _label = Text.pack label,
+                          _documentation = Nothing
+                        }
+                    ],
+                _activeSignature = Just 0,
+                _activeParameter = Nothing
+              }
+        Just (ArgSignature typ path _) -> do
+          logM $ "[getSignatureHelpAtPosition] type hint found; at argument " ++ show path
+          let shown = sigShow typ
+          let label = showSig shown
+          let params = sigParams shown
+          let activeParam = sigParamIdx shown path
+          logM $ "[getSignatureHelpAtPosition] at param idx = " ++ show activeParam ++ " params = " ++ show params
+          return $
+            LSP.SignatureHelp
+              { _signatures =
+                  LSP.List
+                    [ LSP.SignatureInformation
+                        { _parameters = Just $ LSP.List params,
+                          _activeParameter = activeParam,
+                          _label = Text.pack label,
+                          _documentation = Nothing
+                        }
+                    ],
+                _activeSignature = Just 0,
+                _activeParameter = activeParam
+              }
+  where
+    emptyHelp =
+      LSP.SignatureHelp
+        { _signatures = LSP.List [],
+          _activeSignature = Nothing,
+          _activeParameter = Nothing
+        }
+
+data SignatureShow = SignatureShow
+  { sigPath :: !(Maybe ExprPath),
+    sigText :: !String
+  }
+  deriving (Eq, Show)
+
+sigShow :: Type -> [SignatureShow]
+sigShow (Type.DictType fieldMap)
+  | null fields = [SignatureShow Nothing "{}"]
+  | otherwise =
+    let preamble = [SignatureShow Nothing "{\n  "]
+        sep = SignatureShow Nothing ",\n  "
+        fieldsShown = intersperse sep (map showField fields)
+        postamble = [SignatureShow Nothing "\n}"]
+     in concat [preamble, fieldsShown, postamble]
+  where
+    fields = M.toList fieldMap
+    showField :: (String, Type.DictEntryType) -> SignatureShow
+    showField (k, Type.DictRequired v) =
+      SignatureShow (Just $ Key k) $ k ++ ": " ++ showSig (sigShow v)
+    showField (k, Type.DictOptional v) =
+      SignatureShow (Just $ Key k) $ k ++ ": " ++ showSig (sigShow v) ++ "?"
+sigShow (Type.ListType ty) =
+  [ SignatureShow Nothing "[",
+    SignatureShow (Just List) (show ty),
+    SignatureShow Nothing "]"
+  ]
+sigShow (Type.TupleType (a, b, cs)) =
+  let ts = a : b : cs
+      sep = SignatureShow Nothing ", "
+      tsShown = intersperse sep $ zipWith showT [0 ..] ts
+   in SignatureShow Nothing "(" : tsShown ++ [SignatureShow Nothing ")"]
+  where
+    showT :: Int -> Type -> SignatureShow
+    showT n t = SignatureShow (Just $ Tuple n) $ show t
+sigShow ty = [SignatureShow Nothing $ show ty]
+
+showSig :: [SignatureShow] -> String
+showSig = concatMap sigText
+
+sigParams :: [SignatureShow] -> [LSP.ParameterInformation]
+sigParams allShows = map labelToInfo $ getParams 0 allShows
+  where
+    getParams :: LSP.UInt -> [SignatureShow] -> [LSP.ParameterLabel]
+    getParams _ [] = []
+    getParams offset (s : ss) = case getParam offset s of
+      (offset', Nothing) -> getParams offset' ss
+      (offset', Just p) -> p : getParams offset' ss
+
+    getParam :: LSP.UInt -> SignatureShow -> (LSP.UInt, Maybe LSP.ParameterLabel)
+    getParam offset (SignatureShow Nothing txt) =
+      (offset + fromIntegral (length txt), Nothing)
+    getParam offset (SignatureShow (Just _) txt) =
+      let end = offset + fromIntegral (length txt)
+       in (end, Just $ LSP.ParameterLabelOffset offset end)
+
+    labelToInfo :: LSP.ParameterLabel -> LSP.ParameterInformation
+    labelToInfo label =
+      LSP.ParameterInformation
+        { _label = label,
+          _documentation = Nothing
+        }
+
+sigParamIdx :: [SignatureShow] -> ExprPath -> Maybe LSP.UInt
+sigParamIdx allShows path = search 0 allShows
+  where
+    search :: LSP.UInt -> [SignatureShow] -> Maybe LSP.UInt
+    search _ [] = Nothing
+    -- NOTE: do not increment the index on non-param SignatureShows, because
+    -- the index being returned is the index into the parameter list, not the
+    -- show list
+    search idx (SignatureShow Nothing _ : remaining) = search idx remaining
+    search idx (SignatureShow (Just p) _ : remaining)
+      | p == path = Just idx
+      | otherwise = search (idx + 1) remaining
+
+data SignatureContext
+  = JustSignature !Type
+  | ArgSignature !Type !ExprPath !Type
+  deriving (Eq, Show)
+
+getSignatureContext ::
+  (MonadLog m) =>
+  String ->
+  Traversal ->
+  m (Maybe SignatureContext)
+getSignatureContext src t = runMaybeT $ do
+  exprPath <- hoistMaybe $ getExprPath src t
+  lift $ logM $ "[SignatureHelp] at expr path " ++ show exprPath
+  guard $ not $ null exprPath
+  case exprPath of
+    [path] -> JustSignature <$> hoistMaybe (getPathType [path])
+    path -> do
+      -- Using init/last here is fine since we know it has at least 2 elements
+      tipType <- hoistMaybe $ getPathType path
+      parentType <- hoistMaybe $ getPathType $ init path
+      if isContainerType tipType
+        then return $ JustSignature tipType
+        else return $ ArgSignature parentType (last path) tipType
+  where
+    isContainerType :: Type -> Bool
+    isContainerType (Type.DictType _) = True
+    isContainerType (Type.ListType _) = True
+    isContainerType Type.TupleType {} = True
+    isContainerType _ = False
+
+hoistMaybe :: Monad m => Maybe a -> MaybeT m a
+hoistMaybe = MaybeT . pure

--- a/waspc/waspls/src/Wasp/LSP/SignatureHelp.hs
+++ b/waspc/waspls/src/Wasp/LSP/SignatureHelp.hs
@@ -192,14 +192,14 @@ instance IsString SignatureFragment where
 -- | Convert the container type of a signature to a list of fragments.
 --
 -- To avoid unreadably long signatures, dictionary types inside of the container
--- type are written @{ ... }@.
+-- type are written as @{ ... }@.
 signatureToFragments :: Signature -> [SignatureFragment]
 signatureToFragments signature = case signatureType signature of
   Type.DictType fieldMap
     | M.null fieldMap -> ["{}"]
     | otherwise ->
-      let fields = intersperse ", " (map fieldToFragment (M.toList fieldMap))
-       in concat [["{"], fields, ["}"]]
+        let fields = intersperse ",\n  " (map fieldToFragment (M.toList fieldMap))
+         in concat [["{\n  "], fields, ["\n}"]]
   Type.ListType inner -> ["[", Param List (showInnerType inner), "]"]
   Type.TupleType (a, b, cs) ->
     let fieldTypes = a : b : cs

--- a/waspc/waspls/src/Wasp/LSP/Syntax.hs
+++ b/waspc/waspls/src/Wasp/LSP/Syntax.hs
@@ -3,7 +3,7 @@ module Wasp.LSP.Syntax
 
     -- | Module with utilities for working with/looking for patterns in CSTs
     lspPositionToOffset,
-    toOffset,
+    locationAtOffset,
     allP,
     anyP,
     parentIs,
@@ -33,8 +33,8 @@ lspPositionToOffset srcString (J.Position l c) =
 --
 -- If the offset falls on the border between two nodes, it tries to first choose
 -- the leftmost non-trivia token, and then the leftmost token.
-toOffset :: Int -> Traversal -> Traversal
-toOffset targetOffset start = go $ bottom start
+locationAtOffset :: Int -> Traversal -> Traversal
+locationAtOffset targetOffset start = go $ bottom start
   where
     go :: Traversal -> Traversal
     go at

--- a/waspc/waspls/src/Wasp/LSP/Syntax.hs
+++ b/waspc/waspls/src/Wasp/LSP/Syntax.hs
@@ -41,11 +41,11 @@ toOffset targetOffset start = go $ bottom start
       | offsetAt at == targetOffset = at
       | offsetAfter at > targetOffset = at
       | offsetAfter at == targetOffset =
-        if not $ S.syntaxKindIsTrivia $ kindAt at
-          then at
-          else case at & next of
-            Just at' | not (S.syntaxKindIsTrivia (kindAt at')) -> at'
-            _ -> at
+          if not $ S.syntaxKindIsTrivia $ kindAt at
+            then at
+            else case at & next of
+              Just at' | not (S.syntaxKindIsTrivia (kindAt at')) -> at'
+              _ -> at
       -- If @at & next@ fails, the input doesn't contain the offset, so just
       -- return the last node instead.
       | otherwise = maybe at go $ at & next
@@ -76,13 +76,9 @@ isAtExprPlace =
   anyP
     [ allP [parentIs S.DictEntry, hasLeft S.DictKey],
       allP [parentIs S.Decl, hasLeft S.DeclType, hasLeft S.DeclName],
+      parentIs S.List,
       parentIs S.Tuple
     ]
-
--- (parentIs S.DictEntry && hasLeft S.DictKey)
---   || parentIs S.List
---   || (parentIs S.Decl && hasLeft S.DeclType && hasLeft S.DeclName)
---   || parentIs S.Tuple
 
 -- | Show the nodes around the current position
 --

--- a/waspc/waspls/src/Wasp/LSP/Syntax.hs
+++ b/waspc/waspls/src/Wasp/LSP/Syntax.hs
@@ -4,8 +4,6 @@ module Wasp.LSP.Syntax
     -- | Module with utilities for working with/looking for patterns in CSTs
     lspPositionToOffset,
     locationAtOffset,
-    allP,
-    anyP,
     parentIs,
     hasLeft,
     isAtExprPlace,
@@ -20,6 +18,7 @@ import Data.List (find, intercalate)
 import qualified Language.LSP.Types as J
 import qualified Wasp.Analyzer.Parser.CST as S
 import Wasp.Analyzer.Parser.CST.Traverse
+import Wasp.LSP.Util (allP, anyP)
 
 -- | @lspPositionToOffset srcString position@ returns 0-based offset from the
 -- start of @srcString@ to the specified line and column.
@@ -49,14 +48,6 @@ locationAtOffset targetOffset start = go $ bottom start
       -- If @at & next@ fails, the input doesn't contain the offset, so just
       -- return the last node instead.
       | otherwise = maybe at go $ at & next
-
--- | Check if all of the supplied predicates are true
-allP :: Foldable f => f (a -> Bool) -> a -> Bool
-allP preds x = all ($ x) preds
-
--- | Check if any of the supplied predicates are true
-anyP :: Foldable f => f (a -> Bool) -> a -> Bool
-anyP preds x = any ($ x) preds
 
 parentIs :: S.SyntaxKind -> Traversal -> Bool
 parentIs k t = Just k == parentKind t

--- a/waspc/waspls/src/Wasp/LSP/TypeHint.hs
+++ b/waspc/waspls/src/Wasp/LSP/TypeHint.hs
@@ -23,13 +23,16 @@ import qualified Wasp.Analyzer.Type as Type
 import Wasp.Analyzer.TypeDefinitions (DeclType (dtBodyType), getDeclType)
 import Wasp.LSP.Syntax (lexemeAt)
 
--- | Get the type that is expected a location in the CST, or Nothing if the
--- type could not be found for some reason.
+-- | Get the type that is expected a location in the CST, or 'Nothing' if a
+-- type could not be determined.
 getTypeHint :: String -> Traversal -> Maybe Type
 getTypeHint src location = case getExprPath src location of
   Just path -> getPathType path
   _ -> Nothing
 
+-- | Get the type in 'stdTypes' for the expression path. The path must start
+-- with a 'Decl', otherwise 'Nothing' is returned. If the path does not exist in
+-- 'stdTypes', 'Nothing' is returned.
 getPathType :: [ExprPath] -> Maybe Type
 getPathType (Decl declType : path) = getExpectedType declType path
 getPathType _ = Nothing
@@ -55,53 +58,78 @@ data ExprPath
   | Tuple !Int
   deriving (Eq, Show)
 
+-- | Try to get an expression path for the given location, returning 'Nothing'
+-- if no path can be determined.
+--
+-- This function only depends on the syntax to the left of the location, and
+-- tries to be as lenient as possible in finding paths.
 getExprPath :: String -> Traversal -> Maybe [ExprPath]
 getExprPath src location = reverse <$> go location
   where
+    -- Recursively travel up the syntax tree, accumlating a path in reverse
+    -- order. Each recursion adds at most one new path component.
     go :: Traversal -> Maybe [ExprPath]
     go t = case T.up t of
-      Nothing -> Just [] -- Already at the top level
+      Nothing -> Just [] -- Top level of the syntax reached
       Just t' -> case T.kindAt t' of
         S.Program -> Just []
         S.Decl -> do
           typLoc <- find ((== S.DeclType) . T.kindAt) $ T.leftSiblings t
           let typ = lexemeAt src typLoc
-          (Decl typ :) <$> go t'
+          -- Stop recursion after finding a Decl
+          return [Decl typ]
         S.DictEntry -> case find ((== S.DictKey) . T.kindAt) $ T.leftSiblings t of
           Just keyLoc -> do
+            -- There is a key to the left, so @t@ is the value for that key
             let key = lexemeAt src keyLoc
             t'' <- T.up t'
             guard $ T.kindAt t'' == S.Dict
             (Key key :) <$> go t''
           Nothing -> go t'
-        S.List -> (List :) <$> go t'
+        S.List -> (List :) <$> go t' -- Inside a list
         S.Tuple -> do
+          -- Inside a tuple, number of non-comma nodes to the left is the tuple
+          -- index that @t@ is part of.
+          --
+          -- We look at non-comma nodes since there is no common @Expr@ node type.
+          -- We don't count commas directly because we want to be provide help
+          -- even when some commas are missing.
           let nExprsBefore = length $ filter ((/= S.Token Tok.Comma) . T.kindAt) $ T.leftSiblings t
           (Tuple nExprsBefore :) <$> go t'
-        _ -> go t'
+        _ -> go t' -- Found some other node, just ignore it and continue the tree
 
--- | @getExpectedType declType exprPathWithoutDecl@
+-- | @getExpectedType declType exprPathWithoutDecl@ searches 'stdTypeDefs' for
+-- a type that coreesponds to the given path, starting at the declaration type
+-- given by name.
+--
+-- === __Example__
+-- >>> getExpectedType "app" [Key "auth", Key "methods", Key "usernameAndPassword"]
+-- Just (Type.DictType { fields = M.fromList [("configFn", Type.DictOptional { dictEntryType = Type.ExtImportType })] })
 getExpectedType :: String -> [ExprPath] -> Maybe Type
 getExpectedType declType originalPath = do
   topType <- getDeclType declType stdTypes
   go (dtBodyType topType) originalPath
   where
+    -- @go parentType path@ returns the result of following @path@ starting at
+    -- @parentType@.
     go :: Type -> [ExprPath] -> Maybe Type
     go typ [] = Just typ
-    go _ (Decl _ : _) = Nothing
+    go _ (Decl _ : _) = Nothing -- Can't follow a decl in the middle of a path
     go typ (Key key : path) =
       case typ of
         Type.DictType fields -> do
+          -- Get the type of the field corresponding to the eky
           typ' <- Type.dictEntryType <$> fields M.!? key
           go typ' path
-        _ -> Nothing
+        _ -> Nothing -- Not a dict type, can't use Key here
     go typ (List : path) = case typ of
-      Type.ListType typ' -> go typ' path
-      _ -> Nothing
+      Type.ListType typ' -> go typ' path -- Use the inner type of the list
+      _ -> Nothing -- Not a list type, can't use List here
     go typ (Tuple idx : path) = case typ of
       Type.TupleType (a, b, cs) -> case idx of
+        -- Follow the current type (by index) of the tuple
         0 -> go a path
         1 -> go b path
         n | n <= length cs + 2 -> go (cs !! (n - 2)) path
-        _ -> Nothing
-      _ -> Nothing
+        _ -> Nothing -- Index is too large for the tuple type
+      _ -> Nothing -- Not a tuple type, can't use Tuple here

--- a/waspc/waspls/src/Wasp/LSP/TypeHint.hs
+++ b/waspc/waspls/src/Wasp/LSP/TypeHint.hs
@@ -1,0 +1,102 @@
+module Wasp.LSP.TypeHint
+  ( -- * Type hints for CSTs
+    getTypeHint,
+
+    -- * Lower level pieces
+    ExprPath (..),
+    getExprPath,
+    getExpectedType,
+  )
+where
+
+import Control.Monad (guard)
+import Data.Foldable (find)
+import qualified Data.HashMap.Strict as M
+import qualified Wasp.Analyzer.Parser.CST as S
+import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
+import qualified Wasp.Analyzer.Parser.CST.Traverse as T
+import qualified Wasp.Analyzer.Parser.Token as Tok
+import Wasp.Analyzer.StdTypeDefinitions (stdTypes)
+import Wasp.Analyzer.Type (Type)
+import qualified Wasp.Analyzer.Type as Type
+import Wasp.Analyzer.TypeDefinitions (DeclType (dtBodyType), getDeclType)
+import Wasp.LSP.Syntax (lexemeAt)
+
+-- | Get the type that is expected a location in the CST, or Nothing if the
+-- type could not be found for some reason.
+getTypeHint :: String -> Traversal -> Maybe Type
+getTypeHint src location = case getExprPath src location of
+  Just (Decl declType : path) -> getExpectedType declType path
+  _ -> Nothing
+
+-- | A "path" that a location follows down a type.
+--
+-- === __Example__
+-- For the code
+--
+-- @
+-- app todoApp {
+--   auth: {
+--     usernameAndPassword: // cursor right here
+--   }
+-- }
+-- @
+--
+-- The path to the cursor would be @[Decl "app", Key "auth", Key "usernameAndPassword"]@
+data ExprPath
+  = Decl !String
+  | Key !String
+  | List
+  | Tuple !Int
+  deriving (Eq, Show)
+
+getExprPath :: String -> Traversal -> Maybe [ExprPath]
+getExprPath src location = reverse <$> go location
+  where
+    go :: Traversal -> Maybe [ExprPath]
+    go t = case T.up t of
+      Nothing -> Just [] -- Already at the top level
+      Just t' -> case T.kindAt t' of
+        S.Program -> Just []
+        S.Decl -> do
+          typLoc <- find ((== S.DeclType) . T.kindAt) $ T.leftSiblings t
+          let typ = lexemeAt src typLoc
+          (Decl typ :) <$> go t'
+        S.DictEntry -> case find ((== S.DictKey) . T.kindAt) $ T.leftSiblings t of
+          Just keyLoc -> do
+            let key = lexemeAt src keyLoc
+            t'' <- T.up t'
+            guard $ T.kindAt t'' == S.Dict
+            (Key key :) <$> go t''
+          Nothing -> go t'
+        S.List -> (List :) <$> go t'
+        S.Tuple -> do
+          let nExprsBefore = length $ filter ((/= S.Token Tok.Comma) . T.kindAt) $ T.leftSiblings t
+          (Tuple nExprsBefore :) <$> go t'
+        _ -> go t'
+
+-- | @getExpectedType declType exprPathWithoutDecl@
+getExpectedType :: String -> [ExprPath] -> Maybe Type
+getExpectedType declType originalPath = do
+  topType <- getDeclType declType stdTypes
+  go (dtBodyType topType) originalPath
+  where
+    go :: Type -> [ExprPath] -> Maybe Type
+    go typ [] = Just typ
+    go _ (Decl _ : _) = Nothing
+    go typ (Key key : path) =
+      case typ of
+        Type.DictType fields -> do
+          typ' <- Type.dictEntryType <$> fields M.!? key
+          go typ' path
+        _ -> Nothing
+    go typ (List : path) = case typ of
+      Type.ListType typ' -> go typ' path
+      _ -> Nothing
+    go typ (Tuple idx : path) = case typ of
+      Type.TupleType (a, b, cs) -> case idx of
+        0 -> go a path
+        1 -> go b path
+        n | n <= length cs + 2 -> go (cs !! (n - 2)) path
+        _ -> Nothing
+      _ -> Nothing

--- a/waspc/waspls/src/Wasp/LSP/TypeHint.hs
+++ b/waspc/waspls/src/Wasp/LSP/TypeHint.hs
@@ -5,6 +5,7 @@ module Wasp.LSP.TypeHint
     -- * Lower level pieces
     ExprPath (..),
     getExprPath,
+    getPathType,
     getExpectedType,
   )
 where
@@ -26,8 +27,12 @@ import Wasp.LSP.Syntax (lexemeAt)
 -- type could not be found for some reason.
 getTypeHint :: String -> Traversal -> Maybe Type
 getTypeHint src location = case getExprPath src location of
-  Just (Decl declType : path) -> getExpectedType declType path
+  Just path -> getPathType path
   _ -> Nothing
+
+getPathType :: [ExprPath] -> Maybe Type
+getPathType (Decl declType : path) = getExpectedType declType path
+getPathType _ = Nothing
 
 -- | A "path" that a location follows down a type.
 --

--- a/waspc/waspls/src/Wasp/LSP/TypeInference.hs
+++ b/waspc/waspls/src/Wasp/LSP/TypeInference.hs
@@ -4,7 +4,7 @@ module Wasp.LSP.TypeInference
 
     -- * Lower level pieces
     ExprPath,
-    ExprKey (..),
+    ExprPathStep (..),
     findExprPathToLocation,
     findTypeForPath,
   )
@@ -39,11 +39,10 @@ inferTypeAtLocation src location = findExprPathToLocation src location >>= findT
 -- }
 -- @
 --
--- The path to the cursor would be @[Decl "app", Key "auth", Key "usernameAndPassword"]@.
-type ExprPath = [ExprKey]
+-- The path to the cursor would be @[Decl "app", DictKey "auth", DictKey "usernameAndPassword"]@.
+type ExprPath = [ExprPathStep]
 
--- | A single step of an 'ExprPath'.
-data ExprKey
+data ExprPathStep
   = -- | @Decl declType@. Enter a declaration of type @declType@.
     Decl !String
   | -- | @DictKey key@. Enter a dictionary *and* its key @key@.

--- a/waspc/waspls/src/Wasp/LSP/TypeInference.hs
+++ b/waspc/waspls/src/Wasp/LSP/TypeInference.hs
@@ -37,12 +37,13 @@ inferTypeAtLocation src location = case findExprPathAtLocation src location of
 -- @
 -- app todoApp {
 --   auth: {
---     usernameAndPassword: // cursor right here
+--     usernameAndPassword: |
+--                          ^
 --   }
 -- }
 -- @
 --
--- The path to the cursor would be @[Decl "app", Key "auth", Key "usernameAndPassword"]@
+-- The path to the cursor would be @[Decl "app", Key "auth", Key "usernameAndPassword"]@.
 type ExprPath = [ExprKey]
 
 -- | A single step of an 'ExprPath'.

--- a/waspc/waspls/src/Wasp/LSP/Util.hs
+++ b/waspc/waspls/src/Wasp/LSP/Util.hs
@@ -1,6 +1,14 @@
-module Wasp.LSP.Util (waspSourceRegionToLspRange, waspPositionToLspPosition) where
+module Wasp.LSP.Util
+  ( allP,
+    anyP,
+    hoistMaybe,
+    waspSourceRegionToLspRange,
+    waspPositionToLspPosition,
+  )
+where
 
 import Control.Lens ((+~))
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import Data.Function ((&))
 import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
@@ -20,3 +28,15 @@ waspPositionToLspPosition (W.SourcePosition ln col) =
     { _line = fromIntegral ln - 1,
       _character = fromIntegral col - 1
     }
+
+-- | Check if all the supplied predicates are true.
+allP :: Foldable f => f (a -> Bool) -> a -> Bool
+allP preds x = all ($ x) preds
+
+-- | Check if any of the supplied predicates are true.
+anyP :: Foldable f => f (a -> Bool) -> a -> Bool
+anyP preds x = any ($ x) preds
+
+-- | Lift a 'Maybe' into a 'MaybeT' monad transformer.
+hoistMaybe :: Applicative m => Maybe a -> MaybeT m a
+hoistMaybe = MaybeT . pure

--- a/waspc/waspls/test/Wasp/LSP/CompletionTest.hs
+++ b/waspc/waspls/test/Wasp/LSP/CompletionTest.hs
@@ -106,12 +106,19 @@ runCompletionTest testInput =
       fmtedCompletionItems = map fmtCompletionItem completionItems
 
       fmtCompletionItem :: LSP.CompletionItem -> String
-      fmtCompletionItem item =
-        unwords
-          [ printf "label={%s}" (show $ item ^. LSP.label),
-            printf "kind={%s}" (show $ item ^. LSP.kind),
-            printf "detail={%s}" (show $ item ^. LSP.detail)
-          ]
+      fmtCompletionItem item = unwords fields
+        where
+          fields =
+            concat
+              [ field "label" LSP.label,
+                optField "kind" LSP.kind,
+                optField "detail" LSP.detail,
+                optField "insertText" LSP.insertText
+              ]
+          field label getter = [printf "%s={%s}" (label :: String) (show $ item ^. getter)]
+          optField label getter = case item ^. getter of
+            Nothing -> []
+            Just v -> [printf "%s={%s}" (label :: String) (show v)]
    in "Completion items:\n" ++ unlines (map ("  " <>) fmtedCompletionItems)
 
 -- | Parses a completion test case into a pair of the wasp source code to

--- a/waspc/waspls/test/Wasp/LSP/CompletionTest.hs
+++ b/waspc/waspls/test/Wasp/LSP/CompletionTest.hs
@@ -111,12 +111,12 @@ runCompletionTest testInput =
           fields =
             concat
               [ field "label" LSP.label,
-                optField "kind" LSP.kind,
-                optField "detail" LSP.detail,
-                optField "insertText" LSP.insertText
+                optionalField "kind" LSP.kind,
+                optionalField "detail" LSP.detail,
+                optionalField "insertText" LSP.insertText
               ]
           field label getter = [printf "%s={%s}" (label :: String) (show $ item ^. getter)]
-          optField label getter = case item ^. getter of
+          optionalField label getter = case item ^. getter of
             Nothing -> []
             Just v -> [printf "%s={%s}" (label :: String) (show v)]
    in "Completion items:\n" ++ unlines (map ("  " <>) fmtedCompletionItems)

--- a/waspc/waspls/test/Wasp/LSP/completionTests/at_dict_key.golden
+++ b/waspc/waspls/test/Wasp/LSP/completionTests/at_dict_key.golden
@@ -1,1 +1,2 @@
 Completion items:
+  label={"key"} kind={Nothing} detail={Nothing}

--- a/waspc/waspls/test/Wasp/LSP/completionTests/at_dict_key.golden
+++ b/waspc/waspls/test/Wasp/LSP/completionTests/at_dict_key.golden
@@ -1,2 +1,3 @@
 Completion items:
-  label={"key"} kind={Nothing} detail={Nothing}
+  label={"path"} kind={CiField} detail={":: string"} insertText={"path: "}
+  label={"to"} kind={CiField} detail={":: page (declaration type)"} insertText={"to: "}

--- a/waspc/waspls/test/Wasp/LSP/completionTests/dict_key_duplicate.golden
+++ b/waspc/waspls/test/Wasp/LSP/completionTests/dict_key_duplicate.golden
@@ -1,0 +1,3 @@
+Completion items:
+  label={"path"} kind={CiField} detail={":: string"} insertText={"path: "}
+  label={"to"} kind={CiField} detail={":: page (declaration type)"} insertText={"to: "}

--- a/waspc/waspls/test/Wasp/LSP/completionTests/dict_key_duplicate.wasp
+++ b/waspc/waspls/test/Wasp/LSP/completionTests/dict_key_duplicate.wasp
@@ -6,8 +6,9 @@ app todoApp {
   title: "todo!",
 }
 
-route MainRoute { | }
-                  ^
+// we suggest all keys of a dictionary, even when some are already used  
+route MainRoute { path: "/", | }
+                             ^
 page MainPage {
   component: import { MainPage } from "@client/MainPage.jsx",
 }

--- a/waspc/waspls/test/Wasp/LSP/completionTests/route_to.golden
+++ b/waspc/waspls/test/Wasp/LSP/completionTests/route_to.golden
@@ -1,4 +1,4 @@
 Completion items:
-  label={"todoApp"} kind={Just CiVariable} detail={Just ":: app (declaration type)"}
-  label={"MainRoute"} kind={Just CiVariable} detail={Just ":: route (declaration type)"}
   label={"MainPage"} kind={Just CiVariable} detail={Just ":: page (declaration type)"}
+  label={"MainRoute"} kind={Just CiVariable} detail={Just ":: route (declaration type)"}
+  label={"todoApp"} kind={Just CiVariable} detail={Just ":: app (declaration type)"}

--- a/waspc/waspls/test/Wasp/LSP/completionTests/route_to.golden
+++ b/waspc/waspls/test/Wasp/LSP/completionTests/route_to.golden
@@ -1,4 +1,4 @@
 Completion items:
-  label={"MainPage"} kind={Just CiVariable} detail={Just ":: page (declaration type)"}
-  label={"MainRoute"} kind={Just CiVariable} detail={Just ":: route (declaration type)"}
-  label={"todoApp"} kind={Just CiVariable} detail={Just ":: app (declaration type)"}
+  label={"MainPage"} kind={CiVariable} detail={":: page (declaration type)"}
+  label={"MainRoute"} kind={CiVariable} detail={":: route (declaration type)"}
+  label={"todoApp"} kind={CiVariable} detail={":: app (declaration type)"}


### PR DESCRIPTION
### Description

- Adds autocomplete for keys in dictionaries
  - `Wasp.LSP.Completions.DictKeyCompletion`
- Adds type signatures in dictionaries to display what type is expected at the current field
  - `Wasp.LSP.SignatureHelp`
- `Wasp.LSP.TypeInference` for finding types in the concrete syntax tree

To test out the new features, `cabal build` waspc in this branch and set the VSCode Wasp extension's executable path to the build output of Cabal. Cabal shows the location of the executable on the last line of its output, where it says `Linking <filepath> ...`.

Closes #1173 

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [X] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
