### PR TITLE
fixes `useAuth` hook when user entity isn't named `User`

### DIFF
--- a/waspc/data/Generator/templates/server/src/routes/auth/me.js
+++ b/waspc/data/Generator/templates/server/src/routes/auth/me.js
@@ -4,8 +4,8 @@ import { handleRejection } from '../../utils.js'
 import { throwInvalidCredentialsError } from '../../core/auth.js'
 
 export default handleRejection(async (req, res) => {
-  if (req.{= userEntityLower =}) {
-    return res.json(superjsonSerialize(req.{= userEntityLower =}))
+  if (req.user) {
+    return res.json(superjsonSerialize(req.user))
   } else {
     throwInvalidCredentialsError()
   }


### PR DESCRIPTION
### Description

Fixes #1204. It was caused by `/auth/me`, the endpoint called by the `useAuth` hook, using `req.{= userEntityLower =}` instead of `req.user`.

I looked through all the other server code that seemed relevant to auth, including all occurrences of `req.XXX` and `{= userEntiyLower =}`, and didn't find any other similar bugs.

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [X] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
