### PR TITLE
Fix two small typos in the docs and website

### DIFF
--- a/web/docs/guides/auth-ui.md
+++ b/web/docs/guides/auth-ui.md
@@ -140,7 +140,7 @@ You customize all of the available forms by passing props to them.
 Props you can pass to all of the forms:
 - `appearance` - appearance of the form, see below (optional)
 - `logo` - path to your logo (optional)
-- `socialLayout` - layout of the social buttons, which can be `vertical`` or `horizontal` (optional)
+- `socialLayout` - layout of the social buttons, which can be `vertical` or `horizontal` (optional)
 
 ### Theme colors override
 

--- a/web/src/components/Faq.js
+++ b/web/src/components/Faq.js
@@ -28,7 +28,7 @@ const faqs = [
       <br/><br/>
       Ruby on Rails and Django both fall in the category of full-stack web frameworks - they allow you to write backend/server code and also generate html/css that gets sent to the client.
       <br/><br/>
-      The main reason whey they are often today not used as a standalone solution, but rather as an API server combined with frontend libraries such as React & Vue, is to add support for the client side manipulation of DOM.
+      The main reason why they are often today not used as a standalone solution, but rather as an API server combined with frontend libraries such as React & Vue, is to add support for the client side manipulation of DOM.
       That’s especially important for web applications with a lot of dynamic content (e.g. dashboards) where you want “smooth” experience of a desktop app.
       Imagine expanding a post on Twitter or moving a Trello card and suddenly the whole site starts reloading - that's why you need React or Vue.
       <br/><br/>


### PR DESCRIPTION
### Description

This just fixes two small typos: one in the docs and one in the website FAQ. No functional changes.

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
