### PR TITLE
fixed broken tutorial link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Wasp's compiler is built with Haskell and under the hood it generates a web appl
 
 ## Before you begin 
 
-- Check out the [**Getting Started**](https://wasp-lang.dev/docs) guide to get familiar with Wasp's fundamentals. Ideally, you'd also build an app from the [**Pick a Tutorial**](https://wasp-lang.dev/docs/pick-a-tutorial) page to really get a feel for it!
+- Check out the [**Getting Started**](https://wasp-lang.dev/docs) guide to get familiar with Wasp's fundamentals. Ideally, you'd also build an app from the [**Pick a Tutorial**](https://wasp-lang.dev/docs/tutorials/todo-app) page to really get a feel for it!
 - Figure out what you'd like to help with. It can be code, documentation, tutorials, etc. More on this is below.
 - Join our Discord [![**Discord**](https://img.shields.io/discord/686873244791210014?label=chat%20on%20discord)](https://discord.gg/rzdnErX) for faster communication and feedback. We'd be happy to help you find the issue you'll enjoy working on, depending on your interests and skill set!
 - Below you can find links to the good first issues. If you'd like to filter the issues on your own — please, use [this link](https://github.com/wasp-lang/wasp/issues)
@@ -35,7 +35,7 @@ Wasp is a language for developing full-stack web apps. This means there are plen
 
 ## Tutorials or Example apps
 
-Another great way to help is to create an app with Wasp! We have an [Examples](https://wasp-lang.dev/docs/examples) section on our website, as well as the [Tutorials](https://wasp-lang.dev/docs/pick-a-tutorial) page. Both of them can be improved and updated with your projects. 
+Another great way to help is to create an app with Wasp! We have an [Examples](https://wasp-lang.dev/docs/examples) section on our website, as well as the [Tutorials](https://wasp-lang.dev/docs/tutorials/todo-app) page. Both of them can be improved and updated with your projects. 
 
 All that's required is to create an app. And make a tutorial or a blog post to help other people reproduce your work. Some prominent examples are: [Waspello](https://wasp-lang.dev/blog/2021/12/02/waspello), [Waspleau](https://wasp-lang.dev/blog/2022/01/27/waspleau), [It Wasps on My Machine](https://wasp-lang.dev/blog/2022/09/05/dev-excuses-app-tutrial) and [To-Do app](https://wasp-lang.dev/docs/tutorials/todo-app).
 


### PR DESCRIPTION
### Description


After investigating the issue with the broken link on the contirbution.md file, I have successfully resolved the problem. Here is a brief description of how I fixed it:

Identified the root cause of the broken link, which was a typo in the URL or an incorrect path specified.
Accessed the repository's settings and located the relevant page or content that the link was intended to lead to.
Corrected the URL or path, ensuring that it accurately pointed to the desired page or content.
### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [x ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
