### PR TITLE
Adds extra type info to middleware customization fn

### DIFF
--- a/waspc/data/Generator/templates/server/src/middleware/globalMiddleware.ts
+++ b/waspc/data/Generator/templates/server/src/middleware/globalMiddleware.ts
@@ -31,7 +31,7 @@ const defaultGlobalMiddlewareConfig: MiddlewareConfig = new Map([
 
 // This is the global middleware that is the result of applying the user's modifications.
 // It will be used as the basis for Operations and APIs (unless they are further customized).
-const globalMiddlewareConfig = {=& globalMiddlewareConfigFn.importAlias =}(defaultGlobalMiddlewareConfig)
+const globalMiddlewareConfig: MiddlewareConfig = {=& globalMiddlewareConfigFn.importAlias =}(defaultGlobalMiddlewareConfig)
 
 // This function returns an array of Express middleware to be used by a router. It optionally
 // accepts a function that can modify the global middleware for specific route customization.


### PR DESCRIPTION
Without this type declaration, Typescript complains 

![image](https://github.com/wasp-lang/wasp/assets/2223680/b0e7b647-a7e5-4641-b9a7-d0984497d99c)
