### PR TITLE
Rewrite templates to include description

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -16,9 +16,9 @@ import Wasp.Cli.Command.CreateNewProject.ProjectDescription
     obtainNewProjectDescription,
   )
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates
-  ( StarterTemplateInfo (..),
+  ( StarterTemplate (..),
     TemplateMetadata (..),
-    getStarterTemplateInfos,
+    getStarterTemplates,
   )
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates.Local (createProjectOnDiskFromLocalTemplate)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates.Remote (createProjectOnDiskFromRemoteTemplate)
@@ -31,9 +31,9 @@ import qualified Wasp.Util.Terminal as Term
 createNewProject :: Arguments -> Command ()
 createNewProject args = do
   newProjectArgs <- parseNewProjectArgs args & either throwProjectCreationError return
-  starterTemplateInfos <- liftIO getStarterTemplateInfos
+  starterTemplates <- liftIO getStarterTemplates
 
-  newProjectDescription <- obtainNewProjectDescription newProjectArgs starterTemplateInfos
+  newProjectDescription <- obtainNewProjectDescription newProjectArgs starterTemplates
 
   createProjectOnDisk newProjectDescription
   liftIO $ printGettingStartedInstructions $ _absWaspProjectDir newProjectDescription
@@ -56,11 +56,11 @@ createProjectOnDisk
   NewProjectDescription
     { _projectName = projectName,
       _appName = appName,
-      _templateInfo = templateInfo,
+      _template = template,
       _absWaspProjectDir = absWaspProjectDir
     } = do
-    cliSendMessageC $ Msg.Start $ "Creating your project from the \"" ++ show templateInfo ++ "\" template..."
-    case templateInfo of
+    cliSendMessageC $ Msg.Start $ "Creating your project from the \"" ++ show template ++ "\" template..."
+    case template of
       RemoteStarterTemplate TemplateMetadata {_path = remoteTemplatePath} ->
         createProjectOnDiskFromRemoteTemplate absWaspProjectDir projectName appName remoteTemplatePath
       LocalStarterTemplate TemplateMetadata {_path = localTemplatePath} ->

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -16,8 +16,9 @@ import Wasp.Cli.Command.CreateNewProject.ProjectDescription
     obtainNewProjectDescription,
   )
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates
-  ( StarterTemplateName (..),
-    getStarterTemplateNames,
+  ( StarterTemplateInfo (..),
+    TemplateMetadata (..),
+    getStarterTemplateInfos,
   )
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates.Local (createProjectOnDiskFromLocalTemplate)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates.Remote (createProjectOnDiskFromRemoteTemplate)
@@ -30,9 +31,9 @@ import qualified Wasp.Util.Terminal as Term
 createNewProject :: Arguments -> Command ()
 createNewProject args = do
   newProjectArgs <- parseNewProjectArgs args & either throwProjectCreationError return
-  starterTemplateNames <- liftIO getStarterTemplateNames
+  starterTemplateInfos <- liftIO getStarterTemplateInfos
 
-  newProjectDescription <- obtainNewProjectDescription newProjectArgs starterTemplateNames
+  newProjectDescription <- obtainNewProjectDescription newProjectArgs starterTemplateInfos
 
   createProjectOnDisk newProjectDescription
   liftIO $ printGettingStartedInstructions $ _absWaspProjectDir newProjectDescription
@@ -55,12 +56,12 @@ createProjectOnDisk
   NewProjectDescription
     { _projectName = projectName,
       _appName = appName,
-      _templateName = templateName,
+      _templateInfo = templateInfo,
       _absWaspProjectDir = absWaspProjectDir
     } = do
-    cliSendMessageC $ Msg.Start $ "Creating your project from the " ++ show templateName ++ " template..."
-    case templateName of
-      RemoteStarterTemplate remoteTemplateName ->
-        createProjectOnDiskFromRemoteTemplate absWaspProjectDir projectName appName remoteTemplateName
-      LocalStarterTemplate localTemplateName ->
-        liftIO $ createProjectOnDiskFromLocalTemplate absWaspProjectDir projectName appName localTemplateName
+    cliSendMessageC $ Msg.Start $ "Creating your project from the \"" ++ show templateInfo ++ "\" template..."
+    case templateInfo of
+      RemoteStarterTemplate TemplateMetadata {_path = remoteTemplatePath} ->
+        createProjectOnDiskFromRemoteTemplate absWaspProjectDir projectName appName remoteTemplatePath
+      LocalStarterTemplate TemplateMetadata {_path = localTemplatePath} ->
+        liftIO $ createProjectOnDiskFromLocalTemplate absWaspProjectDir projectName appName localTemplatePath

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
@@ -21,9 +21,9 @@ import Wasp.Cli.Command.CreateNewProject.Common
     throwProjectCreationError,
   )
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates
-  ( StarterTemplateInfo,
-    defaultStarterTemplateInfo,
-    findTemplateNameByString,
+  ( StarterTemplate,
+    defaultStarterTemplate,
+    findTemplateByString,
   )
 import Wasp.Cli.FileSystem (getAbsPathToDirInCwd)
 import qualified Wasp.Cli.Interactive as Interactive
@@ -33,7 +33,7 @@ import Wasp.Util (indent, kebabToCamelCase, whenM)
 data NewProjectDescription = NewProjectDescription
   { _projectName :: NewProjectName,
     _appName :: NewProjectAppName,
-    _templateInfo :: StarterTemplateInfo,
+    _template :: StarterTemplate,
     _absWaspProjectDir :: Path' Abs (Dir WaspProjectDir)
   }
 
@@ -62,21 +62,21 @@ instance Show NewProjectAppName where
     - Project name is required.
     - Template name is required, we ask the user to choose from available templates.
 -}
-obtainNewProjectDescription :: NewProjectArgs -> [StarterTemplateInfo] -> Command NewProjectDescription
-obtainNewProjectDescription NewProjectArgs {_projectName = projectNameArg, _templateName = templateNameArg} starterTemplateInfos =
+obtainNewProjectDescription :: NewProjectArgs -> [StarterTemplate] -> Command NewProjectDescription
+obtainNewProjectDescription NewProjectArgs {_projectName = projectNameArg, _templateName = templateNameArg} starterTemplates =
   case projectNameArg of
-    Just projectName -> obtainNewProjectDescriptionFromCliArgs projectName templateNameArg starterTemplateInfos
-    Nothing -> obtainNewProjectDescriptionInteractively templateNameArg starterTemplateInfos
+    Just projectName -> obtainNewProjectDescriptionFromCliArgs projectName templateNameArg starterTemplates
+    Nothing -> obtainNewProjectDescriptionInteractively templateNameArg starterTemplates
 
-obtainNewProjectDescriptionFromCliArgs :: String -> Maybe String -> [StarterTemplateInfo] -> Command NewProjectDescription
+obtainNewProjectDescriptionFromCliArgs :: String -> Maybe String -> [StarterTemplate] -> Command NewProjectDescription
 obtainNewProjectDescriptionFromCliArgs projectName templateNameArg availableTemplates =
   obtainNewProjectDescriptionFromProjectNameAndTemplateArg
     projectName
     templateNameArg
     availableTemplates
-    (return defaultStarterTemplateInfo)
+    (return defaultStarterTemplate)
 
-obtainNewProjectDescriptionInteractively :: Maybe String -> [StarterTemplateInfo] -> Command NewProjectDescription
+obtainNewProjectDescriptionInteractively :: Maybe String -> [StarterTemplate] -> Command NewProjectDescription
 obtainNewProjectDescriptionInteractively templateNameArg availableTemplates = do
   projectName <- liftIO $ Interactive.askForRequiredInput "Enter the project name (e.g. my-project)"
   obtainNewProjectDescriptionFromProjectNameAndTemplateArg
@@ -91,17 +91,17 @@ obtainNewProjectDescriptionInteractively templateNameArg availableTemplates = do
 obtainNewProjectDescriptionFromProjectNameAndTemplateArg ::
   String ->
   Maybe String ->
-  [StarterTemplateInfo] ->
-  Command StarterTemplateInfo ->
+  [StarterTemplate] ->
+  Command StarterTemplate ->
   Command NewProjectDescription
 obtainNewProjectDescriptionFromProjectNameAndTemplateArg projectName templateNameArg availableTemplates obtainTemplateWhenNoArg = do
   absWaspProjectDir <- obtainAvailableProjectDirPath projectName
-  selectedTemplate <- maybe obtainTemplateWhenNoArg findTemplateInfoOrThrow templateNameArg
+  selectedTemplate <- maybe obtainTemplateWhenNoArg findTemplateOrThrow templateNameArg
   mkNewProjectDescription projectName absWaspProjectDir selectedTemplate
   where
-    findTemplateInfoOrThrow :: String -> Command StarterTemplateInfo
-    findTemplateInfoOrThrow templateName =
-      findTemplateNameByString availableTemplates templateName
+    findTemplateOrThrow :: String -> Command StarterTemplate
+    findTemplateOrThrow templateName =
+      findTemplateByString availableTemplates templateName
         & maybe throwInvalidTemplateNameUsedError return
 
 obtainAvailableProjectDirPath :: String -> Command (Path' Abs (Dir WaspProjectDir))
@@ -121,14 +121,14 @@ obtainAvailableProjectDirPath projectName = do
         throwProjectCreationError $
           "Directory \"" ++ projectDirName ++ "\" is not empty."
 
-mkNewProjectDescription :: String -> Path' Abs (Dir WaspProjectDir) -> StarterTemplateInfo -> Command NewProjectDescription
-mkNewProjectDescription projectName absWaspProjectDir templateInfo
+mkNewProjectDescription :: String -> Path' Abs (Dir WaspProjectDir) -> StarterTemplate -> Command NewProjectDescription
+mkNewProjectDescription projectName absWaspProjectDir template
   | isValidWaspIdentifier appName =
       return $
         NewProjectDescription
           { _projectName = NewProjectName projectName,
             _appName = NewProjectAppName appName,
-            _templateInfo = templateInfo,
+            _template = template,
             _absWaspProjectDir = absWaspProjectDir
           }
   | otherwise =

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates.hs
@@ -1,9 +1,9 @@
 module Wasp.Cli.Command.CreateNewProject.StarterTemplates
-  ( getStarterTemplateInfos,
-    StarterTemplateInfo (..),
+  ( getStarterTemplates,
+    StarterTemplate (..),
     TemplateMetadata (..),
-    findTemplateNameByString,
-    defaultStarterTemplateInfo,
+    findTemplateByString,
+    defaultStarterTemplate,
   )
 where
 
@@ -12,7 +12,7 @@ import Data.Foldable (find)
 import qualified Wasp.Cli.Command.CreateNewProject.StarterTemplates.Remote.Github as Github
 import qualified Wasp.Cli.Interactive as Interactive
 
-data StarterTemplateInfo = RemoteStarterTemplate TemplateMetadata | LocalStarterTemplate TemplateMetadata
+data StarterTemplate = RemoteStarterTemplate TemplateMetadata | LocalStarterTemplate TemplateMetadata
   deriving (Eq)
 
 data TemplateMetadata = TemplateMetadata
@@ -22,25 +22,25 @@ data TemplateMetadata = TemplateMetadata
   }
   deriving (Eq, Show)
 
-instance Show StarterTemplateInfo where
+instance Show StarterTemplate where
   show (RemoteStarterTemplate TemplateMetadata {_name = title}) = title
   show (LocalStarterTemplate TemplateMetadata {_name = title}) = title
 
-instance Interactive.Option StarterTemplateInfo where
+instance Interactive.Option StarterTemplate where
   showOption = show
   showOptionDescription (RemoteStarterTemplate TemplateMetadata {_description = description}) = Just description
   showOptionDescription (LocalStarterTemplate TemplateMetadata {_description = description}) = Just description
 
-getStarterTemplateInfos :: IO [StarterTemplateInfo]
-getStarterTemplateInfos = do
-  remoteTemplates <- fromRight [] <$> fetchRemoteStarterTemplateInfos
+getStarterTemplates :: IO [StarterTemplate]
+getStarterTemplates = do
+  remoteTemplates <- fromRight [] <$> fetchRemoteStarterTemplates
   return $ localTemplates ++ remoteTemplates
 
-fetchRemoteStarterTemplateInfos :: IO (Either String [StarterTemplateInfo])
-fetchRemoteStarterTemplateInfos = do
+fetchRemoteStarterTemplates :: IO (Either String [StarterTemplate])
+fetchRemoteStarterTemplates = do
   fmap extractTemplateNames <$> Github.fetchRemoteTemplatesGithubData
   where
-    extractTemplateNames :: [Github.RemoteTemplateGithubData] -> [StarterTemplateInfo]
+    extractTemplateNames :: [Github.RemoteTemplateGithubData] -> [StarterTemplate]
     -- Each folder in the repo is a template.
     extractTemplateNames =
       map
@@ -53,11 +53,11 @@ fetchRemoteStarterTemplateInfos = do
                 }
         )
 
-localTemplates :: [StarterTemplateInfo]
-localTemplates = [defaultStarterTemplateInfo]
+localTemplates :: [StarterTemplate]
+localTemplates = [defaultStarterTemplate]
 
-defaultStarterTemplateInfo :: StarterTemplateInfo
-defaultStarterTemplateInfo = LocalStarterTemplate $ TemplateMetadata {_name = "basic", _path = "basic", _description = "Simple starter template with a single page."}
+defaultStarterTemplate :: StarterTemplate
+defaultStarterTemplate = LocalStarterTemplate $ TemplateMetadata {_name = "basic", _path = "basic", _description = "Simple starter template with a single page."}
 
-findTemplateByString :: [StarterTemplateInfo] -> String -> Maybe StarterTemplateInfo
-findTemplateByString templateInfos query = find ((== query) . show) templateInfos
+findTemplateByString :: [StarterTemplate] -> String -> Maybe StarterTemplate
+findTemplateByString templates query = find ((== query) . show) templates

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates.hs
@@ -59,5 +59,5 @@ localTemplates = [defaultStarterTemplateInfo]
 defaultStarterTemplateInfo :: StarterTemplateInfo
 defaultStarterTemplateInfo = LocalStarterTemplate $ TemplateMetadata {_name = "basic", _path = "basic", _description = "Simple starter template with a single page."}
 
-findTemplateNameByString :: [StarterTemplateInfo] -> String -> Maybe StarterTemplateInfo
-findTemplateNameByString templateNames query = find ((== query) . show) templateNames
+findTemplateByString :: [StarterTemplateInfo] -> String -> Maybe StarterTemplateInfo
+findTemplateByString templateInfos query = find ((== query) . show) templateInfos

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Local.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Local.hs
@@ -14,8 +14,8 @@ import qualified Wasp.Data as Data
 import Wasp.Project (WaspProjectDir)
 
 createProjectOnDiskFromLocalTemplate :: Path' Abs (Dir WaspProjectDir) -> NewProjectName -> NewProjectAppName -> String -> IO ()
-createProjectOnDiskFromLocalTemplate absWaspProjectDir projectName appName templateName = do
-  copyLocalTemplateToNewProjectDir templateName
+createProjectOnDiskFromLocalTemplate absWaspProjectDir projectName appName templatePath = do
+  copyLocalTemplateToNewProjectDir templatePath
   replaceTemplatePlaceholdersInWaspFile appName projectName absWaspProjectDir
   where
     copyLocalTemplateToNewProjectDir :: String -> IO ()

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Remote.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Remote.hs
@@ -21,11 +21,11 @@ createProjectOnDiskFromRemoteTemplate ::
   NewProjectAppName ->
   String ->
   Command ()
-createProjectOnDiskFromRemoteTemplate absWaspProjectDir projectName appName templateName = do
-  fetchGithubTemplateToDisk absWaspProjectDir templateName >>= either throwProjectCreationError pure
+createProjectOnDiskFromRemoteTemplate absWaspProjectDir projectName appName templatePath = do
+  fetchGithubTemplateToDisk absWaspProjectDir templatePath >>= either throwProjectCreationError pure
   liftIO $ replaceTemplatePlaceholdersInWaspFile appName projectName absWaspProjectDir
   where
     fetchGithubTemplateToDisk :: Path' Abs (Dir WaspProjectDir) -> String -> Command (Either String ())
-    fetchGithubTemplateToDisk projectDir templateFolderName = do
-      let templateFolderPath = fromJust . SP.parseRelDir $ templateFolderName
+    fetchGithubTemplateToDisk projectDir templatePathInRepo = do
+      let templateFolderPath = fromJust . SP.parseRelDir $ templatePathInRepo
       liftIO $ fetchFolderFromGithubRepoToDisk starterTemplateGithubRepo templateFolderPath projectDir

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Remote/Github.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Remote/Github.hs
@@ -1,6 +1,8 @@
 module Wasp.Cli.Command.CreateNewProject.StarterTemplates.Remote.Github where
 
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
 import Wasp.Cli.GithubRepo (GithubRepoRef (..))
+import qualified Wasp.Cli.GithubRepo as GR
 
 starterTemplateGithubRepo :: GithubRepoRef
 starterTemplateGithubRepo =
@@ -9,3 +11,26 @@ starterTemplateGithubRepo =
       _repoName = "starters",
       _repoReferenceName = "main"
     }
+
+starterTemplatesDataGithubFilePath :: String
+starterTemplatesDataGithubFilePath = "templates.json"
+
+fetchRemoteTemplatesGithubData :: IO (Either String [RemoteTemplateGithubData])
+fetchRemoteTemplatesGithubData = GR.fetchRepoFileContents starterTemplateGithubRepo starterTemplatesDataGithubFilePath
+
+data RemoteTemplateGithubData = RemoteTemplateGithubData
+  { _name :: String,
+    _description :: String,
+    _path :: String
+  }
+  deriving (Show, Eq)
+
+instance FromJSON RemoteTemplateGithubData where
+  parseJSON = withObject "RemoteTemplateGithubData" $ \obj ->
+    RemoteTemplateGithubData
+      <$> obj
+      .: "name"
+      <*> obj
+      .: "description"
+      <*> obj
+      .: "path"

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Remote/Github.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Remote/Github.hs
@@ -12,7 +12,7 @@ starterTemplateGithubRepo =
       _repoReferenceName = "main"
     }
 
-starterTemplatesDataGithubFilePath :: String
+starterTemplatesDataGithubFilePath :: FilePath
 starterTemplatesDataGithubFilePath = "templates.json"
 
 fetchRemoteTemplatesGithubData :: IO (Either String [RemoteTemplateGithubData])

--- a/waspc/cli/src/Wasp/Cli/GithubRepo.hs
+++ b/waspc/cli/src/Wasp/Cli/GithubRepo.hs
@@ -3,15 +3,10 @@
 module Wasp.Cli.GithubRepo where
 
 import Control.Exception (try)
-import Data.Aeson
-  ( FromJSON,
-    parseJSON,
-    withObject,
-    (.:),
-  )
+import Data.Aeson (FromJSON)
 import Data.Functor ((<&>))
 import Data.List (intercalate)
-import Data.Maybe (fromJust, maybeToList)
+import Data.Maybe (fromJust)
 import qualified Network.HTTP.Simple as HTTP
 import StrongPath (Abs, Dir, Path', Rel, (</>))
 import qualified StrongPath as SP
@@ -69,46 +64,15 @@ fetchFolderFromGithubRepoToDisk githubRepoRef folderInRepoRoot destinationOnDisk
           githubRepoArchiveRootFolderName :: Path' (Rel archiveRoot) (Dir archiveInnerDir)
           githubRepoArchiveRootFolderName = fromJust . SP.parseRelDir $ repoName ++ "-" ++ repoReferenceName
 
-fetchRepoRootFolderContents :: GithubRepoRef -> IO (Either String RepoFolderContents)
-fetchRepoRootFolderContents githubRepo = fetchRepoFolderContents githubRepo Nothing
-
-fetchRepoFolderContents :: GithubRepoRef -> Maybe String -> IO (Either String RepoFolderContents)
-fetchRepoFolderContents githubRepo pathToFolderInRepo = do
+fetchRepoFileContents :: FromJSON a => GithubRepoRef -> String -> IO (Either String a)
+fetchRepoFileContents githubRepo filePath = do
   try (HTTP.httpJSONEither ghRepoInfoRequest) <&> \case
     Right response -> either (Left . show) Right $ HTTP.getResponseBody response
     Left (e :: HTTP.HttpException) -> Left $ show e
   where
-    ghRepoInfoRequest =
-      -- Github returns 403 if we don't specify user-agent.
-      HTTP.addRequestHeader "User-Agent" "wasp-lang/wasp" $ HTTP.parseRequest_ apiURL
-    apiURL = intercalate "/" $ ["https://api.github.com/repos", _repoOwner githubRepo, _repoName githubRepo, "contents"] ++ maybeToList pathToFolderInRepo
+    ghRepoInfoRequest = mkGithubApiRequest apiURL
+    apiURL = intercalate "/" ["https://raw.githubusercontent.com", _repoOwner githubRepo, _repoName githubRepo, _repoReferenceName githubRepo, filePath]
 
-type RepoFolderContents = [RepoObject]
-
-data RepoObject = RepoObject
-  { _name :: String,
-    _type :: RepoObjectType,
-    _downloadUrl :: Maybe String
-  }
-  deriving (Show)
-
-data RepoObjectType = Folder | File
-  deriving (Show, Eq)
-
-instance FromJSON RepoObject where
-  parseJSON = withObject "RepoObject" $ \o -> do
-    name <- o .: "name"
-    type_ <- o .: "type"
-    downloadUrl <- o .: "download_url"
-    return
-      RepoObject
-        { _name = name,
-          _type = parseType type_,
-          _downloadUrl = downloadUrl
-        }
-    where
-      parseType :: String -> RepoObjectType
-      parseType = \case
-        "dir" -> Folder
-        "file" -> File
-        _ -> error "Unable to parse repo object type."
+-- Github returns 403 if we don't specify a user-agent.
+mkGithubApiRequest :: String -> HTTP.Request
+mkGithubApiRequest url = HTTP.addRequestHeader "User-Agent" "wasp-lang/wasp" $ HTTP.parseRequest_ url


### PR DESCRIPTION
- Templates repo now has a `templates.json` file which lists all templates https://github.com/wasp-lang/starters/blob/main/templates.json
- Interactive CLI can now show an option's description
- We now include the `description` from the JSON when listing the options

<img width="705" alt="Screenshot 2023-06-23 at 12 29 13" src="https://github.com/wasp-lang/wasp/assets/2223680/9498bc97-1f6e-4695-92bb-aa193794758e">

