### PR TITLE
Wasp ai fix plan

### DIFF
--- a/waspc/src/Wasp/Util/Aeson.hs
+++ b/waspc/src/Wasp/Util/Aeson.hs
@@ -1,0 +1,13 @@
+module Wasp.Util.Aeson
+  ( encodeToText,
+  )
+where
+
+import Data.Aeson (ToJSON)
+import Data.Aeson.Text (encodeToTextBuilder)
+import Data.Text (Text)
+import Data.Text.Lazy (toStrict)
+import Data.Text.Lazy.Builder (toLazyText)
+
+encodeToText :: ToJSON a => a -> Text
+encodeToText = toStrict . toLazyText . encodeToTextBuilder

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -341,6 +341,7 @@ library
     Wasp.SemanticVersion
     Wasp.TypeScript
     Wasp.Util
+    Wasp.Util.Aeson
     Wasp.Util.Network.Socket
     Wasp.Util.Control.Monad
     Wasp.Util.Fib


### PR DESCRIPTION
The idea is that we send stuff Wasp AI generates for repairs if something is wrong with it.

ChatGPT has been shown to be able to improve stuff it just generated, if you just ask it to do it.

This PR does part of this idea: asks it to fix the Plan. We detect some usual issues and report them to it.

We will later add the same thing for Wasp file, for Operation files, and for Page files, in a bit different manner, but relatively similar.