### PR TITLE
[waspls] implement goto definition for declarations

### DIFF
--- a/waspc/src/Wasp/Analyzer/Parser/CST/Traverse.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/CST/Traverse.hs
@@ -15,6 +15,7 @@ module Wasp.Analyzer.Parser.CST.Traverse
     -- * Traversal operations
 
     -- | See the section on composition functions on how to compose these.
+    top,
     bottom,
     down,
     up,
@@ -136,6 +137,9 @@ pipe ops = foldl' (>=>) Just ops
 -- used for essentially the same purpose in this library.
 (&?) :: Maybe Traversal -> (Traversal -> Maybe Traversal) -> Maybe Traversal
 t &? op = t >>= op
+
+top :: Traversal -> Traversal
+top t = maybe t top $ t & up
 
 -- | Move down the tree to the deepest left-most leaf
 bottom :: Traversal -> Traversal


### PR DESCRIPTION
Allows you to jump to the definition of declarations from uses of the declaration.

Demo:
![decl-goto-def](https://github.com/wasp-lang/wasp/assets/22552467/c3e06817-6389-4d3f-970b-f92d16ca17f7)
