### PR TITLE
Import heuristic for Wasp AI

### DIFF
--- a/waspc/src/Wasp/AI/GenerateNewProject.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject.hs
@@ -15,7 +15,7 @@ import Wasp.AI.GenerateNewProject.Entity (writeEntitiesToWaspFile)
 import Wasp.AI.GenerateNewProject.Operation (OperationType (..), generateAndWriteOperation, getOperationJsFilePath)
 import Wasp.AI.GenerateNewProject.OperationsJsFile (fixOperationsJsFile)
 import Wasp.AI.GenerateNewProject.Page (generateAndWritePage, getPageComponentPath)
-import Wasp.AI.GenerateNewProject.PageComponentFile (fixPageComponent)
+import Wasp.AI.GenerateNewProject.PageComponentFile (fixImportsInPageComponentFile, fixPageComponent)
 import Wasp.AI.GenerateNewProject.Plan (generatePlan)
 import qualified Wasp.AI.GenerateNewProject.Plan as Plan
 import Wasp.AI.GenerateNewProject.Skeleton (generateAndWriteProjectSkeletonAndPresetFiles)
@@ -31,7 +31,7 @@ generateNewProject ::
   CodeAgent ()
 generateNewProject newProjectDetails waspProjectSkeletonFiles = do
   writeToLog . T.pack $
-    "Generating new wasp project named " <> _projectAppName newProjectDetails <> "!"
+    "Generating a new Wasp project named " <> _projectAppName newProjectDetails <> "!"
 
   writeToLog "Generating project skeleton..."
   (waspFilePath, planRules) <-
@@ -41,7 +41,7 @@ generateNewProject newProjectDetails waspProjectSkeletonFiles = do
   plan <- generatePlan newProjectDetails planRules
 
   writeEntitiesToWaspFile waspFilePath (Plan.entities plan)
-  writeToLog "Updated wasp file with entities."
+  writeToLog "Updated the Wasp file with entities."
 
   writeToLog "Generating actions..."
   actions <-
@@ -61,21 +61,27 @@ generateNewProject newProjectDetails waspProjectSkeletonFiles = do
   -- TODO: Pass plan rules into fixWaspFile, as extra guidance what to keep an eye on? We can't just
   --   do it blindly though, some of them are relevant only to plan (e.g. not generating login /
   --   signup page), we would have to do some adapting.
-  writeToLog "Fixing any mistakes in Wasp file..."
+  writeToLog "Fixing mistakes in the Wasp file..."
   fixWaspFile newProjectDetails waspFilePath plan
   writeToLog "Wasp file fixed."
 
-  writeToLog "Fixing any mistakes in NodeJS operations files..."
+  writeToLog "Fixing mistakes in NodeJS operation files..."
   forM_ (nub $ getOperationJsFilePath <$> (queries <> actions)) $ \opFp -> do
     fixOperationsJsFile newProjectDetails waspFilePath opFp
-    writeToLog $ T.pack $ "Fixed NodeJS operations file '" <> opFp <> "'."
-  writeToLog "NodeJS operations files fixed."
+    writeToLog $ T.pack $ "Fixed NodeJS operation file '" <> opFp <> "'."
+  writeToLog "NodeJS operation files fixed."
 
-  writeToLog "Fixing any mistakes in pages..."
+  writeToLog "Fixing common mistakes in pages..."
   forM_ (getPageComponentPath <$> pages) $ \pageFp -> do
     fixPageComponent newProjectDetails waspFilePath pageFp queries actions
     writeToLog $ T.pack $ "Fixed '" <> pageFp <> "' page."
   writeToLog "Pages fixed."
+
+  writeToLog "Fixing import mistakes in pages..."
+  forM_ (getPageComponentPath <$> pages) $ \pageFp -> do
+    fixImportsInPageComponentFile pageFp queries actions
+    writeToLog $ T.pack $ "Fixed '" <> pageFp <> "' page."
+  writeToLog "Imports in pages fixed."
 
   (promptTokensUsed, completionTokensUsed) <- getTotalTokensUsage
   writeToLog $
@@ -84,4 +90,3 @@ generateNewProject newProjectDetails waspProjectSkeletonFiles = do
         fromIntegral (promptTokensUsed + completionTokensUsed) / (1000 :: Double)
 
   writeToLog "Done!"
-  where

--- a/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs
@@ -2,11 +2,21 @@
 
 module Wasp.AI.GenerateNewProject.PageComponentFile
   ( fixPageComponent,
+    fixImportsInPageComponentFile,
+    -- NOTE: Exports below are exported only for testing!
+    getPageComponentFileContentWithFixedImports,
+    partitionComponentFileByImports,
+    getImportedNamesFromImport,
   )
 where
 
+import Control.Arrow (first)
 import Data.Aeson (FromJSON)
-import Data.Maybe (fromMaybe)
+import Data.List (intercalate, isInfixOf, isPrefixOf, partition, stripPrefix)
+import Data.List.Extra (nub)
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Maybe (fromJust, fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics (Generic)
@@ -20,8 +30,60 @@ import Wasp.AI.GenerateNewProject.Common
 import Wasp.AI.GenerateNewProject.Common.Prompts (appDescriptionBlock)
 import qualified Wasp.AI.GenerateNewProject.Common.Prompts as Prompts
 import Wasp.AI.GenerateNewProject.Operation (Operation)
-import Wasp.AI.GenerateNewProject.Page (getAllPossibleImports, makePageDocPrompt)
+import Wasp.AI.GenerateNewProject.Page (getAllPossibleWaspJsClientImports, makePageDocPrompt)
 import Wasp.AI.OpenAI.ChatGPT (ChatMessage (..), ChatRole (..))
+import Wasp.Util (trim)
+
+fixImportsInPageComponentFile :: FilePath -> [Operation] -> [Operation] -> CodeAgent ()
+fixImportsInPageComponentFile pageComponentPath queries actions = do
+  currentPageComponentContent <- fromMaybe (error "couldn't find page file to fix") <$> getFile pageComponentPath
+  let fixedComponentContent = getPageComponentFileContentWithFixedImports currentPageComponentContent allPossibleWaspImports
+  writeToFile pageComponentPath (const fixedComponentContent)
+  where
+    allPossibleWaspImports = getAllPossibleWaspJsClientImports $ queries ++ actions
+
+getPageComponentFileContentWithFixedImports :: Text -> Map String String -> Text
+getPageComponentFileContentWithFixedImports pageComponentContent allPossibleWaspImports =
+  T.intercalate "\n" [nonWaspImportsText, fixedWaspImportsText, remainingCodeText]
+  where
+    fixedWaspImportsText = T.pack $ intercalate "\n" $ mapMaybe (`M.lookup` allPossibleWaspImports) importedNames
+    nonWaspImportsText = T.pack $ intercalate "\n" nonWaspImports
+    remainingCodeText = T.pack $ intercalate "\n" remainingCode
+    importedNames = nub $ concatMap getImportedNamesFromImport waspImports
+    (waspImports, nonWaspImports, remainingCode) = partitionComponentFileByImports pageComponentContent
+
+-- NOTE: Doesn't work correctly for imports that use `as` keyword!
+getImportedNamesFromImport :: String -> [String]
+getImportedNamesFromImport =
+  nub
+    . words
+    . map convertSpecialCharToSpace
+    . trim
+    . removeSuffix "from"
+    . trim
+    . removePrefix "import"
+    . trim
+    . takeWhile (not . (`elem` ['"', '\'']))
+  where
+    convertSpecialCharToSpace char
+      | char `elem` [',', '}', '{'] = ' '
+      | otherwise = char
+
+    removePrefix prefix = fromJust . stripPrefix prefix
+
+    removeSuffix suffix = reverse . removePrefix (reverse suffix) . reverse
+
+partitionComponentFileByImports :: Text -> ([String], [String], [String])
+partitionComponentFileByImports componentContent = (waspImportLines, nonWaspImportLines, "" : remainingCodeLines)
+  where
+    (waspImportLines, nonWaspImportLines) = partition isWaspImportLine importLines
+    (importLines, remainingCodeLines) =
+      first cleanUpImportLines $
+        span isImportLineOrEmpty $ lines $ T.unpack componentContent
+
+    isImportLineOrEmpty l = let l' = trim l in "import" `isPrefixOf` l' || null l'
+    isWaspImportLine = ("@wasp" `isInfixOf`)
+    cleanUpImportLines = filter (not . null) . fmap trim
 
 fixPageComponent :: NewProjectDetails -> FilePath -> FilePath -> [Operation] -> [Operation] -> CodeAgent ()
 fixPageComponent newProjectDetails waspFilePath pageComponentPath queries actions = do
@@ -62,17 +124,15 @@ fixPageComponent newProjectDetails waspFilePath pageComponentPath queries action
 
           Strong guidelines for fixing:
             - Make sure to use only queries and actions that are defined in the Wasp file (listed below)!
-            - Ensure query and action imports are correct. One import per query / action, default imports,
-              name of the file same as name of the query.
             - Use Tailwind CSS to style the page if you didn't.
             - Use <Link /> component from "react-router-dom" to link to other pages where needed.
             - "TODO" comments or "..." that should be replaced with actual implementation.
               Fix these by replacing them with actual implementation.
             - If there are any duplicate imports, make sure to remove them.
             - There might be some invalid JS or JSX syntax -> fix it if there is any.
-            - If there are any js imports of local modules (`from "./`, `from "../`), remove them and instead add the needed implementation directly in the file we are fixing right now.
-            - All @wasp imports must come from the list below:
-              ${possibleImportsList}
+            - If there are any js imports of local modules (`from "./`, `from "../`),
+              remove them and instead add the needed implementation directly in the file we are fixing right now.
+            - Remove redundant imports, but don't change any of the remaining ones.
 
           With this in mind, generate a new, fixed React component (${pageComponentPathText}).
           Do actual fixes, don't leave comments with "TODO"!
@@ -85,7 +145,6 @@ fixPageComponent newProjectDetails waspFilePath pageComponentPath queries action
     basicWaspLangInfoPrompt = Prompts.basicWaspLangInfo
     pageComponentPathText = T.pack pageComponentPath
     pageDocPrompt = makePageDocPrompt $ queries ++ actions
-    possibleImportsList = T.unlines $ getAllPossibleImports $ queries ++ actions
 
 data PageComponent = PageComponent
   { pageComponentImpl :: Text

--- a/waspc/test/AI/GenerateNewProject/PageComponentFileTest.hs
+++ b/waspc/test/AI/GenerateNewProject/PageComponentFileTest.hs
@@ -1,0 +1,92 @@
+module AI.GenerateNewProject.PageComponentFileTest where
+
+import qualified Data.Map as M
+import NeatInterpolation (trimming)
+import Test.Tasty.Hspec
+import Wasp.AI.GenerateNewProject.PageComponentFile
+
+spec_PageComponentFileTest :: Spec
+spec_PageComponentFileTest = do
+  describe "getPageComponentFileContentWithFixedImports" $ do
+    let mockAllPossibleWaspClientImports =
+          M.fromList $
+            [ ("useQuery", "import { useQuery } from '@wasp/queries';"),
+              ("useAction", "import { useAction } from '@wasp/actions';"),
+              ("useAuth", "import useAuth from '@wasp/auth/useAuth';"),
+              ("someAction", "import someAction from '@wasp/actions/someAction';"),
+              ("someQuery", "import someQuery from '@wasp/queries/someQuery';")
+            ]
+    it "should fix incorrect @wasp imports while keeping non-@wasp imports and removing made up @wasp ones." $ do
+      let mockPageComponentFileContent =
+            [trimming|
+              import React from 'react';
+              import { useAuth } from '@wasp/authorization/useAuth';
+              import { useQuery, useAction } from '@wasp/queries_and_actions';
+              import { Link } from 'react-router';
+              import madeUpThingy from '@wasp/madeup';
+              import { someAction } from '@wasp/actions';
+
+              function HomePage () {
+                ...
+              }
+            |]
+      getPageComponentFileContentWithFixedImports
+        mockPageComponentFileContent
+        mockAllPossibleWaspClientImports
+        `shouldBe` [trimming|
+              import React from 'react';
+              import { Link } from 'react-router';
+              import useAuth from '@wasp/auth/useAuth';
+              import { useQuery } from '@wasp/queries';
+              import { useAction } from '@wasp/actions';
+              import someAction from '@wasp/actions/someAction';
+
+              function HomePage () {
+                ...
+              }
+            |]
+
+  describe "getImportedNameFromImport" $ do
+    it "should correctly pick up names from various imports statements" $ do
+      getImportedNamesFromImport "import { foo, barBar} from 'some/path'"
+        `shouldBe` ["foo", "barBar"]
+      getImportedNamesFromImport " import  fooFoo from \"../\" "
+        `shouldBe` ["fooFoo"]
+
+  describe "partitionComponentFileByImports" $ do
+    it "should partition file content to wasp imports, non-wasp imports, and the rest of the file." $ do
+      let fileContent =
+            "\n"
+              <> [trimming|
+              import React from 'react';
+              import { useAuth } from '@wasp/useAuth';
+                import { useQuery } from '@wasp/queries';
+
+              import { someAction } from '@wasp/actions';
+              import { Link } from 'react-router';
+
+              function importStuff () {
+                importStuffNow("@wasp");
+              }
+
+              const a = 5;
+           |]
+              <> "\n\n"
+
+      partitionComponentFileByImports fileContent
+        `shouldBe` ( [ "import { useAuth } from '@wasp/useAuth';",
+                       "import { useQuery } from '@wasp/queries';",
+                       "import { someAction } from '@wasp/actions';"
+                     ],
+                     [ "import React from 'react';",
+                       "import { Link } from 'react-router';"
+                     ],
+                     [ "",
+                       "function importStuff () {",
+                       "  importStuffNow(\"@wasp\");",
+                       "}",
+                       "",
+                       "const a = 5;",
+                       ""
+                     ]
+                   )

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -511,10 +511,12 @@ test-suite waspc-test
   build-depends:
     , aeson
     , base
+    , containers
     , Diff                  ^>= 0.4.1
     , deepseq
     , filepath
     , mtl
+    , neat-interpolation
     , parsec
     , path
     , split
@@ -530,6 +532,7 @@ test-suite waspc-test
     , tasty-quickcheck      ^>= 0.10
     , tasty-golden          ^>= 2.3.5
   other-modules:
+    AI.GenerateNewProject.PageComponentFileTest
     Analyzer.Evaluation.EvaluationErrorTest
     Analyzer.EvaluatorTest
     Analyzer.Parser.ConcreteParserTest


### PR DESCRIPTION
Tested it. It can fix this:
```js
import React from 'react';
import Gmao from 'gmao';
import { useParams, Link } from 'react-router-dom';
import { useQuery, useAction } from '@wasp/actions';
import { getPost, useAuth} from '@wasp/queries/getPost';
import editPost from '@wasp/auth/useAuth';
import { deletePost }  from '@wasp/actions/deletePost';
import { createComment, deleteComment }  from '@wasp';
import Elmao from 'lmao';
```
Into this:
```js
import React from 'react';
import Gmao from 'gmao';
import { useParams, Link } from 'react-router-dom';
import Elmao from 'lmao';
import { useQuery } from '@wasp/queries';
import { useAction } from '@wasp/actions';
import getPost from '@wasp/queries/getPost';
import useAuth from '@wasp/auth/useAuth';
import editPost from '@wasp/actions/editPost';
import deletePost from '@wasp/actions/deletePost';
import createComment from '@wasp/actions/createComment';
import deleteComment from '@wasp/actions/deleteComment';
```

TODO: Go through the prompts and see whether we can remove some of the old instructions for imports (now that we do this).

Leftovers for testing can be found here: https://github.com/wasp-lang/wasp/blob/filip-wasp-ai-leftovers/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs