### PR TITLE
[waspls] Add code actions for scaffolding external code

### DIFF
--- a/waspc/data/lsp/templates/ts/action.fn.js
+++ b/waspc/data/lsp/templates/ts/action.fn.js
@@ -1,0 +1,8 @@
+{{#named?}}export {{/named?}}const {{name}} = async (args, context) => {
+  // Implementation goes here
+}
+
+{{#default?}}
+export default {{name}}
+{{/default?}}
+

--- a/waspc/data/lsp/templates/ts/action.fn.ts
+++ b/waspc/data/lsp/templates/ts/action.fn.ts
@@ -1,0 +1,9 @@
+import { {{upperDeclName}} } from '@wasp/actions/types'
+
+{{#named?}}export {{/named?}}const {{name}}: {{upperDeclName}}<void, void> = async (args, context) => {
+  // Implementation goes here
+}
+
+{{#default?}}
+export default {{name}}
+{{/default?}}

--- a/waspc/data/lsp/templates/ts/page.component.jsx
+++ b/waspc/data/lsp/templates/ts/page.component.jsx
@@ -1,0 +1,9 @@
+{{#named?}}export {{/named?}}function {{name}}() {
+  return (
+    <div>Hello world!</div>
+  )
+}
+
+{{#default?}}
+export default {{name}}
+{{/default?}}

--- a/waspc/data/lsp/templates/ts/page.component.tsx
+++ b/waspc/data/lsp/templates/ts/page.component.tsx
@@ -1,0 +1,10 @@
+{{#named?}}export {{/named?}}function {{name}}() {
+  return (
+    <div>Hello world!</div>
+  )
+}
+
+{{#default?}}
+export default {{name}}
+{{/default?}}
+

--- a/waspc/data/lsp/templates/ts/query.fn.js
+++ b/waspc/data/lsp/templates/ts/query.fn.js
@@ -1,0 +1,7 @@
+{{#named?}}export {{/named?}}const {{name}} = async (args, context) => {
+  // Implementation goes here
+}
+
+{{#default?}}
+export default {{name}}
+{{/default?}}

--- a/waspc/data/lsp/templates/ts/query.fn.ts
+++ b/waspc/data/lsp/templates/ts/query.fn.ts
@@ -1,0 +1,9 @@
+import { {{upperDeclName}} } from '@wasp/queries/types';
+
+{{#named?}}export {{/named?}}const {{name}}: {{upperDeclName}}<void, void> = async (args, context) => {
+  // Implementation goes here
+}
+
+{{#default?}}
+export default {{name}}
+{{/default?}}

--- a/waspc/data/lsp/templates/ts/query.fn.ts
+++ b/waspc/data/lsp/templates/ts/query.fn.ts
@@ -1,4 +1,4 @@
-import { {{upperDeclName}} } from '@wasp/queries/types';
+import { {{upperDeclName}} } from '@wasp/queries/types'
 
 {{#named?}}export {{/named?}}const {{name}}: {{upperDeclName}}<void, void> = async (args, context) => {
   // Implementation goes here

--- a/waspc/src/Wasp/Analyzer/Parser/SourceSpan.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/SourceSpan.hs
@@ -2,6 +2,7 @@
 
 module Wasp.Analyzer.Parser.SourceSpan
   ( SourceSpan (..),
+    spansOverlap,
   )
 where
 
@@ -18,3 +19,8 @@ data SourceSpan = SourceSpan !SourceOffset !SourceOffset
   deriving (Eq, Ord, Show, Generic)
 
 instance NFData SourceSpan
+
+spansOverlap :: SourceSpan -> SourceSpan -> Bool
+spansOverlap (SourceSpan s0 e0) (SourceSpan s1 e1)
+  | s0 == e0 || s1 == e1 = False
+  | otherwise = (s0 <= s1 && e0 > s1) || (s1 <= s0 && e1 > s0)

--- a/waspc/src/Wasp/AppSpec/ExtImport.hs
+++ b/waspc/src/Wasp/AppSpec/ExtImport.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Wasp.AppSpec.ExtImport
   ( ExtImport (..),
@@ -7,7 +8,9 @@ module Wasp.AppSpec.ExtImport
   )
 where
 
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Data (Data)
+import GHC.Generics (Generic)
 import StrongPath (File', Path, Posix, Rel)
 import Wasp.AppSpec.ExternalCode (SourceExternalCodeDir)
 
@@ -28,7 +31,11 @@ data ExtImportName
     ExtImportModule Identifier
   | -- | Represents external imports like @import { Identifier } from "file.js"@
     ExtImportField Identifier
-  deriving (Show, Eq, Data)
+  deriving (Show, Eq, Data, Generic)
+
+instance FromJSON ExtImportName
+
+instance ToJSON ExtImportName
 
 importIdentifier :: ExtImport -> Identifier
 importIdentifier (ExtImport importName _) = case importName of

--- a/waspc/test/Analyzer/Parser/SourceSpanTest.hs
+++ b/waspc/test/Analyzer/Parser/SourceSpanTest.hs
@@ -1,0 +1,27 @@
+module Analyzer.Parser.SourceSpanTest where
+
+import Test.QuickCheck
+import Test.Tasty.Hspec
+import Wasp.Analyzer.Parser.SourceSpan (SourceSpan (SourceSpan), spansOverlap)
+
+spec_SourceSpanTest :: Spec
+spec_SourceSpanTest = do
+  describe "Analyzer.Parser.SourceSpan" $ do
+    describe "spansOverlap works" $ do
+      it "when first is before second" $ do
+        spansOverlap (SourceSpan 0 5) (SourceSpan 10 15) `shouldBe` False
+      it "when first ends right before second starts" $ do
+        spansOverlap (SourceSpan 0 5) (SourceSpan 5 10) `shouldBe` False
+      it "when first overlaps second on its left edge" $ do
+        spansOverlap (SourceSpan 0 5) (SourceSpan 4 10) `shouldBe` True
+      it "when first is second" $ do
+        spansOverlap (SourceSpan 0 5) (SourceSpan 0 5) `shouldBe` True
+      it "when first overlaps second on its right edge" $ do
+        spansOverlap (SourceSpan 4 10) (SourceSpan 0 5) `shouldBe` True
+      it "when second is zero-width" $ do
+        spansOverlap (SourceSpan 0 5) (SourceSpan 2 2) `shouldBe` False
+      it "is commutative" $ do
+        property $ \s0 e0 s1 e1 ->
+          let first = SourceSpan s0 e0
+              second = SourceSpan s1 e1
+           in spansOverlap first second == spansOverlap second first

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -53,6 +53,8 @@ data-files:
   Cli/templates/basic/.wasproot
   Cli/templates/basic/src/.waspignore
   Cli/templates/basic/main.wasp
+  lsp/templates/**/*.js
+  lsp/templates/**/*.ts
   packages/deploy/dist/**/*.js
   packages/deploy/package.json
   packages/deploy/package-lock.json
@@ -387,6 +389,7 @@ library waspls
     , strong-path
     , path
     , async ^>=2.2.4
+    , mustache ^>=2.3.2
     , unliftio-core
     , mtl
     , text

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -344,6 +344,7 @@ library waspls
     Control.Monad.Log
     Control.Monad.Log.Class
     Wasp.LSP.Analysis
+    Wasp.LSP.CodeActions
     Wasp.LSP.Completion
     Wasp.LSP.Completions.Common
     Wasp.LSP.Completions.DictKeyCompletion
@@ -516,6 +517,7 @@ test-suite waspc-test
     Analyzer.Parser.CST.TraverseTest
     Analyzer.Parser.ParseErrorTest
     Analyzer.Parser.SourcePositionTest
+    Analyzer.Parser.SourceSpanTest
     Analyzer.ParserTest
     Analyzer.TestUtil
     Analyzer.TypeChecker.InternalTest

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -345,6 +345,9 @@ library waspls
     Control.Monad.Log.Class
     Wasp.LSP.Analysis
     Wasp.LSP.CodeActions
+    Wasp.LSP.Command
+    Wasp.LSP.Commands.CommandPlugin
+    Wasp.LSP.Commands.ScaffoldTsSymbol
     Wasp.LSP.Completion
     Wasp.LSP.Completions.Common
     Wasp.LSP.Completions.DictKeyCompletion

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -55,6 +55,8 @@ data-files:
   Cli/templates/basic/main.wasp
   lsp/templates/**/*.js
   lsp/templates/**/*.ts
+  lsp/templates/**/*.jsx
+  lsp/templates/**/*.tsx
   packages/deploy/dist/**/*.js
   packages/deploy/package.json
   packages/deploy/package-lock.json

--- a/waspc/waspls/src/Wasp/LSP/CodeActions.hs
+++ b/waspc/waspls/src/Wasp/LSP/CodeActions.hs
@@ -8,7 +8,6 @@ where
 import Control.Lens ((^.))
 import Control.Monad (filterM, (<=<))
 import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Monad.Log.Class (MonadLog (logM))
 import Control.Monad.Reader.Class (asks)
 import Data.Foldable (find)
 import qualified Data.HashMap.Strict as M
@@ -39,7 +38,6 @@ import Wasp.Util.IO (doesFileExist)
 
 getCodeActionsInRange :: LSP.Range -> HandlerM [LSP.CodeAction]
 getCodeActionsInRange range = do
-  logM $ "[getCodeActionsInRange] range=" <> show range
   src <- asks (^. State.currentWaspSource)
   maybeCst <- asks (^. State.cst)
   case maybeCst of
@@ -113,11 +111,10 @@ findCodeActionsForExtImport src extImport = do
       let allowedExts = case maybeCachePathInCache of
             Nothing -> ExtImport.allowedExts $ ExtImport.cachePathExtType cachePathFromSrc
             Just cachePathInCache -> ExtImport.allowedExts $ ExtImport.cachePathExtType cachePathInCache
-      logM $ "Allowed exts: " ++ show allowedExts
       absPath <- fromMaybe (error "[createCodeActions] unreachable: can't get abs path") <$> ExtImport.cachePathToAbsPathWithoutExt cachePathFromSrc
       let unfilteredPaths = map (ExtImport.replaceExtension absPath) allowedExts
+
       -- 4ii-iii. Filter the paths.
-      logM $ "Checking paths: " ++ show unfilteredPaths
       filteredPaths <-
         if createNewFile
           then return unfilteredPaths

--- a/waspc/waspls/src/Wasp/LSP/CodeActions.hs
+++ b/waspc/waspls/src/Wasp/LSP/CodeActions.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Wasp.LSP.CodeActions
+  ( getCodeActionsInRange,
+  )
+where
+
+import Control.Lens ((^.))
+import Control.Monad.Log.Class (MonadLog (logM))
+import Control.Monad.Reader.Class (MonadReader, asks)
+import qualified Data.Text as Text
+import qualified Language.LSP.Types as LSP
+import Wasp.Analyzer.Parser.CST (SyntaxNode)
+import qualified Wasp.Analyzer.Parser.CST as S
+import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
+import qualified Wasp.Analyzer.Parser.CST.Traverse as T
+import Wasp.Analyzer.Parser.SourceSpan (SourceSpan (SourceSpan), spansOverlap)
+import Wasp.LSP.ExtImport.Syntax (ExtImportNode (einName, einPath), extImportAtLocation)
+import Wasp.LSP.ServerState (ServerState)
+import qualified Wasp.LSP.ServerState as State
+import Wasp.LSP.Syntax (lspRangeToSpan)
+
+getCodeActionsInRange :: (MonadLog m, MonadReader ServerState m) => LSP.Range -> m [LSP.CodeAction]
+getCodeActionsInRange range = do
+  logM $ "[getCodeActionsInRange] range=" <> show range
+  src <- asks (^. State.currentWaspSource)
+  maybeCst <- asks (^. State.cst)
+  case maybeCst of
+    Nothing -> pure []
+    Just syntax -> do
+      concat <$> mapM (\f -> f src syntax range) codeActionProviders
+
+codeActionProviders :: (MonadLog m, MonadReader ServerState m) => [String -> [SyntaxNode] -> LSP.Range -> m [LSP.CodeAction]]
+codeActionProviders =
+  [ tsScaffoldActionProvider
+  ]
+
+-- | Provide 'LSP.CodeAction's for missing external imports.
+tsScaffoldActionProvider :: (MonadLog m, MonadReader ServerState m) => String -> [SyntaxNode] -> LSP.Range -> m [LSP.CodeAction]
+tsScaffoldActionProvider src syntax range = do
+  -- VSCode (incorrectly) sends codeAction requests with ranges where the start
+  -- position is equal to the end position. This range contains 0 characters,
+  -- so we add a character to it.
+  --
+  -- NOTE: The LSP specification specifies that the end of a range is exclusive:
+  -- https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#range
+  let sourceSpan =
+        let SourceSpan s e = lspRangeToSpan src range
+         in if s == e then SourceSpan s (e + 1) else SourceSpan s e
+  let extImports = map (extImportAtLocation src) $ collectExtImportNodesInSpan sourceSpan (T.fromSyntaxForest syntax)
+  -- TODO(before merge): create real code actions, and only when there is a diagnostic
+  -- that means i also need to connect each extimport to a diagnostic, hmm
+  return $
+    flip map extImports $ \extImport ->
+      LSP.CodeAction
+        { _title = Text.pack $ "Create function " <> show (einName extImport) <> " in " <> show (einPath extImport),
+          _kind = Just LSP.CodeActionQuickFix,
+          _diagnostics = Nothing,
+          _isPreferred = Nothing,
+          _disabled = Nothing,
+          _edit = Nothing,
+          _command = Just $ LSP.Command {_title = "Create function", _command = "create.function", _arguments = Nothing},
+          _xdata = Nothing
+        }
+  where
+    -- Post-condition: all 'Traversal's returned have @kindAt t == ExtImport@.
+    collectExtImportNodesInSpan :: SourceSpan -> Traversal -> [Traversal]
+    collectExtImportNodesInSpan sourceSpan t =
+      -- Only consider the given traversal if it is within the span.
+      if spansOverlap (T.spanAt t) sourceSpan
+        then case T.kindAt t of
+          S.ExtImport -> [t]
+          _ -> concatMap (collectExtImportNodesInSpan sourceSpan) $ T.children t
+        else []

--- a/waspc/waspls/src/Wasp/LSP/CodeActions.hs
+++ b/waspc/waspls/src/Wasp/LSP/CodeActions.hs
@@ -28,7 +28,7 @@ import Wasp.LSP.ExtImport.ExportsCache (ExtImportLookupResult (..), lookupExtImp
 import Wasp.LSP.ExtImport.Path (WaspStyleExtFilePath)
 import qualified Wasp.LSP.ExtImport.Path as ExtImport
 import Wasp.LSP.ExtImport.Syntax (ExtImportNode (einLocation, einName), extImportAtLocation)
-import Wasp.LSP.ServerM (HandlerM)
+import Wasp.LSP.ServerMonads (HandlerM)
 import qualified Wasp.LSP.ServerState as State
 import Wasp.LSP.Syntax (lspRangeToSpan)
 import qualified Wasp.LSP.TypeInference as Inference

--- a/waspc/waspls/src/Wasp/LSP/CodeActions.hs
+++ b/waspc/waspls/src/Wasp/LSP/CodeActions.hs
@@ -6,21 +6,34 @@ module Wasp.LSP.CodeActions
 where
 
 import Control.Lens ((^.))
+import Control.Monad (filterM)
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Log.Class (MonadLog (logM))
-import Control.Monad.Reader.Class (MonadReader, asks)
+import Control.Monad.Reader.Class (asks)
+import Data.Foldable (find)
+import qualified Data.HashMap.Strict as M
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as Text
 import qualified Language.LSP.Types as LSP
+import qualified StrongPath as SP
+import Text.Printf (printf)
+import Wasp.Analyzer.Parser.AST (ExtImportName (ExtImportField, ExtImportModule))
 import Wasp.Analyzer.Parser.CST (SyntaxNode)
 import qualified Wasp.Analyzer.Parser.CST as S
 import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
 import qualified Wasp.Analyzer.Parser.CST.Traverse as T
 import Wasp.Analyzer.Parser.SourceSpan (SourceSpan (SourceSpan), spansOverlap)
-import Wasp.LSP.ExtImport.Syntax (ExtImportNode (einName, einPath), extImportAtLocation)
-import Wasp.LSP.ServerState (ServerState)
+import qualified Wasp.LSP.Commands.ScaffoldTsSymbol as ScaffoldTS
+import Wasp.LSP.ExtImport.ExportsCache (ExtImportLookupResult (..), lookupExtImport)
+import Wasp.LSP.ExtImport.Path (WaspStyleExtFilePath)
+import qualified Wasp.LSP.ExtImport.Path as ExtImport
+import Wasp.LSP.ExtImport.Syntax (ExtImportNode (einLocation, einName), extImportAtLocation)
+import Wasp.LSP.ServerM (HandlerM)
 import qualified Wasp.LSP.ServerState as State
-import Wasp.LSP.Syntax (lspRangeToSpan)
+import Wasp.LSP.Syntax (findAncestor, findChild, lexemeAt, lspRangeToSpan)
+import Wasp.Util.IO (doesFileExist)
 
-getCodeActionsInRange :: (MonadLog m, MonadReader ServerState m) => LSP.Range -> m [LSP.CodeAction]
+getCodeActionsInRange :: LSP.Range -> HandlerM [LSP.CodeAction]
 getCodeActionsInRange range = do
   logM $ "[getCodeActionsInRange] range=" <> show range
   src <- asks (^. State.currentWaspSource)
@@ -30,13 +43,13 @@ getCodeActionsInRange range = do
     Just syntax -> do
       concat <$> mapM (\f -> f src syntax range) codeActionProviders
 
-codeActionProviders :: (MonadLog m, MonadReader ServerState m) => [String -> [SyntaxNode] -> LSP.Range -> m [LSP.CodeAction]]
+codeActionProviders :: [String -> [SyntaxNode] -> LSP.Range -> HandlerM [LSP.CodeAction]]
 codeActionProviders =
   [ tsScaffoldActionProvider
   ]
 
 -- | Provide 'LSP.CodeAction's for missing external imports.
-tsScaffoldActionProvider :: (MonadLog m, MonadReader ServerState m) => String -> [SyntaxNode] -> LSP.Range -> m [LSP.CodeAction]
+tsScaffoldActionProvider :: String -> [SyntaxNode] -> LSP.Range -> HandlerM [LSP.CodeAction]
 tsScaffoldActionProvider src syntax range = do
   -- VSCode (incorrectly) sends codeAction requests with ranges where the start
   -- position is equal to the end position. This range contains 0 characters,
@@ -50,18 +63,7 @@ tsScaffoldActionProvider src syntax range = do
   let extImports = map (extImportAtLocation src) $ collectExtImportNodesInSpan sourceSpan (T.fromSyntaxForest syntax)
   -- TODO(before merge): create real code actions, and only when there is a diagnostic
   -- that means i also need to connect each extimport to a diagnostic, hmm
-  return $
-    flip map extImports $ \extImport ->
-      LSP.CodeAction
-        { _title = Text.pack $ "Create function " <> show (einName extImport) <> " in " <> show (einPath extImport),
-          _kind = Just LSP.CodeActionQuickFix,
-          _diagnostics = Nothing,
-          _isPreferred = Nothing,
-          _disabled = Nothing,
-          _edit = Nothing,
-          _command = Just $ LSP.Command {_title = "Create function", _command = "create.function", _arguments = Nothing},
-          _xdata = Nothing
-        }
+  concat <$> mapM (findCodeActionsForExtImport src) extImports
   where
     -- Post-condition: all 'Traversal's returned have @kindAt t == ExtImport@.
     collectExtImportNodesInSpan :: SourceSpan -> Traversal -> [Traversal]
@@ -72,3 +74,84 @@ tsScaffoldActionProvider src syntax range = do
           S.ExtImport -> [t]
           _ -> concatMap (collectExtImportNodesInSpan sourceSpan) $ T.children t
         else []
+
+findCodeActionsForExtImport :: String -> ExtImportNode -> HandlerM [LSP.CodeAction]
+findCodeActionsForExtImport src extImport = do
+  {-
+  1. Lookup up the extimport in the exports cache to see if it is valid.
+  2. If it is, then no code actions need to be returned.
+  3. Otherwise, find the decl type of the surrounding decl.
+  4. Use the extension type stored in the cache key to get a list of possible
+     files the user might want to add the code to.
+     i.   Abs path <.> each extension
+     ii.  If at least one of those paths exists on disks, filter out all paths
+         that do not exist.
+     iii. Otherwise, use all the paths.
+  5. For each file, return a code action runs the "wasp.scaffold.ts-symbol"
+     command with the desired export name, the file path, and the decl type.
+  -}
+  lookupExtImport extImport >>= \case
+    ImportSyntaxError -> return [] -- Syntax error in import.
+    ImportCacheMiss -> return [] -- TODO: maybe start filling cache and send an in-progress notification to client?
+    ImportsSymbol _ _ -> return [] -- Valid import.
+    ImportedFileDoesNotExist waspStylePath -> case einName extImport of
+      Nothing -> return [] -- Syntax error in import.
+      Just symbolName -> createCodeActions True symbolName waspStylePath
+    ImportedSymbolDoesNotExist symbolName waspStylePath -> createCodeActions False symbolName waspStylePath
+  where
+    maybeDeclType :: MonadLog m => m (Maybe String)
+    maybeDeclType =
+      case findChild S.DeclType =<< findAncestor S.Decl (einLocation extImport) of
+        Nothing -> do
+          logM "[findCodeActionsForExtImport] can't find containing decl type for external import, can't create code actions."
+          return Nothing
+        Just declType -> return $ Just $ lexemeAt src declType
+
+    createCodeActions :: Bool -> ExtImportName -> WaspStyleExtFilePath -> HandlerM [LSP.CodeAction]
+    createCodeActions createNewFile symbolName waspStylePath =
+      maybeDeclType >>= \case
+        Nothing -> pure []
+        Just declType -> do
+          -- 4. Get paths.
+          let cachePathFromSrc =
+                fromMaybe (error "[createCodeActions] unreachable: invalid wasp style path") $
+                  ExtImport.waspStylePathToCachePath waspStylePath
+          maybeCachePathInCache <- asks (find (== cachePathFromSrc) . M.keys . (^. State.tsExports))
+          let allowedExts = case maybeCachePathInCache of
+                Nothing -> ExtImport.allowedExts $ ExtImport.cachePathExtType cachePathFromSrc
+                Just cachePathInCache -> ExtImport.allowedExts $ ExtImport.cachePathExtType cachePathInCache
+          logM $ "Allowed exts: " ++ show allowedExts
+          absPath <- fromMaybe (error "[createCodeActions] unreachable: can't get abs path") <$> ExtImport.cachePathToAbsPathWithoutExt cachePathFromSrc
+          let unfilteredPaths = map (ExtImport.replaceExtension absPath) allowedExts
+          -- 4ii-iii. Filter the paths.
+          logM $ "Checking paths: " ++ show unfilteredPaths
+          filteredPaths <-
+            if createNewFile
+              then return unfilteredPaths
+              else filterM (liftIO . doesFileExist) unfilteredPaths
+          -- 5. Create a code action for each possible file.
+          return $ map (createCodeAction symbolName declType) filteredPaths
+
+    -- TODO: show filepath relative to root dir (i.e. src/...)
+    createCodeAction :: ExtImportName -> String -> SP.Path' SP.Abs (SP.File a) -> LSP.CodeAction
+    createCodeAction symbolName declType filepath =
+      let args =
+            ScaffoldTS.Args
+              { ScaffoldTS.symbolName = symbolName,
+                ScaffoldTS.declType = declType,
+                ScaffoldTS.filepath = SP.castFile filepath
+              }
+          command = ScaffoldTS.command args
+          title = case symbolName of
+            ExtImportModule name -> printf "Add default export `%s` to %s" name (SP.toFilePath filepath)
+            ExtImportField name -> printf "Create function `%s` in %s" name (SP.toFilePath filepath)
+       in LSP.CodeAction
+            { _title = Text.pack title,
+              _kind = Just LSP.CodeActionQuickFix,
+              _diagnostics = Nothing, -- TODO(before merge): get diagnostics,
+              _isPreferred = Nothing,
+              _disabled = Nothing,
+              _edit = Nothing,
+              _command = Just command,
+              _xdata = Nothing
+            }

--- a/waspc/waspls/src/Wasp/LSP/CodeActions.hs
+++ b/waspc/waspls/src/Wasp/LSP/CodeActions.hs
@@ -1,23 +1,18 @@
-{-# LANGUAGE RankNTypes #-}
-
 module Wasp.LSP.CodeActions
   ( getCodeActionsInRange,
   )
 where
 
 import Control.Lens ((^.))
-import Control.Monad (filterM, (<=<))
+import Control.Monad (filterM)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Reader.Class (asks)
 import Data.Foldable (find)
 import qualified Data.HashMap.Strict as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as Text
-import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP
-import qualified Path as P
 import qualified StrongPath as SP
-import qualified StrongPath.Path as SP
 import Text.Printf (printf)
 import Wasp.Analyzer.Parser.AST (ExtImportName (ExtImportField, ExtImportModule))
 import Wasp.Analyzer.Parser.CST (SyntaxNode)
@@ -34,76 +29,84 @@ import Wasp.LSP.ServerMonads (HandlerM)
 import qualified Wasp.LSP.ServerState as State
 import Wasp.LSP.Syntax (lspRangeToSpan)
 import qualified Wasp.LSP.TypeInference as Inference
+import Wasp.LSP.Util (absFileInProjectRootDir)
 import Wasp.Util.IO (doesFileExist)
 
+-- | Runs all 'codeActionProviders' and concatenates their results.
 getCodeActionsInRange :: LSP.Range -> HandlerM [LSP.CodeAction]
 getCodeActionsInRange range = do
   src <- asks (^. State.currentWaspSource)
   maybeCst <- asks (^. State.cst)
-  case maybeCst of
-    Nothing -> pure []
-    Just syntax -> do
-      concat <$> mapM (\f -> f src syntax range) codeActionProviders
-
-codeActionProviders :: [String -> [SyntaxNode] -> LSP.Range -> HandlerM [LSP.CodeAction]]
-codeActionProviders =
-  [ tsScaffoldActionProvider
-  ]
-
--- | Provide 'LSP.CodeAction's for missing external imports.
-tsScaffoldActionProvider :: String -> [SyntaxNode] -> LSP.Range -> HandlerM [LSP.CodeAction]
-tsScaffoldActionProvider src syntax range = do
-  -- VSCode (incorrectly) sends codeAction requests with ranges where the start
+  -- VSCode sends codeAction requests with ranges where the start
   -- position is equal to the end position. This range contains 0 characters,
   -- so we add a character to it.
   --
-  -- NOTE: The LSP specification specifies that the end of a range is exclusive:
+  -- The LSP specification specifies that the end of a range is exclusive:
   -- https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#range
   let sourceSpan =
         let SourceSpan s e = lspRangeToSpan src range
          in if s == e then SourceSpan s (e + 1) else SourceSpan s e
-  let extImports = map (extImportAtLocation src) $ collectExtImportNodesInSpan sourceSpan (T.fromSyntaxForest syntax)
-  -- TODO(before merge): create real code actions, and only when there is a diagnostic
-  -- that means i also need to connect each extimport to a diagnostic, hmm
+  case maybeCst of
+    Nothing -> pure []
+    Just syntax -> do
+      concat <$> mapM (\f -> f src syntax sourceSpan) codeActionProviders
+
+codeActionProviders :: [String -> [SyntaxNode] -> SourceSpan -> HandlerM [LSP.CodeAction]]
+codeActionProviders =
+  [ tsScaffoldActionProvider
+  ]
+
+-- | Provide 'LSP.CodeAction's for missing external imports. The code actions
+-- run the "Wasp.LSP.Commands.ScaffoldTsSymbol" command to define the missing
+-- function in a JS/TS file.
+tsScaffoldActionProvider :: String -> [SyntaxNode] -> SourceSpan -> HandlerM [LSP.CodeAction]
+tsScaffoldActionProvider src syntax sourceSpan = do
+  let extImports = map (extImportAtLocation src) $ collectExtImportNodesInSpan (T.fromSyntaxForest syntax)
   concat <$> mapM (findCodeActionsForExtImport src) extImports
   where
     -- Post-condition: all 'Traversal's returned have @kindAt t == ExtImport@.
-    collectExtImportNodesInSpan :: SourceSpan -> Traversal -> [Traversal]
-    collectExtImportNodesInSpan sourceSpan t =
+    collectExtImportNodesInSpan :: Traversal -> [Traversal]
+    collectExtImportNodesInSpan t =
       -- Only consider the given traversal if it is within the span.
       if spansOverlap (T.spanAt t) sourceSpan
         then case T.kindAt t of
           S.ExtImport -> [t]
-          _ -> concatMap (collectExtImportNodesInSpan sourceSpan) $ T.children t
+          _ -> concatMap collectExtImportNodesInSpan $ T.children t
         else []
 
+-- | Finds code actions to create a JS/TS function for an external import. Returns
+-- one code action for each JS/TS/JSX/TSX file a function can be created in.
+--
+-- This function also checks to make sure each code action, which runs the
+-- @wasp.scaffold.ts-symbol@ command, has a scaffolding template that can be
+-- used.
 findCodeActionsForExtImport :: String -> ExtImportNode -> HandlerM [LSP.CodeAction]
 findCodeActionsForExtImport src extImport = do
-  {-
-  1. Lookup up the extimport in the exports cache to see if it is valid.
-  2. If it is, then no code actions need to be returned.
-  3. Otherwise, path through the expression tree to the ext import.
-  4. Use the extension type stored in the cache key to get a list of possible
-     files the user might want to add the code to.
-     i.   Abs path <.> each extension
-     ii.  If at least one of those paths exists on disks, filter out all paths
-         that do not exist.
-     iii. Otherwise, use all the paths.
-  5. For each file, return a code action runs the "wasp.scaffold.ts-symbol"
-     command with the desired export name, the file path, and the expr path.
-  -}
+  -- 1. Lookup up the extimport in the exports cache to see if it is valid.
+  -- 2. If it is, then no code actions need to be returned.
+  -- 3. Otherwise, path through the expression tree to the ext import.
+  -- 4. Use the extension type stored in the cache key to get a list of possible
+  --    files the user might want to add the code to.
+  --    i.   Create absolute paths with each extension.
+  --    ii.  If at least one of those paths exists on disks, filter out all paths
+  --         that do not exist.
+  --    iii. Otherwise, use all the paths.
+  -- 5. For each file, return a code action runs the @wasp.scaffold.ts-symbol@
+  --    command with the desired export name, the file path, and the expr path.
+
+  -- 1. Lookup.
   lookupExtImport extImport >>= \case
     ImportSyntaxError -> return [] -- Syntax error in import.
-    ImportCacheMiss -> return [] -- TODO: maybe start filling cache and send an in-progress notification to client?
-    ImportsSymbol _ _ -> return [] -- Valid import.
+    ImportCacheMiss -> return [] -- 2. Not in cache, so we assume it's valid.
+    ImportsSymbol _ _ -> return [] -- 2.
     ImportedFileDoesNotExist waspStylePath -> case einName extImport of
       Nothing -> return [] -- Syntax error in import.
-      Just symbolName -> createCodeActions True symbolName waspStylePath
-    ImportedSymbolDoesNotExist symbolName waspStylePath -> createCodeActions False symbolName waspStylePath
+      Just symbolName -> createCodeActions True symbolName waspStylePath -- 3.
+    ImportedSymbolDoesNotExist symbolName waspStylePath -> createCodeActions False symbolName waspStylePath -- 3.
   where
     createCodeActions :: Bool -> ExtImportName -> WaspStyleExtFilePath -> HandlerM [LSP.CodeAction]
     createCodeActions createNewFile symbolName waspStylePath = do
-      -- 4. Get paths.
+      -- 4.
       let cachePathFromSrc =
             fromMaybe (error "[createCodeActions] unreachable: invalid wasp style path") $
               ExtImport.waspStylePathToCachePath waspStylePath
@@ -114,13 +117,14 @@ findCodeActionsForExtImport src extImport = do
       absPath <- fromMaybe (error "[createCodeActions] unreachable: can't get abs path") <$> ExtImport.cachePathToAbsPathWithoutExt cachePathFromSrc
       let unfilteredPaths = map (ExtImport.replaceExtension absPath) allowedExts
 
-      -- 4ii-iii. Filter the paths.
+      -- 4ii-iii.
       filteredPaths <-
         if createNewFile
           then return unfilteredPaths
           else filterM (liftIO . doesFileExist) unfilteredPaths
       let pathToExtImport = fromMaybe [] $ Inference.findExprPathToLocation src $ einLocation extImport
-      -- 5. Create a code action for each possible file.
+
+      -- 5.
       concat <$> mapM (createCodeAction symbolName pathToExtImport) filteredPaths
 
     -- Returns empty list if wasp.scaffold.ts-symbol does not have a template
@@ -128,7 +132,7 @@ findCodeActionsForExtImport src extImport = do
     createCodeAction :: ExtImportName -> Inference.ExprPath -> SP.Path' SP.Abs (SP.File a) -> HandlerM [LSP.CodeAction]
     createCodeAction symbolName pathToExtImport filepath = do
       -- Strip the root path from @filepath@, using the absolute path if the stripping can not be done.
-      relFilepath <- maybe (SP.fromAbsFile filepath) P.toFilePath . (((`P.stripProperPrefix` SP.toPathAbsFile filepath) <=< P.parseAbsDir) =<<) <$> LSP.getRootPath
+      relFilepath <- maybe (SP.fromAbsFile filepath) SP.toFilePath <$> absFileInProjectRootDir filepath
       let args =
             ScaffoldTS.Args
               { ScaffoldTS.symbolName = symbolName,
@@ -137,7 +141,7 @@ findCodeActionsForExtImport src extImport = do
               }
           command = ScaffoldTS.command args
       let title = case symbolName of
-            ExtImportModule name -> printf "Add default export `%s` to %s" name relFilepath
+            ExtImportModule _ -> printf "Add default export to %s" relFilepath
             ExtImportField name -> printf "Create function `%s` in %s" name relFilepath
       ScaffoldTS.hasTemplateForArgs args >>= \case
         False -> return []
@@ -146,7 +150,7 @@ findCodeActionsForExtImport src extImport = do
             [ LSP.CodeAction
                 { _title = Text.pack title,
                   _kind = Just LSP.CodeActionQuickFix,
-                  _diagnostics = Nothing, -- TODO(before merge): get diagnostics,
+                  _diagnostics = Nothing,
                   _isPreferred = Nothing,
                   _disabled = Nothing,
                   _edit = Nothing,

--- a/waspc/waspls/src/Wasp/LSP/Command.hs
+++ b/waspc/waspls/src/Wasp/LSP/Command.hs
@@ -1,5 +1,17 @@
 module Wasp.LSP.Command
-  ( availableCommands,
+  ( -- * waspls Commands
+
+    -- Executes commands that have been defined as command plugins.
+    --
+    -- To define a new command, create a "Wasp.LSP.Commands.CommandPlugin" for
+    -- it and add the plugin to 'plugins' in this module.
+    --
+    -- When defining a new command, it is recommended to, in addition to the
+    -- 'CommandPlugin', define an @Args@ type that the command expects to be
+    -- passed to it and a @command@ function that takes an @Args@ value and
+    -- returns an 'LSP.Command'. This makes it simpler to call the command
+    -- correctly.
+    availableCommands,
     handler,
   )
 where
@@ -8,9 +20,11 @@ import Control.Arrow ((&&&))
 import Control.Lens ((^.))
 import qualified Data.HashMap.Strict as M
 import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
+import Text.Printf (printf)
 import Wasp.LSP.Commands.CommandPlugin (CommandPlugin (commandHandler, commandName))
 import qualified Wasp.LSP.Commands.ScaffoldTsSymbol as ScaffoldTsSymbol
 import Wasp.LSP.ServerMonads (ServerM)
@@ -23,16 +37,22 @@ plugins =
       [ ScaffoldTsSymbol.plugin
       ]
 
+-- | List of the names of commands that 'handler' can execute.
 availableCommands :: [Text]
 availableCommands = M.keys plugins
 
+-- | Find the relevant 'CommandPlugin' in 'plugins' for the request, or respond
+-- with an error if there is no handler listed for it.
 handler :: LSP.Handlers ServerM
 handler = LSP.requestHandler LSP.SWorkspaceExecuteCommand $ \request respond ->
-  case plugins M.!? (request ^. LSP.params . LSP.command) of
-    Nothing -> do
-      LSP.sendNotification LSP.SWindowShowMessage $
-        LSP.ShowMessageParams
-          { _xtype = LSP.MtError,
-            _message = "waspls can not run the command " <> (request ^. LSP.params . LSP.command)
-          }
-    Just plugin -> commandHandler plugin request respond
+  let command = request ^. LSP.params . LSP.command
+   in case plugins M.!? command of
+        Nothing -> do
+          respond $
+            Left $
+              LSP.ResponseError
+                { _code = LSP.MethodNotFound,
+                  _message = Text.pack $ printf "No handler for command '%s'" command,
+                  _xdata = Nothing
+                }
+        Just plugin -> commandHandler plugin request respond

--- a/waspc/waspls/src/Wasp/LSP/Command.hs
+++ b/waspc/waspls/src/Wasp/LSP/Command.hs
@@ -13,7 +13,7 @@ import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
 import Wasp.LSP.Commands.CommandPlugin (CommandPlugin (commandHandler, commandName))
 import qualified Wasp.LSP.Commands.ScaffoldTsSymbol as ScaffoldTsSymbol
-import Wasp.LSP.ServerM (ServerM)
+import Wasp.LSP.ServerMonads (ServerM)
 
 plugins :: M.HashMap Text CommandPlugin
 plugins =

--- a/waspc/waspls/src/Wasp/LSP/Command.hs
+++ b/waspc/waspls/src/Wasp/LSP/Command.hs
@@ -1,0 +1,38 @@
+module Wasp.LSP.Command
+  ( availableCommands,
+    handler,
+  )
+where
+
+import Control.Arrow ((&&&))
+import Control.Lens ((^.))
+import qualified Data.HashMap.Strict as M
+import Data.Text (Text)
+import qualified Language.LSP.Server as LSP
+import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types.Lens as LSP
+import Wasp.LSP.Commands.CommandPlugin (CommandPlugin (commandHandler, commandName))
+import qualified Wasp.LSP.Commands.ScaffoldTsSymbol as ScaffoldTsSymbol
+import Wasp.LSP.ServerM (ServerM)
+
+plugins :: M.HashMap Text CommandPlugin
+plugins =
+  M.fromList $
+    map
+      (commandName &&& id)
+      [ ScaffoldTsSymbol.plugin
+      ]
+
+availableCommands :: [Text]
+availableCommands = M.keys plugins
+
+handler :: LSP.Handlers ServerM
+handler = LSP.requestHandler LSP.SWorkspaceExecuteCommand $ \request respond ->
+  case plugins M.!? (request ^. LSP.params . LSP.command) of
+    Nothing -> do
+      LSP.sendNotification LSP.SWindowShowMessage $
+        LSP.ShowMessageParams
+          { _xtype = LSP.MtError,
+            _message = "waspls can not run the command " <> (request ^. LSP.params . LSP.command)
+          }
+    Just plugin -> commandHandler plugin request respond

--- a/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DataKinds #-}
+
+module Wasp.LSP.Commands.CommandPlugin
+  ( CommandPlugin (CommandPlugin, commandName, commandHandler),
+  )
+where
+
+import Data.Text (Text)
+import qualified Language.LSP.Server as LSP
+import qualified Language.LSP.Types as LSP
+import Wasp.LSP.ServerM (ServerM)
+
+data CommandPlugin = CommandPlugin
+  { commandName :: Text,
+    commandHandler :: LSP.Handler ServerM 'LSP.WorkspaceExecuteCommand
+  }

--- a/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs
@@ -8,7 +8,7 @@ where
 import Data.Text (Text)
 import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP
-import Wasp.LSP.ServerM (ServerM)
+import Wasp.LSP.ServerMonads (ServerM)
 
 data CommandPlugin = CommandPlugin
   { commandName :: Text,

--- a/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs
@@ -2,15 +2,44 @@
 
 module Wasp.LSP.Commands.CommandPlugin
   ( CommandPlugin (CommandPlugin, commandName, commandHandler),
+    withParsedArgs,
+    invalidParams,
   )
 where
 
+import Control.Lens ((^.))
+import Data.Aeson (FromJSON, Result (Error, Success), Value, fromJSON)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types.Lens as LSP
 import Wasp.LSP.ServerMonads (ServerM)
 
 data CommandPlugin = CommandPlugin
   { commandName :: Text,
     commandHandler :: LSP.Handler ServerM 'LSP.WorkspaceExecuteCommand
   }
+
+withParsedArgs ::
+  (FromJSON args, LSP.MonadLsp c m) =>
+  -- | LSP 'request'.
+  LSP.RequestMessage 'LSP.WorkspaceExecuteCommand ->
+  -- | LSP 'respond'.
+  (Either LSP.ResponseError Value -> m ()) ->
+  -- | Handler that need arguments.
+  (args -> m ()) ->
+  m ()
+withParsedArgs request respond run = case request ^. LSP.params . LSP.arguments of
+  Just (LSP.List [argument]) -> case fromJSON argument of
+    Error err -> respond $ Left $ invalidParams $ Text.pack err
+    Success args -> run args
+  _ -> respond $ Left $ invalidParams "Expected exactly one argument"
+
+invalidParams :: Text -> LSP.ResponseError
+invalidParams msg =
+  LSP.ResponseError
+    { _code = LSP.InvalidParams,
+      _message = msg,
+      _xdata = Nothing
+    }

--- a/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs
@@ -16,11 +16,17 @@ import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
 import Wasp.LSP.ServerMonads (ServerM)
 
+-- | Command name and handler. When a 'LSP.WorkspaceExecuteCommand' request is
+-- received with the command name matching the one listed in a 'CommandPlugin',
+-- the corresponding handler is executed.
 data CommandPlugin = CommandPlugin
   { commandName :: Text,
     commandHandler :: LSP.Handler ServerM 'LSP.WorkspaceExecuteCommand
   }
 
+-- | @withParsedArgs request respond run@ parses args from a 'LSP.WorkspaceExecuteCommand'
+-- request and passes them to @run@. If an error occurs during parsing, responds
+-- with an error and does not execute @run@.
 withParsedArgs ::
   (FromJSON args, LSP.MonadLsp c m) =>
   -- | LSP 'request'.

--- a/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
@@ -6,31 +6,46 @@ module Wasp.LSP.Commands.ScaffoldTsSymbol
 
     -- Command @wasp.scaffold.ts-symbol@ appends a new function with the given
     -- name to end of a particular file.
-    Args (Args, symbolName, declType, filepath),
+    Args (Args, symbolName, pathToExtImport, filepath),
     command,
     plugin,
   )
 where
 
 import Control.Lens ((^.))
-import Data.Aeson (FromJSON, Result (Error, Success), ToJSON (toJSON), fromJSON, object, withObject, (.:), (.=))
+import Control.Monad (unless)
+import Control.Monad.Except (MonadError (throwError), runExceptT)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.Log.Class (logM)
+import Data.Aeson (FromJSON, Result (Error, Success), ToJSON (toJSON), fromJSON, object, parseJSON, withObject, (.:), (.=))
 import qualified Data.Aeson as Aeson
-import Data.Aeson.Types (parseJSON)
+import Data.List (intercalate)
+import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
+import qualified Path as P
 import qualified StrongPath as SP
-import Wasp.Analyzer.Parser.AST (ExtImportName)
+import qualified StrongPath.Path as SP
+import qualified Text.Mustache as Mustache
+import Text.Printf (printf)
+import Wasp.Analyzer.Parser.AST (ExtImportName (ExtImportField, ExtImportModule))
+import qualified Wasp.Data
 import Wasp.LSP.Commands.CommandPlugin (CommandPlugin (CommandPlugin, commandHandler, commandName))
 import Wasp.LSP.ServerM (ServerM)
+import Wasp.LSP.TypeInference (ExprPath)
+import qualified Wasp.LSP.TypeInference as Inference
+import Wasp.Util.IO (doesFileExist)
 
 data Args = Args
   { -- | Name of the symbol to define. If this is 'ExtImportModule', it will
     -- create a function with the specified name and export it as default.
     symbolName :: ExtImportName,
-    -- | The type of the declaration that this import is part of. Used to choose what kind of code to scaffold.
-    declType :: String,
+    -- | Description of where the external import occurs in the source code, used,
+    -- along with the extension of 'filepath', to determine what template to use.
+    pathToExtImport :: ExprPath,
     -- | Path to the file to add the scaffoled code to the end of.
     filepath :: SP.Path' SP.Abs SP.File'
   }
@@ -40,7 +55,7 @@ instance ToJSON Args where
   toJSON args =
     object
       [ "symbolName" .= symbolName args,
-        "declType" .= declType args,
+        "pathToExtImport" .= pathToExtImport args,
         "filepath" .= SP.toFilePath (filepath args)
       ]
 
@@ -48,7 +63,7 @@ instance FromJSON Args where
   parseJSON = withObject "Args" $ \v ->
     Args
       <$> v .: "symbolName"
-      <*> v .: "declType"
+      <*> v .: "pathToExtImport"
       <*> ((maybe (fail "Could not parse filepath") pure . SP.parseAbsFile) =<< v .: "filepath")
 
 command :: Args -> LSP.Command
@@ -69,23 +84,77 @@ plugin =
 handler :: LSP.Handler ServerM 'LSP.WorkspaceExecuteCommand
 handler request respond = case request ^. LSP.params . LSP.arguments of
   Just (LSP.List [argument]) -> case fromJSON argument of
-    Error err ->
-      respond $
-        Left $
-          LSP.ResponseError
-            { _code = LSP.InvalidParams,
-              _message = Text.pack err,
-              _xdata = Nothing
-            }
-    Success args -> handle args
-  _ ->
-    respond $
-      Left $
-        LSP.ResponseError
-          { _code = LSP.InvalidParams,
-            _message = "Expected exactly one argument",
-            _xdata = Nothing
-          }
+    Error err -> respond $ Left $ invalidParams $ Text.pack err
+    Success args -> scaffold args
+  _ -> respond $ Left $ invalidParams "Expected exactly one argument"
   where
-    handle Args {..} = do
-      respond $ Right Aeson.Null
+    scaffold :: Args -> ServerM ()
+    scaffold Args {..} = case P.fileExtension $ SP.toPathAbsFile filepath of
+      Nothing -> respond $ Left $ invalidParams "Invalid filepath: no extension"
+      Just ext ->
+        getTemplateFor pathToExtImport ext >>= \case
+          Left err ->
+            respond $ Left $ invalidParams $ Text.pack err
+          Right template -> do
+            let symbolData = case symbolName of
+                  ExtImportModule name -> ["default?" .= True, "named?" .= False, "name" .= name]
+                  ExtImportField name -> ["default?" .= False, "named?" .= True, "name" .= name]
+            -- TODO(before merge): get the decl name to here somehow
+            let templateData = object $ symbolData ++ ["upperDeclName" .= ("UpperDeclName" :: Text)]
+            let rendered = renderTemplate template templateData
+            fileExists <- liftIO $ doesFileExist filepath
+            logM $ printf "[wasp.scaffold.ts-symbol]: exists=%s rendered=%s" (show fileExists) (show rendered)
+            -- TODO(before merge): use workspace edits
+            unless fileExists $ liftIO $ Text.writeFile (SP.fromAbsFile filepath) ""
+            liftIO $ Text.appendFile (SP.fromAbsFile filepath) rendered
+            respond $ Right Aeson.Null
+
+    invalidParams msg =
+      LSP.ResponseError
+        { _code = LSP.InvalidParams,
+          _message = msg,
+          _xdata = Nothing
+        }
+
+getTemplateFor :: MonadIO m => ExprPath -> String -> m (Either String Mustache.Template)
+getTemplateFor exprPath ext = runExceptT $ do
+  templatesDir <- liftIO getTemplatesDir
+  templateFile <- (templatesDir SP.</>) <$> relTemplateForDeclType exprPath ext
+  templateExists <- liftIO $ doesFileExist templateFile
+  if templateExists
+    then do
+      compileResult <- liftIO $ Mustache.automaticCompile [SP.fromAbsDir templatesDir] (SP.fromAbsFile templateFile)
+      case compileResult of
+        Left err -> error $ printf "Compilation of template %s failed: %s" (SP.fromAbsFile templateFile) (show err)
+        Right template -> return template
+    else throwError $ printf "No scaffolding template for request: %s does not exist" (SP.fromAbsFile templateFile)
+
+renderTemplate :: Mustache.Template -> Aeson.Value -> Text
+renderTemplate template templateData =
+  let (errs, text) = Mustache.checkedSubstituteValue template $ Mustache.toMustache templateData
+   in if null errs
+        then text
+        else error $ printf "Unexpected errors rendering template: " ++ show errs
+
+data TemplatesDir
+
+data Template
+
+templatesDirInDataDir :: SP.Path' (SP.Rel Wasp.Data.DataDir) (SP.Dir TemplatesDir)
+templatesDirInDataDir = [SP.reldir|lsp/templates/ts|]
+
+getTemplatesDir :: IO (SP.Path' SP.Abs (SP.Dir TemplatesDir))
+getTemplatesDir = (SP.</> templatesDirInDataDir) <$> Wasp.Data.getAbsDataDirPath
+
+-- | @relTemplateForDeclType exprPath extension@ returns the relative path to the
+-- scaffold template for the expr path and file type.
+relTemplateForDeclType :: MonadError String m => ExprPath -> String -> m (SP.Path' (SP.Rel TemplatesDir) (SP.File Template))
+relTemplateForDeclType exprPath ext = case SP.parseRelFile $ pathDescription ++ ext of
+  Nothing -> throwError $ "Invalid path from exprPath and ext: " ++ pathDescription ++ ext
+  Just file -> return file
+  where
+    pathDescription = intercalate "." $ map stepDescription exprPath
+    stepDescription (Inference.DictKey k) = printf "%s" k
+    stepDescription Inference.List = "list"
+    stepDescription (Inference.Tuple n) = printf "[%d]" n
+    stepDescription (Inference.Decl decl) = decl

--- a/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Wasp.LSP.Commands.ScaffoldTsSymbol
+  ( -- * Scaffold TS Symbol Command
+
+    -- Command @wasp.scaffold.ts-symbol@ appends a new function with the given
+    -- name to end of a particular file.
+    Args (Args, symbolName, declType, filepath),
+    command,
+    plugin,
+  )
+where
+
+import Control.Lens ((^.))
+import Data.Aeson (FromJSON, Result (Error, Success), ToJSON (toJSON), fromJSON, object, withObject, (.:), (.=))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (parseJSON)
+import qualified Data.Text as Text
+import qualified Language.LSP.Server as LSP
+import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types.Lens as LSP
+import qualified StrongPath as SP
+import Wasp.Analyzer.Parser.AST (ExtImportName)
+import Wasp.LSP.Commands.CommandPlugin (CommandPlugin (CommandPlugin, commandHandler, commandName))
+import Wasp.LSP.ServerM (ServerM)
+
+data Args = Args
+  { -- | Name of the symbol to define. If this is 'ExtImportModule', it will
+    -- create a function with the specified name and export it as default.
+    symbolName :: ExtImportName,
+    -- | The type of the declaration that this import is part of. Used to choose what kind of code to scaffold.
+    declType :: String,
+    -- | Path to the file to add the scaffoled code to the end of.
+    filepath :: SP.Path' SP.Abs SP.File'
+  }
+  deriving (Show, Eq)
+
+instance ToJSON Args where
+  toJSON args =
+    object
+      [ "symbolName" .= symbolName args,
+        "declType" .= declType args,
+        "filepath" .= SP.toFilePath (filepath args)
+      ]
+
+instance FromJSON Args where
+  parseJSON = withObject "Args" $ \v ->
+    Args
+      <$> v .: "symbolName"
+      <*> v .: "declType"
+      <*> ((maybe (fail "Could not parse filepath") pure . SP.parseAbsFile) =<< v .: "filepath")
+
+command :: Args -> LSP.Command
+command args =
+  LSP.Command
+    { _title = "Scaffold TS Code",
+      _command = commandName plugin,
+      _arguments = Just $ LSP.List [toJSON args]
+    }
+
+plugin :: CommandPlugin
+plugin =
+  CommandPlugin
+    { commandName = "wasp.scaffold.ts-symbol",
+      commandHandler = handler
+    }
+
+handler :: LSP.Handler ServerM 'LSP.WorkspaceExecuteCommand
+handler request respond = case request ^. LSP.params . LSP.arguments of
+  Just (LSP.List [argument]) -> case fromJSON argument of
+    Error err ->
+      respond $
+        Left $
+          LSP.ResponseError
+            { _code = LSP.InvalidParams,
+              _message = Text.pack err,
+              _xdata = Nothing
+            }
+    Success args -> handle args
+  _ ->
+    respond $
+      Left $
+        LSP.ResponseError
+          { _code = LSP.InvalidParams,
+            _message = "Expected exactly one argument",
+            _xdata = Nothing
+          }
+  where
+    handle Args {..} = do
+      respond $ Right Aeson.Null

--- a/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
@@ -190,6 +190,7 @@ getTemplateFor exprPath ext = runExceptT $ do
     then do
       compileResult <- liftIO $ Mustache.automaticCompile [SP.fromAbsDir templatesDir] (SP.fromAbsFile templateFile)
       case compileResult of
+        -- Note: 'error' is used here because all templates should be valid.
         Left err -> error $ printf "Compilation of template %s failed: %s" (SP.fromAbsFile templateFile) (show err)
         Right template -> return template
     else throwError $ printf "No scaffolding template for request: %s does not exist" (SP.fromAbsFile templateFile)

--- a/waspc/waspls/src/Wasp/LSP/ExtImport/Path.hs
+++ b/waspc/waspls/src/Wasp/LSP/ExtImport/Path.hs
@@ -28,6 +28,7 @@ import qualified Path as P
 import qualified StrongPath as SP
 import qualified StrongPath.Path as SP
 import Wasp.AppSpec.ExternalCode (SourceExternalCodeDir)
+import Wasp.LSP.Util (stripProperPrefix)
 import Wasp.Project.Common (WaspProjectDir)
 import Wasp.Util.IO (doesFileExist)
 
@@ -71,10 +72,10 @@ absPathToCachePath absFile = do
     Nothing -> pure Nothing
     Just (projectRootDir :: SP.Path' SP.Abs (SP.Dir WaspProjectDir)) ->
       let srcDir = projectRootDir SP.</> srcDirInProjectRootDir
-       in case P.stripProperPrefix (SP.toPathAbsDir srcDir) (SP.toPathAbsFile absFile) of
+       in case stripProperPrefix srcDir absFile of
             Nothing -> pure Nothing
             Just relFile -> do
-              let (extensionLessFile, extType) = splitExtensionType relFile
+              let (extensionLessFile, extType) = splitExtensionType $ SP.toPathRelFile relFile
               pure $ Just $ ExtFileCachePath (SP.fromPathRelFile extensionLessFile) extType
 
 cachePathToAbsPathWithoutExt :: LSP.MonadLsp c m => ExtFileCachePath -> m (Maybe (SP.Path' SP.Abs (SP.File ExtensionlessExtFile)))

--- a/waspc/waspls/src/Wasp/LSP/ExtImport/Syntax.hs
+++ b/waspc/waspls/src/Wasp/LSP/ExtImport/Syntax.hs
@@ -1,5 +1,6 @@
 module Wasp.LSP.ExtImport.Syntax
   ( ExtImportNode (..),
+    extImportAtLocation,
     findExtImportAroundLocation,
     getAllExtImports,
   )

--- a/waspc/waspls/src/Wasp/LSP/Handlers.hs
+++ b/waspc/waspls/src/Wasp/LSP/Handlers.hs
@@ -6,6 +6,7 @@ module Wasp.LSP.Handlers
     didOpenHandler,
     didChangeHandler,
     didSaveHandler,
+    executeCommandHandler,
     completionHandler,
     signatureHelpHandler,
     gotoDefinitionHandler,
@@ -22,6 +23,7 @@ import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
 import Wasp.LSP.Analysis (diagnoseWaspFile)
 import Wasp.LSP.CodeActions (getCodeActionsInRange)
+import qualified Wasp.LSP.Command as Command
 import Wasp.LSP.Completion (getCompletionsAtPosition)
 import Wasp.LSP.DynamicHandlers (registerDynamicCapabilities)
 import Wasp.LSP.GotoDefinition (gotoDefinitionOfSymbolAtPosition)
@@ -70,6 +72,9 @@ didChangeHandler =
 didSaveHandler :: Handlers ServerM
 didSaveHandler =
   LSP.notificationHandler LSP.STextDocumentDidSave $ diagnoseWaspFile . extractUri
+
+executeCommandHandler :: Handlers ServerM
+executeCommandHandler = Command.handler
 
 completionHandler :: Handlers ServerM
 completionHandler =

--- a/waspc/waspls/src/Wasp/LSP/Server.hs
+++ b/waspc/waspls/src/Wasp/LSP/Server.hs
@@ -79,8 +79,7 @@ serve maybeLogFile = do
         where
           runHandler :: ServerM a -> IO a
           runHandler handler =
-            LSP.runLspT env $ do
-              runRLspM stateTVar handler
+            LSP.runLspT env $ runRLspM stateTVar handler
 
   exitCode <-
     LSP.runServer

--- a/waspc/waspls/src/Wasp/LSP/Server.hs
+++ b/waspc/waspls/src/Wasp/LSP/Server.hs
@@ -40,7 +40,8 @@ lspServerHandlers stopReactor =
       didChangeHandler,
       completionHandler,
       signatureHelpHandler,
-      gotoDefinitionHandler
+      gotoDefinitionHandler,
+      codeActionHandler
     ]
 
 serve :: Maybe FilePath -> IO ()

--- a/waspc/waspls/src/Wasp/LSP/Server.hs
+++ b/waspc/waspls/src/Wasp/LSP/Server.hs
@@ -19,6 +19,7 @@ import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP
 import System.Exit (ExitCode (ExitFailure), exitWith)
 import qualified System.Log.Logger
+import qualified Wasp.LSP.Command as Command
 import Wasp.LSP.Debouncer (newDebouncerIO)
 import Wasp.LSP.Handlers
 import Wasp.LSP.Reactor (startReactorThread)
@@ -38,6 +39,7 @@ lspServerHandlers stopReactor =
       didOpenHandler,
       didSaveHandler,
       didChangeHandler,
+      executeCommandHandler,
       completionHandler,
       signatureHelpHandler,
       gotoDefinitionHandler,
@@ -129,7 +131,8 @@ lspServerOptions =
     { LSP.textDocumentSync = Just syncOptions,
       LSP.completionTriggerCharacters = Just [':', ' '],
       LSP.signatureHelpTriggerCharacters = signatureHelpTriggerCharacters,
-      LSP.signatureHelpRetriggerCharacters = signatureHelpRetriggerCharacters
+      LSP.signatureHelpRetriggerCharacters = signatureHelpRetriggerCharacters,
+      LSP.executeCommandCommands = Just Command.availableCommands
     }
 
 -- | Options to tell the client how to update the server about the state of text

--- a/waspc/waspls/src/Wasp/LSP/Syntax.hs
+++ b/waspc/waspls/src/Wasp/LSP/Syntax.hs
@@ -3,6 +3,7 @@ module Wasp.LSP.Syntax
 
     -- | Module with utilities for working with/looking for patterns in CSTs
     lspPositionToOffset,
+    lspRangeToSpan,
     locationAtOffset,
     parentIs,
     hasLeft,
@@ -18,6 +19,7 @@ import Data.List (find, intercalate)
 import qualified Language.LSP.Types as J
 import qualified Wasp.Analyzer.Parser.CST as S
 import Wasp.Analyzer.Parser.CST.Traverse
+import Wasp.Analyzer.Parser.SourceSpan (SourceSpan (SourceSpan))
 import Wasp.LSP.Util (allP, anyP)
 
 -- | @lspPositionToOffset srcString position@ returns 0-based offset from the
@@ -27,6 +29,14 @@ lspPositionToOffset srcString (J.Position l c) =
   let linesBefore = take (fromIntegral l) (lines srcString)
    in -- We add 1 to the length of each line to make sure to count the newline
       sum (map ((+ 1) . length) linesBefore) + fromIntegral c
+
+-- | @lspRangeToSpan srcString range@ returns 0-based source span from start of
+-- @srcString@ to the specified line and column.
+lspRangeToSpan :: String -> J.Range -> SourceSpan
+lspRangeToSpan srcString (J.Range start end) =
+  let startOffset = lspPositionToOffset srcString start
+      endOffset = lspPositionToOffset srcString end
+   in SourceSpan startOffset endOffset
 
 -- | Move to the node containing the offset.
 --

--- a/waspc/waspls/src/Wasp/LSP/Syntax.hs
+++ b/waspc/waspls/src/Wasp/LSP/Syntax.hs
@@ -10,6 +10,7 @@ module Wasp.LSP.Syntax
     isAtExprPlace,
     lexemeAt,
     findChild,
+    findAncestor,
     -- | Printing
     showNeighborhood,
   )
@@ -105,6 +106,12 @@ showNeighborhood t =
 -- | Search for a child node with the matching "SyntaxKind".
 findChild :: S.SyntaxKind -> Traversal -> Maybe Traversal
 findChild skind t = find ((== skind) . kindAt) $ children t
+
+findAncestor :: S.SyntaxKind -> Traversal -> Maybe Traversal
+findAncestor skind t =
+  if kindAt t == skind
+    then Just t
+    else findAncestor skind =<< up t
 
 -- | @lexeme src traversal@
 lexemeAt :: String -> Traversal -> String

--- a/waspc/waspls/src/Wasp/LSP/TypeInference.hs
+++ b/waspc/waspls/src/Wasp/LSP/TypeInference.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Wasp.LSP.TypeInference
   ( -- * Inferred types for CST locations
     inferTypeAtLocation,
@@ -11,8 +13,11 @@ module Wasp.LSP.TypeInference
 where
 
 import Control.Monad (guard)
+import Data.Aeson (ToJSON)
+import Data.Aeson.Types (FromJSON)
 import Data.Foldable (find)
 import qualified Data.HashMap.Strict as M
+import GHC.Generics (Generic)
 import qualified Wasp.Analyzer.Parser.CST as S
 import Wasp.Analyzer.Parser.CST.Traverse (Traversal)
 import qualified Wasp.Analyzer.Parser.CST.Traverse as T
@@ -51,7 +56,11 @@ data ExprPathStep
     List
   | -- | @Tuple idx@. Enter the @idx@-th value inside of a tuple.
     Tuple !Int
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON ExprPathStep
+
+instance FromJSON ExprPathStep
 
 -- | This function only depends on the syntax to the left of the location, and
 -- tries to be as lenient as possible in finding paths.

--- a/waspc/waspls/src/Wasp/LSP/Util.hs
+++ b/waspc/waspls/src/Wasp/LSP/Util.hs
@@ -4,16 +4,23 @@ module Wasp.LSP.Util
     hoistMaybe,
     waspSourceRegionToLspRange,
     waspPositionToLspPosition,
+    stripProperPrefix,
+    absFileInProjectRootDir,
   )
 where
 
 import Control.Lens ((+~))
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import Data.Function ((&))
+import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP hiding (line)
 import qualified Language.LSP.Types.Lens as LSP
+import qualified Path as P
+import qualified StrongPath as SP
+import qualified StrongPath.Path as SP
 import qualified Wasp.Analyzer.Parser as W
 import qualified Wasp.Analyzer.Parser.SourceRegion as W
+import Wasp.Project (WaspProjectDir)
 
 waspSourceRegionToLspRange :: W.SourceRegion -> LSP.Range
 waspSourceRegionToLspRange rgn =
@@ -40,3 +47,17 @@ anyP preds x = any ($ x) preds
 -- | Lift a 'Maybe' into a 'MaybeT' monad transformer.
 hoistMaybe :: Applicative m => Maybe a -> MaybeT m a
 hoistMaybe = MaybeT . pure
+
+stripProperPrefix :: SP.Path' SP.Abs (SP.Dir a) -> SP.Path' SP.Abs (SP.File b) -> Maybe (SP.Path' (SP.Rel a) (SP.File b))
+stripProperPrefix base file =
+  SP.fromPathRelFile
+    <$> P.stripProperPrefix (SP.toPathAbsDir base) (SP.toPathAbsFile file)
+
+-- | @absFileInProjectRootDir file@ finds the path to @file@ if it is inside the
+-- project root directory.
+absFileInProjectRootDir :: LSP.MonadLsp c m => SP.Path' SP.Abs (SP.File a) -> m (Maybe (SP.Path' (SP.Rel WaspProjectDir) (SP.File a)))
+absFileInProjectRootDir file = do
+  maybeProjectRootDir <- (>>= SP.parseAbsDir) <$> LSP.getRootPath
+  case maybeProjectRootDir of
+    Nothing -> pure Nothing
+    Just projectRootDir -> pure $ stripProperPrefix projectRootDir file

--- a/waspc/waspls/src/Wasp/LSP/Util.hs
+++ b/waspc/waspls/src/Wasp/LSP/Util.hs
@@ -10,7 +10,7 @@ where
 import Control.Lens ((+~))
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import Data.Function ((&))
-import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types as LSP hiding (line)
 import qualified Language.LSP.Types.Lens as LSP
 import qualified Wasp.Analyzer.Parser as W
 import qualified Wasp.Analyzer.Parser.SourceRegion as W


### PR DESCRIPTION
When an external import tries to import a symbol from a TypeScript/JavaScript file, waspls now offers quickfix code actions to scaffold a function in that file.

It uses the surrounding context of the external import to determine what code to write for the code action. See [`ScaffoldTsSymbol.hs`](https://github.com/wasp-lang/wasp/blob/457911d5e99a98dd123940e6b0730b147636f411/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs) for a detailed description of how it works. At a high level, there are templates in `data/lsp/templates/ts` named such that waspls chooses a specific one in a specific context. For example, `action.fn.js` contains a template for scaffolding an `action` function in a JavaScript file and would be used when a code action is requested with the cursor at the location marked by `|`:

```wasp
action createTask {
  fn: import { createTask } from "@server/actions.js"|
}
```

The scaffold action runs as a [LSP command](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#workspace_executeCommand). To prepare for wanting to define more commands in waspls in the future, this PR also introduces the concept of [command plugins](https://github.com/wasp-lang/wasp/blob/457911d5e99a98dd123940e6b0730b147636f411/waspc/waspls/src/Wasp/LSP/Commands/CommandPlugin.hs) that define some properties about each command waspls wants to handle.

## Implementation Limitations

The implementation is not perfect and doesn't exactly follow the LSP spec. Fixing this will require a big refactor of how waspls deals with files, which I think isn't worth it for this initial implementation. See [this comment in the code](https://github.com/wasp-lang/wasp/blob/457911d5e99a98dd123940e6b0730b147636f411/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs#L48) that describes the issue in more detail.