### PR TITLE
[docs] Point the page edit to release branch

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -162,7 +162,7 @@ module.exports = {
           blogSidebarCount: "ALL",
           blogSidebarTitle: "All our posts",
           postsPerPage: "ALL",
-          editUrl: "https://github.com/wasp-lang/wasp/edit/main/web/blog",
+          editUrl: "https://github.com/wasp-lang/wasp/edit/release/web",
         },
         theme: {
           customCss: [require.resolve("./src/css/custom.css")],

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -153,7 +153,7 @@ module.exports = {
           sidebarPath: require.resolve("./sidebars.js"),
           sidebarCollapsible: true,
           // Please change this to your repo.
-          editUrl: "https://github.com/wasp-lang/wasp/edit/main/web",
+          editUrl: "https://github.com/wasp-lang/wasp/edit/release/web",
           remarkPlugins: [autoImportTabs, fileExtSwitcher],
         },
         blog: {


### PR DESCRIPTION
### Description
When users click on "Edit this page" in our docs, it will point them to the `release` branch instead of the `main` branch. 

This is more correct since we publish docs from the `release` branch and it will make the PR process more correct since it will be based off of the `release` branch.

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).