### PR TITLE
[docs restructuring] Static Public Files

### DIFF
--- a/web/docs/project/public-files.md
+++ b/web/docs/project/public-files.md
@@ -1,3 +1,22 @@
 ---
 title: Static Public Files
 ---
+
+If you wish to make static files publicly available at the root of your app, you can do so by placing them in the `public` directory in the `src/client` folder:
+
+```
+src
+└── client
+    ├── public
+    │   ├── favicon.ico
+    │   └── robots.txt
+    └── ...
+```
+
+For example, if you have a file `favicon.ico` in the `public` directory, and your app is hosted at `https://myapp.com`, it will be made available at `https://myapp.com/favicon.ico`.
+
+This can be useful if you wish to e.g. override the default `favicon.ico` or provide `robots.txt`.
+
+:::info Usage in client code
+You **can't import these files** from your client code, so e.g. `import favicon from './public/favicon.ico'` won't work.
+:::


### PR DESCRIPTION
Moved documentation for static public files.

I did do some changes, as it seemed to me there was some duplication and that some re-ordering might help a bit -> @infomiho please give it a look! I removed the details about the build dir in the dist directory, since those are implementation details they don't need to know about, and they don't mean much to them.

Before:
![image](https://github.com/wasp-lang/wasp/assets/1536647/dd03d0ba-22f5-4805-9e91-7e263514d3e7)

After:
![image](https://github.com/wasp-lang/wasp/assets/1536647/1b2982e3-ce61-4426-9cd6-e690261481a2)


