### PR TITLE
Updates LSP templates

### DIFF
--- a/waspc/data/lsp/templates/ts/action.fn.ts
+++ b/waspc/data/lsp/templates/ts/action.fn.ts
@@ -1,6 +1,8 @@
 import { {{upperDeclName}} } from '@wasp/actions/types'
 
-{{#named?}}export {{/named?}}const {{name}}: {{upperDeclName}}<void, void> = async (args, context) => {
+type {{upperDeclName}}Payload = void
+type {{upperDeclName}}Result = void
+{{#named?}}export {{/named?}}const {{name}}: {{upperDeclName}}<{{upperDeclName}}Payload, {{upperDeclName}}Result> = async (args, context) => {
   // Implementation goes here
 }
 

--- a/waspc/data/lsp/templates/ts/query.fn.ts
+++ b/waspc/data/lsp/templates/ts/query.fn.ts
@@ -1,6 +1,8 @@
 import { {{upperDeclName}} } from '@wasp/queries/types'
 
-{{#named?}}export {{/named?}}const {{name}}: {{upperDeclName}}<void, void> = async (args, context) => {
+type {{upperDeclName}}Payload = void
+type {{upperDeclName}}Result = void
+{{#named?}}export {{/named?}}const {{name}}: {{upperDeclName}}<{{upperDeclName}}Payload, {{upperDeclName}}Result> = async (args, context) => {
   // Implementation goes here
 }
 

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -53,9 +53,9 @@ data-files:
   Cli/templates/basic/.wasproot
   Cli/templates/basic/src/.waspignore
   Cli/templates/basic/main.wasp
-  lsp/templates/**/*.js
-  lsp/templates/**/*.ts
-  lsp/templates/**/*.jsx
+  Lsp/templates/**/*.js
+  Lsp/templates/**/*.ts
+  Lsp/templates/**/*.jsx
   packages/deploy/dist/**/*.js
   packages/deploy/package.json
   packages/deploy/package-lock.json

--- a/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
@@ -120,10 +120,8 @@ instance ToJSON Args where
 instance FromJSON Args where
   parseJSON = withObject "Args" $ \v ->
     Args
-      <$> v
-      .: "symbolName"
-      <*> v
-      .: "pathToExtImport"
+      <$> v .: "symbolName"
+      <*> v .: "pathToExtImport"
       <*> ((maybe (fail "Could not parse filepath") pure . SP.parseAbsFile) =<< v .: "filepath")
 
 handler :: LSP.Handler ServerM 'LSP.WorkspaceExecuteCommand

--- a/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
+++ b/waspc/waspls/src/Wasp/LSP/Commands/ScaffoldTsSymbol.hs
@@ -8,7 +8,7 @@ module Wasp.LSP.Commands.ScaffoldTsSymbol
     -- name to end of a particular file.
     --
     -- Mustache templates are used to write the code for the new function.
-    -- @templateForRequest@ chooses a template in @data/lsp/template/ts@ based
+    -- @templateForRequest@ chooses a template in @data/Lsp/template/ts@ based
     -- on the location of the external import and the extension of the file that
     -- the function will be appended to.
     --
@@ -120,8 +120,10 @@ instance ToJSON Args where
 instance FromJSON Args where
   parseJSON = withObject "Args" $ \v ->
     Args
-      <$> v .: "symbolName"
-      <*> v .: "pathToExtImport"
+      <$> v
+      .: "symbolName"
+      <*> v
+      .: "pathToExtImport"
       <*> ((maybe (fail "Could not parse filepath") pure . SP.parseAbsFile) =<< v .: "filepath")
 
 handler :: LSP.Handler ServerM 'LSP.WorkspaceExecuteCommand
@@ -192,7 +194,7 @@ hasTemplateForArgs Args {..} = case P.fileExtension $ SP.toPathAbsFile filepath 
   Just ext -> isRight $ templateFileFor pathToExtImport ext
 
 -- | @getTemplateFor pathToExtImport extension@ finds the mustache template in
--- @data/lsp/templates/ts@ and compiles it.
+-- @data/Lsp/templates/ts@ and compiles it.
 getTemplateFor :: MonadIO m => ExprPath -> String -> m (Either String Mustache.Template)
 getTemplateFor exprPath ext = runExceptT $ do
   templatesDir <- liftIO getTemplatesDir
@@ -225,7 +227,7 @@ data Template
 type TemplateFile = SP.Path' (SP.Rel TemplatesDir) (SP.File Template)
 
 templatesDirInDataDir :: SP.Path' (SP.Rel Wasp.Data.DataDir) (SP.Dir TemplatesDir)
-templatesDirInDataDir = [SP.reldir|lsp/templates/ts|]
+templatesDirInDataDir = [SP.reldir|Lsp/templates/ts|]
 
 getTemplatesDir :: IO (SP.Path' SP.Abs (SP.Dir TemplatesDir))
 getTemplatesDir = (SP.</> templatesDirInDataDir) <$> Wasp.Data.getAbsDataDirPath


### PR DESCRIPTION
### Description

Updates the scaffold templates:
- `query` (gives the generic params a name)

  ```ts
   
  type AddUserPayload = void
  type AddUserResult = void
  export const newStuff: AddUser<AddUserPayload, AddUserResult> = async (args, context) => {
    // Implementation goes here
  }
  ```
- `action` (gives the generic params a name)
- the folder rename from `lsp` to `Lsp` to keep it consistent with `Generator` and `Cli`

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
