### PR TITLE
Fixes .env.client copying

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.2
+
+### 🐞 Bug fixes / 🔧 small improvements
+- Wasp copied over the `.env.server` instead of `.env.client` to the client app `.env` file. This prevented using the `.env.client` file in the client app.
+
 ## 0.11.1
 
 ### 🎉 [New feature] Prisma client preview flags 

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
@@ -1,7 +1,7 @@
 app waspBuild {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.11.1"
+    version: "^0.11.2"
   },
   title: "waspBuild"
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
@@ -1,6 +1,6 @@
 app waspCompile {
   wasp: {
-    version: "^0.11.1"
+    version: "^0.11.2"
   },
   title: "waspCompile"
 }

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -536,7 +536,7 @@
             "file",
             "web-app/.env"
         ],
-        "d9649485a674ce3c6b8d668a1253cde3bd8695cb3d2d3a6b7c573a3e2805c7ec"
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/.env
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/.env
@@ -1,4 +1,0 @@
-GOOGLE_CLIENT_ID="google_client_id"
-GOOGLE_CLIENT_SECRET="google_client_secret"
-DATABASE_URL="mock-database-url"
-SENDGRID_API_KEY="sendgrid_api_key"

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
@@ -1,7 +1,7 @@
 app waspComplexTest {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.11.1"
+    version: "^0.11.2"
   },
   auth: {
     userEntity: User,

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -298,7 +298,7 @@
             "file",
             "web-app/.env"
         ],
-        "b267ea48e5ff257c153b4f84102104eec7af8a46827aae6e76fc42c83934cfc0"
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/.env
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/.env
@@ -1,1 +1,0 @@
-DATABASE_URL="mock-database-url"

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
@@ -1,7 +1,7 @@
 app waspJob {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.11.1"
+    version: "^0.11.2"
   },
   title: "waspJob"
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
@@ -1,6 +1,6 @@
 app waspMigrate {
   wasp: {
-    version: "^0.11.1"
+    version: "^0.11.2"
   },
   title: "waspMigrate"
 }

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
@@ -1,6 +1,6 @@
 app waspNew {
   wasp: {
-    version: "^0.11.1"
+    version: "^0.11.2"
   },
   title: "waspNew"
 }

--- a/waspc/src/Wasp/Project/Env.hs
+++ b/waspc/src/Wasp/Project/Env.hs
@@ -21,7 +21,7 @@ readDotEnvServer :: Path' Abs (Dir WaspProjectDir) -> IO [EnvVar]
 readDotEnvServer waspDir = readDotEnvFileInWaspProjectDir waspDir dotEnvServer
 
 readDotEnvClient :: Path' Abs (Dir WaspProjectDir) -> IO [EnvVar]
-readDotEnvClient waspDir = readDotEnvFileInWaspProjectDir waspDir dotEnvServer
+readDotEnvClient waspDir = readDotEnvFileInWaspProjectDir waspDir dotEnvClient
 
 -- | Checks if .env exists in wasp dir, and produces a warning if so.
 -- We have this function because Wasp doesn't use ".env", but still user

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.11.1
+version:        0.11.2
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues


### PR DESCRIPTION
### Description

Fixes a bug where we copied over the `.env.server` instead of `.env.client` for the client app.

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [x] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
