### PR TITLE
[waspls] Use the wasp project root instead of the workspace root

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -4,6 +4,33 @@
 
 ### 🐞 Bug fixes / 🔧 small improvements
 - Wasp copied over the `.env.server` instead of `.env.client` to the client app `.env` file. This prevented using the `.env.client` file in the client app.
+- waspls thought that importing `"@client/file.jsx"` could mean `"@client/file.tsx"`, which could hide some missing import diagnostics and cause go-to definition to jump to the wrong file.
+
+### 🎉 [New Feature] waspls Code Scaffolding
+
+When an external import is missing its implementation, waspls now offers a Code Action to quickly scaffold the missing JavaScript or TypeScript function:
+
+```wasp
+query getTasks {
+  fn: import { getTasks } from "@server/queries.js",
+  //  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  //  ERROR: `getTasks` is not exported from `src/server/queries.ts`
+  entities: [Task],
+}
+```
+
+Using the code action (pressing <kbd>Ctrl</kbd> + <kbd>.</kbd> or clicking the lightbulb 💡 icon in VSCode) will add the following code to `src/server/queries.ts`:
+
+```ts
+import { GetTasks } from '@wasp/queries/types'
+
+import GetTasksInput = void
+import GetTasksOutput = void
+
+export const getTasks: GetTasks<GetTasksInput, GetTasksOutput> = async (args, context) => {
+  // Implementation goes here
+}
+```
 
 ## 0.11.1
 

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -370,6 +370,7 @@ library waspls
     Wasp.LSP.Server
     Wasp.LSP.ServerConfig
     Wasp.LSP.ServerMonads
+    Wasp.LSP.ServerMonads.HasProjectRootDir
     Wasp.LSP.ServerState
     Wasp.LSP.SignatureHelp
     Wasp.LSP.Syntax

--- a/waspc/waspls/src/Wasp/LSP/DynamicHandlers.hs
+++ b/waspc/waspls/src/Wasp/LSP/DynamicHandlers.hs
@@ -64,6 +64,11 @@ registerSourceFileWatcher = do
   -- not available in 3.16. We are limited to 3.16 because we use lsp-1.4.0.0.
   let tsJsGlobPattern = "**/*.{ts,tsx,js,jsx}"
   globPattern <-
+    -- NOTE: We use the workspace root, instead of the wasp root here, because
+    -- 1) The wasp root may not be known yet.
+    -- 2) Using the workspace root results only in the potential to consider
+    --    files that do not matter. Important files won't be missed (the workspace
+    --    root will necessarily contain the wasp root).
     LSP.getRootPath >>= \case
       Nothing -> do
         logM "Could not access projectRootDir when setting up source file watcher. Watching any TS/JS file instead of limiting to src/."

--- a/waspc/waspls/src/Wasp/LSP/ServerMonads/HasProjectRootDir.hs
+++ b/waspc/waspls/src/Wasp/LSP/ServerMonads/HasProjectRootDir.hs
@@ -1,0 +1,10 @@
+module Wasp.LSP.ServerMonads.HasProjectRootDir
+  ( HasProjectRootDir (getProjectRootDir),
+  )
+where
+
+import qualified StrongPath as SP
+import Wasp.Project (WaspProjectDir)
+
+class Monad m => HasProjectRootDir m where
+  getProjectRootDir :: m (Maybe (SP.Path' SP.Abs (SP.Dir WaspProjectDir)))

--- a/waspc/waspls/src/Wasp/LSP/Util.hs
+++ b/waspc/waspls/src/Wasp/LSP/Util.hs
@@ -11,12 +11,12 @@ where
 import Control.Lens ((+~))
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import Data.Function ((&))
-import qualified Language.LSP.Server as LSP
 import qualified Language.LSP.Types as LSP hiding (line)
 import qualified Language.LSP.Types.Lens as LSP
 import qualified StrongPath as SP
 import qualified Wasp.Analyzer.Parser as W
 import qualified Wasp.Analyzer.Parser.SourceRegion as W
+import Wasp.LSP.ServerMonads.HasProjectRootDir (HasProjectRootDir (getProjectRootDir))
 import Wasp.Project (WaspProjectDir)
 import Wasp.Util.StrongPath (stripProperPrefix)
 
@@ -46,11 +46,11 @@ anyP preds x = any ($ x) preds
 hoistMaybe :: Applicative m => Maybe a -> MaybeT m a
 hoistMaybe = MaybeT . pure
 
--- | @absFileInProjectRootDir file@ finds the path to @file@ if it is inside the
+-- | @getPathRelativeToProjectDir file@ finds the path to @file@ if it is inside the
 -- project root directory.
-getPathRelativeToProjectDir :: LSP.MonadLsp c m => SP.Path' SP.Abs (SP.File a) -> m (Maybe (SP.Path' (SP.Rel WaspProjectDir) (SP.File a)))
+getPathRelativeToProjectDir :: HasProjectRootDir m => SP.Path' SP.Abs (SP.File a) -> m (Maybe (SP.Path' (SP.Rel WaspProjectDir) (SP.File a)))
 getPathRelativeToProjectDir file = do
-  maybeProjectRootDir <- (>>= SP.parseAbsDir) <$> LSP.getRootPath
+  maybeProjectRootDir <- getProjectRootDir
   case maybeProjectRootDir of
     Nothing -> pure Nothing
     Just projectRootDir -> pure $ stripProperPrefix projectRootDir file


### PR DESCRIPTION
Previously, waspls used the workspace root to look for external code files, which was incorrect if you opened a workspace larger than the wasp project. This could manifest as false-positive missing import diagnostics (which also breaks a lot of other extimport-related features):

![image](https://github.com/wasp-lang/wasp/assets/22552467/7dc297aa-c937-4d08-be58-357b05703140)

*Above: Example of the incorrect behavior that is now fixed*

Now, waspls uses the actual wasp project root instead of the workspace root. It finds the project root based on the location of the `.wasp` file.

This PR also updates the changelog with a description of the code scaffolding feature.

> [!NOTE]
> This does **not** add support for multi-project workspaces, similar to the following:
> ```
> .
> ├── project1/
> │   ├── src/
> │   ├── .wasproot
> │   └── main.wasp
> └── project2/
>     ├── src/
>     ├── .wasproot
>     └── main.wasp
> ```
> waspls will probably behave strangely in this scenario.
