### PR TITLE
Added new redirect

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -231,7 +231,11 @@ module.exports = {
           {
             from: '/docs/integrations/css-frameworks',
             to: '/docs/project/css-frameworks',
-          }
+          },
+          {
+            from: '/docs/tutorials/todo-app',
+            to: '/docs/tutorial/project-structure',
+          },
         ],
       },
     ],


### PR DESCRIPTION
Added new redirect so people who click on "Take the Tutorial" are taken to the "Project structure" page on the docs.

### Description

> Fixes Issue #1416. Now redirecting to the "Project structure" page on the docs. I didn't redirect to the first page as it explains creating the project, which should already be done considering that people are already running Wasp locally. 

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [X] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

