### PR TITLE
Updated default .gitignore for new Wasp project to be more robust regarding env files

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -2,9 +2,6 @@
 
 ## 0.11.3
 
-### 🐞 Bug fixes
-- Fixes API types exports for TypeScript users
-
 ### 🎉 [New Feature] Type-safe links
 
 Wasp now offers a way to link to pages in your app in a type-safe way. This means that you can't accidentally link to a page that doesn't exist, or pass the wrong arguments to a page.
@@ -48,11 +45,12 @@ import { routes } from '@wasp/router'
 const linkToTask = routes.TaskRoute({ params: { id: 1 } })
 ```
 
-## 0.11.2
+### 🐞 Bug fixes
+- Fixes API types exports for TypeScript users.
+- Default .gitignore that comes with new Wasp project (`wasp new`) is now more aggressive when ignoring .env files, ensuring they don't get committed by accident (wrong name, wrong location, ...).
 
-### 🐞 Bug fixes / 🔧 small improvements
-- Wasp copied over the `.env.server` instead of `.env.client` to the client app `.env` file. This prevented using the `.env.client` file in the client app.
-- waspls thought that importing `"@client/file.jsx"` could mean `"@client/file.tsx"`, which could hide some missing import diagnostics and cause go-to definition to jump to the wrong file.
+
+## 0.11.2
 
 ### 🎉 [New Feature] waspls Code Scaffolding
 
@@ -79,6 +77,11 @@ export const getTasks: GetTasks<GetTasksInput, GetTasksOutput> = async (args, co
   // Implementation goes here
 }
 ```
+
+### 🐞 Bug fixes / 🔧 small improvements
+- Wasp copied over the `.env.server` instead of `.env.client` to the client app `.env` file. This prevented using the `.env.client` file in the client app.
+- waspls thought that importing `"@client/file.jsx"` could mean `"@client/file.tsx"`, which could hide some missing import diagnostics and cause go-to definition to jump to the wrong file.
+
 
 ## 0.11.1
 

--- a/waspc/data/Cli/templates/basic/.gitignore
+++ b/waspc/data/Cli/templates/basic/.gitignore
@@ -1,3 +1,11 @@
 /.wasp/
-/.env.server
-/.env.client
+
+# We ignore env files recognized and used by Wasp.
+.env.server
+.env.client
+
+# To be extra safe, we by default ignore any files with `.env` extension in them.
+# If this is too agressive for you, consider allowing specific files with `!` operator,
+# or modify/delete these two lines.
+*.env
+*.env.*

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
@@ -1,7 +1,7 @@
 app waspBuild {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.11.2"
+    version: "^0.11.3"
   },
   title: "waspBuild"
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
@@ -1,6 +1,6 @@
 app waspCompile {
   wasp: {
-    version: "^0.11.2"
+    version: "^0.11.3"
   },
   title: "waspCompile"
 }

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
@@ -1,7 +1,7 @@
 app waspComplexTest {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.11.2"
+    version: "^0.11.3"
   },
   auth: {
     userEntity: User,

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
@@ -1,7 +1,7 @@
 app waspJob {
   db: { system: PostgreSQL },
   wasp: {
-    version: "^0.11.2"
+    version: "^0.11.3"
   },
   title: "waspJob"
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
@@ -1,6 +1,6 @@
 app waspMigrate {
   wasp: {
-    version: "^0.11.2"
+    version: "^0.11.3"
   },
   title: "waspMigrate"
 }

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
@@ -1,6 +1,6 @@
 app waspNew {
   wasp: {
-    version: "^0.11.2"
+    version: "^0.11.3"
   },
   title: "waspNew"
 }

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.11.2
+version:        0.11.3
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues


### PR DESCRIPTION
Fixes #1411 .

 - [X] **Bug fix** (non-breaking change which fixes an issue).

1. [X] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [X] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
