### PR TITLE
Add docs on how to build wasp from source on M1/M2 macs

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -34,7 +34,32 @@ It can then also run that web app for you, deploy it (not yet but that is coming
 ### Setup
 We use the [`cabal`](https://cabal.readthedocs.io/) command line tool to build
 the project. The best way to install it is via
-[ghcup](https://www.haskell.org/ghcup/). The `ghcup tui` terminal user interface
+[ghcup](https://www.haskell.org/ghcup/) (if you're running an M1/M2 mac make sure to run it in rosetta).
+
+<details>
+<summary>M1/M2 rosetta setup</summary>
+
+1. Regular Shell: just run `arch -x86_64 zsh` in your terminal.
+2. IntelliJ: Preferences -> Tools -> Terminal -> Shell path -> `env /usr/bin/arch -x86_64 /bin/zsh --login`
+3. VSCode: add the following to your local `.vscode/settings.json` file
+
+```json
+{
+  "terminal.integrated.profiles.osx": {
+    "rosetta": {
+      "path": "/usr/bin/arch",
+      "args": ["-arch", "x86_64", "/bin/zsh"],
+      "overrideName": true
+    }
+  },
+  "terminal.integrated.defaultProfile.osx": "rosetta"
+}
+```
+
+To check you can run `sysctl sysctl.proc_translated` and it should print out `sysctl.proc_translated: 1`
+</details>
+
+The `ghcup tui` terminal user interface
 is a convenient way of installing and selecting versions of `cabal`, `hls` and
 `ghc`.
 


### PR DESCRIPTION
### Description

> Adds a short section to the waspc/README.md about how to run/setup rosetta on M1/M2 macs

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
