### PR TITLE
Resolved: run CI workflow only when code inside waspc/ changes

### DIFF
--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -7,7 +7,9 @@ on:
     branches:
       - main
       - release
-  pull_request: { }
+  pull_request:
+    paths:
+      - "waspc/**"
   create: { tags: [v*] }
   schedule:
     # Additionally run once per week (At 00:00 on Sunday) to avoid loosing cache

--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -1,7 +1,9 @@
-name: CI
+name: WASPC-CI
 
 on:
   push:
+    paths:
+      - "waspc/**"
     branches:
       - main
       - release


### PR DESCRIPTION
### Description

Fix Haskell CI workflow only when code inside waspc/ changes (Fixes #291).

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

