### PR TITLE
Fixed text visibility in roadmap section

### DIFF
--- a/web/src/components/Roadmap.js
+++ b/web/src/components/Roadmap.js
@@ -1,7 +1,23 @@
 import React from 'react'
 import Link from '@docusaurus/Link'
 import classNames from 'classnames'
-import { Terminal, Layers, Coffee, Code, Unlock, Repeat, Send, Link2, Grid, ArrowRight, Globe, Settings, Mail, Type, Star } from 'react-feather'
+import {
+  Terminal,
+  Layers,
+  Coffee,
+  Code,
+  Unlock,
+  Repeat,
+  Send,
+  Link2,
+  Grid,
+  ArrowRight,
+  Globe,
+  Settings,
+  Mail,
+  Type,
+  Star,
+} from 'react-feather'
 
 import SectionContainer from './Layouts/SectionContainer'
 
@@ -10,33 +26,41 @@ import styles from '../pages/styles.module.css'
 // TODO(matija): this is duplication from HowItWorks section.
 const GhIssueLink = ({ url, label }) => (
   <Link to={url}>
-    <span className={`
+    <span
+      className={`
         cursor-pointer text-xs
         bg-neutral-600 text-white
         px-2.5 py-1 rounded-full
       `}
     >
-      <div className='group inline-flex gap-1 items-center'>
+      <div className="group inline-flex gap-1 items-center">
         <span>{label}</span>
-        <div className='transition-all group-hover:ml-0.5'>
-          <span className='text-yellow-400'>
+        <div className="transition-all group-hover:ml-0.5">
+          <span className="text-yellow-400">
             <ArrowRight size={14} strokeWidth={2} />
           </span>
         </div>
       </div>
-
     </span>
   </Link>
 )
 
 const Section = ({ features }) => (
-  <ul className='space-y-6'>
-    {features.map(f => (
-      <li className='grid grid-cols-12'>
-        <div className='flex items-center col-start-3 col-span-8'>
+  <ul className="space-y-6">
+    {features.map((f) => (
+      <li className="grid grid-cols-12">
+        <div className="flex items-center col-start-3 col-span-8">
           <span>
-            <span className='text-neutral-600'>{f[0]}</span>
-            {f[1] && <>&nbsp;<GhIssueLink url={'https://github.com/wasp-lang/wasp/issues/' + f[1]} label={f[1]} /></>}
+            <span className="text-neutral-600">{f[0]}</span>
+            {f[1] && (
+              <>
+                &nbsp;
+                <GhIssueLink
+                  url={'https://github.com/wasp-lang/wasp/issues/' + f[1]}
+                  label={f[1]}
+                />
+              </>
+            )}
           </span>
         </div>
       </li>
@@ -45,60 +69,65 @@ const Section = ({ features }) => (
 )
 
 const Roadmap = () => (
-    <SectionContainer className='space-y-16 lg:py-18' id='roadmap'>
-      <div className='grid grid-cols-12'>
-        <div className='col-span-12 text-center'>
-          <h2 className='text-xl lg:text-2xl text-neutral-700 mb-4'>
-            🚧 Roadmap 🚧
-          </h2>
-          <p className='text-neutral-500'>
-            Work on Wasp never stops: get a glimpse of what is coming next!
-          </p>
-        </div>
+  <SectionContainer className="space-y-16 lg:py-18" id="roadmap">
+    <div className="grid grid-cols-12">
+      <div className="col-span-12 text-center">
+        <h2 className="text-xl lg:text-2xl text-neutral-700 mb-4">
+          🚧 Roadmap 🚧
+        </h2>
+        <p className="text-neutral-500">
+          Work on Wasp never stops: get a glimpse of what is coming next!
+        </p>
       </div>
+    </div>
 
-      <div className='grid grid-cols-1 lg:grid-cols-2 md:gap-16'>
-
-        <div
-          className={`
+    <div className="grid grid-cols-1 lg:grid-cols-2 md:gap-16">
+      <div
+        className={`
             bg-yellow-500/5 border border-yellow-500/25
             p-5 rounded-lg
           `}
-        >
-          <div className='font-bold text-center mb-6'>Near-term improvements and features</div>
-          <Section features={[
+      >
+        <div className="font-bold text-center text-neutral-700 mb-6">
+          Near-term improvements and features
+        </div>
+        <Section
+          features={[
             ['Improve Wasp project structure', 734],
             ['Allow custom steps in the build pipeline', 906],
             ['Support for SSR / SSG', 911],
             ['Automatic generation of API for Operations', 863],
             ['Better Prisma support (more features, IDE)', 641],
             ['Support for backend testing', 110],
-            ['Better way to define JS dependencies', 243]
-          ]} />
-        </div>
+            ['Better way to define JS dependencies', 243],
+          ]}
+        />
+      </div>
 
-        <div
-          className={`
+      <div
+        className={`
             bg-yellow-500/20 border border-yellow-500/25
             p-5 rounded-lg
             mt-6 lg:mt-0
           `}
-        >
-          <div className='font-bold text-center mb-6'>Advanced Features</div>
-          <Section features={[
+      >
+        <div className="font-bold text-center text-neutral-700 mb-6">
+          Advanced Features
+        </div>
+        <Section
+          features={[
             ['Top-level data schema', 642],
             ['Automatic generation of CRUD UI', 489],
             ['Multiple targets (e.g. mobile)', 1088],
             ['Multiple servers, serverless'],
             ['Polyglot'],
             ['Multiple frontend libraries'],
-            ['Full-stack modules']
-          ]} />
-        </div>
-
+            ['Full-stack modules'],
+          ]}
+        />
       </div>
-
-    </SectionContainer>
+    </div>
+  </SectionContainer>
 )
 
 export default Roadmap


### PR DESCRIPTION
### Description

Added text-neutral-700 class to the headings of the "Near-term improvements and features" and "Advanced Features" headings to improve visibility. Text before the change was barely visible (as seen in the screenshot below). 

![image](https://github.com/wasp-lang/wasp/assets/46416972/8894b15e-2a8b-4bb3-a443-6f5574bbc460)

The rest of the changes were changes made by the Prettier plugin (you can see it is just reordering/reorganizing lines of code), 

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
