### PR TITLE
fixed typos in waspc/docs/wasplang/src/index.tex

### DIFF
--- a/waspc/docs/wasplang/src/index.tex
+++ b/waspc/docs/wasplang/src/index.tex
@@ -42,7 +42,7 @@ The \texttt{<anything>} inside \texttt{<quoter>} is ambiguous, so to correctly
 parse wasp, a quoter starting with \texttt{\{=tag} must contain all text until
 the first \texttt{tag=\}} or until the end of the input.
 
-The nonterminals for strings, numbers, and identifers are not shown.
+The nonterminals for strings, numbers, and identifiers are not shown.
 
 \subsection{Type System}
 
@@ -308,7 +308,7 @@ to wasp without bloating its core library.
 \subsection{Simplicity}
 
 While wasp is much more complex than old wasp, it is still fairly simple.
-Noteably, control flow is absent. I wanted wasp to be as simple as possible
+Notably, control flow is absent. I wanted wasp to be as simple as possible
 to make experimenting with its implementation less painful. Hopefully, when
 a good implementation is found, it will be flexible enough to bring
 in more complex features as needed.
@@ -345,7 +345,7 @@ data ParamType = StringParam | NumParam
 newtype PageParam = PageParam { name :: String
                               , paramType :: ParamType
                               } deriving (Generic)
-newtype Page = Page { componenent :: Analyzer.Primitive.Import
+newtype Page = Page { component :: Analyzer.Primitive.Import
                     , authRequired :: Maybe Bool
                     , params :: Maybe [PageParam]
                     } deriving (Generic)


### PR DESCRIPTION
### Description

> Typos in index.tex inside the directory waspc/docs.wasplang/src/index.tex has been fixed.

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
