### PR TITLE
fixed typos in waspc/design-docs/db-seeding.org and waspc/design-docs/server-setup.md

### DIFF
--- a/waspc/docs/design-docs/db-seeding.org
+++ b/waspc/docs/design-docs/db-seeding.org
@@ -13,7 +13,7 @@ I might want to have multiple such states, each of them named.
 
 I imagine this would actually be easier to do by doing snapshots of db then having seeding script, so I don't think this is what Prisma is targeting with their =seed=.
 So I probably went here a bit into a different use case -> still interesting though.
-Actuall, I read a bit more and seeding script is also valid way to do this.
+Actually, I read a bit more and seeding script is also valid way to do this.
 
 As for snapshots -> I guess this would come down to doing postgre exports and then saving those in git and loading them.
 I saw this being called "SQL backup file" somewhere.

--- a/waspc/docs/design-docs/server-setup.md
+++ b/waspc/docs/design-docs/server-setup.md
@@ -38,7 +38,7 @@ The solution that people suggested was an async function that returns an object 
 
 ### Basic
   - Dev can specify, through wasp language, a JS function that will be executed on server start.
-    Such function would be async, take no arguments, and return an object that would be avaialable in operations (through `context`).
+    Such function would be async, take no arguments, and return an object that would be available in operations (through `context`).
 
 ### Advanced
   - Instead of returning an object that will be added to `context`, function could return a function that modifies the `context`.


### PR DESCRIPTION
…/server-setup.md

### Description

> typos in waspc/design-docs/db-seeding.org and waspc/design-docs/server-setup.md has been fixed

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
