### PR TITLE
Fix task order in tutorials

### DIFF
--- a/examples/tutorials/TodoApp/src/server/queries.js
+++ b/examples/tutorials/TodoApp/src/server/queries.js
@@ -6,5 +6,6 @@ export const getTasks = async (args, context) => {
   }
   return context.entities.Task.findMany({
     where: { user: { id: context.user.id } },
+    orderBy: { id: 'asc' },
   })
 }

--- a/examples/tutorials/TodoAppTs/src/server/queries.ts
+++ b/examples/tutorials/TodoAppTs/src/server/queries.ts
@@ -8,5 +8,6 @@ export const getTasks: GetTasks<void, Task[]> = async (args, context) => {
   }
   return context.entities.Task.findMany({
     where: { user: { id: context.user.id } },
+    orderBy: { id: 'asc' },
   })
 }

--- a/web/docs/tutorial/05-queries.md
+++ b/web/docs/tutorial/05-queries.md
@@ -81,7 +81,9 @@ Next, create a new file `src/server/queries.ts` and define the TypeScript functi
 
 ```js title="src/server/queries.js"
 export const getTasks = async (args, context) => {
-  return context.entities.Task.findMany({})
+  return context.entities.Task.findMany({
+    orderBy: { id: 'asc' },
+  })
 }
 ```
 
@@ -93,7 +95,9 @@ import { Task } from '@wasp/entities'
 import { GetTasks } from '@wasp/queries/types'
 
 export const getTasks: GetTasks<void, Task[]> = async (args, context) => {
-  return context.entities.Task.findMany({})
+  return context.entities.Task.findMany({
+    orderBy: { id: 'asc' },
+  })
 }
 ```
 

--- a/web/docs/tutorial/07-auth.md
+++ b/web/docs/tutorial/07-auth.md
@@ -330,6 +330,7 @@ export const getTasks = async (args, context) => {
   }
   return context.entities.Task.findMany({
     where: { user: { id: context.user.id } },
+    orderBy: { id: 'asc' },
   })
 }
 ```
@@ -348,6 +349,7 @@ export const getTasks: GetTasks<void, Task[]> = async (args, context) => {
   }
   return context.entities.Task.findMany({
     where: { user: { id: context.user.id } },
+    orderBy: { id: 'asc' },
   })
 }
 ```


### PR DESCRIPTION
Tasks would be returned in correct order as long as users were using SQLite. However, if they switch to PostgreSQL, the task order becomes non-deterministic, causing jumpy UI.