### PR TITLE
fix: stop code blocks shrinking on logo hover

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -51,6 +51,8 @@ module.exports = {
       logo: {
         alt: "Wasp logo",
         src: "img/wasp-logo-eqpar-circle.png",
+        href: "https://wasp-lang.dev/",
+        target: "_self"
       },
       items: [
         {

--- a/web/src/components/Nav/index.js
+++ b/web/src/components/Nav/index.js
@@ -12,12 +12,14 @@ const Nav = () => {
 
   const Logo = () => (
     <div className='flex flex-shrink-0 items-center'>
-      <img
-        src='img/lp/wasp-logo.png'
-        width={35}
-        height={35}
-        alt='Wasp Logo'
-      />
+      <Link to='/'>
+        <img
+          src='img/lp/wasp-logo.png'
+          width={35}
+          height={35}
+          alt='Wasp Logo'
+        />
+      </Link>
       <span className='ml-3 font-semibold text-lg text-neutral-700'>
         Wasp <sup className='text-base text-yellow-500'>βeta</sup>
       </span>

--- a/web/src/components/Nav/index.js
+++ b/web/src/components/Nav/index.js
@@ -166,7 +166,7 @@ const Nav = () => {
                         text-sm font-semibold
                       `}
                     >
-                      Blog Test
+                      Blog
                     </span>
                   </Link>
 

--- a/web/src/components/Nav/index.js
+++ b/web/src/components/Nav/index.js
@@ -12,14 +12,12 @@ const Nav = () => {
 
   const Logo = () => (
     <div className='flex flex-shrink-0 items-center'>
-      <Link to='/'>
-        <img
-          src='img/lp/wasp-logo.png'
-          width={35}
-          height={35}
-          alt='Wasp Logo'
-        />
-      </Link>
+      <img
+        src='img/lp/wasp-logo.png'
+        width={35}
+        height={35}
+        alt='Wasp Logo'
+      />
       <span className='ml-3 font-semibold text-lg text-neutral-700'>
         Wasp <sup className='text-base text-yellow-500'>βeta</sup>
       </span>
@@ -168,7 +166,7 @@ const Nav = () => {
                         text-sm font-semibold
                       `}
                     >
-                      Blog
+                      Blog Test
                     </span>
                   </Link>
 


### PR DESCRIPTION
### Description

Fixes issue #1515 
Not really sure why the bug happens exactly but it's something related to docusaurus and local href for logo button in config. The docusaurus config determines the href and it was not set so the default is siteConfig.baseUrl. Changing it to be an "external" url and then setting target to "_self" so it does not open in new tab fixes the bug and keeps the same behavior. 

Initially for this pull request, I removed the Link tag around the Logo element in Nav/index.js. However, I don't think you need the Logo element because when I removed it, nothing changed. However, since I may be missing something, I decided to add the Link tag back and just commit the bug fix itself. 

### Select what type of change this PR introduces:

2. [x] **Bug fix** (non-breaking change which fixes an issue).
