### PR TITLE
Apple rosetta

### DIFF
--- a/web/docs/introduction/getting-started.md
+++ b/web/docs/introduction/getting-started.md
@@ -107,13 +107,11 @@ Open your terminal and run:
 curl -sSL https://get.wasp-lang.dev/installer.sh | sh
 ```
 
-:::note Apple Silicon
 If you are using macOS on a device with Apple Silicon you might encounter `Bad CPU type in executable` issue. To fix that, please [install Rosetta on your Mac](https://support.apple.com/en-us/HT211861).
 
 ```shell
 softwareupdate --install-rosetta
 ```
-:::
 
 
   </TabItem>

--- a/web/docs/introduction/getting-started.md
+++ b/web/docs/introduction/getting-started.md
@@ -109,7 +109,7 @@ curl -sSL https://get.wasp-lang.dev/installer.sh | sh
 
 :::note Running Wasp on Mac with Mx chip (arm64)
 **Experiencing the 'Bad CPU type in executable' issue on a device with arm64 (Apple Silicon)?**
-Given that the wasp binary is built for x86 and not for arm64 (Apple Silicon), you'll need to install [Rosetta on your Mac](https://support.apple.com/en-us/HT211861). Rosetta is a translation process that enables users to run applications designed for x86 on arm64 (Apple Silicon). To install Rosetta, run the following command in your terminal
+Given that the wasp binary is built for x86 and not for arm64 (Apple Silicon), you'll need to install [Rosetta on your Mac](https://support.apple.com/en-us/HT211861) if you are using a Mac with Mx (M1, M2, ...). Rosetta is a translation process that enables users to run applications designed for x86 on arm64 (Apple Silicon). To install Rosetta, run the following command in your terminal
 ```bash
 softwareupdate --install-rosetta
 ```

--- a/web/docs/introduction/getting-started.md
+++ b/web/docs/introduction/getting-started.md
@@ -109,8 +109,11 @@ curl -sSL https://get.wasp-lang.dev/installer.sh | sh
 
 :::note Something Unclear?
 **Experiencing the 'Bad CPU type in executable' issue on a device with arm64 (Apple Silicon)?**
-
-Given that the wasp binary is built for x86 and not for arm64 (Apple Silicon), you'll need to install [Rosetta on your Mac](https://support.apple.com/en-us/HT211861). Rosetta is a translation process that enables users to run applications designed for x86 on arm64 (Apple Silicon). To install Rosetta, run the following command in your terminal: `softwareupdate --install-rosetta`. Once Rosetta is installed, you should be able to run Wasp without any issues.
+Given that the wasp binary is built for x86 and not for arm64 (Apple Silicon), you'll need to install [Rosetta on your Mac](https://support.apple.com/en-us/HT211861). Rosetta is a translation process that enables users to run applications designed for x86 on arm64 (Apple Silicon). To install Rosetta, run the following command in your terminal
+```bash
+softwareupdate --install-rosetta
+```
+Once Rosetta is installed, you should be able to run Wasp without any issues.
 :::
 
   </TabItem>

--- a/web/docs/introduction/getting-started.md
+++ b/web/docs/introduction/getting-started.md
@@ -107,6 +107,15 @@ Open your terminal and run:
 curl -sSL https://get.wasp-lang.dev/installer.sh | sh
 ```
 
+:::note Apple Silicon
+If you are using macOS on a device with Apple Silicon you might encounter `Bad CPU type in executable` issue. To fix that, please [install Rosetta on your Mac](https://support.apple.com/en-us/HT211861).
+
+```shell
+softwareupdate --install-rosetta
+```
+:::
+
+
   </TabItem>
 
   <TabItem value='win'>

--- a/web/docs/introduction/getting-started.md
+++ b/web/docs/introduction/getting-started.md
@@ -107,12 +107,11 @@ Open your terminal and run:
 curl -sSL https://get.wasp-lang.dev/installer.sh | sh
 ```
 
-If you are using macOS on a device with Apple Silicon you might encounter `Bad CPU type in executable` issue. To fix that, please [install Rosetta on your Mac](https://support.apple.com/en-us/HT211861).
+:::note Something Unclear?
+**Experiencing the 'Bad CPU type in executable' issue on a device with arm64 (Apple Silicon)?**
 
-```shell
-softwareupdate --install-rosetta
-```
-
+Given that the wasp binary is built for x86 and not for arm64 (Apple Silicon), you'll need to install [Rosetta on your Mac](https://support.apple.com/en-us/HT211861). Rosetta is a translation process that enables users to run applications designed for x86 on arm64 (Apple Silicon). To install Rosetta, run the following command in your terminal: `softwareupdate --install-rosetta`. Once Rosetta is installed, you should be able to run Wasp without any issues.
+:::
 
   </TabItem>
 

--- a/web/docs/introduction/getting-started.md
+++ b/web/docs/introduction/getting-started.md
@@ -107,7 +107,7 @@ Open your terminal and run:
 curl -sSL https://get.wasp-lang.dev/installer.sh | sh
 ```
 
-:::note Something Unclear?
+:::note Running Wasp on Mac with Mx chip (arm64)
 **Experiencing the 'Bad CPU type in executable' issue on a device with arm64 (Apple Silicon)?**
 Given that the wasp binary is built for x86 and not for arm64 (Apple Silicon), you'll need to install [Rosetta on your Mac](https://support.apple.com/en-us/HT211861). Rosetta is a translation process that enables users to run applications designed for x86 on arm64 (Apple Silicon). To install Rosetta, run the following command in your terminal
 ```bash


### PR DESCRIPTION
### Description

As agreed in [Discord](https://discord.com/channels/686873244791210014/1130493830647533568/1134961449614184590) I added a note in docs about MacOS Rosetta.

The next step is to detect the Apple SIlicon, check if the Rosetta is installed, and prompt the user to install it if needed. 

```shell
# check if apple silicon
uname -m # returns arm64 if Apple Silicon

# check if Rosetta is installed
pgrep -q oahd # returns a number if is installed
```

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
