### PR TITLE
Add fallback sans-serif font

### DIFF
--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -58,7 +58,7 @@
 
   /* Infima overrides */
   --ifm-container-width-xl: 1280px;
-  --ifm-font-family-base: "Inter";
+  --ifm-font-family-base: "Inter", sans-serif;
   --ifm-color-primary: #bf9900; /* wasp color (ffcc00) darkened by 25% */
   --ifm-color-primary-dark: #8a6f04;
   --ifm-color-primary-darker: rgb(31, 165, 136);

--- a/web/src/pages/index.css
+++ b/web/src/pages/index.css
@@ -1,6 +1,6 @@
 
 html {
-  font-family: Inter;
+  font-family: Inter, sans-serif;
 }
 
 html,


### PR DESCRIPTION
There is a brief flash of fallback font being used until `Inter` is loaded. This change changes that fallback to be a `sans-serif` font instead of an ugly `serif` font.

### Before
https://github.com/wasp-lang/wasp/assets/2223680/21cd074a-92a1-4a4b-b132-d15a7e07fabc

### After
https://github.com/wasp-lang/wasp/assets/2223680/4c1f3ae2-2519-4f77-9520-6c77e2cc2d96
