### PR TITLE
Enabling new OpenAI models for MAGE

### DIFF
--- a/waspc/src/Wasp/AI/OpenAI/ChatGPT.hs
+++ b/waspc/src/Wasp/AI/OpenAI/ChatGPT.hs
@@ -88,7 +88,15 @@ data ChatGPTParams = ChatGPTParams
   deriving (Show)
 
 -- TODO: There are some more data models there but for now we went with these core ones.
-data Model = GPT_3_5_turbo | GPT_3_5_turbo_16k | GPT_4
+data Model
+  = GPT_3_5_turbo_1106
+  | GPT_3_5_turbo
+  | GPT_3_5_turbo_16k
+  | GPT_4_1106_Preview
+  | GPT_4
+  | GPT_4_32k
+  | GPT_4_0613
+  | GPT_4_32k_0613
   deriving (Eq, Bounded, Enum)
 
 instance Show Model where
@@ -96,9 +104,14 @@ instance Show Model where
 
 modelOpenAiId :: Model -> String
 modelOpenAiId = \case
+  GPT_3_5_turbo_1106 -> "gpt-3.5-turbo-1106"
   GPT_3_5_turbo -> "gpt-3.5-turbo"
   GPT_3_5_turbo_16k -> "gpt-3.5-turbo-16k"
+  GPT_4_1106_Preview -> "gpt-4-1106-preview"
   GPT_4 -> "gpt-4"
+  GPT_4_32k -> "gpt-4-32k"
+  GPT_4_0613 -> "gpt-4-0613"
+  GPT_4_32k_0613 -> "gpt-4-32k-0613"
 
 instance FromJSON Model where
   parseJSON = Aeson.withText "Model" $ \t ->


### PR DESCRIPTION
### Enabling new OpenAI models to MAGE Code Agent

This PR enables MAGE to be used with all non-legacy OpenAI chat models.

#### Models
The list of models is taken from the OpenAI website, available here: https://platform.openai.com/docs/models. The list is likely to change (e.g. models become deprecated, new models are added), so updates to the list of models that MAGE supports are probably expected in the future.

One additional idea would be to dynamically generate the list of supported models by querying the API. Although we already do something (kinda) similar when checking whether the GPT-4 model is available, this suggestion seems more complicated to implement and it's unclear if it's actually needed at this time.

#### Plan generation vs the fixing step
Note that the model configuration is still enabled only for the later steps of ChatGPT prompting (fixing the generated Wasp/JS files). The initial step (plan generation) is fixed to use GPT-4. This makes sense (for now) as this is the most powerful model. In the future, though, we might want to expose this to the CLI configuration as well.