### PR TITLE
Fix import/export JS errors in Mage

### DIFF
--- a/waspc/src/Wasp/AI/GenerateNewProject/Common/Prompts.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Common/Prompts.hs
@@ -4,6 +4,8 @@ module Wasp.AI.GenerateNewProject.Common.Prompts
     systemPrompt,
     appDescriptionStartMarkerLine,
     appDescriptionBlock,
+    waspPlanExample,
+    waspPlanSchema,
   )
 where
 
@@ -135,3 +137,46 @@ waspFileExample =
         }
         ```
       |]
+
+waspPlanExample :: Text
+waspPlanExample =
+  [trimming|
+      Here is an example of a plan (a bit simplified, as we didn't list all of the entities/actions/queries/pages):
+
+        {
+          "entities": [{
+            "entityName": "User",
+            "entityBodyPsl": "  id Int @id @default(autoincrement())\n  username String @unique\n  password String\n  tasks Task[]"
+          }],
+          "actions": [{
+            "opName": "createTask",
+            "opFnPath": "@server/actions.js",
+            "opDesc": "Checks that user is authenticated and if so, creates new Task belonging to them. Takes description as an argument and by default sets isDone to false. Returns created Task."
+          }],
+          "queries": [{
+            "opName": "getTask",
+            "opFnPath": "@server/queries.js",
+            "opDesc": "Takes task id as an argument. Checks that user is authenticated, and if so, fetches and returns their task that has specified task id. Throws HttpError(400) if tasks exists but does not belong to them."
+          }],
+          "pages": [{
+            "pageName": "TaskPage",
+            "componentPath": "@client/pages/Task.jsx",
+            "routeName: "TaskRoute",
+            "routePath": "/task/:taskId",
+            "pageDesc": "Diplays a Task with the specified taskId. Allows editing of the Task. Uses getTask query and createTask action.",
+          }]
+        }
+|]
+
+waspPlanSchema :: Text
+waspPlanSchema =
+  [trimming|
+        Plan is represented as JSON with the following schema:
+
+        {
+          "entities": [{ "entityName": string, "entityBodyPsl": string }],
+          "actions": [{ "opName": string, "opFnPath": string, "opDesc": string }],
+          "queries": [{ "opName": string, "opFnPath": string, "opDesc": string }],
+          "pages": [{ "pageName": string, "componentPath": string, "routeName": string, "routePath": string, "pageDesc": string }]
+        }
+  |]

--- a/waspc/src/Wasp/AI/GenerateNewProject/Common/Prompts.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Common/Prompts.hs
@@ -93,7 +93,7 @@ waspFileExample =
           component: import Login from "@client/pages/auth/Login.jsx"
         }
 
-        route DashboardRoute { path: "/", to: Dashboard }
+        route DashboardRoute { path: "/", to: DashboardPage }
         page DashboardPage {
           authRequired: true,
           component: import Dashboard from "@client/pages/Dashboard.jsx"

--- a/waspc/src/Wasp/AI/GenerateNewProject/Common/Prompts.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Common/Prompts.hs
@@ -4,8 +4,6 @@ module Wasp.AI.GenerateNewProject.Common.Prompts
     systemPrompt,
     appDescriptionStartMarkerLine,
     appDescriptionBlock,
-    waspPlanExample,
-    waspPlanSchema,
   )
 where
 
@@ -137,46 +135,3 @@ waspFileExample =
         }
         ```
       |]
-
-waspPlanExample :: Text
-waspPlanExample =
-  [trimming|
-      Here is an example of a plan (a bit simplified, as we didn't list all of the entities/actions/queries/pages):
-
-        {
-          "entities": [{
-            "entityName": "User",
-            "entityBodyPsl": "  id Int @id @default(autoincrement())\n  username String @unique\n  password String\n  tasks Task[]"
-          }],
-          "actions": [{
-            "opName": "createTask",
-            "opFnPath": "@server/actions.js",
-            "opDesc": "Checks that user is authenticated and if so, creates new Task belonging to them. Takes description as an argument and by default sets isDone to false. Returns created Task."
-          }],
-          "queries": [{
-            "opName": "getTask",
-            "opFnPath": "@server/queries.js",
-            "opDesc": "Takes task id as an argument. Checks that user is authenticated, and if so, fetches and returns their task that has specified task id. Throws HttpError(400) if tasks exists but does not belong to them."
-          }],
-          "pages": [{
-            "pageName": "TaskPage",
-            "componentPath": "@client/pages/Task.jsx",
-            "routeName: "TaskRoute",
-            "routePath": "/task/:taskId",
-            "pageDesc": "Diplays a Task with the specified taskId. Allows editing of the Task. Uses getTask query and createTask action.",
-          }]
-        }
-|]
-
-waspPlanSchema :: Text
-waspPlanSchema =
-  [trimming|
-        Plan is represented as JSON with the following schema:
-
-        {
-          "entities": [{ "entityName": string, "entityBodyPsl": string }],
-          "actions": [{ "opName": string, "opFnPath": string, "opDesc": string }],
-          "queries": [{ "opName": string, "opFnPath": string, "opDesc": string }],
-          "pages": [{ "pageName": string, "componentPath": string, "routeName": string, "routePath": string, "pageDesc": string }]
-        }
-  |]

--- a/waspc/src/Wasp/AI/GenerateNewProject/Page.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Page.hs
@@ -117,8 +117,8 @@ generatePage newProjectDetails entityPlans queries actions pPlan = do
         When writing the javascript implementation, make sure to always use the default export. 
         Concretely, define the main component with `const ${pageName} = () => {...}`,
         and then at the end export it with `export default ${pageName}`.
-        It is also really important that the ${pageName} is then imported as a default import. 
-        Concretely, in "pageWaspDecl", use `import ${pageName}` instead of `import { ${pageName} }`.
+        It is also really important that the ${pageName} is then imported as a default import
+        in "pageWaspDecl": use `import ${pageName}` instead of `import { ${pageName} }`.
         This is very important to me, please do as I say.
 
         ${appDescriptionBlock}

--- a/waspc/src/Wasp/AI/GenerateNewProject/Page.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Page.hs
@@ -109,10 +109,17 @@ generatePage newProjectDetails entityPlans queries actions pPlan = do
 
         Example of such JSON:
         {
-          "pageWaspDecl": "route ExampleRoute { path: \"/\", to: ExamplePage }\npage ExamplePage {\n  component: import { ExamplePage } from \"@client/ExamplePage.jsx\",\n  authRequired: true\n}",
+          "pageWaspDecl": "route ExampleRoute { path: \"/\", to: ExamplePage }\npage ExamplePage {\n  component: import ExamplePage from \"@client/ExamplePage.jsx\",\n  authRequired: true\n}",
           "pageJsImpl": "JS imports + React component implementing the page.",
         }
         There should be no other text in the response.
+
+        When writing the javascript implementation, make sure to always use the default export. 
+        Concretely, define the main component with `const ${pageName} = () => {...}`,
+        and then at the end export it with `export default ${pageName}`.
+        It is also really important that the ${pageName} is then imported as a default import. 
+        Concretely, in "pageWaspDecl", use `import ${pageName}` instead of `import { ${pageName} }`.
+        This is very important to me, please do as I say.
 
         ${appDescriptionBlock}
       |]
@@ -127,7 +134,7 @@ makePageDocPrompt =
         ```wasp
         route TasksRoute { path: "/", to: ExamplePage }
         page TasksPage {
-          component: import { Tasks } from "@client/Tasks.jsx",
+          component: import Tasks from "@client/Tasks.jsx",
           authRequired: true
         }
         ```
@@ -142,7 +149,7 @@ makePageDocPrompt =
         import createTask from '@wasp/actions/createTask';
         import toggleTask from '@wasp/actions/toggleTask';
 
-        export function Tasks() {
+        const Tasks = () => {
           const { data: tasks, isLoading, error } = useQuery(getTasks);
           const createTaskFn = useAction(createTask);
           const toggleTaskFn = useAction(toggleTask);
@@ -193,6 +200,7 @@ makePageDocPrompt =
           );
         }
 
+        export default Tasks;
         ```
 
         Here's another example of a Page declaration in Wasp:
@@ -200,7 +208,7 @@ makePageDocPrompt =
         ```wasp
         route DashboardRoute { path: "/dashboard", to: DashboardPage }
         page DashboardPage {
-          component: import { Dashboard } from "@client/Dashboard.jsx",
+          component: import Dashboard from "@client/Dashboard.jsx",
           authRequired: true
         }
         ```
@@ -215,7 +223,7 @@ makePageDocPrompt =
         import getUsers from '@wasp/queries/getUsers';
         import deleteUser from '@wasp/actions/deleteUser';
 
-        export function DashboardPage() {
+        const DashboardPage = () => {
           const { data: users, isLoading, error } = useQuery(getUsers);
           const deleteUserFn = useAction(deleteUser);
 
@@ -250,6 +258,8 @@ makePageDocPrompt =
             </div>
           );
         }
+
+        export default DashboardPage;
         ```
 
         Make sure to style the page with Tailwind CSS and make it as beautiful as possible.

--- a/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs
@@ -169,6 +169,7 @@ fixPageComponent newProjectDetails waspFilePath pageComponentPath = do
             - If there are any js imports of local modules (`from "./`, `from "../`),
               remove them and instead add the needed implementation directly in the file we are fixing right now.
             - Remove redundant imports, but don't change any of the remaining ones.
+            - Make sure that the component is exported as a default export.
 
           With this in mind, generate a new, fixed React component (${pageComponentPathText}).
           Do actual fixes, don't leave comments with "TODO"!

--- a/waspc/src/Wasp/AI/GenerateNewProject/Plan.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Plan.hs
@@ -62,6 +62,8 @@ generatePlan newProjectDetails planRules = do
     appDescriptionBlockText = appDescriptionBlock newProjectDetails
     basicWaspLangInfoPrompt = Prompts.basicWaspLangInfo
     waspFileExamplePrompt = Prompts.waspFileExample
+    waspPlanExample = Prompts.waspPlanExample
+    waspPlanSchema = Prompts.waspPlanSchema
     rulesText = T.pack . unlines $ "Instructions you must follow while generating plan:" : map (" - " ++) planRules
     planPrompt =
       [trimming|
@@ -73,40 +75,9 @@ generatePlan newProjectDetails planRules = do
 
         ${rulesText}
 
-        Plan is represented as JSON with the following schema:
+        ${waspPlanSchema}
 
-        {
-          "entities": [{ "entityName": string, "entityBodyPsl": string }],
-          "actions": [{ "opName": string, "opFnPath": string, "opDesc": string }],
-          "queries": [{ "opName": string, "opFnPath": string, "opDesc": string }],
-          "pages": [{ "pageName": string, "componentPath": string, "routeName": string, "routePath": string, "pageDesc": string }]
-        }
-
-        Here is an example of a plan (a bit simplified, as we didn't list all of the entities/actions/queries/pages):
-
-        {
-          "entities": [{
-            "entityName": "User",
-            "entityBodyPsl": "  id Int @id @default(autoincrement())\n  username String @unique\n  password String\n  tasks Task[]"
-          }],
-          "actions": [{
-            "opName": "createTask",
-            "opFnPath": "@server/actions.js",
-            "opDesc": "Checks that user is authenticated and if so, creates new Task belonging to them. Takes description as an argument and by default sets isDone to false. Returns created Task."
-          }],
-          "queries": [{
-            "opName": "getTask",
-            "opFnPath": "@server/queries.js",
-            "opDesc": "Takes task id as an argument. Checks that user is authenticated, and if so, fetches and returns their task that has specified task id. Throws HttpError(400) if tasks exists but does not belong to them."
-          }],
-          "pages": [{
-            "pageName": "TaskPage",
-            "componentPath": "@client/pages/Task.jsx",
-            "routeName: "TaskRoute",
-            "routePath": "/task/:taskId",
-            "pageDesc": "Diplays a Task with the specified taskId. Allows editing of the Task. Uses getTask query and createTask action.",
-          }]
-        }
+        ${waspPlanExample}
 
         We will later use this plan to write main.wasp file and all the other parts of Wasp app,
         so make sure descriptions are detailed enough to guide implementing them.

--- a/waspc/src/Wasp/AI/GenerateNewProject/Plan.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Plan.hs
@@ -62,8 +62,6 @@ generatePlan newProjectDetails planRules = do
     appDescriptionBlockText = appDescriptionBlock newProjectDetails
     basicWaspLangInfoPrompt = Prompts.basicWaspLangInfo
     waspFileExamplePrompt = Prompts.waspFileExample
-    waspPlanExample = Prompts.waspPlanExample
-    waspPlanSchema = Prompts.waspPlanSchema
     rulesText = T.pack . unlines $ "Instructions you must follow while generating plan:" : map (" - " ++) planRules
     planPrompt =
       [trimming|
@@ -75,9 +73,40 @@ generatePlan newProjectDetails planRules = do
 
         ${rulesText}
 
-        ${waspPlanSchema}
+        Plan is represented as JSON with the following schema:
 
-        ${waspPlanExample}
+        {
+          "entities": [{ "entityName": string, "entityBodyPsl": string }],
+          "actions": [{ "opName": string, "opFnPath": string, "opDesc": string }],
+          "queries": [{ "opName": string, "opFnPath": string, "opDesc": string }],
+          "pages": [{ "pageName": string, "componentPath": string, "routeName": string, "routePath": string, "pageDesc": string }]
+        }
+
+      Here is an example of a plan (a bit simplified, as we didn't list all of the entities/actions/queries/pages):
+
+        {
+          "entities": [{
+            "entityName": "User",
+            "entityBodyPsl": "  id Int @id @default(autoincrement())\n  username String @unique\n  password String\n  tasks Task[]"
+          }],
+          "actions": [{
+            "opName": "createTask",
+            "opFnPath": "@server/actions.js",
+            "opDesc": "Checks that user is authenticated and if so, creates new Task belonging to them. Takes description as an argument and by default sets isDone to false. Returns created Task."
+          }],
+          "queries": [{
+            "opName": "getTask",
+            "opFnPath": "@server/queries.js",
+            "opDesc": "Takes task id as an argument. Checks that user is authenticated, and if so, fetches and returns their task that has specified task id. Throws HttpError(400) if tasks exists but does not belong to them."
+          }],
+          "pages": [{
+            "pageName": "TaskPage",
+            "componentPath": "@client/pages/Task.jsx",
+            "routeName: "TaskRoute",
+            "routePath": "/task/:taskId",
+            "pageDesc": "Diplays a Task with the specified taskId. Allows editing of the Task. Uses getTask query and createTask action.",
+          }]
+        }
 
         We will later use this plan to write main.wasp file and all the other parts of Wasp app,
         so make sure descriptions are detailed enough to guide implementing them.

--- a/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
@@ -90,7 +90,7 @@ fixWaspFile newProjectDetails waspFilePath plan = do
             ${compileErrorsText}
 
             Some common mistakes to look for:
-              - using non-default imports in page components 
+              - Using non-default imports in page components.
                   In a Wasp page, the component should always use the "default import" JS syntax.
                   Instead of `component: import { PageName } from ...`, it should 
                   always be `component: import PageName from ...`.

--- a/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
@@ -91,11 +91,11 @@ fixWaspFile newProjectDetails waspFilePath plan = do
 
             Some common mistakes to look for:
               - Using non-default imports in page components.
-                  In a Wasp page, the component should always use the "default import" JS syntax.
+                  In a Wasp `page` declaration, the `component` should always use the "default import" JS syntax.
                   Instead of `component: import { PageName } from ...`, it should 
                   always be `component: import PageName from ...`.
-                  Fix these by identifying named imports in wasp pages, and replacing 
-                  them with default imports. This only relates to wasp pages, other parts 
+                  Fix these by identifying named imports in wasp `page` declarations, and replacing 
+                  them with default imports. This only relates to wasp `page` declarations, other parts 
                   of a Wasp file do not have to use the default imports.
 
               - Missing ',' between dictionary entries, for example before `entities` field in action/query.

--- a/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
@@ -90,12 +90,20 @@ fixWaspFile newProjectDetails waspFilePath plan = do
             ${compileErrorsText}
 
             Some common mistakes to look for:
+              - using non-default imports in page components 
+                  In a Wasp page, the component should always use the "default import" JS syntax.
+                  Instead of `component: import { PageName } from ...`, it should 
+                  always be `component: import PageName from ...`.
+                  Fix these by identifying named imports in wasp pages, and replacing 
+                  them with default imports. This only relates to wasp pages, other parts 
+                  of a Wasp file do not have to use the default imports.
+
               - Missing ',' between dictionary entries, for example before `entities` field in action/query.
                 Fix these by adding missing ','.
                 For example, the following is missing ',' after the component field:
                 ```wasp
                   page ExamplePage {
-                    component: import { ExamplePage } from "@client/pages/ExamplePage.jsx" // <- missing ','
+                    component: import ExamplePage from "@client/pages/ExamplePage.jsx" // <- missing ','
                     authRequired: true
                   }
                 ```


### PR DESCRIPTION
### Fix import/export JS errors in Mage

> This PR fixes the common mistakes regarding the importing and exporting of JS files. 

Prompts are updated to increase consistency in instructions. Model is now instructed to always generate:
 - default exports in React components (when generating pages)
 - default imports in Wasp `page` declarations
 
 Model is also instructed to edit the named imports/exports in pages (during the fixing stage).
 
 Some prompt elements are extracted away to new `Text` variables for easier readability. 
 
A future option would be to further work on refactoring the prompts, but I don't think that this is now a priority.

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).