### PR TITLE
Moved serverSetupFn to SDK.

### DIFF
--- a/waspc/data/Generator/templates/sdk/package.json
+++ b/waspc/data/Generator/templates/sdk/package.json
@@ -90,6 +90,8 @@
       "./server/dbClient": "./dist/server/dbClient.js",
       {=!  Used by users and by our code, documented. =}
       "./server/config": "./dist/server/config.js",
+      {=!  Used by users and by our code, documented. =}
+      "./server/types": "./dist/server/types/index.js",
       {=!  Parts are used by users, documented. Parts are probably used by our code, undocumented (but accessible). =}
       "./server/utils": "./dist/server/utils.js",
       {=!  Used by our code, uncodumented (but accessible) for users. =}

--- a/waspc/data/Generator/templates/sdk/server/types/index.ts
+++ b/waspc/data/Generator/templates/sdk/server/types/index.ts
@@ -1,0 +1,12 @@
+import { type Application } from 'express'
+import { Server } from 'http'
+
+export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>
+
+export type ServerSetupFnContext = {
+  app: Application,
+  server: Server,
+}
+
+export type { Application } from 'express'
+export type { Server } from 'http'

--- a/waspc/data/Generator/templates/server/src/server.ts
+++ b/waspc/data/Generator/templates/server/src/server.ts
@@ -6,7 +6,7 @@ import config from 'wasp/server/config'
 
 {=# setupFn.isDefined =}
 {=& setupFn.importStatement =}
-import { ServerSetupFn, ServerSetupFnContext } from './types'
+import { ServerSetupFn, ServerSetupFnContext } from 'wasp/server/types'
 {=/ setupFn.isDefined =}
 
 {=# isPgBossJobExecutorUsed =}

--- a/waspc/data/Generator/templates/server/src/types/index.ts
+++ b/waspc/data/Generator/templates/server/src/types/index.ts
@@ -1,18 +1,5 @@
 {{={= =}=}}
 
-import { type Application } from 'express'
-import { Server } from 'http'
-
-export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>
-
-export type ServerSetupFnContext = {
-  app: Application,
-  server: Server,
-}
-
-export type { Application } from 'express'
-export type { Server } from 'http'
-
 {=# isEmailAuthEnabled =}
 export type { GetVerificationEmailContentFn, GetPasswordResetEmailContentFn } from '../auth/providers/email/types';
 {=/ isEmailAuthEnabled =}

--- a/waspc/examples/todo-typescript/.wasp/out/sdk/wasp/package.json
+++ b/waspc/examples/todo-typescript/.wasp/out/sdk/wasp/package.json
@@ -46,6 +46,7 @@
       "./universal/validators": "./dist/universal/validators.js",
       "./server/dbClient": "./dist/server/dbClient.js",
       "./server/config": "./dist/server/config.js",
+      "./server/types": "./dist/server/types/index.js",
       "./server/utils": "./dist/server/utils.js",
       "./server/actions": "./dist/server/actions/index.js",
       "./server/queries": "./dist/server/queries/index.js",

--- a/waspc/examples/todo-typescript/main.wasp
+++ b/waspc/examples/todo-typescript/main.wasp
@@ -41,6 +41,7 @@ app TodoTypescript {
     system: PostgreSQL
   },
   server: {
+    setupFn: import { serverSetup } from "@src/serverSetup.js",
     middlewareConfigFn: import { serverMiddlewareFn } from "@src/serverSetup.js"
   }
 }

--- a/waspc/examples/todo-typescript/src/serverSetup.ts
+++ b/waspc/examples/todo-typescript/src/serverSetup.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import cors from 'cors'
 import type { MiddlewareConfigFn } from 'wasp/server/middleware'
 import config from 'wasp/server/config'
+import type { Application, ServerSetupFn } from 'wasp/server/types'
 
 export const serverMiddlewareFn: MiddlewareConfigFn = (middlewareConfig) => {
   // Example of adding an extra domains to CORS.
@@ -20,4 +21,11 @@ export const fooBarNamespace: MiddlewareConfigFn = (middlewareConfig) => {
   middlewareConfig.set('custom.middleware', customMiddleware)
 
   return middlewareConfig
+}
+
+export const serverSetup: ServerSetupFn = async ({ app }: { app: Application}) => {
+  app.get('/customRoute', (_req, res) => {
+    res.send('I am a custom route')
+  })
+  console.log("I am a server setup function!");
 }

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -94,6 +94,7 @@ genSdkReal spec =
     <++> genEntitiesAndServerTypesDirs spec
     <++> genApis spec
     <++> genMiddleware spec
+    <++> genExportedTypesDir spec
   where
     genFileCopy = return . C.mkTmplFd
 
@@ -287,6 +288,10 @@ genServerUtils :: AppSpec -> Generator FileDraft
 genServerUtils spec = return $ C.mkTmplFdWithData [relfile|server/utils.ts|] tmplData
   where
     tmplData = object ["isAuthEnabled" .= (isAuthEnabled spec :: Bool)]
+
+genExportedTypesDir :: AppSpec -> Generator [FileDraft]
+genExportedTypesDir _spec =
+  return [C.mkTmplFd [relfile|server/types/index.ts|]]
 
 genMiddleware :: AppSpec -> Generator [FileDraft]
 genMiddleware _spec =

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -323,10 +323,8 @@ genExportedTypesDir spec =
   where
     tmplData =
       object
-        [ "isExternalAuthEnabled" .= isExternalAuthEnabled,
-          "isEmailAuthEnabled" .= isEmailAuthEnabled
+        [ "isEmailAuthEnabled" .= isEmailAuthEnabled
         ]
-    isExternalAuthEnabled = AS.App.Auth.isExternalAuthEnabled <$> maybeAuth
     isEmailAuthEnabled = AS.App.Auth.isEmailAuthEnabled <$> maybeAuth
     maybeAuth = AS.App.auth $ snd $ getApp spec
 


### PR DESCRIPTION
Quite simple and straightforward.
Moves some types needed for serverSetup from `server/` to `sdk/server`.