### PR TITLE
Init PrismaClient only when there are entities

### DIFF
--- a/waspc/data/Generator/templates/sdk/server/dbClient.ts
+++ b/waspc/data/Generator/templates/sdk/server/dbClient.ts
@@ -1,11 +1,21 @@
+{{={= =}=}}
+{=# areThereAnyEntitiesDefined =}
 import Prisma from '@prisma/client'
 
-
-const createDbClient = () => {
-  const prisma = new Prisma.PrismaClient()
-
-  return prisma
+function createDbClient(): Prisma.PrismaClient {
+  return new Prisma.PrismaClient()
 }
+{=/ areThereAnyEntitiesDefined =}
+{=^ areThereAnyEntitiesDefined =}
+// * Prisma will not generate a PrismaClient if there no
+//   entities in the schema. Trying to init the PrismaClient
+//   will throw an error.
+// * To avoid throwing an error, we return null if there are no
+//   entities in the schema.
+function createDbClient(): null {
+  return null
+}
+{=/ areThereAnyEntitiesDefined =}
 
 const dbClient = createDbClient()
 

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -28,6 +28,7 @@ import qualified Wasp.AppSpec.ExternalFiles as EC
 import Wasp.AppSpec.Valid (getLowestNodeVersionUserAllows, isAuthEnabled)
 import qualified Wasp.AppSpec.Valid as AS.Valid
 import Wasp.Generator.Common (ProjectRootDir, makeJsonWithEntityData, prismaVersion)
+import Wasp.Generator.DbGenerator (getEntitiesForPrismaSchema)
 import qualified Wasp.Generator.DbGenerator.Auth as DbAuth
 import Wasp.Generator.FileDraft (FileDraft)
 import qualified Wasp.Generator.FileDraft as FD
@@ -336,10 +337,12 @@ genMiddleware _spec =
     ]
 
 genDbClient :: AppSpec -> Generator FileDraft
-genDbClient spec =
+genDbClient spec = do
+  areThereAnyEntitiesDefined <- not . null <$> getEntitiesForPrismaSchema spec
+
+  let tmplData = object ["areThereAnyEntitiesDefined" .= areThereAnyEntitiesDefined]
+
   return $
     C.mkTmplFdWithData
       [relfile|server/dbClient.ts|]
       tmplData
-  where
-    tmplData = object ["areThereAnyEntitiesDefined" .= (not . null . AS.getEntities $ spec)]

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -83,7 +83,6 @@ genSdkReal spec =
       genFileCopy [relfile|core/config.ts|],
       genFileCopy [relfile|core/storage.ts|],
       genFileCopy [relfile|server/index.ts|],
-      genFileCopy [relfile|server/dbClient.ts|],
       genFileCopy [relfile|server/HttpError.ts|],
       genFileCopy [relfile|server/AuthError.ts|],
       genFileCopy [relfile|types/index.ts|],
@@ -93,7 +92,8 @@ genSdkReal spec =
       genServerConfigFile spec,
       genTsConfigJson,
       genServerUtils spec,
-      genPackageJson spec
+      genPackageJson spec,
+      genDbClient spec
     ]
     <++> ServerOpsGen.genOperations spec
     <++> ClientOpsGen.genOperations spec
@@ -334,3 +334,12 @@ genMiddleware _spec =
     [ return $ C.mkTmplFd [relfile|server/middleware/index.ts|],
       return $ C.mkTmplFd [relfile|server/middleware/globalMiddleware.ts|]
     ]
+
+genDbClient :: AppSpec -> Generator FileDraft
+genDbClient spec =
+  return $
+    C.mkTmplFdWithData
+      [relfile|server/dbClient.ts|]
+      tmplData
+  where
+    tmplData = object ["areThereAnyEntitiesDefined" .= (not . null . AS.getEntities $ spec)]


### PR DESCRIPTION
When we have no entities defined in Wasp, and we generate the `PrismaClient`, Prisma generates a dummy client which throws an error when we initialise it.

We now only init the client if there are entities defined.

Closes https://github.com/wasp-lang/wasp/issues/398

