### PR TITLE
Exports HttpMethod and Route types from wasp/client

### DIFF
--- a/waspc/data/Generator/templates/sdk/auth/useAuth.ts
+++ b/waspc/data/Generator/templates/sdk/auth/useAuth.ts
@@ -2,7 +2,7 @@
 import { deserialize as superjsonDeserialize } from 'superjson'
 import { useQuery, addMetadataToQuery } from 'wasp/client/operations'
 import { api, handleApiError } from 'wasp/client/api'
-import { HttpMethod } from 'wasp/types'
+import { HttpMethod } from 'wasp/client'
 import type { AuthUser } from './types'
 
 // PUBLIC API

--- a/waspc/data/Generator/templates/sdk/client/index.ts
+++ b/waspc/data/Generator/templates/sdk/client/index.ts
@@ -9,3 +9,15 @@ import { join as joinPaths } from 'path';
 export function resolveProjectPath(path: string): string {
   return joinPaths('../../../', path);
 }
+
+// PUBLIC API
+// NOTE: This is enough to cover Operations and our APIs (src/Wasp/AppSpec/Api.hs).
+export enum HttpMethod {
+	Get = 'GET',
+	Post = 'POST',
+	Put = 'PUT',
+	Delete = 'DELETE',
+}
+
+// PUBLIC API
+export type Route = { method: HttpMethod; path: string }

--- a/waspc/data/Generator/templates/sdk/client/operations/internal/index.ts
+++ b/waspc/data/Generator/templates/sdk/client/operations/internal/index.ts
@@ -1,5 +1,5 @@
 import { api, handleApiError } from 'wasp/client/api'
-import { HttpMethod } from 'wasp/types'
+import { HttpMethod } from 'wasp/client'
 import {
   serialize as superjsonSerialize,
   deserialize as superjsonDeserialize,

--- a/waspc/data/Generator/templates/sdk/client/operations/queries/core.d.ts
+++ b/waspc/data/Generator/templates/sdk/client/operations/queries/core.d.ts
@@ -1,5 +1,5 @@
 import { type Query } from '../core.js'
-import { Route } from 'wasp/types'
+import { Route } from 'wasp/client'
 import type { Expand, _Awaited, _ReturnType } from 'wasp/universal/types'
 
 // PRIVATE API

--- a/waspc/data/Generator/templates/sdk/client/test/vitest/helpers.tsx
+++ b/waspc/data/Generator/templates/sdk/client/test/vitest/helpers.tsx
@@ -8,10 +8,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeAll, afterEach, afterAll } from 'vitest'
 import { Query } from 'wasp/client/operations/core'
 import config from 'wasp/core/config'
-import { HttpMethod, Route } from 'wasp/types'
-
-// PRIVATE API
-export type { Route } from 'wasp/types'
+import { HttpMethod, Route } from 'wasp/client'
 
 // PRIVATE API
 export type MockQuery = <Input, Output, MockOutput extends Output>(

--- a/waspc/data/Generator/templates/sdk/package.json
+++ b/waspc/data/Generator/templates/sdk/package.json
@@ -19,8 +19,6 @@
       {=!  Used by our code, uncodumented (but accessible) for users. =}
       "./core/storage": "./dist/core/storage.js",
       "./core/auth": "./dist/core/auth.js",
-      {=!  Used by users, documented. =}
-      "./types": "./dist/types/index.js",
       {=!  Used by our code, uncodumented (but accessible) for users. =}
       "./auth/helpers/user": "./dist/auth/helpers/user.js",
       {=!  Used by our code, uncodumented (but accessible) for users. =}

--- a/waspc/data/Generator/templates/sdk/types/index.ts
+++ b/waspc/data/Generator/templates/sdk/types/index.ts
@@ -1,9 +1,0 @@
-// NOTE: This is enough to cover Operations and our APIs (src/Wasp/AppSpec/Api.hs).
-export enum HttpMethod {
-	Get = 'GET',
-	Post = 'POST',
-	Put = 'PUT',
-	Delete = 'DELETE',
-}
-
-export type Route = { method: HttpMethod; path: string }


### PR DESCRIPTION
We were using `@wasp/types` before in the client tests to import `HttpMethod`, I've now exported it from `wasp/client` because the types were general enough and useful across different parts of Wasp.