### PR TITLE
Enables e2e tests and build test

### DIFF
--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -137,14 +137,12 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: export WASP_E2E_TESTS_SKIP_DOCKER=1
 
-      - name: Run tests
-        # TODO: Reenable e2e tests after we merge new e2e tests
+      - name: Run unit tests
         run: cabal test cli-test waspc-test waspls-test
 
-      # TODO: Reenable building of todoApp after we merge build fixes
-      # - name: Ensure todoApp builds
-      #   if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
-      #   run: ./tools/ensure_todoapp_builds.sh
+      - name: Ensure todoApp builds
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
+        run: ./tools/ensure_todoapp_builds.sh
 
       - name: Headless - Cache Node Modules
         id: headless-cache-node-modules
@@ -193,6 +191,9 @@ jobs:
           npm ci
           # Runs the tests with the debug flag so that we can see Wasp output
           DEBUG=pw:webserver npx playwright test
+      
+      - name: Run e2e tests
+        run: cabal test e2e-test
 
       - name: Create binary package (Unix)
         if: startsWith(github.ref, 'refs/tags/v') && (matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest')

--- a/waspc/examples/todo-typescript/src/MainPage.tsx
+++ b/waspc/examples/todo-typescript/src/MainPage.tsx
@@ -46,7 +46,7 @@ export const MainPage = ({ user }: { user: AuthUser }) => {
       )}
       <NewTaskForm />
       {tasks && <TasksList tasks={tasks} />}
-      <h2>All</h2>
+      <h2>Everything</h2>
       {allTasks && <TasksList tasks={allTasks} />}
       <div className="buttons">
         <button


### PR DESCRIPTION
- Enables e2e tests
- Enables build test
  - This is **blocked 🚫** until the internal Todo app builds successfully: https://github.com/wasp-lang/wasp/pull/1781
- Moves e2e tests after headless tests
  - **Reasoning:**  usually when we develop, we don't bother with e2e tests being correct because after we are done with a feature, we fix them. e2e tests take a long time to run and they just fail while we still develop. Because of that and because they run first we don't run the "build" or "headless" tests which might be useful to run while developing.