### PR TITLE
Adds .DS_Store to .waspignore

### DIFF
--- a/waspc/data/Cli/templates/skeleton/.waspignore
+++ b/waspc/data/Cli/templates/skeleton/.waspignore
@@ -1,3 +1,4 @@
 # Ignore editor tmp files
 **/*~
 **/#*#
+.DS_Store

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.waspignore
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.waspignore
@@ -1,3 +1,4 @@
 # Ignore editor tmp files
 **/*~
 **/#*#
+.DS_Store

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.waspignore
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.waspignore
@@ -1,3 +1,4 @@
 # Ignore editor tmp files
 **/*~
 **/#*#
+.DS_Store

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.waspignore
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.waspignore
@@ -1,3 +1,4 @@
 # Ignore editor tmp files
 **/*~
 **/#*#
+.DS_Store

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.waspignore
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.waspignore
@@ -1,3 +1,4 @@
 # Ignore editor tmp files
 **/*~
 **/#*#
+.DS_Store

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.waspignore
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.waspignore
@@ -1,3 +1,4 @@
 # Ignore editor tmp files
 **/*~
 **/#*#
+.DS_Store

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/.waspignore
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/.waspignore
@@ -1,3 +1,4 @@
 # Ignore editor tmp files
 **/*~
 **/#*#
+.DS_Store


### PR DESCRIPTION
We had some issues with e2e-tests, the `.DS_Store` file was copied over to the SDK's `ext-src` dir making the e2e tests platform dependant. 