### PR TITLE
Mage 0.12 producing 0.12

### DIFF
--- a/mage/Dockerfile
+++ b/mage/Dockerfile
@@ -41,7 +41,7 @@ RUN cd .wasp/build/server && npm run bundle
 # TODO: Use pm2?
 # TODO: Use non-root user (node).
 FROM base AS server-production
-RUN curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.11.4-wasp-ai-12
+RUN curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.12.0
 ENV PATH "$PATH:/root/.local/bin"
 ENV NODE_ENV production
 WORKDIR /app

--- a/mage/src/server/jobs/generateApp.ts
+++ b/mage/src/server/jobs/generateApp.ts
@@ -64,7 +64,8 @@ export const generateApp: GenerateAppJob<
   const stdoutMutex = new Mutex();
   let waspCliProcess = null;
   const waspCliProcessArgs = [
-    "new-ai",
+    "new:ai",
+    "--stdout",
     project.name,
     project.description,
     JSON.stringify(projectConfig),


### PR DESCRIPTION
Once we have Mage implemented with Wasp 0.12 producing Wasp 0.11 apps working, then this small PR will just upgrade it to produce Wasp 0.12 apps.

For this to work, we also need to have Wasp 0.12.0 released.

Then, this PR should be merged into the last code that was used to release Mage (with how we are going to do it, that might be `main` this time), and new Mage release should be made.
Probably best to merge it into `main`, and then when all of it is merged into `release`, we also release the new Mage (but after the release for `wasp` CLI happened).

The whole change is supposed to be as simple as:
![image](https://github.com/wasp-lang/wasp/assets/1536647/7ad520c7-ab77-4a73-b849-2a7f5be65cdb)
