### PR TITLE
Uses `noEmit` in tsconfig.json

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/dev/tsconfig.json
+++ b/waspc/data/Generator/templates/sdk/wasp/dev/tsconfig.json
@@ -19,13 +19,6 @@
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
       "@testing-library/jest-dom"
     ],
-    // Since this TS config is used only for IDE support and not for
-    // compilation, the following directory doesn't exist. We need to specify
-    // it to prevent this error:
-    // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
+    "noEmit": true
   },
-  "exclude": [
-    "phantom"
-  ],
 }

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -172,7 +172,7 @@
             "file",
             "../out/sdk/wasp/dev/tsconfig.json"
         ],
-        "507eb35fffcb698bc03427ec79bd3983b78276ec4edde5410ad14d9a0530c046"
+        "40d2264d417695550f88bcb9a28a9ae1a13f64b910a2653c99261bd8acc42e52"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/sdk/wasp/dev/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/sdk/wasp/dev/tsconfig.json
@@ -19,13 +19,6 @@
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
       "@testing-library/jest-dom"
     ],
-    // Since this TS config is used only for IDE support and not for
-    // compilation, the following directory doesn't exist. We need to specify
-    // it to prevent this error:
-    // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
+    "noEmit": true
   },
-  "exclude": [
-    "phantom"
-  ],
 }

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/out/sdk/wasp/dev/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/out/sdk/wasp/dev/tsconfig.json
@@ -19,13 +19,6 @@
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
       "@testing-library/jest-dom"
     ],
-    // Since this TS config is used only for IDE support and not for
-    // compilation, the following directory doesn't exist. We need to specify
-    // it to prevent this error:
-    // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
+    "noEmit": true
   },
-  "exclude": [
-    "phantom"
-  ],
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -172,7 +172,7 @@
             "file",
             "../out/sdk/wasp/dev/tsconfig.json"
         ],
-        "507eb35fffcb698bc03427ec79bd3983b78276ec4edde5410ad14d9a0530c046"
+        "40d2264d417695550f88bcb9a28a9ae1a13f64b910a2653c99261bd8acc42e52"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/sdk/wasp/dev/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/sdk/wasp/dev/tsconfig.json
@@ -19,13 +19,6 @@
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
       "@testing-library/jest-dom"
     ],
-    // Since this TS config is used only for IDE support and not for
-    // compilation, the following directory doesn't exist. We need to specify
-    // it to prevent this error:
-    // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
+    "noEmit": true
   },
-  "exclude": [
-    "phantom"
-  ],
 }

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -382,7 +382,7 @@
             "file",
             "../out/sdk/wasp/dev/tsconfig.json"
         ],
-        "507eb35fffcb698bc03427ec79bd3983b78276ec4edde5410ad14d9a0530c046"
+        "40d2264d417695550f88bcb9a28a9ae1a13f64b910a2653c99261bd8acc42e52"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dev/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dev/tsconfig.json
@@ -19,13 +19,6 @@
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
       "@testing-library/jest-dom"
     ],
-    // Since this TS config is used only for IDE support and not for
-    // compilation, the following directory doesn't exist. We need to specify
-    // it to prevent this error:
-    // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
+    "noEmit": true
   },
-  "exclude": [
-    "phantom"
-  ],
 }

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -172,7 +172,7 @@
             "file",
             "../out/sdk/wasp/dev/tsconfig.json"
         ],
-        "507eb35fffcb698bc03427ec79bd3983b78276ec4edde5410ad14d9a0530c046"
+        "40d2264d417695550f88bcb9a28a9ae1a13f64b910a2653c99261bd8acc42e52"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/dev/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/dev/tsconfig.json
@@ -19,13 +19,6 @@
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
       "@testing-library/jest-dom"
     ],
-    // Since this TS config is used only for IDE support and not for
-    // compilation, the following directory doesn't exist. We need to specify
-    // it to prevent this error:
-    // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
+    "noEmit": true
   },
-  "exclude": [
-    "phantom"
-  ],
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -172,7 +172,7 @@
             "file",
             "../out/sdk/wasp/dev/tsconfig.json"
         ],
-        "507eb35fffcb698bc03427ec79bd3983b78276ec4edde5410ad14d9a0530c046"
+        "40d2264d417695550f88bcb9a28a9ae1a13f64b910a2653c99261bd8acc42e52"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/sdk/wasp/dev/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/sdk/wasp/dev/tsconfig.json
@@ -19,13 +19,6 @@
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
       "@testing-library/jest-dom"
     ],
-    // Since this TS config is used only for IDE support and not for
-    // compilation, the following directory doesn't exist. We need to specify
-    // it to prevent this error:
-    // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
+    "noEmit": true
   },
-  "exclude": [
-    "phantom"
-  ],
 }


### PR DESCRIPTION
- We experienced a hard to reproduce behaviour, sometimes there is a `phantom` dir created in the root project dir.

- Since we use the `tsconfig.json` for IDE support only, we had a hack with an `outDir` and `exclude` to stop Typescript from complaining about overwriting source files. 

- A similar option exists called `noEmit` which does what we need: saying to the Typescript compiler, we don't want to output any files. 