### PR TITLE
Move phantom dir to .wasp

### DIFF
--- a/waspc/data/Cli/templates/skeleton/tsconfig.json
+++ b/waspc/data/Cli/templates/skeleton/tsconfig.json
@@ -26,9 +26,6 @@
     // compilation, the following directory doesn't exist. We need to specify
     // it to prevent this error:
     // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
-  },
-  "exclude": [
-    "phantom"
-  ],
+    "outDir": ".wasp/phantom",
+  }
 }


### PR DESCRIPTION
During the 0.12.0 release, we noticed that Wasp sometimes creates the `phantom` directory in the project root. We aren't yet sure how and why this happens

This is a fake directory we set as the tsconfig's `outDir` option back when introducing TS support to Wasp (I guess we didn't know about the  `noEmit` option).

The long-term plan is still:
- Figuring out why `phantom` appears.
- Using `noEmit` instead of `phantom`.

Until then, I've moved `phantom` to the hidden `.wasp` dir. 