### PR TITLE
Fixes the order of operations in `wasp build`

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build.hs
@@ -53,8 +53,6 @@ build = do
   cliSendMessageC $ Msg.Start "Building wasp project..."
   (warnings, errors) <- liftIO $ buildIO waspProjectDir buildDir
 
-  liftIO $ copyUserFilesNecessaryForBuild waspProjectDir buildDir
-
   liftIO $ printCompilationResult (warnings, errors)
   if null errors
     then do
@@ -63,6 +61,8 @@ build = do
     else
       throwError $
         CommandError "Building of wasp project failed" $ show (length errors) ++ " errors found"
+
+  liftIO $ copyUserFilesNecessaryForBuild waspProjectDir buildDir
   where
     -- Until we implement the solution described in https://github.com/wasp-lang/wasp/issues/1769,
     -- we're copying all files and folders necessary for the build into the .wasp/build directory.


### PR DESCRIPTION
### Replicate the bug

An easy way to replicate this bug is to use `email.provider` as `Dummy` try to run `wasp build`. This is not allowed when building for production.  Complication fails, then SDK copying fails which exists with an IO error and we never print out the compiler errors properly.

| <img width="1106" alt="Screenshot 2024-02-27 at 00 02 56" src="https://github.com/wasp-lang/wasp/assets/2223680/72f124f5-5b8c-47cc-a751-12b089006c58"> |
| --- |
| What happens |

| <img width="708" alt="Screenshot 2024-02-27 at 00 02 51" src="https://github.com/wasp-lang/wasp/assets/2223680/e085461f-6cba-424e-9a33-1aea47697bb6"> |
| --- |
| Expected behaviour |

### Explanation 
The order of actions was wrong when we did `wasp build`.

1. We compiled the Wasp file -> which gives us potential compilation errors
2. Then we tried copying the SDK dir
3. And after that we checked for compilation errors

The issue is that **there is no SDK generated if there are compilation errors**. Which causes the second point to fail.


 