### PR TITLE
Updated Wasp AI to work with newest GPT 3.5 Turbo (0125).

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/AI.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/AI.hs
@@ -57,17 +57,15 @@ createNewProjectInteractiveOnDisk waspProjectDir appName = do
           [ Interactive.Option
               "gpt-4 (planning) + gpt-3.5-turbo (coding)"
               (Just "Ok results. Cheap and fast. Best cost/benefit ratio.")
-              -- NOTE: We are still using 0613 for now, even though it will get deprecated in June 2023,
-              --   because 0125 returns files with newlines missing.
-              (ChatGPT.GPT_4, ChatGPT.GPT_3_5_turbo_0613),
+              (ChatGPT.GPT_4_0613, ChatGPT.GPT_3_5_turbo_0125),
             Interactive.Option
               "gpt-4 (planning) + gpt-4-turbo-preview (coding)"
               (Just "Possibly better results, but somewhat slower and somewhat more expensive (~2-3x).")
-              (ChatGPT.GPT_4, ChatGPT.GPT_4_turbo_Preview),
+              (ChatGPT.GPT_4_0613, ChatGPT.GPT_4_turbo_Preview),
             Interactive.Option
               "gpt-4 (planning + coding)"
               (Just "Best results, but quite slower and quite more expensive (~5x).")
-              (ChatGPT.GPT_4, ChatGPT.GPT_4)
+              (ChatGPT.GPT_4_0613, ChatGPT.GPT_4_0613)
           ]
   temperature <-
     liftIO $

--- a/waspc/src/Wasp/AI/GenerateNewProject/Common.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Common.hs
@@ -153,9 +153,7 @@ codingChatGPTParams projectDetails =
       GPT._temperature = Just $ fromMaybe 0.7 (projectDefaultGptTemperature $ _projectConfig projectDetails)
     }
   where
-    -- NOTE: We are still using 0613 for now, even though it will get deprecated in June 2023,
-    --   because 0125 returns files with newlines missing.
-    defaultCodingGptModel = GPT.GPT_3_5_turbo_0613
+    defaultCodingGptModel = GPT.GPT_3_5_turbo_0125
 
 planningChatGPTParams :: NewProjectDetails -> ChatGPTParams
 planningChatGPTParams projectDetails =
@@ -164,7 +162,7 @@ planningChatGPTParams projectDetails =
       GPT._temperature = Just $ fromMaybe 0.7 (projectDefaultGptTemperature $ _projectConfig projectDetails)
     }
   where
-    defaultPlanningGptModel = GPT.GPT_4
+    defaultPlanningGptModel = GPT.GPT_4_0613
 
 fixingChatGPTParams :: ChatGPTParams -> ChatGPTParams
 fixingChatGPTParams params = params {GPT._temperature = subtract 0.2 <$> GPT._temperature params}

--- a/waspc/src/Wasp/AI/GenerateNewProject/Operation.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Operation.hs
@@ -96,7 +96,7 @@ generateOperation operationType newProjectDetails entityPlans operationPlan = do
 
         Example of response:
         { "opWaspDecl": "${operationTypeText} ${operationName} {\n  fn: import { ${operationName} } from \"${operationFnPath}\",\n  entities: [Task]\n}",
-          "opJsImpl": "export const {$operationName} = async (args, context) => { ... }",
+          "opJsImpl": "export const {$operationName} = async (args, context) => {\n ... \n}",
           "opJsImports": "import { HttpError } from 'wasp/server'"
         }
         "opWaspDecl" and "opJsImpl" are required, "opJsImports" you can skip if none are needed.

--- a/waspc/src/Wasp/AI/GenerateNewProject/OperationsJsFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/OperationsJsFile.hs
@@ -95,6 +95,7 @@ fixOperationsJsFile newProjectDetails waspFilePath opJsFilePath = do
 
           Please respond ONLY with a valid JSON of the format { opJsFileContent: string }.
           There should be no other text in your response. Don't wrap content with the "```" code delimiters.
+          Do not ommit newlines from the code.
 
           ${appDescriptionBlockText}
         |]

--- a/waspc/src/Wasp/AI/GenerateNewProject/Page.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Page.hs
@@ -114,11 +114,12 @@ generatePage newProjectDetails entityPlans queries actions pPlan = do
         }
         There should be no other text in the response.
 
-        When writing the javascript implementation, make sure to always use the default export. 
-        Concretely, define the main component with `const ${pageName} = () => {...}`,
+        When writing the javascript implementation, make sure to always use the default export.
+        Concretely, define the main component with `const ${pageName} = () => {\n...\n}`,
         and then at the end export it with `export default ${pageName}`.
         It is also really important that the ${pageName} is then imported as a default import
         in "pageWaspDecl": use `import ${pageName}` instead of `import { ${pageName} }`.
+        Also, don't ommit newlines in the code.
         This is very important to me, please do as I say.
 
         ${appDescriptionBlock}

--- a/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/PageComponentFile.hs
@@ -82,6 +82,7 @@ fixPageComponent newProjectDetails waspFilePath pageComponentPath = do
           Do actual fixes, don't leave comments with "TODO"!
           Please respond ONLY with a valid JSON of the format { pageComponentImpl: string }.
           There should be no other text in your response. Don't wrap content with the "```" code delimiters.
+          Don't ommit newlines from the code.
 
           ${appDescriptionBlockText}
         |]

--- a/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/WaspFile.hs
@@ -134,6 +134,8 @@ fixWaspFile newProjectDetails waspFilePath plan = do
                 ```
               - I noticed that you sometimes by accident add redundant "}" at the end of the Wasp file while fixing it.
                 Be careful not to do that.
+              - Don't by accident put all the declarations under `app {...}`! `route`, `page`, `entity`, `job`, `action`, `query`, those are all standalone and don't go inside of `app`. Assume all the declarations are at the right level in the file and keep that as it is, don't change that.
+              - Don't remove any newlines.
               - We are using SQLite as a database for Prisma, so we can't use scalar arrays in PSL, like `String[]`,
                 as those are not supported in SQLite. We can of course normally use arrays of other models, like `Task[]`.
 
@@ -144,6 +146,7 @@ fixWaspFile newProjectDetails waspFilePath plan = do
             Make extra sure to fix compiler errors, if there are any.
             Please respond ONLY with a valid JSON of the format { waspFileContent: string }.
             There should be no other text in your response. Don't wrap content with the "```" code delimiters.
+            Don't ommit newlines from the code.
 
             ${appDescriptionBlockText}
           |]


### PR DESCRIPTION
We had issues with 0125 dropping newlines from files and returning as one big line, and also with putting all the declarations in main.wasp under `app {...}`.

I did some prompt engineering here :D to try to combat that, and it seems it works. I didn't have enough time to run it many times, but I did manage to get it to produce working apps without any of those mistakes couple of times in a row.

We should do some more testing, to confirm it indeed works and doesn't make those mistakes, and then we can merge.