### PR TITLE
Add `auth/types` import path to `package.json`

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/package.json
+++ b/waspc/data/Generator/templates/sdk/wasp/package.json
@@ -26,6 +26,8 @@
       {=!  Used by our code, uncodumented (but accessible) for users. =}
       "./auth/providers/types": "./dist/auth/providers/types.js",
       {=!  Used by our code, uncodumented (but accessible) for users. =}
+      "./auth/types": "./dist/auth/types.js",
+      {=!  Used by users, documented. =}
       "./auth/utils": "./dist/auth/utils.js",
       {=!  Used by our code, uncodumented (but accessible) for users. =}
       "./auth/password": "./dist/auth/password.js",

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -207,7 +207,7 @@
             "file",
             "../out/sdk/wasp/package.json"
         ],
-        "20c4c4663e34042e15c588f4855a3c91b746d60981918adc8cae756861a185e1"
+        "af14fbde431a1479046c5ef42441719523de002494c785544f563e79a1382713"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/sdk/wasp/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/sdk/wasp/package.json
@@ -34,6 +34,7 @@
     "./auth/password": "./dist/auth/password.js",
     "./auth/providers/types": "./dist/auth/providers/types.js",
     "./auth/session": "./dist/auth/session.js",
+    "./auth/types": "./dist/auth/types.js",
     "./auth/utils": "./dist/auth/utils.js",
     "./auth/validation": "./dist/auth/validation.js",
     "./client": "./dist/client/index.js",

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/out/sdk/wasp/package.json
@@ -34,6 +34,7 @@
     "./auth/password": "./dist/auth/password.js",
     "./auth/providers/types": "./dist/auth/providers/types.js",
     "./auth/session": "./dist/auth/session.js",
+    "./auth/types": "./dist/auth/types.js",
     "./auth/utils": "./dist/auth/utils.js",
     "./auth/validation": "./dist/auth/validation.js",
     "./client": "./dist/client/index.js",

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -207,7 +207,7 @@
             "file",
             "../out/sdk/wasp/package.json"
         ],
-        "20c4c4663e34042e15c588f4855a3c91b746d60981918adc8cae756861a185e1"
+        "af14fbde431a1479046c5ef42441719523de002494c785544f563e79a1382713"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/sdk/wasp/package.json
@@ -34,6 +34,7 @@
     "./auth/password": "./dist/auth/password.js",
     "./auth/providers/types": "./dist/auth/providers/types.js",
     "./auth/session": "./dist/auth/session.js",
+    "./auth/types": "./dist/auth/types.js",
     "./auth/utils": "./dist/auth/utils.js",
     "./auth/validation": "./dist/auth/validation.js",
     "./client": "./dist/client/index.js",

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -480,7 +480,7 @@
             "file",
             "../out/sdk/wasp/package.json"
         ],
-        "418aa323e5e98dd561371f99f808e16fb57087fe8025e797552745d93e363eb4"
+        "e3b7828a4e3873f9aa8b8afa43291b6009f7f62b480d14398a5243f9b29c06e1"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/package.json
@@ -40,6 +40,7 @@
     "./auth/password": "./dist/auth/password.js",
     "./auth/providers/types": "./dist/auth/providers/types.js",
     "./auth/session": "./dist/auth/session.js",
+    "./auth/types": "./dist/auth/types.js",
     "./auth/utils": "./dist/auth/utils.js",
     "./auth/validation": "./dist/auth/validation.js",
     "./client": "./dist/client/index.js",

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -214,7 +214,7 @@
             "file",
             "../out/sdk/wasp/package.json"
         ],
-        "57a930679c0d5e4b61ec93989bc3c2ea25dc25d4c9be987e8baf63f6ecb0c494"
+        "d9fb9957880ed80c302bfc34d7b8b6da9529251dae231db58027cf3375ec5a2d"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/package.json
@@ -35,6 +35,7 @@
     "./auth/password": "./dist/auth/password.js",
     "./auth/providers/types": "./dist/auth/providers/types.js",
     "./auth/session": "./dist/auth/session.js",
+    "./auth/types": "./dist/auth/types.js",
     "./auth/utils": "./dist/auth/utils.js",
     "./auth/validation": "./dist/auth/validation.js",
     "./client": "./dist/client/index.js",

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -207,7 +207,7 @@
             "file",
             "../out/sdk/wasp/package.json"
         ],
-        "20c4c4663e34042e15c588f4855a3c91b746d60981918adc8cae756861a185e1"
+        "af14fbde431a1479046c5ef42441719523de002494c785544f563e79a1382713"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/sdk/wasp/package.json
@@ -34,6 +34,7 @@
     "./auth/password": "./dist/auth/password.js",
     "./auth/providers/types": "./dist/auth/providers/types.js",
     "./auth/session": "./dist/auth/session.js",
+    "./auth/types": "./dist/auth/types.js",
     "./auth/utils": "./dist/auth/utils.js",
     "./auth/validation": "./dist/auth/validation.js",
     "./client": "./dist/client/index.js",


### PR DESCRIPTION
TS LSP and VS Code know how to find the correct types and provide IDE support without needing an explicit exports definition.

TSC, on the other hand, requires the package to export all symbols the user code references (types or otherwise).

Several users reported this error (e.g., in https://github.com/wasp-lang/open-saas/issues/77).