### PR TITLE
AuthMethods + Template Haskell experiment

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
@@ -27,12 +27,12 @@ import { SocialButton } from '../social/SocialButton'
 {=# isAnyPasswordBasedAuthEnabled =}
 import { useHistory } from 'react-router-dom'
 {=/ isAnyPasswordBasedAuthEnabled =}
-{=# isUsernameAndPasswordAuthEnabled =}
+{=# providers.isUsernameAndPasswordAuthEnabled =}
 import { useUsernameAndPassword } from '../usernameAndPassword/useUsernameAndPassword'
-{=/ isUsernameAndPasswordAuthEnabled =}
-{=# isEmailAuthEnabled =}
+{=/ providers.isUsernameAndPasswordAuthEnabled =}
+{=# providers.isEmailAuthEnabled =}
 import { useEmail } from '../email/useEmail'
-{=/ isEmailAuthEnabled =}
+{=/ providers.isEmailAuthEnabled =}
 
 {=# areBothSocialAndPasswordBasedAuthEnabled =}
 const OrContinueWith = styled('div', {
@@ -105,15 +105,15 @@ const SocialAuthButtons = styled('div', {
     }
 })
 {=/ isSocialAuthEnabled =}
-{=# isGoogleAuthEnabled =}
+{=# providers.isGoogleAuthEnabled =}
 const googleSignInUrl = `${config.apiUrl}{= googleSignInPath =}`
-{=/ isGoogleAuthEnabled =}
-{=# isKeycloakAuthEnabled =}
+{=/ providers.isGoogleAuthEnabled =}
+{=# providers.isKeycloakAuthEnabled =}
 const keycloakSignInUrl = `${config.apiUrl}{= keycloakSignInPath =}`
-{=/ isKeycloakAuthEnabled =}
-{=# isGitHubAuthEnabled =}
+{=/ providers.isKeycloakAuthEnabled =}
+{=# providers.isGitHubAuthEnabled =}
 const gitHubSignInUrl = `${config.apiUrl}{= gitHubSignInPath =}`
-{=/ isGitHubAuthEnabled =}
+{=/ providers.isGitHubAuthEnabled =}
 
 {=!
 // Since we allow users to add additional fields to the signup form, we don't
@@ -151,7 +151,7 @@ export const LoginSignupForm = ({
   {=/ isAnyPasswordBasedAuthEnabled =}
   const hookForm = useForm<LoginSignupFormFields>()
   const { register, formState: { errors }, handleSubmit: hookFormHandleSubmit } = hookForm
-  {=# isUsernameAndPasswordAuthEnabled =}
+  {=# providers.isUsernameAndPasswordAuthEnabled =}
   const { handleSubmit } = useUsernameAndPassword({
     isLogin,
     onError: onErrorHandler,
@@ -159,8 +159,8 @@ export const LoginSignupForm = ({
       history.push('{= onAuthSucceededRedirectTo =}')
     },
   });
-  {=/ isUsernameAndPasswordAuthEnabled =}
-  {=# isEmailAuthEnabled =}
+  {=/ providers.isUsernameAndPasswordAuthEnabled =}
+  {=# providers.isEmailAuthEnabled =}
   const { handleSubmit } = useEmail({
     isLogin,
     onError: onErrorHandler,
@@ -172,7 +172,7 @@ export const LoginSignupForm = ({
       history.push('{= onAuthSucceededRedirectTo =}')
     },
   });
-  {=/ isEmailAuthEnabled =}
+  {=/ providers.isEmailAuthEnabled =}
   {=# isAnyPasswordBasedAuthEnabled =}
   async function onSubmit (data) {
     setIsLoading(true);
@@ -191,17 +191,17 @@ export const LoginSignupForm = ({
         <SocialAuth>
           <SocialAuthLabel>{cta} with</SocialAuthLabel>
           <SocialAuthButtons gap='large' direction={socialButtonsDirection}>
-            {=# isGoogleAuthEnabled =}
+            {=# providers.isGoogleAuthEnabled =}
               <SocialButton href={googleSignInUrl}><SocialIcons.Google/></SocialButton>
-            {=/ isGoogleAuthEnabled =}
+            {=/ providers.isGoogleAuthEnabled =}
 
-            {=# isKeycloakAuthEnabled =}
+            {=# providers.isKeycloakAuthEnabled =}
               <SocialButton href={keycloakSignInUrl}><SocialIcons.Keycloak/></SocialButton>
-            {=/ isKeycloakAuthEnabled =}
+            {=/ providers.isKeycloakAuthEnabled =}
 
-            {=# isGitHubAuthEnabled =}
+            {=# providers.isGitHubAuthEnabled =}
               <SocialButton href={gitHubSignInUrl}><SocialIcons.GitHub/></SocialButton>
-            {=/ isGitHubAuthEnabled =}
+            {=/ providers.isGitHubAuthEnabled =}
           </SocialAuthButtons>
         </SocialAuth>
       {=/ isSocialAuthEnabled =}
@@ -217,7 +217,7 @@ export const LoginSignupForm = ({
       {=/ areBothSocialAndPasswordBasedAuthEnabled =}
       {=# isAnyPasswordBasedAuthEnabled =}
         <Form onSubmit={hookFormHandleSubmit(onSubmit)}>
-          {=# isUsernameAndPasswordAuthEnabled =}
+          {=# providers.isUsernameAndPasswordAuthEnabled =}
           <FormItemGroup>
             <FormLabel>Username</FormLabel>
             <FormInput
@@ -229,8 +229,8 @@ export const LoginSignupForm = ({
             />
             {errors.username && <FormError>{errors.username.message}</FormError>}
           </FormItemGroup>
-          {=/ isUsernameAndPasswordAuthEnabled =}
-          {=# isEmailAuthEnabled =}
+          {=/ providers.isUsernameAndPasswordAuthEnabled =}
+          {=# providers.isEmailAuthEnabled =}
           <FormItemGroup>
             <FormLabel>E-mail</FormLabel>
             <FormInput
@@ -242,7 +242,7 @@ export const LoginSignupForm = ({
             />
             {errors.email && <FormError>{errors.email.message}</FormError>}
           </FormItemGroup>
-          {=/ isEmailAuthEnabled =}
+          {=/ providers.isEmailAuthEnabled =}
           <FormItemGroup>
             <FormLabel>Password</FormLabel>
             <FormInput

--- a/waspc/src/Wasp/AppSpec/App/Auth.hs
+++ b/waspc/src/Wasp/AppSpec/App/Auth.hs
@@ -1,32 +1,23 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Wasp.AppSpec.App.Auth
   ( Auth (..),
     AuthMethods (..),
-    ExternalAuthConfig (..),
-    EmailAuthConfig (..),
-    UsernameAndPasswordConfig (..),
-    isUsernameAndPasswordAuthEnabled,
-    isExternalAuthEnabled,
-    isGoogleAuthEnabled,
-    isKeycloakAuthEnabled,
-    isGitHubAuthEnabled,
-    isEmailAuthEnabled,
-    userSignupFieldsForEmailAuth,
-    userSignupFieldsForUsernameAuth,
-    userSignupFieldsForExternalAuth,
+    generateIsAuthMethodEnabled,
   )
 where
 
 import Data.Data (Data)
 import Data.Maybe (isJust)
-import Wasp.AppSpec.App.Auth.EmailVerification (EmailVerificationConfig)
-import Wasp.AppSpec.App.Auth.PasswordReset (PasswordResetConfig)
-import Wasp.AppSpec.App.EmailSender (EmailFromField)
+import Language.Haskell.TH
+import Wasp.AppSpec.App.Auth.AuthMethods (AuthMethod, generateAuthMethods)
 import Wasp.AppSpec.Core.Ref (Ref)
 import Wasp.AppSpec.Entity (Entity)
-import Wasp.AppSpec.ExtImport (ExtImport)
+import Wasp.Util (toLowerFirst)
+
+$(generateAuthMethods)
 
 data Auth = Auth
   { userEntity :: Ref Entity,
@@ -37,67 +28,14 @@ data Auth = Auth
   }
   deriving (Show, Eq, Data)
 
-data AuthMethods = AuthMethods
-  { usernameAndPassword :: Maybe UsernameAndPasswordConfig,
-    google :: Maybe ExternalAuthConfig,
-    gitHub :: Maybe ExternalAuthConfig,
-    keycloak :: Maybe ExternalAuthConfig,
-    email :: Maybe EmailAuthConfig
-  }
-  deriving (Show, Eq, Data)
-
-data UsernameAndPasswordConfig = UsernameAndPasswordConfig
-  { userSignupFields :: Maybe ExtImport
-  }
-  deriving (Show, Eq, Data)
-
-data ExternalAuthConfig = ExternalAuthConfig
-  { configFn :: Maybe ExtImport,
-    userSignupFields :: Maybe ExtImport
-  }
-  deriving (Show, Eq, Data)
-
-data EmailAuthConfig = EmailAuthConfig
-  { userSignupFields :: Maybe ExtImport,
-    fromField :: EmailFromField,
-    emailVerification :: EmailVerificationConfig,
-    passwordReset :: PasswordResetConfig
-  }
-  deriving (Show, Eq, Data)
-
-isUsernameAndPasswordAuthEnabled :: Auth -> Bool
-isUsernameAndPasswordAuthEnabled = isJust . usernameAndPassword . methods
-
-isExternalAuthEnabled :: Auth -> Bool
-isExternalAuthEnabled auth =
-  any
-    ($ auth)
-    -- NOTE: Make sure to add new external auth methods here.
-    [ isGoogleAuthEnabled,
-      isGitHubAuthEnabled,
-      isKeycloakAuthEnabled
-    ]
-
-isGoogleAuthEnabled :: Auth -> Bool
-isGoogleAuthEnabled = isJust . google . methods
-
-isKeycloakAuthEnabled :: Auth -> Bool
-isKeycloakAuthEnabled = isJust . keycloak . methods
-
-isGitHubAuthEnabled :: Auth -> Bool
-isGitHubAuthEnabled = isJust . gitHub . methods
-
-isEmailAuthEnabled :: Auth -> Bool
-isEmailAuthEnabled = isJust . email . methods
-
--- These helper functions are used to avoid ambiguity when using the
--- `userSignupFields` function (otherwise we need to use the DuplicateRecordFields
--- extension in each module that uses them).
-userSignupFieldsForEmailAuth :: EmailAuthConfig -> Maybe ExtImport
-userSignupFieldsForEmailAuth = userSignupFields
-
-userSignupFieldsForUsernameAuth :: UsernameAndPasswordConfig -> Maybe ExtImport
-userSignupFieldsForUsernameAuth = userSignupFields
-
-userSignupFieldsForExternalAuth :: ExternalAuthConfig -> Maybe ExtImport
-userSignupFieldsForExternalAuth = userSignupFields
+generateIsAuthMethodEnabled :: Q [Dec]
+generateIsAuthMethodEnabled = do
+  let authMethodNames = map (\method -> (mkName . show $ method, (mkName . toLowerFirst . show) method)) [minBound .. maxBound :: AuthMethod]
+  clauses <- mapM generateClause authMethodNames
+  return [FunD (mkName "isAuthMethodEnabled") clauses]
+  where
+    generateClause :: (Name, Name) -> Q Clause
+    generateClause (authMethodCtor, authMethodName) = do
+      let authVar = mkName "auth"
+      body <- [|isJust ($(varE authMethodName) ($(varE (mkName "methods")) $(varE authVar)))|]
+      return $ Clause [ConP authMethodCtor [], VarP authVar] (NormalB body) []

--- a/waspc/src/Wasp/AppSpec/App/Auth/AuthMethods.hs
+++ b/waspc/src/Wasp/AppSpec/App/Auth/AuthMethods.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Wasp.AppSpec.App.Auth.AuthMethods
+  ( generateAuthMethods,
+    userSignupFieldsForEmailAuth,
+    userSignupFieldsForUsernameAuth,
+    userSignupFieldsForExternalAuth,
+    isAuthMethodExternal,
+    AuthMethod (..),
+    UsernameAndPasswordConfig (..),
+    ExternalAuthConfig (..),
+    EmailAuthConfig (..),
+  )
+where
+
+import Data.Data (Data)
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax (VarBangType)
+import Wasp.AppSpec.App.Auth.EmailVerification (EmailVerificationConfig)
+import Wasp.AppSpec.App.Auth.PasswordReset (PasswordResetConfig)
+import Wasp.AppSpec.App.EmailSender (EmailFromField)
+import Wasp.AppSpec.ExtImport (ExtImport)
+import Wasp.Util (toLowerFirst)
+
+data AuthMethod = UsernameAndPassword | Email | Google | Keycloak | GitHub deriving (Show, Enum, Bounded)
+
+data UsernameAndPasswordConfig = UsernameAndPasswordConfig
+  { userSignupFields :: Maybe ExtImport
+  }
+  deriving (Show, Eq, Data)
+
+data ExternalAuthConfig = ExternalAuthConfig
+  { configFn :: Maybe ExtImport,
+    userSignupFields :: Maybe ExtImport
+  }
+  deriving (Show, Eq, Data)
+
+data EmailAuthConfig = EmailAuthConfig
+  { userSignupFields :: Maybe ExtImport,
+    fromField :: EmailFromField,
+    emailVerification :: EmailVerificationConfig,
+    passwordReset :: PasswordResetConfig
+  }
+  deriving (Show, Eq, Data)
+
+configType :: AuthMethod -> Name
+configType UsernameAndPassword = ''UsernameAndPasswordConfig
+configType Email = ''EmailAuthConfig
+configType Google = ''ExternalAuthConfig
+configType Keycloak = ''ExternalAuthConfig
+configType GitHub = ''ExternalAuthConfig
+
+-- Generate the AuthMethods data type
+-- data AuthMethods = AuthMethods
+--   { usernameAndPassword :: Maybe UsernameAndPasswordConfig,
+--     google :: Maybe ExternalAuthConfig,
+--     gitHub :: Maybe ExternalAuthConfig,
+--     keycloak :: Maybe ExternalAuthConfig,
+--     email :: Maybe EmailAuthConfig
+--     ...
+--   } deriving (Show, Eq, Data)
+generateAuthMethods :: Q [Dec]
+generateAuthMethods = do
+  let authMethodsName = mkName "AuthMethods"
+  let authMethodsCtorName = mkName "AuthMethods"
+  let fields = generateField <$> [UsernameAndPassword .. GitHub]
+  -- data AuthMethods
+  let authMethods =
+        dataD
+          (cxt [])
+          authMethodsName
+          []
+          Nothing
+          [recC authMethodsCtorName fields]
+          [derivClause Nothing [[t|Show|], [t|Eq|], [t|Data|]]]
+  sequence [authMethods]
+  where
+    -- usernameAndPassword :: Maybe UsernameAndPasswordConfig
+    generateField :: AuthMethod -> Q VarBangType
+    generateField authMethod = do
+      let fieldName = mkName (toLowerFirst (show authMethod))
+      let fieldConfigType = configType authMethod
+      let fieldType = appT (conT ''Maybe) (conT fieldConfigType)
+      let fieldStrictness = bang noSourceUnpackedness noSourceStrictness
+      varBangType fieldName $ bangType fieldStrictness fieldType
+
+-- These helper functions are used to avoid ambiguity when using the
+-- `userSignupFields` function (otherwise we need to use the DuplicateRecordFields
+-- extension in each module that uses them).
+userSignupFieldsForEmailAuth :: EmailAuthConfig -> Maybe ExtImport
+userSignupFieldsForEmailAuth = userSignupFields
+
+userSignupFieldsForUsernameAuth :: UsernameAndPasswordConfig -> Maybe ExtImport
+userSignupFieldsForUsernameAuth = userSignupFields
+
+userSignupFieldsForExternalAuth :: ExternalAuthConfig -> Maybe ExtImport
+userSignupFieldsForExternalAuth = userSignupFields
+
+isAuthMethodExternal :: AuthMethod -> Bool
+isAuthMethodExternal Google = True
+isAuthMethodExternal Keycloak = True
+isAuthMethodExternal GitHub = True
+isAuthMethodExternal _ = False

--- a/waspc/src/Wasp/AppSpec/App/Auth/IsEnabled.hs
+++ b/waspc/src/Wasp/AppSpec/App/Auth/IsEnabled.hs
@@ -1,0 +1,12 @@
+module Wasp.AppSpec.App.Auth.IsEnabled where
+
+import Language.Haskell.TH
+import Wasp.AppSpec.App.Auth (Auth (..), AuthMethods (..), generateIsAuthMethodEnabled)
+import Wasp.AppSpec.App.Auth.AuthMethods (AuthMethod(..), isAuthMethodExternal)
+
+$(generateIsAuthMethodEnabled)
+
+isExternalAuthEnabled :: Auth -> Bool
+isExternalAuthEnabled auth = any check [minBound .. maxBound :: AuthMethod]
+  where
+    check method = isAuthMethodExternal method && isAuthMethodEnabled method auth

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -26,6 +26,8 @@ import Wasp.AppSpec.App (App)
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App as App
 import qualified Wasp.AppSpec.App.Auth as Auth
+import Wasp.AppSpec.App.Auth.AuthMethods (AuthMethod (Email, UsernameAndPassword))
+import qualified Wasp.AppSpec.App.Auth.IsEnabled as Auth.IsEnabled
 import qualified Wasp.AppSpec.App.Client as Client
 import qualified Wasp.AppSpec.App.Db as AS.Db
 import qualified Wasp.AppSpec.App.EmailSender as AS.EmailSender
@@ -169,7 +171,7 @@ validateOnlyEmailOrUsernameAndPasswordAuthIsUsed spec =
         | areBothAuthMethodsUsed
       ]
       where
-        areBothAuthMethodsUsed = Auth.isEmailAuthEnabled auth && Auth.isUsernameAndPasswordAuthEnabled auth
+        areBothAuthMethodsUsed = Auth.IsEnabled.isAuthMethodEnabled Email auth && Auth.IsEnabled.isAuthMethodEnabled UsernameAndPassword auth
 
 validateDbIsPostgresIfPgBossUsed :: AppSpec -> [ValidationError]
 validateDbIsPostgresIfPgBossUsed spec =
@@ -182,7 +184,7 @@ validateEmailSenderIsDefinedIfEmailAuthIsUsed :: AppSpec -> [ValidationError]
 validateEmailSenderIsDefinedIfEmailAuthIsUsed spec = case App.auth app of
   Nothing -> []
   Just auth ->
-    if Auth.isEmailAuthEnabled auth && isNothing (App.emailSender app)
+    if Auth.IsEnabled.isAuthMethodEnabled Email auth && isNothing (App.emailSender app)
       then [GenericValidationError "app.emailSender must be specified when using email auth. You can use the Dummy email sender for development purposes."]
       else []
   where

--- a/waspc/src/Wasp/Generator/AuthProviders.hs
+++ b/waspc/src/Wasp/Generator/AuthProviders.hs
@@ -1,6 +1,13 @@
 module Wasp.Generator.AuthProviders where
 
+import Data.Aeson (KeyValue ((.=)), object)
+import qualified Data.Aeson as Aeson
 import Data.Maybe (fromJust)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import Wasp.AppSpec.App.Auth.AuthMethods (AuthMethod (..))
+import qualified Wasp.AppSpec.App.Auth.IsEnabled as AS.Auth.IsEnabled
 import Wasp.Generator.AuthProviders.Common (makeProviderId)
 import qualified Wasp.Generator.AuthProviders.Email as E
 import qualified Wasp.Generator.AuthProviders.Local as L
@@ -43,3 +50,11 @@ emailAuthProvider =
     { E._providerId = fromJust $ makeProviderId "email",
       E._displayName = "Email and password"
     }
+
+getAuthProvidersJson :: AS.Auth.Auth -> Aeson.Value
+getAuthProvidersJson auth = object $ (\(key, fn) -> key .= fn auth) . mapAuthMethodToPair <$> listOfAllAuthMethods
+  where
+    listOfAllAuthMethods = [minBound .. maxBound] :: [AuthMethod]
+
+    mapAuthMethodToPair :: AuthMethod -> (Text, AS.Auth.Auth -> Bool)
+    mapAuthMethodToPair method = (Text.pack $ "is" ++ show method ++ "AuthEnabled", AS.Auth.IsEnabled.isAuthMethodEnabled method)

--- a/waspc/src/Wasp/Generator/SdkGenerator/Auth/EmailAuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Auth/EmailAuthG.hs
@@ -7,6 +7,8 @@ import Data.Aeson (object, (.=))
 import StrongPath (relfile)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import Wasp.AppSpec.App.Auth.AuthMethods (AuthMethod (Email))
+import qualified Wasp.AppSpec.App.Auth.IsEnabled as AS.Auth.IsEnabled
 import Wasp.Generator.AuthProviders (emailAuthProvider)
 import Wasp.Generator.AuthProviders.Email
   ( serverLoginUrl,
@@ -24,7 +26,7 @@ import qualified Wasp.Util as Util
 
 genEmailAuth :: AS.Auth.Auth -> Generator [FileDraft]
 genEmailAuth auth
-  | AS.Auth.isEmailAuthEnabled auth =
+  | AS.Auth.IsEnabled.isAuthMethodEnabled Email auth =
       sequence
         [ genIndex,
           genServerUtils auth

--- a/waspc/src/Wasp/Generator/SdkGenerator/Auth/LocalAuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Auth/LocalAuthG.hs
@@ -7,6 +7,8 @@ import Data.Aeson (object, (.=))
 import StrongPath (relfile)
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import Wasp.AppSpec.App.Auth.AuthMethods (AuthMethod (UsernameAndPassword))
+import qualified Wasp.AppSpec.App.Auth.IsEnabled as AS.Auth.IsEnabled
 import Wasp.Generator.AuthProviders (localAuthProvider)
 import Wasp.Generator.AuthProviders.Local (serverLoginUrl, serverSignupUrl)
 import Wasp.Generator.FileDraft (FileDraft)
@@ -18,7 +20,7 @@ genLocalAuth = genActions
 
 genActions :: AS.Auth.Auth -> Generator [FileDraft]
 genActions auth
-  | AS.Auth.isUsernameAndPasswordAuthEnabled auth =
+  | AS.Auth.IsEnabled.isAuthMethodEnabled UsernameAndPassword auth =
       sequence
         [ genLocalLoginAction,
           genLocalSignupAction

--- a/waspc/src/Wasp/Generator/SdkGenerator/Auth/OAuthAuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Auth/OAuthAuthG.hs
@@ -7,6 +7,8 @@ import Data.Aeson (object, (.=))
 import StrongPath (File', Path', Rel', reldir, relfile)
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import Wasp.AppSpec.App.Auth.AuthMethods (AuthMethod (GitHub, Google, Keycloak))
+import qualified Wasp.AppSpec.App.Auth.IsEnabled as AS.Auth.IsEnabled
 import Wasp.Generator.AuthProviders
   ( gitHubAuthProvider,
     googleAuthProvider,
@@ -20,7 +22,7 @@ import Wasp.Generator.SdkGenerator.Common as C
 
 genOAuthAuth :: AS.Auth.Auth -> Generator [FileDraft]
 genOAuthAuth auth
-  | AS.Auth.isExternalAuthEnabled auth =
+  | AS.Auth.IsEnabled.isExternalAuthEnabled auth =
       genHelpers auth
   | otherwise = return []
 
@@ -28,9 +30,9 @@ genHelpers :: AS.Auth.Auth -> Generator [FileDraft]
 genHelpers auth =
   return $
     concat
-      [ [gitHubHelpers | AS.Auth.isGitHubAuthEnabled auth],
-        [googleHelpers | AS.Auth.isGoogleAuthEnabled auth],
-        [keycloakHelpers | AS.Auth.isKeycloakAuthEnabled auth]
+      [ [gitHubHelpers | AS.Auth.IsEnabled.isAuthMethodEnabled GitHub auth],
+        [googleHelpers | AS.Auth.IsEnabled.isAuthMethodEnabled Google auth],
+        [keycloakHelpers | AS.Auth.IsEnabled.isAuthMethodEnabled Keycloak auth]
       ]
   where
     gitHubHelpers = mkHelpersFd gitHubAuthProvider [relfile|GitHub.tsx|]

--- a/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
@@ -9,6 +9,8 @@ import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import Wasp.AppSpec.App.Auth.AuthMethods (AuthMethod (Email, UsernameAndPassword))
+import qualified Wasp.AppSpec.App.Auth.IsEnabled as AS.Auth.IsEnabled
 import Wasp.AppSpec.Valid (getApp)
 import Wasp.Generator.Common (makeJsArrayFromHaskellList)
 import qualified Wasp.Generator.DbGenerator.Auth as DbAuth
@@ -122,8 +124,8 @@ genIndexTs auth =
         [ "isEmailAuthEnabled" .= isEmailAuthEnabled,
           "isLocalAuthEnabled" .= isLocalAuthEnabled
         ]
-    isEmailAuthEnabled = AS.Auth.isEmailAuthEnabled auth
-    isLocalAuthEnabled = AS.Auth.isUsernameAndPasswordAuthEnabled auth
+    isEmailAuthEnabled = AS.Auth.IsEnabled.isAuthMethodEnabled Email auth
+    isLocalAuthEnabled = AS.Auth.IsEnabled.isAuthMethodEnabled UsernameAndPassword auth
 
 genProvidersTypes :: AS.Auth.Auth -> Generator FileDraft
 genProvidersTypes auth = return $ C.mkTmplFdWithData [relfile|auth/providers/types.ts|] tmplData

--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/EmailAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/EmailAuthG.hs
@@ -19,6 +19,7 @@ import StrongPath
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import qualified Wasp.AppSpec.App.Auth.AuthMethods as AS.AuthMethods
 import qualified Wasp.AppSpec.App.Auth.EmailVerification as AS.Auth.EmailVerification
 import qualified Wasp.AppSpec.App.Auth.PasswordReset as AS.Auth.PasswordReset
 import qualified Wasp.AppSpec.App.EmailSender as AS.EmailSender
@@ -42,7 +43,7 @@ genEmailAuth spec auth = case emailAuth of
   where
     emailAuth = AS.Auth.email $ AS.Auth.methods auth
 
-genEmailAuthConfig :: AS.AppSpec -> AS.Auth.EmailAuthConfig -> Generator FileDraft
+genEmailAuthConfig :: AS.AppSpec -> AS.AuthMethods.EmailAuthConfig -> Generator FileDraft
 genEmailAuthConfig spec emailAuthConfig = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     tmplFile = C.srcDirInServerTemplatesDir </> SP.castRel authIndexFileInSrcDir
@@ -67,7 +68,7 @@ genEmailAuthConfig spec emailAuthConfig = return $ C.mkTmplFdWithDstAndData tmpl
           "email" .= email
         ]
 
-    fromField = AS.Auth.fromField emailAuthConfig
+    fromField = AS.AuthMethods.fromField emailAuthConfig
     maybeName = AS.EmailSender.name fromField
     email = AS.EmailSender.email fromField
 
@@ -77,10 +78,10 @@ genEmailAuthConfig spec emailAuthConfig = return $ C.mkTmplFdWithDstAndData tmpl
     passwordResetClientRoute = getRoutePathFromRef spec $ AS.Auth.PasswordReset.clientRoute passwordReset
     getPasswordResetEmailContent = extImportToImportJson relPathToServerSrcDir $ AS.Auth.PasswordReset.getEmailContentFn passwordReset
     getVerificationEmailContent = extImportToImportJson relPathToServerSrcDir $ AS.Auth.EmailVerification.getEmailContentFn emailVerification
-    maybeUserSignupFields = AS.Auth.userSignupFieldsForEmailAuth emailAuthConfig
+    maybeUserSignupFields = AS.AuthMethods.userSignupFieldsForEmailAuth emailAuthConfig
 
-    emailVerification = AS.Auth.emailVerification emailAuthConfig
-    passwordReset = AS.Auth.passwordReset emailAuthConfig
+    emailVerification = AS.AuthMethods.emailVerification emailAuthConfig
+    passwordReset = AS.AuthMethods.passwordReset emailAuthConfig
 
     relPathToServerSrcDir :: Path Posix (Rel importLocation) (Dir C.ServerSrcDir)
     relPathToServerSrcDir = [reldirP|../../../|]

--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/LocalAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/LocalAuthG.hs
@@ -19,6 +19,7 @@ import StrongPath
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import qualified Wasp.AppSpec.App.Auth.AuthMethods as AS.AuthMethods
 import Wasp.Generator.AuthProviders (localAuthProvider)
 import qualified Wasp.Generator.AuthProviders.Local as Local
 import Wasp.Generator.FileDraft (FileDraft)
@@ -39,7 +40,7 @@ genLocalAuth auth = case usernameAndPasswordAuth of
   where
     usernameAndPasswordAuth = AS.Auth.usernameAndPassword $ AS.Auth.methods auth
 
-genLocalAuthConfig :: AS.Auth.UsernameAndPasswordConfig -> Generator FileDraft
+genLocalAuthConfig :: AS.AuthMethods.UsernameAndPasswordConfig -> Generator FileDraft
 genLocalAuthConfig usernameAndPasswordConfig = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)
   where
     tmplFile = C.srcDirInServerTemplatesDir </> SP.castRel authIndexFileInSrcDir
@@ -52,7 +53,7 @@ genLocalAuthConfig usernameAndPasswordConfig = return $ C.mkTmplFdWithDstAndData
           "userSignupFields" .= extImportToImportJson relPathToServerSrcDir maybeUserSignupFields
         ]
 
-    maybeUserSignupFields = AS.Auth.userSignupFieldsForUsernameAuth usernameAndPasswordConfig
+    maybeUserSignupFields = AS.AuthMethods.userSignupFieldsForUsernameAuth usernameAndPasswordConfig
 
     authIndexFileInSrcDir :: Path' (Rel C.ServerSrcDir) File'
     authIndexFileInSrcDir = [relfile|auth/providers/config/username.ts|]

--- a/waspc/src/Wasp/Generator/WebAppGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/AuthG.hs
@@ -8,6 +8,7 @@ import StrongPath (relfile)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import qualified Wasp.AppSpec.App.Auth.IsEnabled as AS.Auth.IsEnabled
 import Wasp.AppSpec.Valid (getApp)
 import Wasp.Generator.AuthProviders.OAuth (serverExchangeCodeForTokenUrl)
 import Wasp.Generator.FileDraft (FileDraft)
@@ -34,7 +35,7 @@ genCreateAuthRequiredPage auth =
       (object ["onAuthFailedRedirectTo" .= AS.Auth.onAuthFailedRedirectTo auth])
 
 genOAuthAuth :: AS.Auth.Auth -> Generator [FileDraft]
-genOAuthAuth auth = sequence [genOAuthCodeExchange auth | AS.Auth.isExternalAuthEnabled auth]
+genOAuthAuth auth = sequence [genOAuthCodeExchange auth | AS.Auth.IsEnabled.isExternalAuthEnabled auth]
 
 genOAuthCodeExchange :: AS.Auth.Auth -> Generator FileDraft
 genOAuthCodeExchange auth =

--- a/waspc/src/Wasp/Generator/WebAppGenerator/RouterGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/RouterGenerator.hs
@@ -15,7 +15,7 @@ import StrongPath.Types (Posix)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
-import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
+import qualified Wasp.AppSpec.App.Auth.IsEnabled as AS.App.Auth.IsEnabled
 import qualified Wasp.AppSpec.App.Client as AS.App.Client
 import qualified Wasp.AppSpec.ExtImport as AS.ExtImport
 import qualified Wasp.AppSpec.Page as AS.Page
@@ -97,7 +97,7 @@ createRouterTemplateData spec =
     { _routes = routes,
       _pagesToImport = pages,
       _isAuthEnabled = isAuthEnabled spec,
-      _isExternalAuthEnabled = (AS.App.Auth.isExternalAuthEnabled <$> maybeAuth) == Just True,
+      _isExternalAuthEnabled = (AS.App.Auth.IsEnabled.isExternalAuthEnabled <$> maybeAuth) == Just True,
       _rootComponent = extImportToImportJson relPathToWebAppSrcDir maybeRootComponent,
       _baseDir = SP.fromAbsDirP $ C.getBaseDir spec
     }

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -224,6 +224,8 @@ library
     Wasp.AppSpec.Crud
     Wasp.AppSpec.App
     Wasp.AppSpec.App.Auth
+    Wasp.AppSpec.App.Auth.AuthMethods
+    Wasp.AppSpec.App.Auth.IsEnabled
     Wasp.AppSpec.App.Auth.PasswordReset
     Wasp.AppSpec.App.Auth.EmailVerification
     Wasp.AppSpec.App.Client


### PR DESCRIPTION
I was think how can we make adding a new auth method a more type safe process. Since we are kinda loosely defining them by adding a new key in the `AuthMethods` record, we don't really have a union data type over which we can force exhaustive pattern matches. 

I've played a bit with Template Haskell to try to change that. 