### PR TITLE
Fix mismatching variable names in backend/seed documentation

### DIFF
--- a/web/docs/data-model/backends.md
+++ b/web/docs/data-model/backends.md
@@ -171,7 +171,7 @@ export const devSeedSimple = async (prisma) => {
 }
 
 async function createUser(prisma, data) {
-  const newUser = await prismaClient.user.create({
+  const newUser = await prisma.user.create({
     data: {
       auth: {
         create: {
@@ -180,7 +180,7 @@ async function createUser(prisma, data) {
               providerName: 'username',
               providerUserId: data.username,
               providerData: sanitizeAndSerializeProviderData({
-                password: data.password
+                hashedPassword: data.password
               }),
             },
           },
@@ -218,7 +218,7 @@ async function createUser(
   prisma: PrismaClient,
   data: { username: string, password: string }
 ): Promise<AuthUser> {
-  const newUser = await prismaClient.user.create({
+  const newUser = await prisma.user.create({
     data: {
       auth: {
         create: {
@@ -227,7 +227,7 @@ async function createUser(
               providerName: 'username',
               providerUserId: data.username,
               providerData: sanitizeAndSerializeProviderData<'username'>({
-                password: data.password
+                hashedPassword: data.password
               }),
             },
           },

--- a/web/versioned_docs/version-0.13.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.13.0/data-model/backends.md
@@ -171,7 +171,7 @@ export const devSeedSimple = async (prisma) => {
 }
 
 async function createUser(prisma, data) {
-  const newUser = await prismaClient.user.create({
+  const newUser = await prisma.user.create({
     data: {
       auth: {
         create: {
@@ -180,7 +180,7 @@ async function createUser(prisma, data) {
               providerName: 'username',
               providerUserId: data.username,
               providerData: sanitizeAndSerializeProviderData({
-                password: data.password
+                hashedPassword: data.password
               }),
             },
           },
@@ -218,7 +218,7 @@ async function createUser(
   prisma: PrismaClient,
   data: { username: string, password: string }
 ): Promise<AuthUser> {
-  const newUser = await prismaClient.user.create({
+  const newUser = await prisma.user.create({
     data: {
       auth: {
         create: {
@@ -227,7 +227,7 @@ async function createUser(
               providerName: 'username',
               providerUserId: data.username,
               providerData: sanitizeAndSerializeProviderData<'username'>({
-                password: data.password
+                hashedPassword: data.password
               }),
             },
           },


### PR DESCRIPTION
### Description

Renamed parameter `password` to `hashedPassword` in `sanitizeAndSerializeProviderData` to match its implementation.

Renamed variable name `prismaClient` to `prisma` to match the parameters name.

### Select what type of change this PR introduces:

1. [x] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
