### PR TITLE
Updates SDK tsconfig to enable the `incremental`

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
+++ b/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
@@ -28,6 +28,7 @@
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
       "@testing-library/jest-dom"
     ],
+    "incremental": true,
     // todo(filip): Only works with common js, see https://www.typescriptlang.org/tsconfig#paths and daily-article.
     // "paths": {
     //   "@wasp/*": [


### PR DESCRIPTION
This helps with Vite HMR working properly since rebuilds of the SDK files would result in full reload instead of proper HMR. 

This also has some nice side-effects:
- faster rebuilds of the SDK (helpful for https://github.com/wasp-lang/wasp/issues/1840)
- less Vite messages (helpful for https://github.com/wasp-lang/wasp/issues/1829)