### PR TITLE
Testing types of `todoApp` in CI

### DIFF
--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: Run unit tests
         run: cabal test cli-test waspc-test waspls-test
 
-      - name: Ensure todoApp builds
+      - name: Ensure todoApp works
         if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
         run: ./tools/ensure_todoapp_builds.sh
 

--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Ensure todoApp works
         if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
-        run: ./tools/ensure_todoapp_builds.sh
+        run: ./tools/ensure_todoapp_works.sh
 
       - name: Headless - Cache Node Modules
         id: headless-cache-node-modules

--- a/waspc/examples/todoApp/package-lock.json
+++ b/waspc/examples/todoApp/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@types/express": "^4.17.13",
         "@types/react": "^18.0.37",
+        "@types/uuid": "^9.0.8",
         "prisma": "4.16.2",
         "typescript": "^5.1.0",
         "vite": "^4.3.9"
@@ -2410,6 +2411,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "node_modules/@vitest/expect": {
       "version": "1.3.0",

--- a/waspc/examples/todoApp/package.json
+++ b/waspc/examples/todoApp/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/react": "^18.0.37",
+    "@types/uuid": "^9.0.8",
     "prisma": "4.16.2",
     "typescript": "^5.1.0",
     "vite": "^4.3.9"

--- a/waspc/examples/todoApp/src/App.tsx
+++ b/waspc/examples/todoApp/src/App.tsx
@@ -15,11 +15,13 @@ export function App({ children }: any) {
 
   const connectionIcon = isConnected ? '🟢' : '🔴'
 
+  const appName = import.meta.env.REACT_APP_NAME ? import.meta.env.REACT_APP_NAME : 'TODO App'
+
   return (
     <div className="app border-spacing-2 p-4">
       <header className="flex justify-between">
         <h1 className="font-bold text-3xl mb-5">
-          <Link to="/">ToDo App</Link>
+          <Link to="/">{appName}</Link>
         </h1>
         <h2>
           Your site was loaded at: {date?.toLocaleString()} {connectionIcon}

--- a/waspc/tools/ensure_todoapp_builds.sh
+++ b/waspc/tools/ensure_todoapp_builds.sh
@@ -13,6 +13,9 @@ cd "$dir/../examples/todoApp"
 # Compile example app.
 cabal run wasp-cli build
 
+echo "Ensure the app has no IDE type errors"
+npx tsc --noEmit --skipLibCheck
+
 # Make sure they build.
 echo "Ensure client builds"
 cd .wasp/build/web-app

--- a/waspc/tools/ensure_todoapp_works.sh
+++ b/waspc/tools/ensure_todoapp_works.sh
@@ -6,14 +6,14 @@
 
 # Gets the directory of where this script lives.
 dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-echo "Running ensure_todoapp_builds.sh from $dir"
+echo "Running ensure_todoapp_works.sh from $dir"
 
 cd "$dir/../examples/todoApp"
 
 # Compile example app.
 cabal run wasp-cli build
 
-echo "Ensure the app has no IDE type errors"
+echo "Ensure the user's code has no TypeScript errors (shown in the IDE)."
 npx tsc --noEmit --skipLibCheck
 
 # Make sure they build.


### PR DESCRIPTION
Sometimes we have type errors in the IDE due to `tsconfig.json` not being properly set up. We want to raise those errors in the CI so we can avoid releasing with type issues.

This should help with this class of issues: #1989