### PR TITLE
Adding `postLogin` and `postSignup` hooks

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/hooks.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/hooks.ts
@@ -1,0 +1,29 @@
+import { type ProviderId } from '../../auth/utils.js'
+import { type PrismaClient } from '@prisma/client'
+
+export type AuthHookFn =
+  | OnUserSignUpHookFn
+  | OnUserLoginHookFn
+  | OnUserLogoutHookFn
+
+type OnUserLoginHookFn = (context: {
+  providerId: ProviderId
+  prisma: PrismaClient
+}) => Promise<void> | void
+type OnUserSignUpHookFn = (context: {
+  providerId: ProviderId
+  prisma: PrismaClient
+}) => Promise<void> | void
+type OnUserLogoutHookFn = (context: {
+  providerId: ProviderId
+  prisma: PrismaClient
+}) => Promise<void> | void
+
+type HookType = 'onUserSignUp' | 'onUserLogin' | 'onUserLogout'
+
+export function defineHook<HT extends HookType>(
+  hookType: HT,
+  hookFn: AuthHookFn,
+): AuthHookFn {
+  return hookFn
+}

--- a/waspc/data/Generator/templates/server/src/auth/hooks.ts
+++ b/waspc/data/Generator/templates/server/src/auth/hooks.ts
@@ -1,0 +1,39 @@
+{{={= =}=}}
+import { prisma } from 'wasp/server'
+import { type ProviderId } from 'wasp/auth/utils'
+import { type AuthHookFn } from 'wasp/auth/hooks'
+
+{=# onUserSignUpHook.isDefined =}
+{=& onUserSignUpHook.importStatement =}
+export const onUserSignUpHook = addExtraParamsToTheHookCall({= onUserSignUpHook.importIdentifier =})
+{=/ onUserSignUpHook.isDefined =}
+{=^ onUserSignUpHook.isDefined =}
+export const onUserSignUpHook = undefined
+{=/ onUserSignUpHook.isDefined =}
+
+{=# onUserLoginHook.isDefined =}
+{=& onUserLoginHook.importStatement =}
+export const onUserLoginHook = addExtraParamsToTheHookCall({= onUserLoginHook.importIdentifier =})
+{=/ onUserLoginHook.isDefined =}
+{=^ onUserLoginHook.isDefined =}
+export const onUserLoginHook = undefined
+{=/ onUserLoginHook.isDefined =}
+
+{=# onUserLogoutHook.isDefined =}
+{=& onUserLogoutHook.importStatement =}
+export const onUserLogoutHook = addExtraParamsToTheHookCall({= onUserLogoutHook.importIdentifier =})
+{=/ onUserLogoutHook.isDefined =}
+{=^ onUserLogoutHook.isDefined =}
+export const onUserLogout = undefined
+{=/ onUserLogout.isDefined =}
+
+type InternalAuthHookFn = ({ providerId }: { providerId: ProviderId }) => Promise<void> | void
+
+function addExtraParamsToTheHookCall(hookFn: AuthHookFn): InternalAuthHookFn {
+  return ({ providerId }) => {
+    return hookFn({
+      providerId,
+      prisma,
+    })
+  }
+}

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/login.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/login.ts
@@ -36,6 +36,8 @@ export function getLoginRoute() {
     
         const auth = await findAuthWithUserBy({ id: authIdentity.authId })
         const session = await createSession(auth.id)
+
+        // postLogin(providerId)
       
         return res.json({
             sessionId: session.id,

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
@@ -137,6 +137,8 @@ export function getSignupRoute({
             console.error("Failed to send email verification email:", e);
             throw new HttpError(500, "Failed to send email verification email.");
         }
+
+        // postSignup(providerId)
       
         return res.json({ success: true });
     };

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/user.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/user.ts
@@ -63,6 +63,9 @@ async function getAuthIdFromProviderDetails(
   })
 
   if (existingAuthIdentity) {
+
+    // postLogin(providerId)
+
     return existingAuthIdentity.{= authFieldOnAuthIdentityEntityName =}.id
   } else {
     const userFields = await validateAndGetUserFields(
@@ -80,6 +83,8 @@ async function getAuthIdFromProviderDetails(
       // rely on Prisma to validate the data.
       userFields as any,
     )
+
+    // postSignup(providerId)
 
     return user.auth.id
   }

--- a/waspc/data/Generator/templates/server/src/auth/providers/username/login.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/username/login.ts
@@ -32,9 +32,11 @@ export default handleRejection(async (req, res) => {
 
   const auth = await findAuthWithUserBy({
     id: authIdentity.authId
-  }) 
+  })
 
   const session = await createSession(auth.id)
+
+  // postLogin(providerId)
 
   return res.json({
       sessionId: session.id,

--- a/waspc/data/Generator/templates/server/src/auth/providers/username/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/username/signup.ts
@@ -44,6 +44,8 @@ export function getSignupRoute({
     } catch (e: unknown) {
       rethrowPossibleAuthError(e)
     }
+
+    // postSignup(providerId)
   
     return res.json({ success: true })
   })

--- a/waspc/examples/todoApp/main.wasp
+++ b/waspc/examples/todoApp/main.wasp
@@ -39,6 +39,10 @@ app todoApp {
         },
       },
     },
+    hooks: {
+      postSignup: import { postSingupHook } from "@src/auth/hooks.js",
+      postLogin: import { postLoginHook } from "@src/auth/hooks.js",
+    },
     onAuthFailedRedirectTo: "/login",
     onAuthSucceededRedirectTo: "/profile"
   },

--- a/waspc/examples/todoApp/main.wasp
+++ b/waspc/examples/todoApp/main.wasp
@@ -39,10 +39,10 @@ app todoApp {
         },
       },
     },
-    hooks: {
-      postSignup: import { postSingupHook } from "@src/auth/hooks.js",
-      postLogin: import { postLoginHook } from "@src/auth/hooks.js",
-    },
+    // hooks: {
+    //   postSignup: import { postSingupHook } from "@src/auth/hooks.js",
+    //   postLogin: import { postLoginHook } from "@src/auth/hooks.js",
+    // },
     onAuthFailedRedirectTo: "/login",
     onAuthSucceededRedirectTo: "/profile"
   },

--- a/waspc/examples/todoApp/src/App.tsx
+++ b/waspc/examples/todoApp/src/App.tsx
@@ -5,13 +5,17 @@ import { useQuery, getDate } from "wasp/client/operations";
 
 import './Main.css'
 import { getName } from './user'
+import { emailSender } from "wasp/server/email";
 
-export function App({ children }: any) {
+
+export function App({ children }: { children: React.ReactNode }) {
   const { data: user } = useAuth()
   const { data: date } = useQuery(getDate)
   const { isConnected } = useSocket()
 
   const connectionIcon = isConnected ? '🟢' : '🔴'
+
+  emailSender;
 
   return (
     <div className="app border-spacing-2 p-4">
@@ -28,7 +32,7 @@ export function App({ children }: any) {
               Hello, <Link to="/profile">{getName(user)}</Link>
             </div>
             <div>
-              <button className="btn btn-primary" onClick={logout}>
+              <button type="button" className="btn btn-primary" onClick={logout}>
                 Logout
               </button>
             </div>

--- a/waspc/examples/todoApp/src/auth/hooks.ts
+++ b/waspc/examples/todoApp/src/auth/hooks.ts
@@ -1,9 +1,9 @@
-import { defineHook } from 'wasp/server/auth'
+// import { defineHook } from 'wasp/server/auth'
 
-export const postLoginHook = defineHook('postLogin', async (providerId) => {
-  // Do something after the user logs in.
-})
+// export const postLoginHook = defineHook('postLogin', async (providerId) => {
+//   // Do something after the user logs in.
+// })
 
-export const postSingupHook = defineHook('postSignup', async (providerId) => {
-  // Do something after the user signs up.
-})
+// export const postSingupHook = defineHook('postSignup', async (providerId) => {
+//   // Do something after the user signs up.
+// })

--- a/waspc/examples/todoApp/src/auth/hooks.ts
+++ b/waspc/examples/todoApp/src/auth/hooks.ts
@@ -1,0 +1,9 @@
+import { defineHook } from 'wasp/server/auth'
+
+export const postLoginHook = defineHook('postLogin', async (providerId) => {
+  // Do something after the user logs in.
+})
+
+export const postSingupHook = defineHook('postSignup', async (providerId) => {
+  // Do something after the user signs up.
+})

--- a/waspc/src/Wasp/AppSpec/App/Auth.hs
+++ b/waspc/src/Wasp/AppSpec/App/Auth.hs
@@ -33,7 +33,8 @@ data Auth = Auth
     externalAuthEntity :: Maybe (Ref Entity),
     methods :: AuthMethods,
     onAuthFailedRedirectTo :: String,
-    onAuthSucceededRedirectTo :: Maybe String
+    onAuthSucceededRedirectTo :: Maybe String,
+    hooks :: Maybe AuthHooks
   }
   deriving (Show, Eq, Data)
 
@@ -62,6 +63,13 @@ data EmailAuthConfig = EmailAuthConfig
     fromField :: EmailFromField,
     emailVerification :: EmailVerificationConfig,
     passwordReset :: PasswordResetConfig
+  }
+  deriving (Show, Eq, Data)
+
+data AuthHooks = AuthHooks
+  { onUserSignedUp :: Maybe ExtImport,
+    onUserSignedIn :: Maybe ExtImport,
+    onUserSignedOut :: Maybe ExtImport
   }
   deriving (Show, Eq, Data)
 


### PR DESCRIPTION
A lot of users asked for the ability to execute code after some user has signed up or logged in.

We decided in a internal RFC that we want to build these hooks like we did the client and server setup functions: by importing user defined function and executing it where it makes sense.

In this PR, I have now only create a sketch of the API I plan on implementing. There are some open questions:
- [ ] **Which params do we want to pass to the hook?**
  I went with the minimal `ProviderId` which is an object containing the provider name and the user ID for that provider. They can probably fetch everything else they need.

- [ ] **Do we want the hook to be async?**
  Probably yes. They'd made want to send some info to an external API.

- [ ] **Do we want the hook to _block_ while it executes?**
  Aka the login and signup process won't continue until the hook code finished executing.

- [ ] **Do we use the same hooks (postLogin and postSignup) for both email, username and _OAuth_ providers?**
  Maybe yes, since it's the simplest thing to do.

- [ ] **Do we have special hook for OAuth providers?** 
  I'm wondering about this since for OAuth providers there is a moment of signup and a moment of login, but _usually_ it's not that important of a distinction. 

- [ ] **Do we want some `preLogin` and `preSignup` hooks?**
  The users haven't requested this, so maybe not add it immedietly? 

- [ ] **Can the `pre` hooks modify data or reject signup or login?**
  If they can't, I don't see much point in having these hooks.
  
  Closes https://github.com/wasp-lang/wasp/issues/1556