### PR TITLE
Extracts Message component from OAuthCallback page

### DIFF
--- a/waspc/data/Generator/templates/react-app/src/auth/pages/OAuthCallback.tsx
+++ b/waspc/data/Generator/templates/react-app/src/auth/pages/OAuthCallback.tsx
@@ -5,35 +5,14 @@ import { Redirect, useLocation } from 'react-router-dom'
 import { useAuth } from 'wasp/client/auth'
 import { api } from 'wasp/client/api'
 import { initSession } from 'wasp/auth/helpers/user'
+import { MessageLoading, MessageError } from "../../components/Message";
 
 const wrapperStyles = {
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  padding: "4rem",
-};
-
-const commonMessageStyles = {
   display: 'flex',
   alignItems: 'center',
-  gap: '.5rem',
-  borderRadius: '.5rem',
-  padding: '1rem',
-};
-
-const errorMessageStyles = {
-  ...commonMessageStyles,
-  borderColor: 'rgb(240 82 82)',
-  backgroundColor: 'rgb(253 232 232)',
-  color: 'rgb(200 30 30)',
-};
-
-const loadingMessageStyles = {
-  ...commonMessageStyles,
-  borderColor: 'rgb(107 114 128)',
-  backgroundColor: 'rgb(243 244 246)',
-  color: 'rgb(55 65 81)',
-};
+  justifyContent: 'center',
+  padding: '4rem',
+}
 
 export function OAuthCallbackPage() {
   const { isLoading, error, user } = useOAuthCallbackHandler();
@@ -44,8 +23,8 @@ export function OAuthCallbackPage() {
 
   return (
     <div style={wrapperStyles}>
-      {error && <div style={errorMessageStyles}><MessageIcon /> {error}</div>}
-      {isLoading && <div style={loadingMessageStyles}><MessageIcon /> Please wait a moment while we log you in.</div>}
+      {error && <MessageError>{error}</MessageError>}
+      {isLoading && <MessageLoading>Please wait a moment while we log you in.</MessageLoading>}
     </div>
   );
 }
@@ -98,26 +77,6 @@ function useOAuthCallbackHandler() {
     isLoading,
   };
 }
-
-const MessageIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="1.25rem"
-    height="1.25rem"
-    fill="currentColor"
-    stroke="currentColor"
-    strokeWidth={0}
-    aria-hidden="true"
-    viewBox="0 0 20 20"
-  >
-    <path
-      fillRule="evenodd"
-      stroke="none"
-      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"
-      clipRule="evenodd"
-    />
-  </svg>
-)
 
 async function exchangeOAuthCodeForToken(data: {
   code: string

--- a/waspc/data/Generator/templates/react-app/src/components/Message.tsx
+++ b/waspc/data/Generator/templates/react-app/src/components/Message.tsx
@@ -1,0 +1,65 @@
+const commonMessageStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '.5rem',
+  borderRadius: '.5rem',
+  padding: '1rem',
+}
+
+const errorMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(240 82 82)',
+  backgroundColor: 'rgb(253 232 232)',
+  color: 'rgb(200 30 30)',
+}
+
+const loadingMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(107 114 128)',
+  backgroundColor: 'rgb(243 244 246)',
+  color: 'rgb(55 65 81)',
+}
+
+export function MessageError({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={errorMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+export function MessageLoading({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={loadingMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+const MessageIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1.25rem"
+    height="1.25rem"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth={0}
+    aria-hidden="true"
+    viewBox="0 0 20 20"
+  >
+    <path
+      fillRule="evenodd"
+      stroke="none"
+      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"
+      clipRule="evenodd"
+    />
+  </svg>
+)

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/files.manifest
@@ -210,6 +210,7 @@ waspBuild/.wasp/build/web-app/public/.gitkeep
 waspBuild/.wasp/build/web-app/public/favicon.ico
 waspBuild/.wasp/build/web-app/public/manifest.json
 waspBuild/.wasp/build/web-app/scripts/validate-env.mjs
+waspBuild/.wasp/build/web-app/src/components/Message.tsx
 waspBuild/.wasp/build/web-app/src/index.tsx
 waspBuild/.wasp/build/web-app/src/logo.png
 waspBuild/.wasp/build/web-app/src/router.tsx

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -548,6 +548,13 @@
     [
         [
             "file",
+            "web-app/src/components/Message.tsx"
+        ],
+        "8851c3201f8e165d647a66abe5457e837cfb750790f393428d16be51c41ee2e5"
+    ],
+    [
+        [
+            "file",
             "web-app/src/index.tsx"
         ],
         "ff83778b7f03a8f15116bc73adce607c2c13fc9cbd4228626980a530541aaeb2"

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/components/Message.tsx
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/src/components/Message.tsx
@@ -1,0 +1,65 @@
+const commonMessageStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '.5rem',
+  borderRadius: '.5rem',
+  padding: '1rem',
+}
+
+const errorMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(240 82 82)',
+  backgroundColor: 'rgb(253 232 232)',
+  color: 'rgb(200 30 30)',
+}
+
+const loadingMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(107 114 128)',
+  backgroundColor: 'rgb(243 244 246)',
+  color: 'rgb(55 65 81)',
+}
+
+export function MessageError({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={errorMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+export function MessageLoading({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={loadingMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+const MessageIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1.25rem"
+    height="1.25rem"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth={0}
+    aria-hidden="true"
+    viewBox="0 0 20 20"
+  >
+    <path
+      fillRule="evenodd"
+      stroke="none"
+      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"
+      clipRule="evenodd"
+    />
+  </svg>
+)

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/files.manifest
@@ -207,6 +207,7 @@ waspCompile/.wasp/out/web-app/public/.gitkeep
 waspCompile/.wasp/out/web-app/public/favicon.ico
 waspCompile/.wasp/out/web-app/public/manifest.json
 waspCompile/.wasp/out/web-app/scripts/validate-env.mjs
+waspCompile/.wasp/out/web-app/src/components/Message.tsx
 waspCompile/.wasp/out/web-app/src/index.tsx
 waspCompile/.wasp/out/web-app/src/logo.png
 waspCompile/.wasp/out/web-app/src/router.tsx

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -562,6 +562,13 @@
     [
         [
             "file",
+            "web-app/src/components/Message.tsx"
+        ],
+        "8851c3201f8e165d647a66abe5457e837cfb750790f393428d16be51c41ee2e5"
+    ],
+    [
+        [
+            "file",
             "web-app/src/index.tsx"
         ],
         "ff83778b7f03a8f15116bc73adce607c2c13fc9cbd4228626980a530541aaeb2"

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/components/Message.tsx
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/src/components/Message.tsx
@@ -1,0 +1,65 @@
+const commonMessageStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '.5rem',
+  borderRadius: '.5rem',
+  padding: '1rem',
+}
+
+const errorMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(240 82 82)',
+  backgroundColor: 'rgb(253 232 232)',
+  color: 'rgb(200 30 30)',
+}
+
+const loadingMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(107 114 128)',
+  backgroundColor: 'rgb(243 244 246)',
+  color: 'rgb(55 65 81)',
+}
+
+export function MessageError({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={errorMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+export function MessageLoading({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={loadingMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+const MessageIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1.25rem"
+    height="1.25rem"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth={0}
+    aria-hidden="true"
+    viewBox="0 0 20 20"
+  >
+    <path
+      fillRule="evenodd"
+      stroke="none"
+      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"
+      clipRule="evenodd"
+    />
+  </svg>
+)

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/files.manifest
@@ -464,6 +464,7 @@ waspComplexTest/.wasp/out/web-app/public/manifest.json
 waspComplexTest/.wasp/out/web-app/scripts/validate-env.mjs
 waspComplexTest/.wasp/out/web-app/src/auth/pages/OAuthCallback.tsx
 waspComplexTest/.wasp/out/web-app/src/auth/pages/createAuthRequiredPage.jsx
+waspComplexTest/.wasp/out/web-app/src/components/Message.tsx
 waspComplexTest/.wasp/out/web-app/src/index.tsx
 waspComplexTest/.wasp/out/web-app/src/logo.png
 waspComplexTest/.wasp/out/web-app/src/router.tsx

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -1138,7 +1138,7 @@
             "file",
             "web-app/src/auth/pages/OAuthCallback.tsx"
         ],
-        "cae2fb9d5e096386387ef5caa75f3d2730c1fcd86d91ba8a6efbe023cb66b529"
+        "09bd320039ac42ffc821bc7c40737cc5d6ee7cd0b6ddc47c85c4284b2bd70a44"
     ],
     [
         [
@@ -1146,6 +1146,13 @@
             "web-app/src/auth/pages/createAuthRequiredPage.jsx"
         ],
         "04ca0c6aa20114998fb60080474026d80b9efbb7fc3cbe29f86a5ecab2300b05"
+    ],
+    [
+        [
+            "file",
+            "web-app/src/components/Message.tsx"
+        ],
+        "8851c3201f8e165d647a66abe5457e837cfb750790f393428d16be51c41ee2e5"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/auth/pages/OAuthCallback.tsx
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/auth/pages/OAuthCallback.tsx
@@ -4,35 +4,14 @@ import { Redirect, useLocation } from 'react-router-dom'
 import { useAuth } from 'wasp/client/auth'
 import { api } from 'wasp/client/api'
 import { initSession } from 'wasp/auth/helpers/user'
+import { MessageLoading, MessageError } from "../../components/Message";
 
 const wrapperStyles = {
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  padding: "4rem",
-};
-
-const commonMessageStyles = {
   display: 'flex',
   alignItems: 'center',
-  gap: '.5rem',
-  borderRadius: '.5rem',
-  padding: '1rem',
-};
-
-const errorMessageStyles = {
-  ...commonMessageStyles,
-  borderColor: 'rgb(240 82 82)',
-  backgroundColor: 'rgb(253 232 232)',
-  color: 'rgb(200 30 30)',
-};
-
-const loadingMessageStyles = {
-  ...commonMessageStyles,
-  borderColor: 'rgb(107 114 128)',
-  backgroundColor: 'rgb(243 244 246)',
-  color: 'rgb(55 65 81)',
-};
+  justifyContent: 'center',
+  padding: '4rem',
+}
 
 export function OAuthCallbackPage() {
   const { isLoading, error, user } = useOAuthCallbackHandler();
@@ -43,8 +22,8 @@ export function OAuthCallbackPage() {
 
   return (
     <div style={wrapperStyles}>
-      {error && <div style={errorMessageStyles}><MessageIcon /> {error}</div>}
-      {isLoading && <div style={loadingMessageStyles}><MessageIcon /> Please wait a moment while we log you in.</div>}
+      {error && <MessageError>{error}</MessageError>}
+      {isLoading && <MessageLoading>Please wait a moment while we log you in.</MessageLoading>}
     </div>
   );
 }
@@ -97,26 +76,6 @@ function useOAuthCallbackHandler() {
     isLoading,
   };
 }
-
-const MessageIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="1.25rem"
-    height="1.25rem"
-    fill="currentColor"
-    stroke="currentColor"
-    strokeWidth={0}
-    aria-hidden="true"
-    viewBox="0 0 20 20"
-  >
-    <path
-      fillRule="evenodd"
-      stroke="none"
-      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"
-      clipRule="evenodd"
-    />
-  </svg>
-)
 
 async function exchangeOAuthCodeForToken(data: {
   code: string

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/components/Message.tsx
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/src/components/Message.tsx
@@ -1,0 +1,65 @@
+const commonMessageStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '.5rem',
+  borderRadius: '.5rem',
+  padding: '1rem',
+}
+
+const errorMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(240 82 82)',
+  backgroundColor: 'rgb(253 232 232)',
+  color: 'rgb(200 30 30)',
+}
+
+const loadingMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(107 114 128)',
+  backgroundColor: 'rgb(243 244 246)',
+  color: 'rgb(55 65 81)',
+}
+
+export function MessageError({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={errorMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+export function MessageLoading({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={loadingMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+const MessageIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1.25rem"
+    height="1.25rem"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth={0}
+    aria-hidden="true"
+    viewBox="0 0 20 20"
+  >
+    <path
+      fillRule="evenodd"
+      stroke="none"
+      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"
+      clipRule="evenodd"
+    />
+  </svg>
+)

--- a/waspc/e2e-test/test-outputs/waspJob-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/files.manifest
@@ -242,6 +242,7 @@ waspJob/.wasp/out/web-app/public/.gitkeep
 waspJob/.wasp/out/web-app/public/favicon.ico
 waspJob/.wasp/out/web-app/public/manifest.json
 waspJob/.wasp/out/web-app/scripts/validate-env.mjs
+waspJob/.wasp/out/web-app/src/components/Message.tsx
 waspJob/.wasp/out/web-app/src/index.tsx
 waspJob/.wasp/out/web-app/src/logo.png
 waspJob/.wasp/out/web-app/src/router.tsx

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -632,6 +632,13 @@
     [
         [
             "file",
+            "web-app/src/components/Message.tsx"
+        ],
+        "8851c3201f8e165d647a66abe5457e837cfb750790f393428d16be51c41ee2e5"
+    ],
+    [
+        [
+            "file",
             "web-app/src/index.tsx"
         ],
         "ff83778b7f03a8f15116bc73adce607c2c13fc9cbd4228626980a530541aaeb2"

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/components/Message.tsx
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/src/components/Message.tsx
@@ -1,0 +1,65 @@
+const commonMessageStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '.5rem',
+  borderRadius: '.5rem',
+  padding: '1rem',
+}
+
+const errorMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(240 82 82)',
+  backgroundColor: 'rgb(253 232 232)',
+  color: 'rgb(200 30 30)',
+}
+
+const loadingMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(107 114 128)',
+  backgroundColor: 'rgb(243 244 246)',
+  color: 'rgb(55 65 81)',
+}
+
+export function MessageError({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={errorMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+export function MessageLoading({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={loadingMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+const MessageIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1.25rem"
+    height="1.25rem"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth={0}
+    aria-hidden="true"
+    viewBox="0 0 20 20"
+  >
+    <path
+      fillRule="evenodd"
+      stroke="none"
+      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"
+      clipRule="evenodd"
+    />
+  </svg>
+)

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/files.manifest
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/files.manifest
@@ -211,6 +211,7 @@ waspMigrate/.wasp/out/web-app/public/.gitkeep
 waspMigrate/.wasp/out/web-app/public/favicon.ico
 waspMigrate/.wasp/out/web-app/public/manifest.json
 waspMigrate/.wasp/out/web-app/scripts/validate-env.mjs
+waspMigrate/.wasp/out/web-app/src/components/Message.tsx
 waspMigrate/.wasp/out/web-app/src/index.tsx
 waspMigrate/.wasp/out/web-app/src/logo.png
 waspMigrate/.wasp/out/web-app/src/router.tsx

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -562,6 +562,13 @@
     [
         [
             "file",
+            "web-app/src/components/Message.tsx"
+        ],
+        "8851c3201f8e165d647a66abe5457e837cfb750790f393428d16be51c41ee2e5"
+    ],
+    [
+        [
+            "file",
             "web-app/src/index.tsx"
         ],
         "ff83778b7f03a8f15116bc73adce607c2c13fc9cbd4228626980a530541aaeb2"

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/components/Message.tsx
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/src/components/Message.tsx
@@ -1,0 +1,65 @@
+const commonMessageStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '.5rem',
+  borderRadius: '.5rem',
+  padding: '1rem',
+}
+
+const errorMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(240 82 82)',
+  backgroundColor: 'rgb(253 232 232)',
+  color: 'rgb(200 30 30)',
+}
+
+const loadingMessageStyles = {
+  ...commonMessageStyles,
+  borderColor: 'rgb(107 114 128)',
+  backgroundColor: 'rgb(243 244 246)',
+  color: 'rgb(55 65 81)',
+}
+
+export function MessageError({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={errorMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+export function MessageLoading({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div style={loadingMessageStyles}>
+      <MessageIcon /> {children}
+    </div>
+  )
+}
+
+const MessageIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1.25rem"
+    height="1.25rem"
+    fill="currentColor"
+    stroke="currentColor"
+    strokeWidth={0}
+    aria-hidden="true"
+    viewBox="0 0 20 20"
+  >
+    <path
+      fillRule="evenodd"
+      stroke="none"
+      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM9 9a1 1 0 0 0 0 2v3a1 1 0 0 0 1 1h1a1 1 0 1 0 0-2v-3a1 1 0 0 0-1-1H9z"
+      clipRule="evenodd"
+    />
+  </svg>
+)

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -195,6 +195,7 @@ genSrcDir spec =
     [ genFileCopy [relfile|logo.png|],
       genFileCopy [relfile|utils.js|],
       genFileCopy [relfile|vite-env.d.ts|],
+      genFileCopy [relfile|components/Message.tsx|],
       getIndexTs spec
     ]
     <++> genAuth spec


### PR DESCRIPTION
Extract the `MessageLoading` and `MessageError` compnents from the `OAuthCallback` page since it can be useful elsewhere (like in the `createAuthRequiredComponent`.

|  ![Screenshot 2024-04-24 at 12 58 49](https://github.com/wasp-lang/wasp/assets/2223680/ac017b7a-687d-4d41-91ef-260c39e5f40e) |
| --- |
| `MessageError` |


|![Screenshot 2024-04-24 at 13 00 10](https://github.com/wasp-lang/wasp/assets/2223680/025c74a7-acb8-4e2a-8149-bcdd53b64bcc)|
| --- |
| `MessageLoading` |
