### PR TITLE
Hide Prisma update message

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -67,6 +67,7 @@ These changes only apply to getting auth fields from the `user` object you recei
 ### 🔧 Small improvements
 
 - Improved the default loading spinner while waiting for the user to be fetched.
+- Hides Prisma update message to avoid confusion since users can't need to update Prisma by themselves.
 
 ## 0.13.2 (2024-04-11)
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -67,7 +67,7 @@ These changes only apply to getting auth fields from the `user` object you recei
 ### 🔧 Small improvements
 
 - Improved the default loading spinner while waiting for the user to be fetched.
-- Hides Prisma update message to avoid confusion since users can't need to update Prisma by themselves.
+- Hides Prisma update message to avoid confusion since users shouldn't update Prisma by themselves.
 
 ## 0.13.2 (2024-04-11)
 

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -133,8 +133,10 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
       putStrLn $ "\nInternal Wasp error (bug in compiler):\n" ++ indent 2 (show e)
       exitFailure
 
--- | Sets environment variables that are visible to the commands run by the CLI.
+-- | Sets env variables that are visible to the commands run by the CLI.
 -- For example, we can use this to hide update messages by tools like Prisma.
+-- The env variables are visible to our CLI and any child processes spawned by it.
+-- The env variables won't be set in the terminal session after the CLI exits.
 setDefaultCliEnvVars :: IO ()
 setDefaultCliEnvVars = do
   mapM_ (uncurry Env.setEnv) cliEnvVars

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -8,6 +8,7 @@ import Data.Char (isSpace)
 import Data.List (intercalate)
 import Main.Utf8 (withUtf8)
 import System.Environment (getArgs)
+import qualified System.Environment as Env
 import System.Exit (exitFailure)
 import Wasp.Cli.Command (runCommand)
 import Wasp.Cli.Command.BashCompletion (bashCompletion, generateBashCompletionScript, printBashCompletionInstruction)
@@ -80,6 +81,8 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
       exitFailure
     NodeVersion.VersionCheckSuccess -> pure ()
 
+  setDefaultCliEnvVars
+
   case commandCall of
     Command.Call.New newArgs -> runCommand $ createNewProject newArgs
     Command.Call.NewAi newAiArgs -> case newAiArgs of
@@ -129,6 +132,15 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
     handleInternalErrors e = do
       putStrLn $ "\nInternal Wasp error (bug in compiler):\n" ++ indent 2 (show e)
       exitFailure
+
+-- | Sets environment variables that are visible to the commands run by the CLI.
+-- For example, we can use this to hide update messages by tools like Prisma.
+setDefaultCliEnvVars :: IO ()
+setDefaultCliEnvVars = do
+  mapM_ (uncurry Env.setEnv) cliEnvVars
+  where
+    cliEnvVars :: [(String, String)]
+    cliEnvVars = [("PRISMA_HIDE_UPDATE_MESSAGE", "true")]
 
 {- ORMOLU_DISABLE -}
 printUsage :: IO ()

--- a/waspc/src/Wasp/Generator/DbGenerator/Jobs.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Jobs.hs
@@ -178,9 +178,12 @@ runPrismaCommandAsJobWithExtraEnv ::
   [String] ->
   J.Job
 runPrismaCommandAsJobWithExtraEnv fromDir envVars projectRootDir cmdArgs =
-  runNodeCommandAsJobWithExtraEnv envVars fromDir (absPrismaExecutableFp waspProjectDir) cmdArgs J.Db
+  runNodeCommandAsJobWithExtraEnv (defaultEnvVars ++ envVars) fromDir (absPrismaExecutableFp waspProjectDir) cmdArgs J.Db
   where
     waspProjectDir = projectRootDir </> waspProjectDirFromProjectRootDir
+    defaultEnvVars =
+      [ ("PRISMA_HIDE_UPDATE_MESSAGE", "true")
+      ]
 
 -- | NOTE: The expectation is that `npm install` was already executed
 -- such that we can use the locally installed package.

--- a/waspc/src/Wasp/Generator/DbGenerator/Jobs.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Jobs.hs
@@ -178,12 +178,9 @@ runPrismaCommandAsJobWithExtraEnv ::
   [String] ->
   J.Job
 runPrismaCommandAsJobWithExtraEnv fromDir envVars projectRootDir cmdArgs =
-  runNodeCommandAsJobWithExtraEnv (defaultEnvVars ++ envVars) fromDir (absPrismaExecutableFp waspProjectDir) cmdArgs J.Db
+  runNodeCommandAsJobWithExtraEnv envVars fromDir (absPrismaExecutableFp waspProjectDir) cmdArgs J.Db
   where
     waspProjectDir = projectRootDir </> waspProjectDirFromProjectRootDir
-    defaultEnvVars =
-      [ ("PRISMA_HIDE_UPDATE_MESSAGE", "true")
-      ]
 
 -- | NOTE: The expectation is that `npm install` was already executed
 -- such that we can use the locally installed package.


### PR DESCRIPTION
Closes #1777

When testing locally, it's necessary to clear the Prisma telemetry cache so it outputs the message each time instead of caching the response: https://www.npmjs.com/package/checkpoint-client#clearing-the-cache