### PR TITLE
Adds `"module"` to `tsconfig.json`

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -42,6 +42,9 @@ These changes improve code readability and lower the complexity of accessing use
 
 These changes only apply to getting auth fields from the `user` object you receive from Wasp, for example in the `authRequired` enabled pages or `context.user` on the server. If you are fetching the user and auth fields with your own queries, you _can_ keep using most of the helpers. Read more [about using the auth helpers](https://wasp-lang.dev/docs/auth/entities#including-the-user-with-other-entities).
 
+### 🐞 Bug fixes
+- Update the `tsconfig.json` to make sure IDEs don't underline `import.meta.env` when users use client env vars.
+
 ### 🔧 Small improvements
 
 - Improved the default loading spinner while waiting for the user to be fetched.

--- a/waspc/data/Cli/templates/skeleton/tsconfig.json
+++ b/waspc/data/Cli/templates/skeleton/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/tsconfig.json
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.

--- a/waspc/examples/crud-testing/tsconfig.json
+++ b/waspc/examples/crud-testing/tsconfig.json
@@ -5,6 +5,11 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    // We're bundling all code in the end so this is the most appropriate option,
+    // it's also important for autocomplete to work properly.
+    "moduleResolution": "bundler",
     // JSX support
     "jsx": "preserve",
     "strict": true,

--- a/waspc/examples/pg-vector-example/tsconfig.json
+++ b/waspc/examples/pg-vector-example/tsconfig.json
@@ -5,6 +5,11 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    // We're bundling all code in the end so this is the most appropriate option,
+    // it's also important for autocomplete to work properly.
+    "moduleResolution": "bundler",
     // JSX support
     "jsx": "preserve",
     "strict": true,

--- a/waspc/examples/todo-typescript/tsconfig.json
+++ b/waspc/examples/todo-typescript/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.

--- a/waspc/examples/todoApp/tsconfig.json
+++ b/waspc/examples/todoApp/tsconfig.json
@@ -5,6 +5,7 @@
 // compiler. Proper TS compiler configuration in Wasp is coming soon :)
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "esnext",
     // We're bundling all code in the end so this is the most appropriate option,
     // it's also important for autocomplete to work properly.
@@ -20,19 +21,21 @@
       "esnext"
     ],
     "allowJs": true,
-    "types": [
+    "typeRoots": [
       // This is needed to properly support Vitest testing with jest-dom matchers.
       // Types for jest-dom are not recognized automatically and Typescript complains
       // about missing types e.g. when using `toBeInTheDocument` and other matchers.
-      "@testing-library/jest-dom"
+      "node_modules/@testing-library",
+      // Specifying type roots overrides the default behavior of looking at the
+      // node_modules/@types folder so we had to list it explicitly.
+      // Source 1: https://www.typescriptlang.org/tsconfig#typeRoots 
+      // Source 2: https://github.com/testing-library/jest-dom/issues/546#issuecomment-1889884843
+      "node_modules/@types"
     ],
     // Since this TS config is used only for IDE support and not for
     // compilation, the following directory doesn't exist. We need to specify
     // it to prevent this error:
     // https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
-    "outDir": "phantom",
-  },
-  "exclude": [
-    "phantom"
-  ],
+    "outDir": ".wasp/phantom"
+  }
 }


### PR DESCRIPTION
Closes #1989 

**Investigation:** Default `tsconfig.json` that Vite uses includes a `"module"` option, while our setup _does not_. This has been the case since the Wasp version 0.9.0 (when we introduced Vite and `import.meta.env` replaced `process.env`)! 

If we don't put a `module` value, Typescript uses an implicit default:
```
Default:
CommonJS if "target" is ES3 or ES5; 
ES6/ES2015 otherwise.
```
Since our target is `esnext`, the implicit default is `ES6`. 
We can't use use `import.meta` with `module` set to ES6, since it's too low and Typescript complains. We need  to put some value explicitly which is _at least_ ES2020, so we put `esnext` to match our target.

### Left to do
- [x] Update Changelog
- [ ] Update all other starters
  - [x] OpenSaaS https://github.com/wasp-lang/open-saas/commit/8a4eb95ebeb58c8e7fac458ddf79a1da6336f801
  - [x] todo-ts https://github.com/wasp-lang/starters/commit/21eb0d0bfade8c6f72d5b410dc4060d1a96e493e
  - [x] embeddings https://github.com/wasp-lang/starters/commit/21eb0d0bfade8c6f72d5b410dc4060d1a96e493e
  - [ ] Mage (we'd need to update Mage to use latest Wasp compiler version anyways, so I won't do it now)