### PR TITLE
Fixes the default `netlify.toml` in the built web app

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -62,7 +62,9 @@ These changes improve code readability and lower the complexity of accessing use
 These changes only apply to getting auth fields from the `user` object you receive from Wasp, for example in the `authRequired` enabled pages or `context.user` on the server. If you are fetching the user and auth fields with your own queries, you _can_ keep using most of the helpers. Read more [about using the auth helpers](https://wasp-lang.dev/docs/auth/entities#including-the-user-with-other-entities).
 
 ### 🐞 Bug fixes
+
 - Update the `tsconfig.json` to make sure IDEs don't underline `import.meta.env` when users use client env vars.
+- Fixes the `netlify.toml` to include the correct build path for the client app.
 
 ### 🔧 Small improvements
 

--- a/waspc/data/Generator/templates/react-app/netlify.toml
+++ b/waspc/data/Generator/templates/react-app/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  publish = "build/"
+  publish = ".wasp/build/web-app/build/"
 
 [[redirects]]
   from = "/*"

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -515,7 +515,7 @@
             "file",
             "web-app/netlify.toml"
         ],
-        "854009c7d1b2630a55099439f89e4947188ea4160c9d1388b46b5a5cf6ab461a"
+        "56ab3a5a45f041facffdebef3f0eeddcbddbeb67a9fc62dc8a2924e92d73a715"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/netlify.toml
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  publish = "build/"
+  publish = ".wasp/build/web-app/build/"
 
 [[redirects]]
   from = "/*"

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -529,7 +529,7 @@
             "file",
             "web-app/netlify.toml"
         ],
-        "854009c7d1b2630a55099439f89e4947188ea4160c9d1388b46b5a5cf6ab461a"
+        "56ab3a5a45f041facffdebef3f0eeddcbddbeb67a9fc62dc8a2924e92d73a715"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/netlify.toml
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  publish = "build/"
+  publish = ".wasp/build/web-app/build/"
 
 [[redirects]]
   from = "/*"

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -1103,7 +1103,7 @@
             "file",
             "web-app/netlify.toml"
         ],
-        "854009c7d1b2630a55099439f89e4947188ea4160c9d1388b46b5a5cf6ab461a"
+        "56ab3a5a45f041facffdebef3f0eeddcbddbeb67a9fc62dc8a2924e92d73a715"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/netlify.toml
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  publish = "build/"
+  publish = ".wasp/build/web-app/build/"
 
 [[redirects]]
   from = "/*"

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -599,7 +599,7 @@
             "file",
             "web-app/netlify.toml"
         ],
-        "854009c7d1b2630a55099439f89e4947188ea4160c9d1388b46b5a5cf6ab461a"
+        "56ab3a5a45f041facffdebef3f0eeddcbddbeb67a9fc62dc8a2924e92d73a715"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/netlify.toml
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  publish = "build/"
+  publish = ".wasp/build/web-app/build/"
 
 [[redirects]]
   from = "/*"

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -529,7 +529,7 @@
             "file",
             "web-app/netlify.toml"
         ],
-        "854009c7d1b2630a55099439f89e4947188ea4160c9d1388b46b5a5cf6ab461a"
+        "56ab3a5a45f041facffdebef3f0eeddcbddbeb67a9fc62dc8a2924e92d73a715"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/netlify.toml
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  publish = "build/"
+  publish = ".wasp/build/web-app/build/"
 
 [[redirects]]
   from = "/*"

--- a/web/docs/advanced/deployment/manually.md
+++ b/web/docs/advanced/deployment/manually.md
@@ -258,7 +258,7 @@ Carefully follow the instructions i.e. do you want to create a new app or use an
 The final step is to run:
 
 ```shell
-netlify deploy --prod`
+netlify deploy --prod
 ```
 
 That is it! Your client should be live at `https://<app-name>.netlify.app` ✨

--- a/web/versioned_docs/version-0.11.8/advanced/deployment/manually.md
+++ b/web/versioned_docs/version-0.11.8/advanced/deployment/manually.md
@@ -231,7 +231,7 @@ Carefully follow the instructions i.e. do you want to create a new app or use an
 The final step is to run:
 
 ```shell
-netlify deploy --prod`
+netlify deploy --prod
 ```
 
 That is it! Your client should be live at `https://<app-name>.netlify.app` ✨

--- a/web/versioned_docs/version-0.12.0/advanced/deployment/manually.md
+++ b/web/versioned_docs/version-0.12.0/advanced/deployment/manually.md
@@ -252,7 +252,7 @@ Carefully follow the instructions i.e. do you want to create a new app or use an
 The final step is to run:
 
 ```shell
-netlify deploy --prod`
+netlify deploy --prod
 ```
 
 That is it! Your client should be live at `https://<app-name>.netlify.app` ✨

--- a/web/versioned_docs/version-0.13.0/advanced/deployment/manually.md
+++ b/web/versioned_docs/version-0.13.0/advanced/deployment/manually.md
@@ -258,7 +258,7 @@ Carefully follow the instructions i.e. do you want to create a new app or use an
 The final step is to run:
 
 ```shell
-netlify deploy --prod`
+netlify deploy --prod
 ```
 
 That is it! Your client should be live at `https://<app-name>.netlify.app` ✨


### PR DESCRIPTION
Closes #1948 
Closes #1999 

I've deployed the server and the DB to Fly and the client to Netlify: https://famous-centaur-b5b687.netlify.app

Following the deployment docs on manually deploying to Netlify (+ the fix from this PR) results in a properly deployed client to Netlify - no need to update the docs ✅ 

I've also fixed some weird formatting in the docs, minor stuff.