### PR TITLE
Add replyTo field to SendGrid provider and Email type

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.3 (TBD)
+
+### 🎉 New features
+
+- Wasp now supports the replyTo field in the emailSender.send method. This field allows you to specify the email address to which the recipient can reply to. This feature is only available for the SendGrid provider.
+
 ## 0.13.2 (2024-04-11)
 
 ### 🐞 Bug fixes

--- a/waspc/data/Generator/templates/sdk/wasp/server/email/core/providers/sendgrid.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/email/core/providers/sendgrid.ts
@@ -4,7 +4,7 @@ import type { SendGridProvider, EmailSender } from "../types";
 
 // PRIVATE API
 export function initSendGridEmailSender(
-  provider: SendGridProvider
+    provider: SendGridProvider
 ): EmailSender {
   SendGrid.setApiKey(provider.apiKey);
 
@@ -18,6 +18,7 @@ export function initSendGridEmailSender(
           email: fromField.email,
           name: fromField.name,
         },
+        replyTo: email.replyTo,
         to: email.to,
         subject: email.subject,
         text: email.text,

--- a/waspc/data/Generator/templates/sdk/wasp/server/email/core/types.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/email/core/types.ts
@@ -45,6 +45,7 @@ export type Email = {
   {=^ isDefaultFromFieldDefined =}
   from: EmailFromField;
   {=/ isDefaultFromFieldDefined =}
+  replyTo?: string;
   to: string;
   subject: string;
   text: string;

--- a/web/docs/advanced/email/email.md
+++ b/web/docs/advanced/email/email.md
@@ -384,6 +384,10 @@ The `send` method accepts an object with the following fields:
 
     The email address of the sender.
 
+- `replyTo?: string`
+
+  The email address to which the recipient can reply to. Only available for SendGrid provider.
+
 - `to: string` <Required />
 
   The recipient's email address.


### PR DESCRIPTION
### Description

This PR introduces the following changes: 

Add optional replyTo field to Email type (commit 7ddc0345dc6a7d26679779c50dc36483ba333695): This commit adds a new optional field replyTo to the Email type. This allows for specifying a different email address that recipients will reply to.

Add optional replyTo field to SendGrid provider (commit adae95b7afbdbbb73095b713d78c49376a8d82d7): This commit extends the SendGrid provider to support the new replyTo field. If provided, the SendGrid provider will use this field as the reply-to address in the emails it sends.  

Document replyTo field for SendGrid provider (commit 1120faee609f8c10886abf22d259e4b58046f243): This commit adds documentation for the new replyTo field in the SendGrid provider. This helps to ensure that the usage of this new field is clear to other developers.  

These changes provide more flexibility in handling replies to emails sent by the application since without the replyTo field set, replying to an E-Mail sent by SendGrid will result in a `550 Mailbox not found`.

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change). 
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [x] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [x] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
