### PR TITLE
Upon signup with email, we now warn about email in terminal in Dummy email provider is used.

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
@@ -166,7 +166,12 @@ export const LoginSignupForm = ({
     onError: onErrorHandler,
     showEmailVerificationPending() {
       hookForm.reset()
-      setSuccessMessage(`You've signed up successfully! Check your email for the confirmation link.`)
+      setSuccessMessage(
+        `You've signed up successfully! Check your email for the confirmation link.`
+        {=# isEmailSenderProviderSetToDummy =}
+        + ` (NOTE(DEV): Your Wasp app is using Dummy email provider, which doesn't really send emails: instead, check server logs in the terminal for the email)`
+        {=/ isEmailSenderProviderSetToDummy =}
+      )
     },
     onLoginSuccess() {
       history.push('{= onAuthSucceededRedirectTo =}')

--- a/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
@@ -39,7 +39,7 @@ genAuth spec =
             genFileCopy [relfile|auth/logout.ts|],
             genUseAuth auth
           ]
-        <++> genAuthForms auth
+        <++> genAuthForms app auth
         <++> genLocalAuth auth
         <++> genOAuthAuth auth
         <++> genEmailAuth auth
@@ -56,7 +56,8 @@ genAuth spec =
           ]
         <++> genIndexTs auth
   where
-    maybeAuth = AS.App.auth $ snd $ getApp spec
+    app = snd $ getApp spec
+    maybeAuth = AS.App.auth app
     genFileCopy = return . C.mkTmplFd
 
 -- | Generates React hook that Wasp developer can use in a component to get


### PR DESCRIPTION
This PR was inspired as a possible solution to https://github.com/wasp-lang/open-saas/issues/137  -> give it a read, it is important for the context.

Result is this, upon successful signup:

![image](https://github.com/wasp-lang/wasp/assets/1536647/891f20a9-38ed-4e5c-bc0e-bbe8c7c8c3bd)

I could have added the same thing for other email auth forms (password reset, ...) but felt that might be a bit much.

I am not even sure about this. It seems to me like it will help people on the happy path, when they are creating their first account, and can't find that email in the email. Solution can also be just making it clearer in the docs, putting warnings about it in the right place, and that might be enough. For example, once they are ready to start doing something with their open-saas app, we can mention in the guide that Dummy provider is used and they will not receive emails.

But I wanted to try this. At the end, this is the best way to inform the dev.

The problem is, there are other situations where Dummy provider might surprise them, e.g. if job is sneidng email or something. And we have no warning in that case. We just can't in every case inform them about this. Nor should we , it would be annoying. So I though ok, this is "entry point" and likely if they will get confused, it will happen here, so we can teach them here.

I am ok with dropping this PR if we conclude it is more harm then good, but if others like it, we can merge it.