### PR TITLE
Made sidebar in docs nicer while also adding link to examples.

### DIFF
--- a/web/docs/tutorial/07-auth.md
+++ b/web/docs/tutorial/07-auth.md
@@ -535,8 +535,9 @@ You should be ready to learn about more complicated features and go more in-dept
 
 Looking for inspiration?
 
-- Get a jump start on your next project with [Starter Templates](../project/starter-templates)
-- Make a real-time app with [Web Sockets](../advanced/web-sockets)
+- Get a jump start on your next project with [Starter Templates](../project/starter-templates).
+- Check out our [official examples](https://github.com/wasp-lang/wasp/tree/release/examples).
+- Make a real-time app with [Web Sockets](../advanced/web-sockets).
 
 :::note
 If you notice that some of the features you'd like to have are missing, or have any other kind of feedback, please write to us on [Discord](https://discord.gg/rzdnErX) or create an issue on [Github](https://github.com/wasp-lang/wasp), so we can learn which features to add/improve next 🙏

--- a/web/sidebars.js
+++ b/web/sidebars.js
@@ -14,7 +14,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Tutorial',
-      collapsed: true,
+      collapsed: false,
       collapsible: true,
       items: [
         'tutorial/create',
@@ -34,7 +34,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Data Model',
-      collapsed: true,
+      collapsed: false,
       collapsible: true,
       items: [
         'data-model/entities',
@@ -55,7 +55,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Authentication',
-      collapsed: true,
+      collapsed: false,
       collapsible: true,
       items: [
         'auth/overview',
@@ -79,7 +79,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Project Setup',
-      collapsed: true,
+      collapsed: false,
       collapsible: true,
       items: [
         'project/starter-templates',
@@ -97,14 +97,14 @@ module.exports = {
     {
       type: 'category',
       label: 'Wasp AI',
-      collapsed: true,
+      collapsed: false,
       collapsible: true,
       items: ['wasp-ai/creating-new-app', 'wasp-ai/developing-existing-app'],
     },
     {
       type: 'category',
       label: 'Advanced Features',
-      collapsed: true,
+      collapsed: false,
       collapsible: true,
       items: [
         {
@@ -129,14 +129,14 @@ module.exports = {
     {
       type: 'category',
       label: 'General',
-      collapsed: true,
+      collapsed: false,
       collapsible: true,
       items: ['general/language', 'general/cli'],
     },
     {
       type: 'category',
       label: 'Miscellaneous',
-      collapsed: true,
+      collapsed: false,
       collapsible: true,
       items: [
         'contributing',

--- a/web/sidebars.js
+++ b/web/sidebars.js
@@ -4,7 +4,7 @@ module.exports = {
       type: 'category',
       label: 'Getting Started',
       collapsed: false,
-      collapsible: false,
+      collapsible: true,
       items: [
         'introduction/introduction',
         'introduction/quick-start',
@@ -14,8 +14,8 @@ module.exports = {
     {
       type: 'category',
       label: 'Tutorial',
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       items: [
         'tutorial/create',
         'tutorial/project-structure',
@@ -27,10 +27,15 @@ module.exports = {
       ],
     },
     {
+      type: 'link',
+      label: 'Examples',
+      href: 'https://github.com/wasp-lang/wasp/tree/release/examples'
+    },
+    {
       type: 'category',
       label: 'Data Model',
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       items: [
         'data-model/entities',
         {
@@ -50,8 +55,8 @@ module.exports = {
     {
       type: 'category',
       label: 'Authentication',
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       items: [
         'auth/overview',
         'auth/ui',
@@ -74,8 +79,8 @@ module.exports = {
     {
       type: 'category',
       label: 'Project Setup',
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       items: [
         'project/starter-templates',
         'project/customizing-app',
@@ -92,15 +97,15 @@ module.exports = {
     {
       type: 'category',
       label: 'Wasp AI',
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       items: ['wasp-ai/creating-new-app', 'wasp-ai/developing-existing-app'],
     },
     {
       type: 'category',
       label: 'Advanced Features',
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       items: [
         {
           type: 'category',
@@ -124,15 +129,15 @@ module.exports = {
     {
       type: 'category',
       label: 'General',
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       items: ['general/language', 'general/cli'],
     },
     {
       type: 'category',
       label: 'Miscellaneous',
-      collapsed: false,
-      collapsible: false,
+      collapsed: true,
+      collapsible: true,
       items: [
         'contributing',
         'telemetry',

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -86,8 +86,8 @@
 
   /* Docs */
   --ifm-menu-color: var(--ifm-color-gray-800);
-  --sidebar-category-color: var(--ifm-color-gray-600);
-  --sidebar-category-spacing: 2em;
+  --sidebar-item-level-1-color: var(--ifm-color-primary);
+  --sidebar-item-level-1-spacing: 1em;
 }
 
 :root[data-theme='dark'] {
@@ -116,21 +116,18 @@
   opacity: 0.7;
 }
 
-.theme-doc-sidebar-item-category-level-1 {
-  margin-bottom: var(--sidebar-category-spacing);
+.theme-doc-sidebar-item-category-level-1,.theme-doc-sidebar-item-link-level-1 {
+  margin-bottom: var(--sidebar-item-level-1-spacing);
 }
 
-.theme-doc-sidebar-item-category-level-1 > .menu__list {
-  /* remove indentation from 1st level categories */
-  padding-left: 0;
-}
-
-.theme-doc-sidebar-item-category-level-1
-  > .menu__list-item-collapsible
-  > .menu__link {
-  color: var(--sidebar-category-color);
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-link-level-1 > .menu__link {
+  color: var(--sidebar-item-level-1-color);
   font-weight: bold;
-  font-size: var(--ifm-h6-font-size);
+}
+
+.theme-doc-sidebar-item-category > .menu__list-item-collapsible > .menu__link {
+  color: var(--sidebar-item-level-1-color);
 }
 
 /******** DOCS NAVBAR *********/

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -126,10 +126,6 @@
   font-weight: bold;
 }
 
-.theme-doc-sidebar-item-category > .menu__list-item-collapsible > .menu__link {
-  color: var(--sidebar-item-level-1-color);
-}
-
 /******** DOCS NAVBAR *********/
 
 /* This hides Docs version dropdown when not on docs (i.e. when we are on blog). */


### PR DESCRIPTION
Main thing I wanted to do was add Examples link to the top level.
But to do that, I have to update the styling to be more uniform as it didn't account for having non-category stuff at top level.

This is what it looked like before this PR:

![image](https://github.com/wasp-lang/wasp/assets/1536647/3a56feac-94f7-49d2-bd1e-078684d9186e)


This is what it looks like now with this PR (notice also additional Examples link in the sidebar at the top level):

![image](https://github.com/wasp-lang/wasp/assets/1536647/642db35e-2123-417b-89fa-e8c53519f65a)

Closes #2009 .