### PR TITLE
Extracted deployment to top lvl of docs sidebar.

### DIFF
--- a/web/sidebars.js
+++ b/web/sidebars.js
@@ -102,16 +102,6 @@ module.exports = {
       collapsed: false,
       collapsible: false,
       items: [
-        {
-          type: 'category',
-          label: 'Deployment',
-          collapsed: true,
-          items: [
-            'advanced/deployment/overview',
-            'advanced/deployment/cli',
-            'advanced/deployment/manually',
-          ],
-        },
         'advanced/email/email',
         'advanced/jobs',
         'advanced/web-sockets',
@@ -119,6 +109,17 @@ module.exports = {
         'advanced/apis',
         'advanced/middleware-config',
         'advanced/links',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Deployment',
+      collapsed: false,
+      collapsible: false,
+      items: [
+        'advanced/deployment/overview',
+        'advanced/deployment/cli',
+        'advanced/deployment/manually',
       ],
     },
     {


### PR DESCRIPTION
Didn't make sense to have it under Advanced/, it is the only part that has another level and it deserves its own section. Also, people should be able to easily see where the deployment part of docs are not dig for it under Advanced. This will make even more sense / look better with changes from #2068 due to styling improvements.