### PR TITLE
Improved default gitignore regarding .env rules.

### DIFF
--- a/examples/hackathon-submissions/.gitignore
+++ b/examples/hackathon-submissions/.gitignore
@@ -1,18 +1,16 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
-/.wasp/
-/.env.server
-/.env.client
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example
+
 # Local Netlify folder
 .netlify

--- a/examples/streaming/.gitignore
+++ b/examples/streaming/.gitignore
@@ -1,13 +1,14 @@
 .wasp/
+
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dot-env files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/examples/streaming/.gitignore
+++ b/examples/streaming/.gitignore
@@ -1,8 +1,7 @@
 .wasp/
-
 node_modules/
 
-# We by default ignore any dot-env files to avoid committing any secrets by accident.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
 .env

--- a/examples/thoughts/.gitignore
+++ b/examples/thoughts/.gitignore
@@ -1,13 +1,14 @@
 .wasp/
+
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dot-env files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/examples/thoughts/.gitignore
+++ b/examples/thoughts/.gitignore
@@ -1,8 +1,7 @@
 .wasp/
-
 node_modules/
 
-# We by default ignore any dot-env files to avoid committing any secrets by accident.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
 .env

--- a/examples/todo-typescript/.gitignore
+++ b/examples/todo-typescript/.gitignore
@@ -1,13 +1,14 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example
+

--- a/examples/tutorials/TodoApp/.gitignore
+++ b/examples/tutorials/TodoApp/.gitignore
@@ -1,13 +1,14 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example
+

--- a/examples/tutorials/TodoAppTs/.gitignore
+++ b/examples/tutorials/TodoAppTs/.gitignore
@@ -1,13 +1,13 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/examples/waspello/.gitignore
+++ b/examples/waspello/.gitignore
@@ -1,16 +1,13 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
-/.wasp/
-/.env.server
-/.env.client
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/examples/waspleau/.gitignore
+++ b/examples/waspleau/.gitignore
@@ -1,17 +1,13 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
-/.wasp/
-/.env.server
-/.env.client
-.DS_Store
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/examples/websockets-realtime-voting/.gitignore
+++ b/examples/websockets-realtime-voting/.gitignore
@@ -1,13 +1,13 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -81,6 +81,7 @@ These changes only apply to getting auth fields from the `user` object you recei
 - Improved the default loading spinner while waiting for the user to be fetched.
 - Hides Prisma update message to avoid confusion since users shouldn't update Prisma by themselves.
 - When an unknown OAuth error happens, Wasp now logs the error on the server to help with debugging.
+- Improved default gitignore to more tightly target dotenv files and to allow for example dotenv files and .env.client.
 
 ## 0.13.2 (2024-04-11)
 

--- a/waspc/data/Cli/templates/skeleton/.gitignore
+++ b/waspc/data/Cli/templates/skeleton/.gitignore
@@ -1,13 +1,14 @@
 .wasp/
+
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dot-env files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/waspc/data/Cli/templates/skeleton/.gitignore
+++ b/waspc/data/Cli/templates/skeleton/.gitignore
@@ -1,8 +1,7 @@
 .wasp/
-
 node_modules/
 
-# We by default ignore any dot-env files to avoid committing any secrets by accident.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
 .env

--- a/waspc/examples/crud-testing/.gitignore
+++ b/waspc/examples/crud-testing/.gitignore
@@ -1,16 +1,13 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
-/.wasp/
-/.env.server
-/.env.client
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/waspc/examples/pg-vector-example/.gitignore
+++ b/waspc/examples/pg-vector-example/.gitignore
@@ -1,14 +1,13 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
-/.wasp/
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/waspc/examples/todo-typescript/.gitignore
+++ b/waspc/examples/todo-typescript/.gitignore
@@ -1,13 +1,13 @@
 .wasp/
 node_modules/
-**/.DS_Store
 
-# We ignore env files recognized and used by Wasp.
-.env.server
-.env.client
-
-# To be extra safe, we by default ignore any files with `.env` extension in them.
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/waspc/examples/todoApp/.gitignore
+++ b/waspc/examples/todoApp/.gitignore
@@ -1,4 +1,13 @@
-/.wasp/
-/.env.server
-/.env.client
-/node_modules
+.wasp/
+node_modules/
+
+# We by default ignore any dotenv files to avoid committing any secrets by accident.
+# If this is too agressive for you, consider allowing specific files with `!` operator,
+# or modify/delete these two lines.
+.env
+.env.*
+# Don't ignore .env.client as it can't contain any secrets.
+!.env.client
+# Don't ignore example env files.
+!.env.example
+!.env.*.example

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -88,7 +88,9 @@ In the root of your Wasp project you can create two distinct files:
 `.env.server` should not be committed to version control as it can contain secrets and is therefore by default already ignored in the `.gitignore` file that comes with a new Wasp app.
 On the other hand, `.env.client` can be committed as it must not contain any secrets.
 
-<!-- `dotenv` files are a popular method for storing configuration: to learn more about them in general, check out the [dotenv npm package](https://www.npmjs.com/package/dotenv). -->
+:::info Dotenv files
+  `dotenv` files are a popular method for storing configuration: to learn more about them in general, check out the [dotenv npm package](https://www.npmjs.com/package/dotenv).
+:::
 
 ### 2. Using Shell
 If you set environment variables in the shell where you run your Wasp commands (e.g., `wasp start`), Wasp will recognize them.

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -85,9 +85,10 @@ In the root of your Wasp project you can create two distinct files:
     REACT_APP_SOME_VAR_NAME=somevalue
     ```
 
-These files should not be committed to version control, and they are already ignored by default in the `.gitignore` file that comes with Wasp.
+`.env.server` should not be committed to version control as it can contain secrets and is therefore by default already ignored in the `.gitignore` file that comes with a new Wasp app.
+On the other hand, `.env.client` can be commited as it must not contain any secrets.
 
-<!-- `dotenv` files are a popular method for storing configuration: to learn more about them in general, check out the [README of the lib we use for them](https://github.com/stackbuilders/dotenv-hs). -->
+<!-- `dotenv` files are a popular method for storing configuration: to learn more about them in general, check out the [dotenv npm package](https://www.npmjs.com/package/dotenv). -->
 
 ### 2. Using Shell
 If you set environment variables in the shell where you run your Wasp commands (e.g., `wasp start`), Wasp will recognize them.

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -86,7 +86,7 @@ In the root of your Wasp project you can create two distinct files:
     ```
 
 `.env.server` should not be committed to version control as it can contain secrets and is therefore by default already ignored in the `.gitignore` file that comes with a new Wasp app.
-On the other hand, `.env.client` can be commited as it must not contain any secrets.
+On the other hand, `.env.client` can be committed as it must not contain any secrets.
 
 <!-- `dotenv` files are a popular method for storing configuration: to learn more about them in general, check out the [dotenv npm package](https://www.npmjs.com/package/dotenv). -->
 


### PR DESCRIPTION
Inspired by and solves this PR https://github.com/wasp-lang/wasp/pull/1678 and some dotenv reading lately, I improved our default Wasp gitignore to have better rules for dotenv files.

Now it doesn't ignore .env.client.example and .env.server.example and any other dotenv example files.
Also, it doesn't ignore .env.client any more, because there is no need -> no secrets are anyway allowed in that file, and it can be committed to version control.
Finally, I relaxed ignoring of all dotenv files a bit -> it is enough to ignore those with .env prefix, not all that contain .env. anywhere inside of them, that was a bit too aggressive I think.

I also updated the docs with info on .env.client, explaining it can be versioned. 

Pls let me know if this is ok, if so, I will proceed updating all the example apps with this and then merging.

TODO:
- [x] Update all the example apps! OpenSaas also.
- [x] Add to ChangeLog