### PR TITLE
Again updated default .gitignore: removed !.env.client.

### DIFF
--- a/examples/hackathon-submissions/.gitignore
+++ b/examples/hackathon-submissions/.gitignore
@@ -1,14 +1,12 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example
 

--- a/examples/streaming/.gitignore
+++ b/examples/streaming/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/examples/thoughts/.gitignore
+++ b/examples/thoughts/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/examples/todo-typescript/.gitignore
+++ b/examples/todo-typescript/.gitignore
@@ -1,14 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example
-

--- a/examples/tutorials/TodoApp/.gitignore
+++ b/examples/tutorials/TodoApp/.gitignore
@@ -1,14 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example
-

--- a/examples/tutorials/TodoAppTs/.gitignore
+++ b/examples/tutorials/TodoAppTs/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/examples/waspello/.gitignore
+++ b/examples/waspello/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/examples/waspleau/.gitignore
+++ b/examples/waspleau/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/examples/websockets-realtime-voting/.gitignore
+++ b/examples/websockets-realtime-voting/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/waspc/data/Cli/templates/skeleton/.gitignore
+++ b/waspc/data/Cli/templates/skeleton/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/waspc/examples/crud-testing/.gitignore
+++ b/waspc/examples/crud-testing/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/waspc/examples/pg-vector-example/.gitignore
+++ b/waspc/examples/pg-vector-example/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/waspc/examples/todo-typescript/.gitignore
+++ b/waspc/examples/todo-typescript/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/waspc/examples/todoApp/.gitignore
+++ b/waspc/examples/todoApp/.gitignore
@@ -1,13 +1,11 @@
 .wasp/
 node_modules/
 
-# We by default ignore any dotenv files to avoid committing any secrets by accident.
-# If this is too agressive for you, consider allowing specific files with `!` operator,
-# or modify/delete these two lines.
+# Ignore all dotenv files by default to prevent accidentally committing any secrets.
+# To include specific dotenv files, use the `!` operator or adjust these rules.
 .env
 .env.*
-# Don't ignore .env.client as it can't contain any secrets.
-!.env.client
-# Don't ignore example env files.
+
+# Don't ignore example dotenv files.
 !.env.example
 !.env.*.example

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -85,7 +85,7 @@ In the root of your Wasp project you can create two distinct files:
     REACT_APP_SOME_VAR_NAME=somevalue
     ```
 
-`.env.server` should not be committed to version control as it can contain secrets, while `.env.server` can be versioned as it must not contain any secrets.
+`.env.server` should not be committed to version control as it can contain secrets, while `.env.client` can be versioned as it must not contain any secrets.
 By default, in the `.gitignore` file that comes with a new Wasp app, we ignore all dotenv files.
 
 :::info Dotenv files

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -85,8 +85,8 @@ In the root of your Wasp project you can create two distinct files:
     REACT_APP_SOME_VAR_NAME=somevalue
     ```
 
-`.env.server` should not be committed to version control as it can contain secrets and is therefore by default already ignored in the `.gitignore` file that comes with a new Wasp app.
-On the other hand, `.env.client` can be committed as it must not contain any secrets.
+`.env.server` should not be committed to version control as it can contain secrets, while `.env.server` can be versioned as it must not contain any secrets.
+By default, in the `.gitignore` file that comes with a new Wasp app, we ignore all dotenv files.
 
 :::info Dotenv files
   `dotenv` files are a popular method for storing configuration: to learn more about them in general, check out the [dotenv npm package](https://www.npmjs.com/package/dotenv).


### PR DESCRIPTION
Follow up on https://github.com/wasp-lang/wasp/pull/2083 -> I realized after working on open-saas it is actually better to not by default include .env.client. We will instead in the future add a piece of the docs where we will tell them about the idea of versioning .env.client -> but that should be done as a separate thing, together with the idea of vault for storing .env.server and so on.

So, for now I removed `!.env.client` from default gitignore.