### PR TITLE
Updates e2e tests to match output of Typescript 5.5

### DIFF
--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/sdk/wasp/dist/server/types/index.d.ts
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/sdk/wasp/dist/server/types/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { type Application } from 'express';
 import { Server } from 'http';
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>;

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { type Application } from 'express';
 import { Server } from 'http';
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>;

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { type Application } from 'express';
 import { Server } from 'http';
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/Auth.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/Auth.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="react" />
 import { type State, type CustomizationOptions, type ErrorMessage, type AdditionalSignupFields } from './types';
 export declare const AuthContext: import("react").Context<{
     isLoading: boolean;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/Login.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/Login.d.ts
@@ -1,3 +1,2 @@
-/// <reference types="react" />
 import { type CustomizationOptions } from './types';
 export declare function LoginForm({ appearance, logo, socialLayout, }: CustomizationOptions): React.JSX.Element;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/Signup.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/Signup.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="react" />
 import { type CustomizationOptions, type AdditionalSignupFields } from './types';
 export declare function SignupForm({ appearance, logo, socialLayout, additionalFields, }: CustomizationOptions & {
     additionalFields?: AdditionalSignupFields;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/internal/common/LoginSignupForm.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/internal/common/LoginSignupForm.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="react" />
 import type { AdditionalSignupFields } from '../../types';
 export type LoginSignupFormFields = {
     [key: string]: string;
 };
 export declare const LoginSignupForm: ({ state, socialButtonsDirection, additionalSignupFields, }: {
-    state: 'login' | 'signup';
-    socialButtonsDirection?: 'horizontal' | 'vertical';
+    state: "login" | "signup";
+    socialButtonsDirection?: "horizontal" | "vertical";
     additionalSignupFields?: AdditionalSignupFields;
 }) => import("react").JSX.Element;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/internal/social/SocialIcons.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/internal/social/SocialIcons.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="react" />
 export declare const Google: () => import("react").JSX.Element;
 export declare const Keycloak: () => import("react").JSX.Element;
 export declare const GitHub: () => import("react").JSX.Element;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/types.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/forms/types.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="react" />
 import { createTheme } from '@stitches/react';
 import { UseFormReturn, RegisterOptions } from 'react-hook-form';
 import type { LoginSignupFormFields } from './internal/common/LoginSignupForm';

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/helpers/Google.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/helpers/Google.d.ts
@@ -1,3 +1,2 @@
-/// <reference types="react" />
 export declare const signInUrl: string;
 export declare function SignInButton(): React.JSX.Element;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/lucia.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/auth/lucia.d.ts
@@ -12,7 +12,7 @@ import { type User } from "wasp/entities";
  *    make fetching the User easier.
  */
 export declare const auth: Lucia<{}, {
-    userId: User['id'];
+    userId: User["id"];
 }>;
 declare module "lucia" {
     interface Register {

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/client/router/Link.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/client/router/Link.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="react" />
 import { Link as RouterLink } from 'react-router-dom';
 import { type Routes } from './index';
 type RouterLinkProps = Parameters<typeof RouterLink>[0];

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/core/stitches.config.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/core/stitches.config.d.ts
@@ -1,5 +1,4 @@
-/// <reference types="react" />
-export declare const styled: <Type extends import("@stitches/react/types/util").Function | keyof JSX.IntrinsicElements | import("react").ComponentType<any>, Composers extends (string | import("@stitches/react/types/util").Function | import("react").ComponentType<any> | {
+export declare const styled: <Type extends keyof JSX.IntrinsicElements | React.ComponentType<any> | import("@stitches/react/types/util").Function, Composers extends (string | React.ComponentType<any> | import("@stitches/react/types/util").Function | {
     [name: string]: unknown;
 })[], CSS = import("@stitches/react/types/css-util").CSS<{}, {
     colors: {
@@ -58,7 +57,7 @@ export declare const styled: <Type extends import("@stitches/react/types/util").
     fontSizes: {
         sm: string;
     };
-}, import("@stitches/react/types/config").DefaultThemeMap, {}>>, css: <Composers extends (string | import("@stitches/react/types/util").Function | import("react").ExoticComponent<any> | import("react").JSXElementConstructor<any> | {
+}, import("@stitches/react/types/config").DefaultThemeMap, {}>>, css: <Composers extends (string | React.ExoticComponent<any> | React.JSXElementConstructor<any> | import("@stitches/react/types/util").Function | {
     [name: string]: unknown;
 })[], CSS = import("@stitches/react/types/css-util").CSS<{}, {
     colors: {

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/jobs/mySpecialJob.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/jobs/mySpecialJob.d.ts
@@ -3,26 +3,26 @@ import { type JobFn } from 'wasp/server/jobs/core/pgBoss';
 declare const entities: {};
 export type MySpecialJob<Input extends JSONObject, Output extends JSONValue | void> = JobFn<Input, Output, typeof entities>;
 export declare const mySpecialJob: {
-    readonly defaultJobOptions: import("pg-boss").SendOptions;
-    readonly startAfter: string | number | Date;
+    readonly defaultJobOptions: Parameters<import("pg-boss")["send"]>[2];
+    readonly startAfter: number | string | Date;
     readonly entities: {};
     readonly jobSchedule: {
-        cron: string;
-        args: object;
-        options: import("pg-boss").ScheduleOptions;
-    };
-    delay(startAfter: string | number | Date): any;
-    submit(jobArgs: JSONObject, jobOptions?: import("pg-boss").SendOptions): Promise<{
+        cron: Parameters<import("pg-boss")["schedule"]>[1];
+        args: Parameters<import("pg-boss")["schedule"]>[2];
+        options: Parameters<import("pg-boss")["schedule"]>[3];
+    } | null;
+    delay(startAfter: number | string | Date): any;
+    submit(jobArgs: JSONObject, jobOptions?: Parameters<import("pg-boss")["send"]>[2]): Promise<{
         readonly pgBoss: {
-            readonly cancel: () => Promise<void>;
-            readonly resume: () => Promise<void>;
-            readonly details: () => Promise<Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
+            readonly cancel: () => ReturnType<import("pg-boss")["cancel"]>;
+            readonly resume: () => ReturnType<import("pg-boss")["resume"]>;
+            readonly details: () => Promise<(Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
                 data: JSONObject;
             } & ({
                 state: "failed";
                 output: object;
             } | {
-                state: "retry" | "created" | "active" | "expired" | "cancelled";
+                state: "created" | "retry" | "active" | "expired" | "cancelled";
                 output: null;
             } | {
                 state: "completed";
@@ -35,7 +35,7 @@ export declare const mySpecialJob: {
                 } | {
                     value: true;
                 };
-            })>;
+            })) | null>;
         };
         readonly job: import("./core/job").Job;
         readonly jobId: string;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/jobs/returnHelloJob.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/jobs/returnHelloJob.d.ts
@@ -5,28 +5,28 @@ declare const entities: {
 };
 export type ReturnHelloJob<Input extends JSONObject, Output extends JSONValue | void> = JobFn<Input, Output, typeof entities>;
 export declare const returnHelloJob: {
-    readonly defaultJobOptions: import("pg-boss").SendOptions;
-    readonly startAfter: string | number | Date;
+    readonly defaultJobOptions: Parameters<import("pg-boss")["send"]>[2];
+    readonly startAfter: number | string | Date;
     readonly entities: {
         User: import(".prisma/client").Prisma.UserDelegate<import(".prisma/client").Prisma.RejectOnNotFound | import(".prisma/client").Prisma.RejectPerOperation, import("@prisma/client/runtime").DefaultArgs>;
     };
     readonly jobSchedule: {
-        cron: string;
-        args: object;
-        options: import("pg-boss").ScheduleOptions;
-    };
-    delay(startAfter: string | number | Date): any;
-    submit(jobArgs: JSONObject, jobOptions?: import("pg-boss").SendOptions): Promise<{
+        cron: Parameters<import("pg-boss")["schedule"]>[1];
+        args: Parameters<import("pg-boss")["schedule"]>[2];
+        options: Parameters<import("pg-boss")["schedule"]>[3];
+    } | null;
+    delay(startAfter: number | string | Date): any;
+    submit(jobArgs: JSONObject, jobOptions?: Parameters<import("pg-boss")["send"]>[2]): Promise<{
         readonly pgBoss: {
-            readonly cancel: () => Promise<void>;
-            readonly resume: () => Promise<void>;
-            readonly details: () => Promise<Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
+            readonly cancel: () => ReturnType<import("pg-boss")["cancel"]>;
+            readonly resume: () => ReturnType<import("pg-boss")["resume"]>;
+            readonly details: () => Promise<(Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
                 data: JSONObject;
             } & ({
                 state: "failed";
                 output: object;
             } | {
-                state: "retry" | "created" | "active" | "expired" | "cancelled";
+                state: "created" | "retry" | "active" | "expired" | "cancelled";
                 output: null;
             } | {
                 state: "completed";
@@ -39,7 +39,7 @@ export declare const returnHelloJob: {
                 } | {
                     value: true;
                 };
-            })>;
+            })) | null>;
         };
         readonly job: import("./core/job").Job;
         readonly jobId: string;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { type Application } from 'express';
 import { Server } from 'http';
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>;

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/dist/server/jobs/mySpecialJob.d.ts
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/dist/server/jobs/mySpecialJob.d.ts
@@ -3,26 +3,26 @@ import { type JobFn } from 'wasp/server/jobs/core/pgBoss';
 declare const entities: {};
 export type MySpecialJob<Input extends JSONObject, Output extends JSONValue | void> = JobFn<Input, Output, typeof entities>;
 export declare const mySpecialJob: {
-    readonly defaultJobOptions: import("pg-boss").SendOptions;
-    readonly startAfter: string | number | Date;
+    readonly defaultJobOptions: Parameters<import("pg-boss")["send"]>[2];
+    readonly startAfter: number | string | Date;
     readonly entities: {};
     readonly jobSchedule: {
-        cron: string;
-        args: object;
-        options: import("pg-boss").ScheduleOptions;
-    };
-    delay(startAfter: string | number | Date): any;
-    submit(jobArgs: JSONObject, jobOptions?: import("pg-boss").SendOptions): Promise<{
+        cron: Parameters<import("pg-boss")["schedule"]>[1];
+        args: Parameters<import("pg-boss")["schedule"]>[2];
+        options: Parameters<import("pg-boss")["schedule"]>[3];
+    } | null;
+    delay(startAfter: number | string | Date): any;
+    submit(jobArgs: JSONObject, jobOptions?: Parameters<import("pg-boss")["send"]>[2]): Promise<{
         readonly pgBoss: {
-            readonly cancel: () => Promise<void>;
-            readonly resume: () => Promise<void>;
-            readonly details: () => Promise<Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
+            readonly cancel: () => ReturnType<import("pg-boss")["cancel"]>;
+            readonly resume: () => ReturnType<import("pg-boss")["resume"]>;
+            readonly details: () => Promise<(Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
                 data: JSONObject;
             } & ({
                 state: "failed";
                 output: object;
             } | {
-                state: "retry" | "created" | "active" | "expired" | "cancelled";
+                state: "created" | "retry" | "active" | "expired" | "cancelled";
                 output: null;
             } | {
                 state: "completed";
@@ -35,7 +35,7 @@ export declare const mySpecialJob: {
                 } | {
                     value: true;
                 };
-            })>;
+            })) | null>;
         };
         readonly job: import("./core/job").Job;
         readonly jobId: string;

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { type Application } from 'express';
 import { Server } from 'http';
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>;

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/sdk/wasp/dist/server/types/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { type Application } from 'express';
 import { Server } from 'http';
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>;


### PR DESCRIPTION
Typescript 5.5 [just shipped](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/) and it [changed a bit](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#simplified-reference-directive-declaration-emit) how they create the declaration files (`d.ts`).

This caused our e2e tests to change and the CI will fail in the future for everyone if we don't update them.