### PR TITLE
Add instructions for accessing the dev database

### DIFF
--- a/web/docs/data-model/backends.md
+++ b/web/docs/data-model/backends.md
@@ -73,9 +73,9 @@ Also, make sure that:
 - You have [Docker installed](https://www.docker.com/get-started/) and in `PATH`.
 - The port `5432` isn't taken.
 
-### Accessing the Dev Database
-
-In case you might want to connect to the dev database through the CLI or using external tools like [pgAdmin](https://www.pgadmin.org/), the credentials are printed in the console when you run `wasp db start`.
+:::tip
+In case you might want to connect to the dev database through the external tool like `psql` or [pgAdmin](https://www.pgadmin.org/), the credentials are printed in the console when you run `wasp db start`, at the very beginning.
+:::
 
 ### Connecting to an existing database
 

--- a/web/docs/data-model/backends.md
+++ b/web/docs/data-model/backends.md
@@ -75,10 +75,7 @@ Also, make sure that:
 
 ### Accessing the Dev Database
 
-To connect to the dev database through the CLI or using tools like [pgAdmin](https://www.pgadmin.org/), use the following credentials:
-
-- User: `postgresWaspDevUser`
-- Password: `postgresWaspDevPass`
+In case you might want to connect to the dev database through the CLI or using external tools like [pgAdmin](https://www.pgadmin.org/), the credentials are printed in the console when you run `wasp db start`.
 
 ### Connecting to an existing database
 

--- a/web/docs/data-model/backends.md
+++ b/web/docs/data-model/backends.md
@@ -73,6 +73,13 @@ Also, make sure that:
 - You have [Docker installed](https://www.docker.com/get-started/) and in `PATH`.
 - The port `5432` isn't taken.
 
+### Accessing the Dev Database
+
+To connect to the dev database through the CLI or using tools like [pgAdmin](https://www.pgadmin.org/), use the following credentials:
+
+- User: `postgresWaspDevUser`
+- Password: `postgresWaspDevPass`
+
 ### Connecting to an existing database
 
 If you want to spin up your own dev database (or connect to an external one), you can tell Wasp about it using the `DATABASE_URL` environment variable. Wasp will use the value of `DATABASE_URL` as a connection string.


### PR DESCRIPTION
### Description

Add the instructions for accessing the dev database under the [Connecting to a Database](https://wasp-lang.dev/docs/data-model/backends#connecting-to-a-database) section. 

~~I think providing the default credentials for the dev database in the docs is important because Some developers might want to access the database using external tools like **pgAdmin** or **datagrip** like me. **Prisma db studio** is not enough.~~

~~Also, personally, I found it really hard to look for the credentials online, even AI doesn't know the right credentials yet.~~

There's a chance that some developers may overlook the additional info printed in the console that contains the credentials for accessing the database directly. Therefore, as suggested by @Martinsos, it would be better to add a note in the documentation about where to find the credentials instead of putting them directly in the docs, for easier maintainability.

### Type of change this PR introduces:
[x] **Just code/docs improvement** (no functional change).