### PR TITLE
Enable building current docs

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -164,7 +164,7 @@ module.exports = {
           // ------ Configuration for multiple docs versions ------ //
 
           // "current" docs (under /docs) are in-progress docs, so we show them only in development.
-          includeCurrentVersion: includeCurrentVersion,
+          includeCurrentVersion,
           // In development, we want "current" docs to be the default docs (served at /docs),
           // to make it easier for us a bit. Otherwise, by default, the latest versioned docs
           // will be served under /docs.

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -3,6 +3,8 @@ const lightCodeTheme = require('prism-react-renderer/themes/github')
 const autoImportTabs = require('./src/remark/auto-import-tabs')
 const fileExtSwitcher = require('./src/remark/file-ext-switcher')
 
+const includeCurrentVersion = process.env.DOCS_INCLUDE_CURRENT_VERSION === 'true'
+
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
   title: 'Wasp',
@@ -162,16 +164,16 @@ module.exports = {
           // ------ Configuration for multiple docs versions ------ //
 
           // "current" docs (under /docs) are in-progress docs, so we show them only in development.
-          includeCurrentVersion: process.env.NODE_ENV === 'development',
+          includeCurrentVersion: includeCurrentVersion,
           // In development, we want "current" docs to be the default docs (served at /docs),
           // to make it easier for us a bit. Otherwise, by default, the latest versioned docs
           // will be served under /docs.
           lastVersion:
-            process.env.NODE_ENV === 'development' ? 'current' : undefined,
+            includeCurrentVersion ? 'current' : undefined,
 
           // Uncomment line below to build and show only current docs, for faster build times
           // during development, if/when needed.
-          // onlyIncludeVersions: process.env.NODE_ENV === 'development' ? ["current"] : undefined,
+          // onlyIncludeVersions: includeCurrentVersion ? ["current"] : undefined,
 
           // "versions" option here enables us to customize each version of docs individually,
           // and there are also other options if we ever need to customize versioned docs further.
@@ -179,7 +181,7 @@ module.exports = {
             // We provide config for `current` only during development because otherwise
             // we don't even build them (due to includeCurrentVersion above), so this config
             // would cause error in that case.
-            ...(process.env.NODE_ENV === 'development'
+            ...(includeCurrentVersion
               ? {
                   current: {
                     label: 'Next', // Label shown in the documentation to address this version of docs.

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start --port 3002",
+    "start": "DOCS_INCLUDE_CURRENT_VERSION=true docusaurus start --port 3002",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
This change enables us to build docs with the "current" docs included (useful for creating preview docs at some internal URL before they are released to users).

### Before

- We used `NODE_ENV` to check if we wanted to include the current docs.
- Worked in dev. ✅ 
- We were unable to include the current docs in the production build. 🟥 

### After

- Now we used `DOCS_INCLUDE_CURRENT_VERSION` to check if we want to include the current docs.
- Works in dev. ✅ 
- We now can include the current docs if we wanted to in the production build. ✅ 