### PR TITLE
Migrate streaming example to 0.14.0

### DIFF
--- a/examples/streaming/main.wasp
+++ b/examples/streaming/main.wasp
@@ -1,6 +1,6 @@
 app streaming {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "streaming"
 }

--- a/examples/streaming/schema.prisma
+++ b/examples/streaming/schema.prisma
@@ -1,0 +1,8 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}


### PR DESCRIPTION
This app opens up an interesting question - do we require `schema.prisma` file even for apps that don't use entities?