### PR TITLE
Fix db reset failing after wasp clean

### DIFF
--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -18,7 +18,7 @@ import Wasp.Cli.Command.Clean (clean)
 import Wasp.Cli.Command.Compile (compile)
 import Wasp.Cli.Command.CreateNewProject (createNewProject)
 import qualified Wasp.Cli.Command.CreateNewProject.AI as Command.CreateNewProject.AI
-import Wasp.Cli.Command.Db (runDbCommand)
+import qualified Wasp.Cli.Command.Db as Command.Db
 import qualified Wasp.Cli.Command.Db.Migrate as Command.Db.Migrate
 import qualified Wasp.Cli.Command.Db.Reset as Command.Db.Reset
 import qualified Wasp.Cli.Command.Db.Seed as Command.Db.Seed
@@ -105,7 +105,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
     Command.Call.Compile -> runCommand compile
     Command.Call.Db dbArgs -> case dbArgs of
       ["start"] -> runCommand Command.Start.Db.start
-      _dbCommand -> dbCli dbArgs
+      _commandOnDb -> runCommandOnRunningDb dbArgs
     Command.Call.Version -> printVersion
     Command.Call.Studio -> runCommand studio
     Command.Call.Uninstall -> runCommand uninstall
@@ -219,9 +219,10 @@ printVersion = do
 
 -- TODO: maybe extract to a separate module, e.g. DbCli.hs?
 
--- | Execute a command that acts on the database.
-dbCli :: [String] -> IO ()
-dbCli args = maybe printDbUsage runDbCommand parsedCommand
+-- | Execute a command that acts on a running database.
+runCommandOnRunningDb :: [String] -> IO ()
+runCommandOnRunningDb args =
+  maybe printDbUsage Command.Db.runCommandOnRunningDb parsedCommand
   where
     parsedCommand = case args of
       ["reset"] -> Just Command.Db.Reset.reset

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -218,14 +218,14 @@ printVersion = do
 -- TODO: maybe extract to a separate module, e.g. DbCli.hs?
 dbCli :: [String] -> IO ()
 dbCli args = case args of
+  -- These commands don't require an existing and running database.
+  ["start"] -> runCommand Command.Start.Db.start
   -- These commands require an existing and running database.
   ["reset"] -> runCommandThatRequiresDbRunning Command.Db.Reset.reset
   "migrate-dev" : optionalMigrateArgs -> runCommandThatRequiresDbRunning $ Command.Db.Migrate.migrateDev optionalMigrateArgs
   ["seed"] -> runCommandThatRequiresDbRunning $ Command.Db.Seed.seed Nothing
   ["seed", seedName] -> runCommandThatRequiresDbRunning $ Command.Db.Seed.seed $ Just seedName
   ["studio"] -> runCommandThatRequiresDbRunning Command.Db.Studio.studio
-  -- These commands don't require an existing and running database.
-  ["start"] -> runCommand Command.Start.Db.start
   _unknownDbCommand -> printDbUsage
 
 {- ORMOLU_DISABLE -}

--- a/waspc/cli/src/Wasp/Cli/Command/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Db.hs
@@ -1,5 +1,5 @@
 module Wasp.Cli.Command.Db
-  ( runDbCommand,
+  ( runCommandOnRunningDb,
   )
 where
 
@@ -9,8 +9,8 @@ import Wasp.Cli.Command.Require (DbConnectionEstablished (DbConnectionEstablishe
 import Wasp.CompileOptions (CompileOptions (generatorWarningsFilter))
 import Wasp.Generator.Monad (GeneratorWarning (GeneratorNeedsMigrationWarning))
 
-runDbCommand :: Command a -> IO ()
-runDbCommand = runCommand . makeDbCommand
+runCommandOnRunningDb :: Command a -> IO ()
+runCommandOnRunningDb = runCommand . makeDbCommand
 
 -- | This function makes sure that all the prerequisites which db commands
 --   need are set up (e.g. makes sure Prisma CLI is installed).

--- a/waspc/cli/src/Wasp/Cli/Command/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Db.hs
@@ -1,5 +1,5 @@
 module Wasp.Cli.Command.Db
-  ( runCommandOnRunningDb,
+  ( runCommandThatRequiresDbRunning,
   )
 where
 
@@ -9,8 +9,8 @@ import Wasp.Cli.Command.Require (DbConnectionEstablished (DbConnectionEstablishe
 import Wasp.CompileOptions (CompileOptions (generatorWarningsFilter))
 import Wasp.Generator.Monad (GeneratorWarning (GeneratorNeedsMigrationWarning))
 
-runCommandOnRunningDb :: Command a -> IO ()
-runCommandOnRunningDb = runCommand . makeDbCommand
+runCommandThatRequiresDbRunning :: Command a -> IO ()
+runCommandThatRequiresDbRunning = runCommand . makeDbCommand
 
 -- | This function makes sure that all the prerequisites which db commands
 --   need are set up (e.g. makes sure Prisma CLI is installed).


### PR DESCRIPTION
This PR fixes `wasp db reset` failing after `wasp clean`:
```
$ wasp clean

🐝 --- Deleting the .wasp/ directory... -------------------------------------------


✅ --- Deleted the .wasp/ directory. ----------------------------------------------


🐝 --- Deleting the node_modules/ directory... ------------------------------------


✅ --- Deleted the node_modules/ directory. ---------------------------------------

$ wasp db reset

🐝 --- Resetting the database... --------------------------------------------------

wasp-bin: /home/filip/Projects/wasp/wasp-repo/waspc/examples/todoApp/node_modules/.bin/prisma: streamingProcess: chdir: invalid argument (Bad file descriptor)
$ 
``` 