### PR TITLE
Add css wildcard for template files

### DIFF
--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -32,6 +32,7 @@ data-files:
   Generator/templates/server/npmrc
   Generator/templates/**/*.prisma
   Generator/templates/**/*.toml
+  Generator/templates/**/*.css
   Generator/templates/**/*.ts
   Generator/templates/**/*.json
   Generator/templates/**/*.ico


### PR DESCRIPTION
Classic cabal issues:

![image](https://github.com/user-attachments/assets/2eb0c324-829d-4358-b122-961a1050bdd2)
