### PR TITLE
Make Mage use 0.14.0

### DIFF
--- a/mage/Dockerfile
+++ b/mage/Dockerfile
@@ -41,7 +41,7 @@ RUN cd .wasp/build/server && npm run bundle
 # TODO: Use pm2?
 # TODO: Use non-root user (node).
 FROM base AS server-production
-RUN curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.13.1
+RUN curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.14.0
 ENV PATH "$PATH:/root/.local/bin"
 ENV NODE_ENV production
 WORKDIR /app


### PR DESCRIPTION
Bumps Wasp version to 0.14.0 in the Mage `Dockerfile`. After we release 0.14.0, we'll deploy a new version of Mage which will then use this new Dockerfile.