### PR TITLE
Use `websocket` transport for the websocket client

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/client/webSocket/WebSocketProvider.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/webSocket/WebSocketProvider.tsx
@@ -16,7 +16,13 @@ export type WebSocketContextValue = {
 // PRIVATE API
 // TODO: In the future, it would be nice if users could pass more
 // options to `io`, likely via some `configFn`.
-export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(config.apiUrl, { autoConnect: {= autoConnect =} })
+export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
+  config.apiUrl,
+  {
+    transports: ['websocket'],
+    autoConnect: {= autoConnect =},
+  }
+)
 
 function refreshAuthToken() {
   // NOTE: When we figure out how `auth: true` works for Operations, we should

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/jobs/mySpecialJob.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/jobs/mySpecialJob.d.ts
@@ -16,7 +16,7 @@ export declare const mySpecialJob: {
         readonly pgBoss: {
             readonly cancel: () => ReturnType<import("pg-boss")["cancel"]>;
             readonly resume: () => ReturnType<import("pg-boss")["resume"]>;
-            readonly details: () => Promise<(Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
+            readonly details: () => Promise<Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
                 data: JSONObject;
             } & ({
                 state: "failed";
@@ -35,7 +35,7 @@ export declare const mySpecialJob: {
                 } | {
                     value: true;
                 };
-            })) | null>;
+            })>;
         };
         readonly job: import("./core/job").Job;
         readonly jobId: string;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/jobs/returnHelloJob.d.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/dist/server/jobs/returnHelloJob.d.ts
@@ -20,7 +20,7 @@ export declare const returnHelloJob: {
         readonly pgBoss: {
             readonly cancel: () => ReturnType<import("pg-boss")["cancel"]>;
             readonly resume: () => ReturnType<import("pg-boss")["resume"]>;
-            readonly details: () => Promise<(Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
+            readonly details: () => Promise<Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
                 data: JSONObject;
             } & ({
                 state: "failed";
@@ -39,7 +39,7 @@ export declare const returnHelloJob: {
                 } | {
                     value: true;
                 };
-            })) | null>;
+            })>;
         };
         readonly job: import("./core/job").Job;
         readonly jobId: string;

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/dist/server/jobs/mySpecialJob.d.ts
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/dist/server/jobs/mySpecialJob.d.ts
@@ -16,7 +16,7 @@ export declare const mySpecialJob: {
         readonly pgBoss: {
             readonly cancel: () => ReturnType<import("pg-boss")["cancel"]>;
             readonly resume: () => ReturnType<import("pg-boss")["resume"]>;
-            readonly details: () => Promise<(Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
+            readonly details: () => Promise<Omit<import("pg-boss").JobWithMetadata<JSONObject>, "output" | "state"> & {
                 data: JSONObject;
             } & ({
                 state: "failed";
@@ -35,7 +35,7 @@ export declare const mySpecialJob: {
                 } | {
                     value: true;
                 };
-            })) | null>;
+            })>;
         };
         readonly job: import("./core/job").Job;
         readonly jobId: string;


### PR DESCRIPTION
Closes #2040

### Background

When users deploy a Wasp app with websockets and their deployment provider (e.g. Fly) uses a load balancer, there are some "socket.io session ID" errors. This happens because socket.io client is trying to first establish an HTTP connection to the server. It sends multiple HTTP requests and for each the "socket.io session ID" needs to match. This becomes a problem when the different HTTP requests go to different servers.

The docs suggest either:
- using **sticky load balancing** (for client X, only use server A and not servers B or C)
- or to switch to using only the **websocket transport** (eliminating the multiple HTTP requests and just having one TCP connection). 

More details: https://github.com/wasp-lang/wasp/issues/2040#issuecomment-2244663846

### Changes in this PR

Changes the connection mode for the socket.io client from the default `["polling", "websocket"]` to `["websocket"]` because `polling` option uses multiple HTTP requests to establish the Websocket connection.
### Future work

Of course, this might not be ideal for some people - that's why we have this issue: #2203 which would allow users to override the connection mode to whatever they want.