### PR TITLE
docs: updating v0.13 references in docs to 0.14

### DIFF
--- a/web/docs/auth/auth-hooks.md
+++ b/web/docs/auth/auth-hooks.md
@@ -40,7 +40,7 @@ To use auth hooks, you must first declare them in the Wasp file:
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   auth: {
     userEntity: User,
@@ -59,7 +59,7 @@ app myApp {
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   auth: {
     userEntity: User,
@@ -349,7 +349,7 @@ Read more about the data the `onBeforeOAuthRedirect` hook receives in the [API R
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   auth: {
     userEntity: User,
@@ -368,7 +368,7 @@ app myApp {
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   auth: {
     userEntity: User,

--- a/web/docs/auth/email.md
+++ b/web/docs/auth/email.md
@@ -49,7 +49,7 @@ Let's start with adding the following to our `main.wasp` file:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -83,7 +83,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/github.md
+++ b/web/docs/auth/social-auth/github.md
@@ -43,7 +43,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -68,7 +68,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -296,7 +296,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -374,7 +374,7 @@ For an up to date info about the data received from GitHub, please refer to the 
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -421,7 +421,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -489,7 +489,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -513,7 +513,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/google.md
+++ b/web/docs/auth/social-auth/google.md
@@ -43,7 +43,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -66,7 +66,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -317,7 +317,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -337,7 +337,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -400,7 +400,7 @@ For an up to date info about the data received from Google, please refer to the 
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -447,7 +447,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -515,7 +515,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -539,7 +539,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/keycloak.md
+++ b/web/docs/auth/social-auth/keycloak.md
@@ -42,7 +42,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -65,7 +65,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -283,7 +283,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -303,7 +303,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -359,7 +359,7 @@ For up-to-date info about the data received from Keycloak, please refer to the [
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -406,7 +406,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -474,7 +474,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -498,7 +498,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/overview.md
+++ b/web/docs/auth/social-auth/overview.md
@@ -36,7 +36,7 @@ Here's what the full setup looks like:
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -63,7 +63,7 @@ model User {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -148,7 +148,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -180,7 +180,7 @@ export const userSignupFields = {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/username-and-pass.md
+++ b/web/docs/auth/username-and-pass.md
@@ -44,7 +44,7 @@ Let's start with adding the following to our `main.wasp` file:
 ```wasp title="main.wasp" {11}
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -64,7 +64,7 @@ app myApp {
 ```wasp title="main.wasp"  {11}
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -623,7 +623,7 @@ When you receive the `user` object [on the client or the server](./overview.md#a
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -647,7 +647,7 @@ model User {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -678,7 +678,7 @@ model User {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -699,7 +699,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/docs/data-model/crud.md
+++ b/web/docs/data-model/crud.md
@@ -73,7 +73,7 @@ We can start by running `wasp new tasksCrudApp` and then adding the following to
 ```wasp title="main.wasp"
 app tasksCrudApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "Tasks Crud App",
 

--- a/web/docs/introduction/introduction.md
+++ b/web/docs/introduction/introduction.md
@@ -55,7 +55,7 @@ Let's give our app a title and let's immediately turn on the full-stack authenti
 ```wasp title="main.wasp"
 app RecipeApp {
   title: "My Recipes",
-  wasp: { version: "^0.13.0" },
+  wasp: { version: "^0.14.0" },
   auth: {
     methods: { usernameAndPassword: {} },
     onAuthFailedRedirectTo: "/login",

--- a/web/docs/migrate-from-0-13-to-0-14.md
+++ b/web/docs/migrate-from-0-13-to-0-14.md
@@ -50,7 +50,7 @@ psl=}
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "MyApp",
 }

--- a/web/docs/project/customizing-app.md
+++ b/web/docs/project/customizing-app.md
@@ -9,7 +9,7 @@ Each Wasp project can have only one `app` type declaration. It is used to config
 ```wasp
 app todoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "ToDo App",
   head: [
@@ -27,7 +27,7 @@ You may want to change the title of your app, which appears in the browser tab, 
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "BookFace"
 }
@@ -42,7 +42,7 @@ An example of adding extra style sheets and scripts:
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   head: [  // optional
@@ -58,7 +58,7 @@ app myApp {
 ```wasp
 app todoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "ToDo App",
   head: [

--- a/web/docs/tutorial/03-pages.md
+++ b/web/docs/tutorial/03-pages.md
@@ -194,7 +194,7 @@ Your Wasp file should now look like this:
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "TodoApp"
 }
@@ -211,7 +211,7 @@ page MainPage {
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "TodoApp"
 }

--- a/web/docs/tutorial/07-auth.md
+++ b/web/docs/tutorial/07-auth.md
@@ -38,7 +38,7 @@ Next, tell Wasp to use full-stack [authentication](../auth/overview):
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   // highlight-start
   title: "TodoApp",

--- a/web/versioned_docs/version-0.14.0/auth/auth-hooks.md
+++ b/web/versioned_docs/version-0.14.0/auth/auth-hooks.md
@@ -40,7 +40,7 @@ To use auth hooks, you must first declare them in the Wasp file:
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   auth: {
     userEntity: User,
@@ -59,7 +59,7 @@ app myApp {
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   auth: {
     userEntity: User,
@@ -349,7 +349,7 @@ Read more about the data the `onBeforeOAuthRedirect` hook receives in the [API R
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   auth: {
     userEntity: User,
@@ -368,7 +368,7 @@ app myApp {
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   auth: {
     userEntity: User,

--- a/web/versioned_docs/version-0.14.0/auth/email.md
+++ b/web/versioned_docs/version-0.14.0/auth/email.md
@@ -49,7 +49,7 @@ Let's start with adding the following to our `main.wasp` file:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -83,7 +83,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/github.md
@@ -68,7 +68,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -296,7 +296,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -374,7 +374,7 @@ For an up to date info about the data received from GitHub, please refer to the 
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -421,7 +421,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -489,7 +489,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -513,7 +513,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/github.md
@@ -43,7 +43,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/google.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/google.md
@@ -43,7 +43,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -66,7 +66,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -317,7 +317,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -337,7 +337,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -400,7 +400,7 @@ For an up to date info about the data received from Google, please refer to the 
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -447,7 +447,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -515,7 +515,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -539,7 +539,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/keycloak.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/keycloak.md
@@ -42,7 +42,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -65,7 +65,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -283,7 +283,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -303,7 +303,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -359,7 +359,7 @@ For up-to-date info about the data received from Keycloak, please refer to the [
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -406,7 +406,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -474,7 +474,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -498,7 +498,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/overview.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/overview.md
@@ -36,7 +36,7 @@ Here's what the full setup looks like:
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -63,7 +63,7 @@ model User {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -148,7 +148,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -180,7 +180,7 @@ export const userSignupFields = {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.14.0/auth/username-and-pass.md
+++ b/web/versioned_docs/version-0.14.0/auth/username-and-pass.md
@@ -44,7 +44,7 @@ Let's start with adding the following to our `main.wasp` file:
 ```wasp title="main.wasp" {11}
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -64,7 +64,7 @@ app myApp {
 ```wasp title="main.wasp"  {11}
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -623,7 +623,7 @@ When you receive the `user` object [on the client or the server](./overview.md#a
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -647,7 +647,7 @@ model User {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -678,7 +678,7 @@ model User {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {
@@ -699,7 +699,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.14.0/data-model/crud.md
+++ b/web/versioned_docs/version-0.14.0/data-model/crud.md
@@ -73,7 +73,7 @@ We can start by running `wasp new tasksCrudApp` and then adding the following to
 ```wasp title="main.wasp"
 app tasksCrudApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "Tasks Crud App",
 

--- a/web/versioned_docs/version-0.14.0/introduction/introduction.md
+++ b/web/versioned_docs/version-0.14.0/introduction/introduction.md
@@ -55,7 +55,7 @@ Let's give our app a title and let's immediately turn on the full-stack authenti
 ```wasp title="main.wasp"
 app RecipeApp {
   title: "My Recipes",
-  wasp: { version: "^0.13.0" },
+  wasp: { version: "^0.14.0" },
   auth: {
     methods: { usernameAndPassword: {} },
     onAuthFailedRedirectTo: "/login",

--- a/web/versioned_docs/version-0.14.0/migrate-from-0-13-to-0-14.md
+++ b/web/versioned_docs/version-0.14.0/migrate-from-0-13-to-0-14.md
@@ -50,7 +50,7 @@ psl=}
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "MyApp",
 }

--- a/web/versioned_docs/version-0.14.0/project/customizing-app.md
+++ b/web/versioned_docs/version-0.14.0/project/customizing-app.md
@@ -9,7 +9,7 @@ Each Wasp project can have only one `app` type declaration. It is used to config
 ```wasp
 app todoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "ToDo App",
   head: [
@@ -27,7 +27,7 @@ You may want to change the title of your app, which appears in the browser tab, 
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "BookFace"
 }
@@ -42,7 +42,7 @@ An example of adding extra style sheets and scripts:
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "My App",
   head: [  // optional
@@ -58,7 +58,7 @@ app myApp {
 ```wasp
 app todoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "ToDo App",
   head: [

--- a/web/versioned_docs/version-0.14.0/tutorial/03-pages.md
+++ b/web/versioned_docs/version-0.14.0/tutorial/03-pages.md
@@ -194,7 +194,7 @@ Your Wasp file should now look like this:
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "TodoApp"
 }
@@ -211,7 +211,7 @@ page MainPage {
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   title: "TodoApp"
 }

--- a/web/versioned_docs/version-0.14.0/tutorial/07-auth.md
+++ b/web/versioned_docs/version-0.14.0/tutorial/07-auth.md
@@ -38,7 +38,7 @@ Next, tell Wasp to use full-stack [authentication](../auth/overview):
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.13.0"
+    version: "^0.14.0"
   },
   // highlight-start
   title: "TodoApp",


### PR DESCRIPTION
### Description
A small documentation fix was found while writing about Wasp's GitHub OAuth. The doc still references the v0.13 version, instead of the new v0.14.

### Select what type of change this PR introduces:
1. [X] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Update example apps if needed
If you did code changes and added a new feature or modified an existing feature, make sure you satisfy the following:
1. [ ] I updated `waspc/examples/todoApp` as needed (updated modified feature or added new feature) and manually checked it works correctly.
2. [ ] I updated `waspc/headless-test/examples/todoApp` and its e2e tests as needed (updated modified feature and its tests or added new feature and new tests for it).
