### PR TITLE
Fixes Prisma array expr for empty arrays

### DIFF
--- a/waspc/src/Wasp/Psl/Parser/Argument.hs
+++ b/waspc/src/Wasp/Psl/Parser/Argument.hs
@@ -18,7 +18,6 @@ import Wasp.Psl.Parser.Common
   ( brackets,
     colon,
     commaSep,
-    commaSep1,
     float,
     identifier,
     integer,
@@ -69,7 +68,7 @@ funcCallExpr =
 arrayExpr :: Parser Psl.Argument.Expression
 arrayExpr =
   Psl.Argument.ArrayExpr
-    <$> brackets (commaSep1 expression)
+    <$> brackets (commaSep expression)
 
 -- NOTE: For now we are not supporting negative numbers.
 --   I couldn't figure out from Prisma docs if there could be the case

--- a/waspc/test/Psl/Common/ModelTest.hs
+++ b/waspc/test/Psl/Common/ModelTest.hs
@@ -15,6 +15,7 @@ sampleBodySchema =
     posts Post[] @relation("UserPosts", references: [id]) @customattr
     weirdType Unsupported("weird")
     anotherId String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+    someField   String[] @default([])
 
     @@someattr([id, username], [posts])
   |]
@@ -110,6 +111,20 @@ sampleBodyAst =
                     { Psl.Attribute._attrName = "db.Uuid",
                       Psl.Attribute._attrArgs =
                         []
+                    }
+                ]
+            }
+        ),
+      Psl.Model.ElementField
+        ( Psl.Model.Field
+            { Psl.Model._name = "someField",
+              Psl.Model._type = Psl.Model.String,
+              Psl.Model._typeModifiers = [Psl.Model.List],
+              Psl.Model._attrs =
+                [ Psl.Attribute.Attribute
+                    { Psl.Attribute._attrName = "default",
+                      Psl.Attribute._attrArgs =
+                        [Psl.Argument.ArgUnnamed (Psl.Argument.ArrayExpr [])]
                     }
                 ]
             }

--- a/waspc/test/Psl/Parser/ArgumentTest.hs
+++ b/waspc/test/Psl/Parser/ArgumentTest.hs
@@ -36,6 +36,9 @@ spec_parseArgumentPslPart = do
                     Psl.Argument.IdentifierExpr "pg_trgm",
                     Psl.Argument.FuncExpr "postgis" [Psl.Argument.ArgNamed "version" (Psl.Argument.StringExpr "2.1")]
                   ]
+            ),
+            ( "[]",
+              Psl.Argument.ArgUnnamed (Psl.Argument.ArrayExpr [])
             )
           ]
     let runTest (psl, expected) =

--- a/waspc/test/Psl/Parser/AttributeTest.hs
+++ b/waspc/test/Psl/Parser/AttributeTest.hs
@@ -53,6 +53,12 @@ spec_parseAttributePslPart = do
                         ]
                     )
                 ]
+            ),
+            ( "@default([])",
+              Psl.Attribute.Attribute
+                "default"
+                [ Psl.Argument.ArgUnnamed $ Psl.Argument.ArrayExpr []
+                ]
             )
           ]
     runTestsFor attribute tests

--- a/waspc/test/Psl/Parser/SchemaTest.hs
+++ b/waspc/test/Psl/Parser/SchemaTest.hs
@@ -63,6 +63,7 @@ spec_parsePslSchema = do
             user        User       @relation(fields: [userId], references: [id])
             userId      Int
             votes       TaskVote[]
+            someField   String[] @default([])
           }
 
           model TaskVote {
@@ -230,7 +231,16 @@ spec_parsePslSchema = do
                             "votes"
                             (Psl.Model.UserType "TaskVote")
                             [Psl.Model.List]
-                            []
+                            [],
+                        Psl.Model.ElementField $
+                          Psl.Model.Field
+                            "someField"
+                            Psl.Model.String
+                            [Psl.Model.List]
+                            [ Psl.Attribute.Attribute
+                                "default"
+                                [Psl.Argument.ArgUnnamed $ Psl.Argument.ArrayExpr []]
+                            ]
                       ]
                   ),
               Psl.Schema.ModelBlock $


### PR DESCRIPTION
Pretty self explanatory - the parser expected one or more values in array expression, but empty arrays are perfectly legal e.g. to say "the default value should be an empty array".

```prisma
someField   String[] @default([])
```

[Prisma's grammar](https://github.com/prisma/prisma-engines/blob/ae0473d812da9ce31f8c62740c937afb9623f2dc/psl/schema-ast/src/parser/datamodel.pest#L159) also indicates that, so that's a mistake on my part.