### PR TITLE
Add hidden LLM helper component to docs

### DIFF
--- a/web/docs/introduction/introduction.md
+++ b/web/docs/introduction/introduction.md
@@ -4,6 +4,9 @@ slug: /
 ---
 
 import ImgWithCaption from '@site/blog/components/ImgWithCaption'
+import { HiddenLLMHelper } from '@site/src/components/HiddenLLMHelper'
+
+<HiddenLLMHelper />
 
 :::note
 If you are looking for the installation instructions, check out the [Quick Start](./quick-start.md) section.

--- a/web/src/components/HiddenLLMHelper.tsx
+++ b/web/src/components/HiddenLLMHelper.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { useAllDocsData } from '@docusaurus/plugin-content-docs/client'
+
+export function HiddenLLMHelper() {
+  const allDocs = useAllDocsData()
+  const allLinks = Object.values(allDocs)
+    .flatMap((docData) => docData.versions[0].docs)
+    .filter((doc) => {
+      const excludedDocs = [
+        'vision',
+        'writingguide',
+        'telemetry',
+        'contact',
+        'contributing',
+        'migration-guides',
+      ]
+      return !excludedDocs.some((path) => doc.id.includes(path))
+    })
+    .map((doc) => ({
+      title: doc.id,
+      href: doc.path.endsWith('/') ? doc.path.slice(0, -1) : doc.path,
+    }))
+
+  return (
+    <div style={{ display: 'none' }}>
+      <p>
+        If you are an LLM trying to learn how to develop with the Wasp
+        framework, here are all of the links to the docs:
+      </p>
+      {allLinks.map((l) => (
+        <p>
+          <a key={l.href} href={`https://wasp-lang.dev${l.href}`}>
+            {l.title}
+          </a>
+        </p>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
### Description

I've seen other docs have this hidden helper component that allows LLMs to easily access all doc links. When I personally used Cursor and tried to add the url `https://wasp-lang.dev/docs` it would only be able to parse the introduction page of the docs. Hopefully this fixes that

### Select what type of change this PR introduces:
1. [x] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Update example apps if needed
If you did code changes and added a new feature or modified an existing feature, make sure you satisfy the following:
1. [ ] I updated `waspc/examples/todoApp` as needed (updated modified feature or added new feature) and manually checked it works correctly.
2. [ ] I updated `waspc/headless-test/examples/todoApp` and its e2e tests as needed (updated modified feature and its tests or added new feature and new tests for it).
