### PR TITLE
Change the Arrivederci to Goodbye, and fix CSS wrapping issues with titles

### DIFF
--- a/web/src/components/HowItWorks.js
+++ b/web/src/components/HowItWorks.js
@@ -9,7 +9,7 @@ const Feature = ({ title, description, url }) => (
     <div className="lg:mt-5">
       <dt>
         <h4 className="mb-4">
-          <span className="rounded bg-yellow-500/25 px-2 py-1 text-neutral-700 featureTitle">
+          <span className="rounded bg-yellow-500/25 px-2 py-1 text-neutral-700 box-decoration-clone leading-[1.73]">
             {title}
           </span>
         </h4>

--- a/web/src/components/HowItWorks.js
+++ b/web/src/components/HowItWorks.js
@@ -9,7 +9,7 @@ const Feature = ({ title, description, url }) => (
     <div className="lg:mt-5">
       <dt>
         <h4 className="mb-4">
-          <span className="rounded bg-yellow-500/25 px-2 py-1 text-neutral-700">
+          <span className="rounded bg-yellow-500/25 px-2 py-1 text-neutral-700 featureTitle">
             {title}
           </span>
         </h4>
@@ -79,7 +79,7 @@ const HowItWorks = () => {
               />
 
               <Feature
-                title="Arrivederci boilerplate"
+                title="Goodbye boilerplate"
                 description="Write only the code that matters, let Wasp handle the rest."
                 url="https://www.youtube.com/watch?v=x5nsBbLvKnU"
               />

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -152,3 +152,10 @@
   height: 100%;
   border: 0;
 }
+
+/***** HowItWorks *****/
+.featureTitle {
+  line-height: 1.73;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -152,10 +152,3 @@
   height: 100%;
   border: 0;
 }
-
-/***** HowItWorks *****/
-.featureTitle {
-  line-height: 1.73;
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
-}


### PR DESCRIPTION
### Description

> Describe your PR! If it fixes specific issue, mention it with "Fixes # (issue)".
Change the word: "Arrivederci" to "Goodbye" to make it more universal

Fixed wrapping issue with titles in same section:
Before:
![image](https://github.com/user-attachments/assets/18b77382-33a0-43ef-bccf-909e0ede3c34)

After:
![image](https://github.com/user-attachments/assets/8e9b8c4c-6d39-4a92-b209-361356f6c308)



### Select what type of change this PR introduces:
1. [X] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).
