### PR TITLE
Waspello: Fix submit button labels

### DIFF
--- a/examples/waspello/src/auth/LoginPage.jsx
+++ b/examples/waspello/src/auth/LoginPage.jsx
@@ -38,6 +38,7 @@ const LoginPage = (props) => {
       <div className="auth-form-container">
         <EmailAndPassForm
           title='Log in with your account'
+          submitButtonLabel='Log in'
           userField={usernameFieldVal}
           passField={passwordFieldVal}
           setUser={setUsernameFieldVal}

--- a/examples/waspello/src/auth/SignupPage.jsx
+++ b/examples/waspello/src/auth/SignupPage.jsx
@@ -41,6 +41,7 @@ const SignupPage = (props) => {
 
         <EmailAndPassForm
           title='Sign up for your account'
+          submitButtonLabel='Sign up'
           userField={usernameFieldVal}
           passField={passwordFieldVal}
           setUser={setUsernameFieldVal}

--- a/examples/waspello/src/auth/components/EmailAndPassForm.jsx
+++ b/examples/waspello/src/auth/components/EmailAndPassForm.jsx
@@ -7,7 +7,7 @@ const inputFieldClasses = `
   transition ease-out duration-200
   h-10 px-2 text-sm placeholder:text-neutral-500
 `
-const EmailAndPassForm = ({ title, userField, passField, setUser, setPass, handleSignup }) => (
+const EmailAndPassForm = ({ title, submitButtonLabel, userField, passField, setUser, setPass, handleSignup }) => (
     <div className='w-full text-center'>
         <h2 className='text-base font-bold text-neutral-600'>
           {title}
@@ -34,7 +34,7 @@ const EmailAndPassForm = ({ title, userField, passField, setUser, setPass, handl
             hover:bg-yellow-400
           `}
           type='submit'
-          value='Sign up'
+          value={submitButtonLabel}
         />
       </form>
     </div>


### PR DESCRIPTION
### Description

This PR fixes a bug in Waspello example app.
Previously, both sign up and log in pages used "Sign up" for submit button label.
This was confusing as it was not clear if you are signing in or creating a new account.

**Before**
![Screenshot before](https://github.com/user-attachments/assets/d36885c2-b36a-4767-8294-8dc1467b417c)

**After**

![Screenshot after](https://github.com/user-attachments/assets/747d93e2-9c6e-4f75-a2f2-a25ccb372e6f)

### Select what type of change this PR introduces:
1. [ ] **Just code/docs improvement** (no functional change).
2. [x] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Update example apps if needed
If you did code changes and added a new feature or modified an existing feature, make sure you satisfy the following:
1. [ ] I updated `waspc/examples/todoApp` as needed (updated modified feature or added new feature) and manually checked it works correctly.
2. [ ] I updated `waspc/headless-test/examples/todoApp` and its e2e tests as needed (updated modified feature and its tests or added new feature and new tests for it).
