### PR TITLE
Force internal port to 8080

### DIFF
--- a/waspc/packages/deploy/src/providers/fly/setup/setup.ts
+++ b/waspc/packages/deploy/src/providers/fly/setup/setup.ts
@@ -85,6 +85,7 @@ async function setupServer(deploymentInfo: DeploymentInfo<SetupOptions>) {
 	await $`flyctl launch --no-deploy ${launchArgs}`;
 
 	const minMachinesOptionRegex = /min_machines_running = 0/g;
+	const internalPortOptionRegex = /internal_port = \d+/g;
 
 	if (!doesLocalTomlContainLine(minMachinesOptionRegex)) {
 		await question(`\n⚠️  There was a possible issue setting up your server app.
@@ -107,6 +108,24 @@ Contact the Wasp Team at our Discord server if you need help with this: https://
 Press any key to continue or Ctrl+C to cancel.`);
 	} else {
 		replaceLineInLocalToml(minMachinesOptionRegex, 'min_machines_running = 1');
+	}
+
+	if (!doesLocalTomlContainLine(internalPortOptionRegex)) {
+		await question(`\n⚠️  There was an issue setting up your server app.
+We tried modifying your server fly.toml to set ${boldText(
+		'internal_port = 8080',
+	)}, but couldn't find the option ${boldText(
+	'internal_port',
+)} in the fly.toml.
+
+This means your server app might not be accessible.
+
+Contact the Wasp Team at our Discord server if you need help with this: https://discord.gg/rzdnErX
+
+Press any key to continue or Ctrl+C to cancel.`);
+	} else {
+		// the default fly.toml assumes port 8080 (or 3000, depending on flyctl version).
+		replaceLineInLocalToml(internalPortOptionRegex, 'internal_port = 8080');
 	}
 
 	copyLocalServerTomlToProject(deploymentInfo.tomlFilePaths);


### PR DESCRIPTION
### Description

This is a proposed fix for https://github.com/wasp-lang/wasp/issues/2398. This is similar to a fix that was made to the client setup. Another option would be to change like 120 to `PORT=3000` but my guess is older version of `flyctl` used port 8080 and don't want to break those.

### Select what type of change this PR introduces:
1. [ ] **Just code/docs improvement** (no functional change).
2. [X] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Update example apps if needed
If you did code changes and added a new feature or modified an existing feature, make sure you satisfy the following:
1. [ ] I updated `waspc/examples/todoApp` as needed (updated modified feature or added new feature) and manually checked it works correctly.
2. [ ] I updated `waspc/headless-test/examples/todoApp` and its e2e tests as needed (updated modified feature and its tests or added new feature and new tests for it).
