### PR TITLE
Docs for user defined env vars validation

### DIFF
--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -399,7 +399,7 @@ const analyticsId: string = env.REACT_APP_ANALYTICS_ID
 </TabItem>
 </Tabs>
 
-You can use `import.meta.env.REACT_APP_SOME_VAR_NAME` directly in your code, but it's not recommended because it's not validated and can lead to runtime errors if the env var is not defined.
+You can use `import.meta.env.REACT_APP_SOME_VAR_NAME` directly in your code. We don't recommend this. `import.meta.env` isn't validated and missing env vars can cause runtime errors.
 
 ### Server Env Vars
 

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -229,7 +229,7 @@ If your code requires some environment variables, you usually want to ensure tha
 
 :::
 
-Let's look at an example of defining env vars validation:
+Take a look at an example of defining env vars validation:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -223,9 +223,10 @@ If your code requires some environment variables, you usually want to ensure tha
 :::info What is Zod?
 
 [Zod](https://zod.dev/) is a library that lets you define what you expect from your data. For example, you can use Zod to define that:
+
 - A value should be a string that's a valid email address.
 - A value should be a number between 0 and 100.
-- etc.
+- ... and much more.
 
 :::
 
@@ -277,7 +278,7 @@ export const clientEnvValidationSchema = defineEnvValidationSchema(
 )
 ```
 
-The defineEnvValidationSchema` function ensures your Zod schema is type-checked.
+The `defineEnvValidationSchema` function ensures your Zod schema is type-checked.
 
 </TabItem>
 </Tabs>
@@ -294,21 +295,21 @@ app myApp {
 }
 ```
 
-We defined schemas for both the client and the server env vars and told Wasp to use them. Wasp merges your env validation schemas with the built-in env vars validation schemas when it validates the `process.env` object on the server and the `import.meta.env` object on the client.
+You defined schemas for both the client and the server env vars and told Wasp to use them. Wasp merges your env validation schemas with the built-in env vars validation schemas when it validates the `process.env` object on the server and the `import.meta.env` object on the client.
 
 This means you can use the `env` object to access **your env vars** like this:
 
 ```ts title="src/stripe.ts"
 import { env } from 'wasp/server'
 
-const stripeApiKey: string = env.STRIPE_API_KEY
+const stripeApiKey = env.STRIPE_API_KEY
 ```
 
 Read more about the env object in the [API Reference](#api-reference).
 
 ## API Reference
 
-There are **Wasp-defined** and **user-defined** env vars. Wasp has built-in validation for its env vars and you can define your own validation for your env vars.
+There are **Wasp-defined** and **user-defined** env vars. Wasp already comes with built-in validation for Wasp-defined env vars. For your env vars, you can define your own validation.
 
 ### Client Env Vars
 
@@ -350,7 +351,7 @@ export const envValidationSchema = defineEnvValidationSchema(
 )
 ```
 
-We are using the `defineEnvValidationSchema` helper to get type-checking for the Zod schema.
+The `defineEnvValidationSchema` function ensures your Zod schema is type-checked.
 
 </TabItem>
 </Tabs>
@@ -390,16 +391,16 @@ const analyticsId = env.REACT_APP_ANALYTICS_ID
 import { env } from 'wasp/client'
 
 // Wasp-defined
-const apiUrl: string = env.REACT_APP_API_URL
+const apiUrl = env.REACT_APP_API_URL
 
 // User-defined
-const analyticsId: string = env.REACT_APP_ANALYTICS_ID
+const analyticsId = env.REACT_APP_ANALYTICS_ID
 ```
 
 </TabItem>
 </Tabs>
 
-You can use `import.meta.env.REACT_APP_SOME_VAR_NAME` directly in your code. We don't recommend this. `import.meta.env` isn't validated and missing env vars can cause runtime errors.
+You can use `import.meta.env.REACT_APP_SOME_VAR_NAME` directly in your code. We don't recommend this since `import.meta.env` isn't validated and missing env vars can cause runtime errors.
 
 ### Server Env Vars
 
@@ -441,7 +442,7 @@ export const envValidationSchema = defineEnvValidationSchema(
 )
 ```
 
-We are using the `defineEnvValidationSchema` helper to get type-checking for the Zod schema.
+The `defineEnvValidationSchema` function ensures your Zod schema is type-checked.
 
 </TabItem>
 </Tabs>
@@ -481,13 +482,13 @@ const stripeApiKey = env.STRIPE_API_KEY
 import { env } from 'wasp/server'
 
 // Wasp-defined
-const serverUrl: string = env.WASP_SERVER_URL
+const serverUrl = env.WASP_SERVER_URL
 
 // User-defined
-const stripeApiKey: string = env.STRIPE_API_KEY
+const stripeApiKey = env.STRIPE_API_KEY
 ```
 
 </TabItem>
 </Tabs>
 
-You can use `process.env.SOME_SECRET` directly in your code, but it's not recommended because it's not validated and can lead to runtime errors if the env var is not defined.
+You can use `process.env.SOME_SECRET` directly in your code. We don't recommend this since `process.env` isn't validated and missing env vars can cause runtime errors.

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -234,15 +234,21 @@ Let's look at an example of defining env vars validation:
 ```js title="src/env.js"
 import * as z from 'zod'
 
-export const serverEnvValidationSchema = z.object({
-  STRIPE_API_KEY: z.string({
-    required_error: 'STRIPE_API_KEY is required.',
-  }),
-})
+import { defineEnvValidationSchema } from 'wasp/env'
 
-export const clientEnvValidationSchema = z.object({
-  REACT_APP_NAME: z.string().default('TODO App'),
-})
+export const serverEnvValidationSchema = defineEnvValidationSchema(
+  z.object({
+    STRIPE_API_KEY: z.string({
+      required_error: 'STRIPE_API_KEY is required.',
+    }),
+  })
+)
+
+export const clientEnvValidationSchema = defineEnvValidationSchema(
+  z.object({
+    REACT_APP_NAME: z.string().default('TODO App'),
+  })
+)
 ```
 
 </TabItem>
@@ -313,11 +319,15 @@ You can define your client env vars validation like this:
 ```js title="src/env.js"
 import * as z from 'zod'
 
-export const envValidationSchema = z.object({
-  REACT_APP_ANALYTICS_ID: z.string({
-    required_error: 'REACT_APP_ANALYTICS_ID is required.',
-  }),
-})
+import { defineEnvValidationSchema } from 'wasp/env'
+
+export const envValidationSchema = defineEnvValidationSchema(
+  z.object({
+    REACT_APP_ANALYTICS_ID: z.string({
+      required_error: 'REACT_APP_ANALYTICS_ID is required.',
+    }),
+  })
+)
 ```
 
 </TabItem>
@@ -400,11 +410,15 @@ You can define your env vars validation like this:
 ```js title="src/env.js"
 import * as z from 'zod'
 
-export const envValidationSchema = z.object({
-  STRIPE_API_KEY: z.string({
-    required_error: 'STRIPE_API_KEY is required.',
-  }),
-})
+import { defineEnvValidationSchema } from 'wasp/env'
+
+export const envValidationSchema = defineEnvValidationSchema(
+  z.object({
+    STRIPE_API_KEY: z.string({
+      required_error: 'STRIPE_API_KEY is required.',
+    }),
+  })
+)
 ```
 
 </TabItem>

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -274,7 +274,7 @@ export const clientEnvValidationSchema = defineEnvValidationSchema(
 )
 ```
 
-We are using the `defineEnvValidationSchema` helper to get type-checking for the Zod schema.
+The defineEnvValidationSchema` function ensures your Zod schema is type-checked.
 
 </TabItem>
 </Tabs>

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -53,7 +53,7 @@ Here are the client env vars that Wasp defines:
 These are some general env variables used for various Wasp features:
 
 <EnvVarsTable envVars={[
-  { name: "REACT_APP_API_URL", type: "URL", isRequired: false, defaultValue: "http://localhost:3001", note: "The client uses this as the server URL." }
+{ name: "REACT_APP_API_URL", type: "URL", isRequired: false, defaultValue: "http://localhost:3001", note: "The client uses this as the server URL." }
 ]} />
 
 ## Server Env Vars
@@ -91,11 +91,11 @@ Read more about the `env` object in the [API reference](#server-env-vars-1).
 These are some general env variables used for various Wasp features:
 
 <EnvVarsTable envVars={[
-  { name: "DATABASE_URL", type: "String", isRequired: true, note: "The URL of the PostgreSQL database you want your app to use." },
-  { name: "WASP_WEB_CLIENT_URL", type: "URL", isRequired: true, note: "Server uses this value as your client URL in various features e.g. linking to your app in e-mails." },
-  { name: "WASP_SERVER_URL", type: "URL", isRequired: true, note: "Server uses this value as your server URL in various features e.g. to redirect users when logging in with OAuth providers like Google or GitHub." },
-  { name: "JWT_SECRET", type: "String", isRequired: true, note: <span>Needed to generate secure tokens. <a href="https://jwtsecret.com/generate" target="_blank" rel="noreferrer">Generate</a> a random string at least 32 characters long.</span> },
-  { name: "PORT", type: "Integer", isRequired: false, defaultValue: "3001", note: "This is where the server listens for requests." }
+{ name: "DATABASE_URL", type: "String", isRequired: true, note: "The URL of the PostgreSQL database you want your app to use." },
+{ name: "WASP_WEB_CLIENT_URL", type: "URL", isRequired: true, note: "Server uses this value as your client URL in various features e.g. linking to your app in e-mails." },
+{ name: "WASP_SERVER_URL", type: "URL", isRequired: true, note: "Server uses this value as your server URL in various features e.g. to redirect users when logging in with OAuth providers like Google or GitHub." },
+{ name: "JWT_SECRET", type: "String", isRequired: true, note: <span>Needed to generate secure tokens. <a href="https://jwtsecret.com/generate" target="_blank" rel="noreferrer">Generate</a> a random string at least 32 characters long.</span> },
+{ name: "PORT", type: "Integer", isRequired: false, defaultValue: "3001", note: "This is where the server listens for requests." }
 ]} />
 
 #### SMTP Email Sender
@@ -103,10 +103,10 @@ These are some general env variables used for various Wasp features:
 If you are using `SMTP` as your email sender, you need to provide the following environment variables:
 
 <EnvVarsTable envVars={[
-  { name: "SMTP_HOST", type: "String", isRequired: true, note: "The SMTP server host." },
-  { name: "SMTP_PORT", type: "Integer", isRequired: true, note: "The SMTP server port." },
-  { name: "SMTP_USERNAME", type: "String", isRequired: true, note: "The SMTP server username." },
-  { name: "SMTP_PASSWORD", type: "String", isRequired: true, note: "The SMTP server password." }
+{ name: "SMTP_HOST", type: "String", isRequired: true, note: "The SMTP server host." },
+{ name: "SMTP_PORT", type: "Integer", isRequired: true, note: "The SMTP server port." },
+{ name: "SMTP_USERNAME", type: "String", isRequired: true, note: "The SMTP server username." },
+{ name: "SMTP_PASSWORD", type: "String", isRequired: true, note: "The SMTP server password." }
 ]} />
 
 #### SendGrid Email Sender
@@ -114,7 +114,7 @@ If you are using `SMTP` as your email sender, you need to provide the following 
 If you are using `SendGrid` as your email sender, you need to provide the following environment variables:
 
 <EnvVarsTable envVars={[
-  { name: "SENDGRID_API_KEY", type: "String", isRequired: true, note: "The SendGrid API key." }
+{ name: "SENDGRID_API_KEY", type: "String", isRequired: true, note: "The SendGrid API key." }
 ]} />
 
 #### Mailgun Email Sender
@@ -122,9 +122,9 @@ If you are using `SendGrid` as your email sender, you need to provide the follow
 If you are using `Mailgun` as your email sender, you need to provide the following environment variables:
 
 <EnvVarsTable envVars={[
-  { name: "MAILGUN_API_KEY", type: "String", isRequired: true, note: "The Mailgun API key." },
-  { name: "MAILGUN_DOMAIN", type: "String", isRequired: true, note: "The Mailgun domain." },
-  { name: "MAILGUN_API_URL", type: "URL", isRequired: false, note: <span>Useful if you want to use the EU API endpoint (<code>https://api.eu.mailgun.net</code>).</span> }
+{ name: "MAILGUN_API_KEY", type: "String", isRequired: true, note: "The Mailgun API key." },
+{ name: "MAILGUN_DOMAIN", type: "String", isRequired: true, note: "The Mailgun domain." },
+{ name: "MAILGUN_API_URL", type: "URL", isRequired: false, note: <span>Useful if you want to use the EU API endpoint (<code>https://api.eu.mailgun.net</code>).</span> }
 ]} />
 
 #### OAuth Providers
@@ -132,8 +132,8 @@ If you are using `Mailgun` as your email sender, you need to provide the followi
 If you are using OAuth, you need to provide the following environment variables:
 
 <EnvVarsTable envVars={[
-  { name: "<PROVIDER_NAME>_CLIENT_ID", type: "String", isRequired: true, note: "The client ID provided by the OAuth provider." },
-  { name: "<PROVIDER_NAME>_CLIENT_SECRET", type: "String", isRequired: true, note: "The client secret provided by the OAuth provider." }
+{ name: "<PROVIDER_NAME>_CLIENT_ID", type: "String", isRequired: true, note: "The client ID provided by the OAuth provider." },
+{ name: "<PROVIDER_NAME>_CLIENT_SECRET", type: "String", isRequired: true, note: "The client secret provided by the OAuth provider." }
 ]} />
 
 <small>
@@ -144,13 +144,13 @@ If you are using OAuth, you need to provide the following environment variables:
 If you are using [Keycloak](../auth/social-auth/keycloak.md), you'll need to provide one extra environment variable:
 
 <EnvVarsTable envVars={[
-  { name: "KEYCLOAK_REALM_URL", type: "URL", isRequired: true, note: "The URL of the Keycloak realm." }
+{ name: "KEYCLOAK_REALM_URL", type: "URL", isRequired: true, note: "The URL of the Keycloak realm." }
 ]} />
 
 #### Jobs
 
 <EnvVarsTable envVars={[
-  { name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs#declaring-jobs">custom config</a> for PgBoss.</span> }
+{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs#declaring-jobs">custom config</a> for PgBoss.</span> }
 ]} />
 
 #### Development
@@ -158,8 +158,9 @@ If you are using [Keycloak](../auth/social-auth/keycloak.md), you'll need to pro
 We provide some helper env variables in development:
 
 <!-- TODO: this not really Boolean, it's really a string that accepts "true" as only true value -->
+
 <EnvVarsTable envVars={[
-  { name: "SKIP_EMAIL_VERIFICATION_IN_DEV", type: "Boolean", isRequired: false, defaultValue: "false", note: "If set to true, automatically sets user emails as verified in development." }
+{ name: "SKIP_EMAIL_VERIFICATION_IN_DEV", type: "Boolean", isRequired: false, defaultValue: "false", note: "If set to true, automatically sets user emails as verified in development." }
 ]} />
 
 ## Defining Env Vars in Development
@@ -217,7 +218,80 @@ We talk about how to define env vars for each deployment option in the [deployme
 
 ## Custom Env Var Validations
 
-TODO: when the Zod validation PRs are merged, describe how users can define their own validations.
+If your code requires some custom env variables, you might want to ensure that they are defined and have the correct values. You can define your env vars validation by defining a [Zod object schema](https://zod.dev/) and importing it in the `main.wasp` file.
+
+:::info What is Zod?
+
+[Zod](https://zod.dev/) is a library that enables you to define what you expect from your data. For example, you can use Zod to define that a string should be an email address, or that a number should be between 0 and 100.
+
+:::
+
+This is how you can define a custom env var validation schema for the client and the server:
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```js title="src/env.js"
+import * as z from 'zod'
+
+export const serverEnvValidationSchema = z.object({
+  STRIPE_API_KEY: z.string({
+    required_error: 'STRIPE_API_KEY is required.',
+  }),
+})
+
+export const clientEnvValidationSchema = z.object({
+  REACT_APP_NAME: z.string().default('TODO App'),
+})
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title="src/env.ts"
+import * as z from 'zod'
+
+import { defineEnvValidationSchema } from 'wasp/env'
+
+export const serverEnvValidationSchema = defineEnvValidationSchema(
+  z.object({
+    STRIPE_API_KEY: z.string({
+      required_error: 'STRIPE_API_KEY is required.',
+    }),
+  })
+)
+
+export const clientEnvValidationSchema = defineEnvValidationSchema(
+  z.object({
+    REACT_APP_NAME: z.string().default('TODO App'),
+  })
+)
+```
+
+</TabItem>
+</Tabs>
+
+```wasp title="main.wasp"
+app myApp {
+  ...
+  client: {
+    envValidationSchema: import { clientEnvValidationSchema } from "@src/env",
+  },
+  server: {
+    envValidationSchema: import { serverEnvValidationSchema } from "@src/env",
+  },
+}
+```
+
+Wasp merges your env validation schemas with the built-in env vars validation schemas when it validates the `process.env` object on the server and the `import.meta.env` object on the client.
+
+This means you can use the `env` object to access **your env vars** like this:
+
+```ts
+import { env } from 'wasp/server/env'
+
+const stripeApiKey: string = env.STRIPE_API_KEY
+```
 
 ## API Reference
 

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -222,7 +222,10 @@ If your code requires some environment variables, you usually want to ensure tha
 
 :::info What is Zod?
 
-[Zod](https://zod.dev/) is a library that lets you define what you expect from your data. For example, you can use Zod to define that a value should be a string that's a valid email address or that a value should be a number between 0 and 100.
+[Zod](https://zod.dev/) is a library that lets you define what you expect from your data. For example, you can use Zod to define that:
+- A value should be a string that's a valid email address.
+- A value should be a number between 0 and 100.
+- etc.
 
 :::
 


### PR DESCRIPTION
This PR will cover:
- [x] The way users access the validated `env` object on the server and the client
- [x] How users can define their custom env vars validation