### PR TITLE
Add Remark plugin for Wasp version search & replace

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -92,3 +92,9 @@ We should not keep too many versions of documentation, especially now in Beta wh
 Therefore, we should be quite liberal with deleting the older versions of docs.
 
 Also, it might make sense to delete the previous version of docs if only bug fixes were done in the latest version.
+
+#### Latest Wasp version variable
+
+We have a custom remark plugin that allows us to use `{latestWaspVersion}` in our code blocks, which will be replaced with the latest Wasp version in `versions.json` when the docs are built. This allows us to have the up to date Wasp version in the docs, without having to manually update it every time we release a new version of Wasp.
+
+Check the plugin [here](./src/remark//search-and-replace.js) for more info.

--- a/web/docs/auth/auth-hooks.md
+++ b/web/docs/auth/auth-hooks.md
@@ -55,7 +55,7 @@ To use auth hooks, you must first declare them in the Wasp file:
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   auth: {
     userEntity: User,
@@ -77,7 +77,7 @@ app myApp {
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   auth: {
     userEntity: User,
@@ -583,7 +583,7 @@ If you want to refresh the token periodically, use a [Wasp Job](../advanced/jobs
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   auth: {
     userEntity: User,
@@ -605,7 +605,7 @@ app myApp {
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   auth: {
     userEntity: User,

--- a/web/docs/auth/email.md
+++ b/web/docs/auth/email.md
@@ -50,7 +50,7 @@ Let's start with adding the following to our `main.wasp` file:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -85,7 +85,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/entities/entities.md
+++ b/web/docs/auth/entities/entities.md
@@ -470,7 +470,7 @@ For example, you might set it to `User`:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/discord.md
+++ b/web/docs/auth/social-auth/discord.md
@@ -42,7 +42,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -67,7 +67,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -276,7 +276,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -296,7 +296,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -361,7 +361,7 @@ For an up to date info about the data received from Discord, please refer to the
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -408,7 +408,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -476,7 +476,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -500,7 +500,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/github.md
+++ b/web/docs/auth/social-auth/github.md
@@ -43,7 +43,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -68,7 +68,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -296,7 +296,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -374,7 +374,7 @@ For an up to date info about the data received from GitHub, please refer to the 
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -421,7 +421,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -489,7 +489,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -513,7 +513,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/google.md
+++ b/web/docs/auth/social-auth/google.md
@@ -43,7 +43,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -66,7 +66,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -317,7 +317,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -337,7 +337,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -400,7 +400,7 @@ For an up to date info about the data received from Google, please refer to the 
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -447,7 +447,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -515,7 +515,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -539,7 +539,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/keycloak.md
+++ b/web/docs/auth/social-auth/keycloak.md
@@ -42,7 +42,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -65,7 +65,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -283,7 +283,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -303,7 +303,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -359,7 +359,7 @@ For up-to-date info about the data received from Keycloak, please refer to the [
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -406,7 +406,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -474,7 +474,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -498,7 +498,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/social-auth/overview.md
+++ b/web/docs/auth/social-auth/overview.md
@@ -36,7 +36,7 @@ Here's what the full setup looks like:
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -63,7 +63,7 @@ model User {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -148,7 +148,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -180,7 +180,7 @@ export const userSignupFields = {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/docs/auth/username-and-pass.md
+++ b/web/docs/auth/username-and-pass.md
@@ -45,7 +45,7 @@ Let's start with adding the following to our `main.wasp` file:
 ```wasp title="main.wasp" {11}
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -66,7 +66,7 @@ app myApp {
 ```wasp title="main.wasp"  {11}
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -624,7 +624,7 @@ When you receive the `user` object [on the client or the server](./overview.md#a
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -649,7 +649,7 @@ model User {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -681,7 +681,7 @@ model User {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -703,7 +703,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/docs/data-model/crud.md
+++ b/web/docs/data-model/crud.md
@@ -73,7 +73,7 @@ We can start by running `wasp new tasksCrudApp` and then adding the following to
 ```wasp title="main.wasp"
 app tasksCrudApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "Tasks Crud App",
 

--- a/web/docs/data-model/prisma-file.md
+++ b/web/docs/data-model/prisma-file.md
@@ -66,7 +66,7 @@ Finally, Prisma models become Wasp Entities which can be then used in the `main.
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
 }

--- a/web/docs/general/wasp-ts-config.md
+++ b/web/docs/general/wasp-ts-config.md
@@ -138,7 +138,7 @@ import { App } from 'wasp-config'
 
 const app = new App('todoApp', {
   title: 'ToDo App',
-  wasp: { version: '^0.16.0' },
+  wasp: { version: '{latestWaspVersion}' },
   // head: []
 });
 

--- a/web/docs/introduction/introduction.md
+++ b/web/docs/introduction/introduction.md
@@ -61,7 +61,7 @@ Let's give our app a title and let's immediately turn on the full-stack authenti
 ```wasp title="main.wasp"
 app RecipeApp {
   title: "My Recipes",
-  wasp: { version: "^0.16.0" },
+  wasp: { version: "{latestWaspVersion}" },
   auth: {
     methods: { usernameAndPassword: {} },
     onAuthFailedRedirectTo: "/login",

--- a/web/docs/project/customizing-app.md
+++ b/web/docs/project/customizing-app.md
@@ -9,7 +9,7 @@ Each Wasp project can have only one `app` type declaration. It is used to config
 ```wasp
 app todoApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "ToDo App",
   head: [
@@ -27,7 +27,7 @@ You may want to change the title of your app, which appears in the browser tab, 
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "BookFace"
 }
@@ -42,7 +42,7 @@ An example of adding extra style sheets and scripts:
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   head: [  // optional
@@ -58,7 +58,7 @@ app myApp {
 ```wasp
 app todoApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "ToDo App",
   head: [

--- a/web/docs/tutorial/02-project-structure.md
+++ b/web/docs/tutorial/02-project-structure.md
@@ -97,7 +97,7 @@ The default `main.wasp` file generated with `wasp new` on the previous page look
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.16.0" // Pins the version of Wasp to use.
+    version: "{latestWaspVersion}" // Pins the version of Wasp to use.
   },
   title: "TodoApp" // Used as the browser tab title. Note that all strings in Wasp are double quoted!
 }
@@ -117,7 +117,7 @@ page MainPage {
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.16.0" // Pins the version of Wasp to use.
+    version: "{latestWaspVersion}" // Pins the version of Wasp to use.
   },
   title: "TodoApp" // Used as the browser tab title. Note that all strings in Wasp are double quoted!
 }

--- a/web/docs/tutorial/03-pages.md
+++ b/web/docs/tutorial/03-pages.md
@@ -194,7 +194,7 @@ Your Wasp file should now look like this:
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "TodoApp"
 }
@@ -211,7 +211,7 @@ page MainPage {
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   title: "TodoApp"
 }

--- a/web/docs/tutorial/07-auth.md
+++ b/web/docs/tutorial/07-auth.md
@@ -38,7 +38,7 @@ Next, tell Wasp to use full-stack [authentication](../auth/overview):
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.16.0"
+    version: "{latestWaspVersion}"
   },
   // highlight-start
   title: "TodoApp",

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -2,6 +2,7 @@ const lightCodeTheme = require('prism-react-renderer/themes/github')
 
 const autoImportTabs = require('./src/remark/auto-import-tabs')
 const fileExtSwitcher = require('./src/remark/file-ext-switcher')
+const searchAndReplace = require('./src/remark/search-and-replace')
 
 const includeCurrentVersion =
   process.env.DOCS_INCLUDE_CURRENT_VERSION === 'true'
@@ -161,7 +162,7 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           sidebarCollapsible: true,
           editUrl: 'https://github.com/wasp-lang/wasp/edit/release/web',
-          remarkPlugins: [autoImportTabs, fileExtSwitcher],
+          remarkPlugins: [autoImportTabs, fileExtSwitcher, searchAndReplace],
 
           // ------ Configuration for multiple docs versions ------ //
 

--- a/web/src/remark/search-and-replace.js
+++ b/web/src/remark/search-and-replace.js
@@ -1,0 +1,25 @@
+const visit = require('unist-util-visit')
+const docsVersions = require('../../versions.json')
+
+const latestWaspVersion = docsVersions[0]
+
+const replacements = [
+  {
+    search: /{latestWaspVersion}/g,
+    replace: `^${latestWaspVersion}`,
+  },
+]
+
+function searchAndReplace(tree) {
+  visit(tree, (node) => {
+    // NOTE: For now we only replace in code blocks to keep
+    // the search and replace logic simple.
+    if (node.type === 'code') {
+      replacements.forEach(({ search, replace }) => {
+        node.value = node.value.replace(search, replace)
+      })
+    }
+  })
+}
+
+module.exports = () => searchAndReplace

--- a/web/versioned_docs/version-0.16.0/auth/auth-hooks.md
+++ b/web/versioned_docs/version-0.16.0/auth/auth-hooks.md
@@ -55,7 +55,7 @@ To use auth hooks, you must first declare them in the Wasp file:
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   auth: {
     userEntity: User,
@@ -77,7 +77,7 @@ app myApp {
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   auth: {
     userEntity: User,
@@ -583,7 +583,7 @@ If you want to refresh the token periodically, use a [Wasp Job](../advanced/jobs
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   auth: {
     userEntity: User,
@@ -605,7 +605,7 @@ app myApp {
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   auth: {
     userEntity: User,

--- a/web/versioned_docs/version-0.16.0/auth/email.md
+++ b/web/versioned_docs/version-0.16.0/auth/email.md
@@ -50,7 +50,7 @@ Let's start with adding the following to our `main.wasp` file:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -85,7 +85,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.16.0/auth/entities/entities.md
+++ b/web/versioned_docs/version-0.16.0/auth/entities/entities.md
@@ -470,7 +470,7 @@ For example, you might set it to `User`:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/discord.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/discord.md
@@ -42,7 +42,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -67,7 +67,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -276,7 +276,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -296,7 +296,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -361,7 +361,7 @@ For an up to date info about the data received from Discord, please refer to the
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -408,7 +408,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -476,7 +476,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -500,7 +500,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/github.md
@@ -43,7 +43,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -68,7 +68,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -296,7 +296,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -374,7 +374,7 @@ For an up to date info about the data received from GitHub, please refer to the 
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -421,7 +421,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -489,7 +489,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -513,7 +513,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/google.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/google.md
@@ -43,7 +43,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -66,7 +66,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -317,7 +317,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -337,7 +337,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -400,7 +400,7 @@ For an up to date info about the data received from Google, please refer to the 
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -447,7 +447,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -515,7 +515,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -539,7 +539,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/keycloak.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/keycloak.md
@@ -42,7 +42,7 @@ Let's start by properly configuring the Auth object:
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -65,7 +65,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -283,7 +283,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -303,7 +303,7 @@ app myApp {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -359,7 +359,7 @@ For up-to-date info about the data received from Keycloak, please refer to the [
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -406,7 +406,7 @@ export function getConfig() {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -474,7 +474,7 @@ When you receive the `user` object [on the client or the server](../overview.md#
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -498,7 +498,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/overview.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/overview.md
@@ -36,7 +36,7 @@ Here's what the full setup looks like:
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -63,7 +63,7 @@ model User {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -148,7 +148,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -180,7 +180,7 @@ export const userSignupFields = {
 ```wasp title=main.wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.16.0/auth/username-and-pass.md
+++ b/web/versioned_docs/version-0.16.0/auth/username-and-pass.md
@@ -45,7 +45,7 @@ Let's start with adding the following to our `main.wasp` file:
 ```wasp title="main.wasp" {11}
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -66,7 +66,7 @@ app myApp {
 ```wasp title="main.wasp"  {11}
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -624,7 +624,7 @@ When you receive the `user` object [on the client or the server](./overview.md#a
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -649,7 +649,7 @@ model User {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -681,7 +681,7 @@ model User {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {
@@ -703,7 +703,7 @@ app myApp {
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   auth: {

--- a/web/versioned_docs/version-0.16.0/data-model/crud.md
+++ b/web/versioned_docs/version-0.16.0/data-model/crud.md
@@ -73,7 +73,7 @@ We can start by running `wasp new tasksCrudApp` and then adding the following to
 ```wasp title="main.wasp"
 app tasksCrudApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "Tasks Crud App",
 

--- a/web/versioned_docs/version-0.16.0/data-model/prisma-file.md
+++ b/web/versioned_docs/version-0.16.0/data-model/prisma-file.md
@@ -66,7 +66,7 @@ Finally, Prisma models become Wasp Entities which can be then used in the `main.
 ```wasp title="main.wasp"
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
 }

--- a/web/versioned_docs/version-0.16.0/deployment/deployment-methods/paas.md
+++ b/web/versioned_docs/version-0.16.0/deployment/deployment-methods/paas.md
@@ -594,7 +594,7 @@ jobs:
           node-version: '20'
 
       - name: Install Wasp
-        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.15.0 # Change to your Wasp version
+        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
 
       - name: Wasp Build
         run: wasp build
@@ -699,7 +699,7 @@ jobs:
           node-version: '20'
 
       - name: Install Wasp
-        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.15.0 # Change to your Wasp version
+        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
 
       - name: Wasp Build
         run: cd ./app && wasp build

--- a/web/versioned_docs/version-0.16.0/general/wasp-ts-config.md
+++ b/web/versioned_docs/version-0.16.0/general/wasp-ts-config.md
@@ -138,7 +138,7 @@ import { App } from 'wasp-config'
 
 const app = new App('todoApp', {
   title: 'ToDo App',
-  wasp: { version: '^0.15.0' },
+  wasp: { version: '{latestWaspVersion}' },
   // head: []
 });
 

--- a/web/versioned_docs/version-0.16.0/introduction/introduction.md
+++ b/web/versioned_docs/version-0.16.0/introduction/introduction.md
@@ -61,7 +61,7 @@ Let's give our app a title and let's immediately turn on the full-stack authenti
 ```wasp title="main.wasp"
 app RecipeApp {
   title: "My Recipes",
-  wasp: { version: "^0.15.0" },
+  wasp: { version: "{latestWaspVersion}" },
   auth: {
     methods: { usernameAndPassword: {} },
     onAuthFailedRedirectTo: "/login",

--- a/web/versioned_docs/version-0.16.0/project/customizing-app.md
+++ b/web/versioned_docs/version-0.16.0/project/customizing-app.md
@@ -9,7 +9,7 @@ Each Wasp project can have only one `app` type declaration. It is used to config
 ```wasp
 app todoApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "ToDo App",
   head: [
@@ -27,7 +27,7 @@ You may want to change the title of your app, which appears in the browser tab, 
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "BookFace"
 }
@@ -42,7 +42,7 @@ An example of adding extra style sheets and scripts:
 ```wasp
 app myApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "My App",
   head: [  // optional
@@ -58,7 +58,7 @@ app myApp {
 ```wasp
 app todoApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "ToDo App",
   head: [

--- a/web/versioned_docs/version-0.16.0/tutorial/02-project-structure.md
+++ b/web/versioned_docs/version-0.16.0/tutorial/02-project-structure.md
@@ -97,7 +97,7 @@ The default `main.wasp` file generated with `wasp new` on the previous page look
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.15.0" // Pins the version of Wasp to use.
+    version: "{latestWaspVersion}" // Pins the version of Wasp to use.
   },
   title: "TodoApp" // Used as the browser tab title. Note that all strings in Wasp are double quoted!
 }
@@ -117,7 +117,7 @@ page MainPage {
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.15.0" // Pins the version of Wasp to use.
+    version: "{latestWaspVersion}" // Pins the version of Wasp to use.
   },
   title: "TodoApp" // Used as the browser tab title. Note that all strings in Wasp are double quoted!
 }

--- a/web/versioned_docs/version-0.16.0/tutorial/03-pages.md
+++ b/web/versioned_docs/version-0.16.0/tutorial/03-pages.md
@@ -194,7 +194,7 @@ Your Wasp file should now look like this:
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "TodoApp"
 }
@@ -211,7 +211,7 @@ page MainPage {
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   title: "TodoApp"
 }

--- a/web/versioned_docs/version-0.16.0/tutorial/07-auth.md
+++ b/web/versioned_docs/version-0.16.0/tutorial/07-auth.md
@@ -38,7 +38,7 @@ Next, tell Wasp to use full-stack [authentication](../auth/overview):
 ```wasp title="main.wasp"
 app TodoApp {
   wasp: {
-    version: "^0.15.0"
+    version: "{latestWaspVersion}"
   },
   // highlight-start
   title: "TodoApp",


### PR DESCRIPTION
Added a simple plugin to search & replace `{latestWaspVersion}` string in code blocks with the actual latest value based on `versions.json` file.

It uses the sem ver range format e.g. `^0.16.0` because this is what we needed. If we need to expand it, it's easy enough to update the plugin. 

I've tested it in dev, prod build and adding a new version e.g. 0.17.0 and it worked well. 