### PR TITLE
session cookie auth with JWT backward compatibility

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/api/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/api/index.ts
@@ -1,3 +1,4 @@
+{{={= =}=}}
 import axios, { type AxiosInstance, type AxiosError } from 'axios'
 
 import { config } from 'wasp/client'
@@ -40,10 +41,12 @@ export function removeLocalUserData(): void {
 }
 
 api.interceptors.request.use((request) => {
+  {=^ isCookieAuthEnabled =}
   const sessionId = getSessionId()
   if (sessionId) {
     request.headers['Authorization'] = `Bearer ${sessionId}`
   }
+  {=/ isCookieAuthEnabled =}
   return request
 })
 

--- a/waspc/data/Generator/templates/sdk/wasp/auth/helpers/user.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/helpers/user.ts
@@ -1,9 +1,12 @@
+{{={= =}=}}
 import { setSessionId } from 'wasp/client/api'
 import { invalidateAndRemoveQueries } from '../../client/operations/internal/resources.js'
 
 // PRIVATE API
 export async function initSession(sessionId: string): Promise<void> {
+    {=^ isCookieAuthEnabled =}
     setSessionId(sessionId)
+    {=/ isCookieAuthEnabled =}
     // We need to invalidate queries after login in order to get the correct user
     // data in the React components (using `useAuth`).
     // Redirects after login won't work properly without this.

--- a/waspc/data/Generator/templates/sdk/wasp/auth/login.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/login.ts
@@ -7,7 +7,9 @@ export default async function login(username: string, password: string): Promise
     const args = { username, password }
     const response = await api.post('{= loginPath =}', args)
 
+    {=^ isCookieAuthEnabled =}
     await initSession(response.data.sessionId)
+    {=/ isCookieAuthEnabled =}
   } catch (error) {
     throw handleApiError(error)
   }

--- a/waspc/data/Generator/templates/sdk/wasp/auth/logout.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/logout.ts
@@ -1,3 +1,4 @@
+{{={= =}=}}
 import { api, removeLocalUserData } from 'wasp/client/api'
 import { invalidateAndRemoveQueries } from '../client/operations/internal/resources.js'
 
@@ -9,7 +10,9 @@ export default async function logout(): Promise<void> {
     // Even if the logout request fails, we still want to remove the local user data
     // in case the logout failed because of a network error and the user walked away
     // from the computer.
+    {=^ isCookieAuthEnabled =}
     removeLocalUserData()
+    {=/ isCookieAuthEnabled =}
 
     // TODO(filip): We are currently invalidating and removing  all the queries, but
     // we should remove only the non-public, user-dependent ones.

--- a/waspc/data/Generator/templates/sdk/wasp/auth/useAuth.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/useAuth.ts
@@ -21,7 +21,12 @@ function createUserGetter(): Query<void, AuthUser | null> {
   const getMeRoute = { method: HttpMethod.Get, path: `/${getMeRelativePath}` }
   const getMe: QueryFunction<void, AuthUser | null> = async () =>  {
     try {
+      {=# isCookieAuthEnabled =}
+      const response = await api.get(getMeRoute.path, { withCredentials: true })
+      {=/ isCookieAuthEnabled =}
+      {=^ isCookieAuthEnabled =}
       const response = await api.get(getMeRoute.path)
+      {=/ isCookieAuthEnabled =}
       const userData = superjsonDeserialize<AuthUserData | null>(response.data)
       return makeAuthUserIfPossible(userData)
     } catch (error) {

--- a/waspc/data/Generator/templates/sdk/wasp/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/utils.ts
@@ -1,6 +1,7 @@
 {{={= =}=}}
 import { hashPassword } from './password.js'
 import { prisma, HttpError } from 'wasp/server'
+import { config } from 'wasp/server'
 import { sleep } from 'wasp/server/utils'
 import {
   type {= userEntityUpper =},
@@ -336,4 +337,20 @@ function providerDataHasPasswordField(
 // PRIVATE API
 export function createInvalidCredentialsError(message?: string): HttpError {
   return new HttpError(401, 'Invalid credentials', { message })
+}
+
+export function verifyRequestOrigin(origin: string, allowedHosts: string[] = []): boolean {
+  try {
+    const originUrl = new URL(origin)
+    const allowedOrigins = [...config.allowedOrigins, ...allowedHosts].map((host) => {
+      try {
+        return new URL(host).host
+      } catch {
+        return host
+      }
+    })
+    return allowedOrigins.some((host) => originUrl.host === host)
+  } catch (error) {
+    return false
+  }
 }

--- a/waspc/data/Generator/templates/sdk/wasp/client/webSocket/WebSocketProvider.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/webSocket/WebSocketProvider.tsx
@@ -21,6 +21,9 @@ export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
   {
     transports: ['websocket'],
     autoConnect: {= autoConnect =},
+    {=# isCookieAuthEnabled =}
+    withCredentials: true,
+    {=/ isCookieAuthEnabled =}
   }
 )
 
@@ -37,9 +40,17 @@ function refreshAuthToken() {
   }
 }
 
+{=# isCookieAuthEnabled =}
+if (socket.connected) {
+  socket.disconnect()
+  socket.connect()
+}
+{=/ isCookieAuthEnabled =}
+{=^ isCookieAuthEnabled =}
 refreshAuthToken()
 apiEventsEmitter.on('sessionId.set', refreshAuthToken)
 apiEventsEmitter.on('sessionId.clear', refreshAuthToken)
+{=/ isCookieAuthEnabled =}
 
 // PRIVATE API
 export const WebSocketContext: Context<WebSocketContextValue> = createContext<WebSocketContextValue>({

--- a/waspc/data/Generator/templates/sdk/wasp/core/auth.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/core/auth.ts
@@ -1,20 +1,77 @@
+{{={= =}=}}
 import { handleRejection } from 'wasp/server/utils'
+{=# isCookieAuthEnabled =}
+import { 
+  getSessionAndUserFromSessionId,
+  getSessionFromCookie,
+  createSessionCookieWithHttpOnly,
+  createBlankCookie
+} from 'wasp/auth/session'
+{=/ isCookieAuthEnabled =}
+{=^ isCookieAuthEnabled =}
 import { getSessionAndUserFromBearerToken } from 'wasp/auth/session'
+{=/ isCookieAuthEnabled =}
 import { createInvalidCredentialsError } from 'wasp/auth/utils'
 
 /**
  * Auth middleware
- *
- * If the request includes an `Authorization` header it will try to authenticate the request,
- * otherwise it will let the request through.
- *
+ * 
+ * Validates the session cookie or JWT and authenticates the request.
  * - If authentication succeeds it sets `req.sessionId` and `req.user`
  *   - `req.user` is the user that made the request and it's used in
  *      all Wasp features that need to know the user that made the request.
  *   - `req.sessionId` is the ID of the session that authenticated the request.
  * - If the request is not authenticated, it throws an error.
+ * 
+ * cookieEnabled: true (session cookie) -
+ * We can immediately jump in and validate the session cookie.
+ * 
+ * cookieEnabled: false (JWT local storage) -
+ * If the request includes an `Authorization` header it will try to authenticate the request,
+ * otherwise it will let the request through.
+ *
  */
 const auth = handleRejection(async (req, res, next) => {
+  {=# isCookieAuthEnabled =}
+  const cookieHeader = req.headers.cookie ?? ''
+  if (!cookieHeader) {
+    req.sessionId = null
+    req.user = null
+    return next()
+  }
+
+  const sessionId = getSessionFromCookie(cookieHeader)
+  if (!sessionId) {
+    req.sessionId = null
+    req.user = null
+    return next()
+  }
+  try {
+    const sessionAndUser = await getSessionAndUserFromSessionId(sessionId)
+
+    if (sessionAndUser === null) {
+      res.setHeader("Set-Cookie", createBlankCookie().serialize())
+      req.sessionId = null
+      req.user = null
+      return next()
+    }
+
+    if (sessionAndUser.session && sessionAndUser.session.fresh) {
+      res.setHeader("Set-Cookie", createSessionCookieWithHttpOnly(sessionAndUser.session.id).serialize())
+    }
+
+    req.sessionId = sessionAndUser.session.id
+    req.user = sessionAndUser.user
+
+    next()
+  } catch (err) {
+    res.setHeader("Set-Cookie", createBlankCookie().serialize())
+    req.sessionId = null
+    req.user = null
+    return next()
+  }
+  {=/ isCookieAuthEnabled =}
+  {=^ isCookieAuthEnabled =}
   const authHeader = req.get('Authorization')
   // NOTE(matija): for now we let tokenless requests through and make it operation's
   // responsibility to verify whether the request is authenticated or not. In the future
@@ -35,6 +92,7 @@ const auth = handleRejection(async (req, res, next) => {
   req.user = sessionAndUser.user
 
   next()
+  {=/ isCookieAuthEnabled =}
 })
 
 export default auth

--- a/waspc/data/Generator/templates/sdk/wasp/server/config.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/config.ts
@@ -13,6 +13,7 @@ type Config = {
   serverUrl: string;
   cookieEnabled: boolean;
   {=# isCookieAuthEnabled =}
+  allowedOrigins: string[];
   apiPrefix: string;
   cookieName: string;
   cookieExpires: boolean;
@@ -32,6 +33,7 @@ type Config = {
 const frontendUrl = stripTrailingSlash(env.WASP_WEB_CLIENT_URL)
 const serverUrl = stripTrailingSlash(env.WASP_SERVER_URL)
 {=# isCookieAuthEnabled =}
+const allowedOrigins = env.ALLOWED_ORIGINS.split(',').map((origin) => origin.trim())
 const apiPrefix = stripTrailingSlash(env.WASP_API_PREFIX)
 const cookieName = env.COOKIE_NAME
 const cookieExpires = env.COOKIE_EXPIRES
@@ -53,6 +55,7 @@ const config: Config = {
   allowedCORSOrigins,
   {=# isCookieAuthEnabled =}
   cookieEnabled: true,
+  allowedOrigins,
   apiPrefix,
   cookieName,
   cookieExpires,

--- a/waspc/data/Generator/templates/sdk/wasp/server/config.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/config.ts
@@ -11,6 +11,16 @@ type Config = {
   databaseUrl: string;
   frontendUrl: string;
   serverUrl: string;
+  cookieEnabled: boolean;
+  {=# isCookieAuthEnabled =}
+  apiPrefix: string;
+  cookieName: string;
+  cookieExpires: boolean;
+  cookieSecure: boolean;
+  cookieSameSite: 'lax' | 'strict' | 'none';
+  cookiePath: string;
+  sessionExpiresIn: number;
+  {=/ isCookieAuthEnabled =}
   allowedCORSOrigins: string | string[];
   {=# isAuthEnabled =}
   auth: {
@@ -21,9 +31,18 @@ type Config = {
 
 const frontendUrl = stripTrailingSlash(env.WASP_WEB_CLIENT_URL)
 const serverUrl = stripTrailingSlash(env.WASP_SERVER_URL)
+{=# isCookieAuthEnabled =}
+const apiPrefix = stripTrailingSlash(env.WASP_API_PREFIX)
+const cookieName = env.COOKIE_NAME
+const cookieExpires = env.COOKIE_EXPIRES
+const cookieSecure = env.COOKIE_SECURE
+const cookieSameSite = env.COOKIE_SAME_SITE
+const cookiePath = env.COOKIE_PATH
+const sessionExpiresIn = Number(env.SESSION_EXPIRES_IN_SECONDS)
+{=/ isCookieAuthEnabled =}
 
 const allowedCORSOriginsPerEnv: Record<NodeEnv, string | string[]> = {
-  development: '*',
+  development: [frontendUrl],
   production: [frontendUrl]
 }
 const allowedCORSOrigins = allowedCORSOriginsPerEnv[env.NODE_ENV]
@@ -32,6 +51,19 @@ const config: Config = {
   frontendUrl,
   serverUrl,
   allowedCORSOrigins,
+  {=# isCookieAuthEnabled =}
+  cookieEnabled: true,
+  apiPrefix,
+  cookieName,
+  cookieExpires,
+  cookieSecure,
+  cookieSameSite,
+  cookiePath,
+  sessionExpiresIn,
+  {=/ isCookieAuthEnabled =}
+  {=^ isCookieAuthEnabled =}
+  cookieEnabled: false,
+  {=/ isCookieAuthEnabled =}
   env: env.NODE_ENV,
   isDevelopment: env.NODE_ENV === 'development',
   port: env.PORT,

--- a/waspc/data/Generator/templates/sdk/wasp/server/env.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/env.ts
@@ -16,6 +16,39 @@ const waspServerCommonSchema = z.object({
   {= databaseUrlEnvVarName =}: z.string({
     required_error: '{= databaseUrlEnvVarName =} is required',
   }),
+  {=# isCookieAuthEnabled =}
+  WASP_API_PREFIX: z
+    .string()
+    .min(1, { message: 'WASP_API_PREFIX cannot be empty.' })
+    .refine((val) => val.startsWith('/'), {
+      message: `WASP_API_PREFIX must start with a '/' (e.g., '/api').`,
+    })
+    .default('/api'),
+  COOKIE_NAME: z
+    .string()
+    .min(1, { message: 'COOKIE_NAME cannot be empty.' })
+    .default('session'),
+  COOKIE_EXPIRES: z
+    .boolean()
+    .default(true),
+  COOKIE_SAME_SITE: z
+    .enum(['lax', 'strict', 'none'], {
+      errorMap: () => ({
+        message: 'COOKIE_SAME_SITE must be one of: lax, strict, or none.',
+      }),
+    })
+    .default('lax'),
+  COOKIE_PATH: z
+    .string()
+    .min(1, { message: 'COOKIE_PATH cannot be empty.' })
+    .default('/'),
+  SESSION_EXPIRES_IN_SECONDS: z
+    .string()
+    .refine((val) => !isNaN(Number(val)), {
+      message: 'SESSION_EXPIRES_IN_SECONDS must be a valid number',
+    })
+    .default('2592000'), // default to 30 days (in seconds)
+  {=/ isCookieAuthEnabled =}
   PG_BOSS_NEW_OPTIONS: z.string().optional(),
   {=# isEmailSenderEnabled =}
   {=# enabledEmailSenders.isSmtpProviderEnabled =}
@@ -128,6 +161,11 @@ const serverDevSchema = z.object({
     .default('{= defaultServerUrl =}'),
   WASP_WEB_CLIENT_URL: clientUrlSchema
     .default('{= defaultClientUrl =}'),
+  {=# isCookieAuthEnabled =}
+  COOKIE_SECURE: z
+    .boolean()
+    .default(false),
+  {=/ isCookieAuthEnabled =}
   {=# isAuthEnabled =}
   JWT_SECRET: jwtTokenSchema
     .default('DEVJWTSECRET'),
@@ -138,6 +176,11 @@ const serverProdSchema = z.object({
   NODE_ENV: z.literal('production'),
   WASP_SERVER_URL: serverUrlSchema,
   WASP_WEB_CLIENT_URL: clientUrlSchema,
+  {=# isCookieAuthEnabled =}
+  COOKIE_SECURE: z
+    .boolean()
+    .default(true),
+  {=/ isCookieAuthEnabled =}
   {=# isAuthEnabled =}
   JWT_SECRET: jwtTokenSchema,
   {=/ isAuthEnabled =}

--- a/waspc/data/Generator/templates/sdk/wasp/server/env.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/env.ts
@@ -17,6 +17,10 @@ const waspServerCommonSchema = z.object({
     required_error: '{= databaseUrlEnvVarName =} is required',
   }),
   {=# isCookieAuthEnabled =}
+  ALLOWED_ORIGINS: z
+    .string()
+    .transform((val) => val.split(',').map((origin) => origin.trim()))
+    .default('{= defaultClientUrl =}'),
   WASP_API_PREFIX: z
     .string()
     .min(1, { message: 'WASP_API_PREFIX cannot be empty.' })

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/login.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/login.ts
@@ -46,7 +46,7 @@ export function getLoginRoute() {
             user: auth.user,
         })
         
-        const session = await createSession(auth.id)
+        const session = await createSession(auth.id, res)
 
         await onAfterLoginHook({
             req,

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/oneTimeCode.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/oneTimeCode.ts
@@ -27,7 +27,7 @@ export function setupOneTimeCodeRoute(router: Router) {
         throw new HttpError(400, "Unable to login with the OAuth provider. The code is invalid.");
       }
 
-      const session = await createSession(auth.id);
+      const session = await createSession(auth.id, res);
 
       tokenStore.markUsed(code);
 

--- a/waspc/data/Generator/templates/server/src/auth/providers/username/login.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/username/login.ts
@@ -45,7 +45,7 @@ export default handleRejection(async (req, res) => {
       user: auth.user,
   })
 
-  const session = await createSession(auth.id)
+  const session = await createSession(auth.id, res)
 
   await onAfterLoginHook({
     req,

--- a/waspc/data/Generator/templates/server/src/middleware/globalMiddleware.ts
+++ b/waspc/data/Generator/templates/server/src/middleware/globalMiddleware.ts
@@ -20,7 +20,12 @@ const {=& globalMiddlewareConfigFn.importAlias =} = (mc: MiddlewareConfig) => mc
 // NOTE: Remember to update the docs of these change.
 const defaultGlobalMiddlewareConfig: MiddlewareConfig = new Map([
   ['helmet', helmet()],
-  ['cors', cors({ origin: config.allowedCORSOrigins })],
+  {=# isCookieAuthEnabled =}
+  ['cors', cors({ origin: config.allowedCORSOrigins, credentials: true })],
+  {=/ isCookieAuthEnabled =}
+  {=^ isCookieAuthEnabled =}
+  ['cors', cors({ origin: config.allowedCORSOrigins})],
+  {=/ isCookieAuthEnabled =}
   ['logger', logger('dev')],
   ['express.json', express.json()],
   ['express.urlencoded', express.urlencoded({ extended: false })],

--- a/waspc/data/Generator/templates/server/src/routes/auth/logout.ts
+++ b/waspc/data/Generator/templates/server/src/routes/auth/logout.ts
@@ -3,10 +3,10 @@ import { createInvalidCredentialsError } from 'wasp/auth/utils'
 import { invalidateSession } from 'wasp/auth/session'
 
 export default handleRejection(async (req, res) => {
-  if (req.sessionId) {
-    await invalidateSession(req.sessionId)
-    return res.json({ success: true })
-  } else {
-    throw createInvalidCredentialsError()
-  }
+if (req.sessionId) {
+  await invalidateSession(req.sessionId, res)
+  return res.json({ success: true })
+} else {
+  throw createInvalidCredentialsError()
+}
 })

--- a/waspc/data/Generator/templates/server/src/webSocket/initialization.ts
+++ b/waspc/data/Generator/templates/server/src/webSocket/initialization.ts
@@ -6,8 +6,13 @@ import type { ServerType } from 'wasp/server/webSocket'
 
 import { config, prisma } from 'wasp/server'
 
-{=# isAuthEnabled =}
+{=# isCookieAuthEnabled =}
+import { getSessionAndUserFromSessionId, getSessionFromCookie } from 'wasp/auth/session'
+{=/ isCookieAuthEnabled =}
+{=# isJwtAuthEnabled =}
 import { getSessionAndUserFromSessionId } from 'wasp/auth/session'
+{=/ isJwtAuthEnabled =}
+{=# isAuthEnabled =}
 import { makeAuthUserIfPossible } from 'wasp/auth/user'
 {=/ isAuthEnabled =}
 
@@ -20,12 +25,20 @@ export async function init(server: http.Server): Promise<void> {
   const io: ServerType = new Server(server, {
     cors: {
       origin: config.frontendUrl,
+      {=# isCookieAuthEnabled =}
+      credentials: true,
+      {=/ isCookieAuthEnabled =}
     }
   })
 
   {=# isAuthEnabled =}
   io.use(addUserToSocketDataIfAuthenticated)
   {=/ isAuthEnabled =}
+
+  {=# isCookieAuthEnabled =}
+  const apiNamespace = io.of(config.apiPrefix)
+  apiNamespace.use(addUserToSocketDataIfAuthenticated)
+  {=/ isCookieAuthEnabled =}
 
   const context = {
     entities: {
@@ -38,7 +51,26 @@ export async function init(server: http.Server): Promise<void> {
   await ({= userWebSocketFn.importIdentifier =} as any)(io, context)
 }
 
-{=# isAuthEnabled =}
+{=# isCookieAuthEnabled =}
+async function addUserToSocketDataIfAuthenticated(socket: Socket, next: (err?: Error) => void) {
+  const cookieHeader = socket.handshake.headers.cookie ?? ''
+  const sessionId = cookieHeader ? getSessionFromCookie(cookieHeader) : null
+
+  if (sessionId) {
+    try {
+      const sessionAndUser = await getSessionAndUserFromSessionId(sessionId)
+      const user = sessionAndUser ? makeAuthUserIfPossible(sessionAndUser.user) : null
+      socket.data = {
+        ...socket.data,
+        user,
+      }
+    } catch (err) { }
+  }
+  next()
+}
+{=/ isCookieAuthEnabled =}
+
+{=# isJwtAuthEnabled =}
 async function addUserToSocketDataIfAuthenticated(socket: Socket, next: (err?: Error) => void) {
   const sessionId = socket.handshake.auth.sessionId
   if (sessionId) {
@@ -53,4 +85,4 @@ async function addUserToSocketDataIfAuthenticated(socket: Socket, next: (err?: E
   }
   next()
 }
-{=/ isAuthEnabled =}
+{=/ isJwtAuthEnabled =}

--- a/waspc/examples/todoApp/.env.client.example
+++ b/waspc/examples/todoApp/.env.client.example
@@ -1,2 +1,4 @@
-#REACT_APP_API_URL=http://localhost:3001
+REACT_APP_API_URL=http://localhost:3000/api
+VITE_WASP_API_PREFIX=/api
+VITE_WASP_SERVER_URL=http://localhost:3001
 #PORT=3000

--- a/waspc/examples/todoApp/main.wasp
+++ b/waspc/examples/todoApp/main.wasp
@@ -9,6 +9,7 @@ app todoApp {
     // autoConnect: false
   },
   auth: {
+    cookieEnabled: true,
     userEntity: User,
     methods: {
       // usernameAndPassword: {

--- a/waspc/examples/todoApp/src/webSocket.ts
+++ b/waspc/examples/todoApp/src/webSocket.ts
@@ -6,15 +6,28 @@ export const webSocketFn: WebSocketDefinition<
   ServerToClientEvents,
   InterServerEvents
 > = (io, context) => {
-  io.on('connection', (socket) => {
+
+  const apiNamespace = io.of('/api');
+  apiNamespace.on('connection', (socket) => {
     const username = socket.data.user?.getFirstProviderUserId() ?? 'Unknown'
     console.log('a user connected: ', username)
 
     socket.on('chatMessage', async (msg) => {
       console.log('message: ', msg)
-      io.emit('chatMessage', { id: uuidv4(), username, text: msg })
+      apiNamespace.emit('chatMessage', { id: uuidv4(), username, text: msg })
     })
   })
+
+  // io.on('connection', (socket) => {
+  //   const username = socket.data.user?.getFirstProviderUserId() ?? 'Unknown'
+  //   console.log('a user connected: ', username)
+
+  //   socket.on('chatMessage', async (msg) => {
+  //     console.log('message: ', msg)
+  //     io.emit('chatMessage', { id: uuidv4(), username, text: msg })
+  //   })
+  // })
+
 }
 
 interface ServerToClientEvents {

--- a/waspc/examples/todoApp/vite.config.ts
+++ b/waspc/examples/todoApp/vite.config.ts
@@ -1,7 +1,39 @@
-import { defineConfig } from 'vite'
+import { loadEnv } from 'vite'
 
-export default defineConfig({
+const mode = process.env.NODE_ENV || 'development'
+const env = loadEnv(mode, process.cwd(), 'VITE_')
+
+const apiPrefix =
+  env.VITE_WASP_API_PREFIX?.trim() || '/api'
+
+const apiPrefixWithoutSlash = apiPrefix.replace(/^\//, '')
+const serverUrl = env.VITE_WASP_SERVER_URL?.trim() || 'http://localhost:3001'
+
+export default {
   server: {
-    open: false,
+    open: true,
+    proxy: {
+      [apiPrefix]: {
+        target: serverUrl,
+        changeOrigin: true,
+        rewrite: (path) =>
+          path.replace(new RegExp(`^/${apiPrefixWithoutSlash}`), ''),
+        ws: true,
+      },
+      '/socket.io/': {
+        target: serverUrl,
+        changeOrigin: true,
+        ws: true,
+      },
+    },
   },
-})
+}
+
+
+// import { defineConfig } from 'vite'
+
+// export default defineConfig({
+//   server: {
+//     open: false,
+//   },
+// })

--- a/waspc/src/Wasp/AppSpec/App/Auth.hs
+++ b/waspc/src/Wasp/AppSpec/App/Auth.hs
@@ -16,6 +16,7 @@ module Wasp.AppSpec.App.Auth
     isKeycloakAuthEnabled,
     isGitHubAuthEnabled,
     isEmailAuthEnabled,
+    isCookieAuthEnabled,
     userSignupFieldsForEmailAuth,
     userSignupFieldsForUsernameAuth,
     userSignupFieldsForExternalAuth,
@@ -24,7 +25,7 @@ where
 
 import Data.Aeson (FromJSON)
 import Data.Data (Data)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, fromMaybe)
 import GHC.Generics (Generic)
 import Wasp.AppSpec.App.Auth.EmailVerification (EmailVerificationConfig)
 import Wasp.AppSpec.App.Auth.PasswordReset (PasswordResetConfig)
@@ -43,7 +44,8 @@ data Auth = Auth
     onAfterSignup :: Maybe ExtImport,
     onBeforeOAuthRedirect :: Maybe ExtImport,
     onBeforeLogin :: Maybe ExtImport,
-    onAfterLogin :: Maybe ExtImport
+    onAfterLogin :: Maybe ExtImport,
+    cookieEnabled :: Maybe Bool
   }
   deriving (Show, Eq, Data, Generic, FromJSON)
 
@@ -104,6 +106,9 @@ isGitHubAuthEnabled = isJust . gitHub . methods
 
 isEmailAuthEnabled :: Auth -> Bool
 isEmailAuthEnabled = isJust . email . methods
+
+isCookieAuthEnabled :: Auth -> Bool
+isCookieAuthEnabled = fromMaybe False . cookieEnabled
 
 -- These helper functions are used to avoid ambiguity when using the
 -- `userSignupFields` function (otherwise we need to use the DuplicateRecordFields

--- a/waspc/src/Wasp/Generator/SdkGenerator/Auth/LocalAuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Auth/LocalAuthG.hs
@@ -20,7 +20,7 @@ genActions :: AS.Auth.Auth -> Generator [FileDraft]
 genActions auth
   | AS.Auth.isUsernameAndPasswordAuthEnabled auth =
       sequence
-        [ genLocalLoginAction,
+        [ genLocalLoginAction auth,
           genLocalSignupAction
         ]
   | otherwise = return []
@@ -32,7 +32,11 @@ genLocalSignupAction = return $ C.mkTmplFdWithData (SP.castRel [relfile|auth/sig
     tmplData = object ["signupPath" .= serverSignupUrl localAuthProvider]
 
 -- | Generates file with login function to be used by Wasp developer.
-genLocalLoginAction :: Generator FileDraft
-genLocalLoginAction = return $ C.mkTmplFdWithData (SP.castRel [relfile|auth/login.ts|]) tmplData
+genLocalLoginAction :: AS.Auth.Auth -> Generator FileDraft
+genLocalLoginAction auth = return $ C.mkTmplFdWithData (SP.castRel [relfile|auth/login.ts|]) tmplData
   where
-    tmplData = object ["loginPath" .= serverLoginUrl localAuthProvider]
+    tmplData =
+      object
+        [ "loginPath" .= serverLoginUrl localAuthProvider,
+          "isCookieAuthEnabled" .= AS.Auth.isCookieAuthEnabled auth
+        ]

--- a/waspc/src/Wasp/Generator/SdkGenerator/EnvValidation.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/EnvValidation.hs
@@ -9,6 +9,7 @@ import Data.Maybe (isJust)
 import StrongPath (relfile)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.App.Client as AS.App.Client
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
 import qualified Wasp.AppSpec.App.Server as AS.App.Server
@@ -42,6 +43,7 @@ genServerEnv spec = return $ C.mkTmplFdWithData tmplPath tmplData
     tmplData =
       object
         [ "isAuthEnabled" .= isJust maybeAuth,
+          "isCookieAuthEnabled" .= maybe False AS.Auth.isCookieAuthEnabled maybeAuth,
           "databaseUrlEnvVarName" .= Db.databaseUrlEnvVarName,
           "defaultClientUrl" .= WebApp.getDefaultDevClientUrl spec,
           "defaultServerUrl" .= Server.defaultDevServerUrl,

--- a/waspc/src/Wasp/Generator/SdkGenerator/WebSocketGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/WebSocketGenerator.hs
@@ -10,6 +10,7 @@ import StrongPath (relfile)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
 import qualified Wasp.AppSpec.App.WebSocket as AS.App.WS
 import Wasp.AppSpec.Valid (getApp, isAuthEnabled)
@@ -50,7 +51,12 @@ genWebSocketProvider spec = return $ C.mkTmplFdWithData [relfile|client/webSocke
   where
     maybeWebSocket = AS.App.webSocket $ snd $ getApp spec
     shouldAutoConnect = (AS.App.WS.autoConnect <$> maybeWebSocket) /= Just (Just False)
-    tmplData = object ["autoConnect" .= map toLower (show shouldAutoConnect)]
+    maybeAuth = AS.App.auth $ snd $ getApp spec
+    tmplData =
+      object
+        [ "autoConnect" .= map toLower (show shouldAutoConnect),
+          "isCookieAuthEnabled" .= maybe False AS.Auth.isCookieAuthEnabled maybeAuth
+        ]
 
 depsRequiredByWebSockets :: AppSpec -> [AS.Dependency.Dependency]
 depsRequiredByWebSockets spec =

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -31,6 +31,7 @@ import StrongPath
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
 import qualified Wasp.AppSpec.App.Server as AS.App.Server
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
@@ -259,9 +260,11 @@ genMiddleware spec =
       genOperationsMiddleware spec
     ]
   where
+    maybeAuth = AS.App.auth $ snd $ getApp spec
     tmplData =
       object
-        [ "globalMiddlewareConfigFn" .= globalMiddlewareConfigFnTmplData
+        [ "globalMiddlewareConfigFn" .= globalMiddlewareConfigFnTmplData,
+          "isCookieAuthEnabled" .= maybe False AS.Auth.isCookieAuthEnabled maybeAuth
         ]
 
     globalMiddlewareConfigFnTmplData :: Aeson.Value


### PR DESCRIPTION
### Description

Session cookie auth option with full JWT backwards compatibility by default. Addresses concerns from #573 
- CSRF protection and httpOnly cookie
- Full compatibility with websocket
- JWTs will work by default if the flag cookieEnabled is not set

Note: I see that there is ongoing work for things that will affect this feature, like porting the server and client onto the same site, etc. I've included in the example Todo App a few modifications that can get you up and running on the same site for now.

### Select what type of change this PR introduces:
1. [ ] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [x] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected). 

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Update example apps if needed
If you did code changes and added a new feature or modified an existing feature, make sure you satisfy the following:
1. [x] I updated `waspc/examples/todoApp` as needed (updated modified feature or added new feature) and manually checked it works correctly.
2. [ ] I updated `waspc/headless-test/examples/todoApp` and its e2e tests as needed (updated modified feature and its tests or added new feature and new tests for it).
