### PR TITLE
Version management, updates, Dev builds to wasp  🤯

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Call.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Call.hs
@@ -11,7 +11,8 @@ data Call
   | Compile
   | Db Arguments -- db args
   | Build
-  | Version
+  | Version (Maybe String) Bool -- --force
+  | Update Bool -- --force
   | Telemetry
   | Deps
   | Dockerfile
@@ -21,6 +22,7 @@ data Call
   | GenerateBashCompletionScript
   | BashCompletionListCommands
   | WaspLS
+  | Secret Arguments -- testing versioning passthrough args
   | Deploy Arguments -- deploy cmd passthrough args
   | Test Arguments -- "client" | "server", then test cmd passthrough args
   | Unknown Arguments -- all args

--- a/waspc/cli/src/Wasp/Cli/Command/Version/Download.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Version/Download.hs
@@ -1,0 +1,226 @@
+module Wasp.Cli.Command.Version.Download
+  ( downloadVersion
+  , updateWasp
+  , getLatestVersionFromGithub
+  , isVersionLessThan
+  , forceInstallLatest
+  , forceInstallSpecific
+  ) where
+
+import Control.Monad (when)
+import Control.Exception (try, SomeException)
+import Network.HTTP.Simple
+  ( httpBS
+  , getResponseBody
+  , parseRequest
+  , setRequestHeader
+  , getResponseStatusCode
+  , httpNoBody
+  , Response
+  )
+import qualified Data.ByteString.Char8 as BS
+import System.IO.Temp (withSystemTempDirectory)
+import System.Directory
+  ( doesDirectoryExist
+  , doesFileExist
+  , copyFile
+  , removeDirectoryRecursive
+  , renameDirectory
+  , removeFile
+  , executable
+  , setPermissions
+  , emptyPermissions
+  )
+import System.FilePath ((</>))
+import System.Process (callProcess, callCommand)
+import System.Exit (exitFailure)
+import System.Info (os)
+import Data.Aeson (decode)
+import qualified Data.Aeson.Types as Aeson (parseMaybe, (.:))
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import Wasp.Cli.Command.Version.Paths 
+  ( getVersionPaths
+  , getVersionFile
+  , getWaspRootDir
+  , getWaspBinDir
+  )
+
+-- | Update Wasp to latest version
+updateWasp :: IO ()
+updateWasp = do
+  currentVer <- getCurrentReleaseVersion
+  latestVer <- getLatestVersionFromGithub
+  
+  when (isVersionLessThan currentVer latestVer) $ do
+    putStrLn $ "Updating from ${currentVer} to ${latestVer}..."
+    handleDownloadResult =<< try (downloadVersion latestVer)
+    updateSystemMetadata latestVer
+
+getCurrentReleaseVersion :: IO String
+getCurrentReleaseVersion = getVersionFile "release" >>= readFile
+
+handleDownloadResult :: Either SomeException () -> IO ()
+handleDownloadResult (Left e) = do
+  putStrLn $ "Update failed: " ++ show e
+  exitFailure
+handleDownloadResult (Right _) = return ()
+
+updateSystemMetadata :: String -> IO ()
+updateSystemMetadata version = do
+  updateMainBinary version
+  writeVersionFiles version
+
+writeVersionFiles :: String -> IO ()
+writeVersionFiles version = do
+  releaseFile <- getVersionFile "release"
+  activeFile <- getVersionFile "active"
+  writeFile releaseFile version
+  writeFile activeFile version
+
+-- | Download and install specific version
+downloadVersion :: String -> IO ()
+downloadVersion version = do
+  -- Step 1: Check if the GitHub release exists
+  versionExists <- checkGitHubRelease version
+  if not versionExists
+    then do
+      putStrLn $ "❌ Error: Version " ++ version ++ " does not exist. See https://github.com/wasp-lang/wasp/releases for available versions."
+      exitFailure
+    else do
+      putStrLn $ "Starting download..."
+
+  -- Step 2: Use a temporary directory for download & extraction
+  withSystemTempDirectory "wasp-download" $ \tmpDir -> do
+    let archiveFile = tmpDir </> getPlatformString
+    downloadArchive version archiveFile
+    extractArchive archiveFile tmpDir
+    _ <- return tmpDir
+
+    versionDir <- getVersionDir version
+    ensureCleanInstallation versionDir
+    renameDirectory tmpDir versionDir
+    putStrLn $ "✅ Wasp version " ++ version ++ " downloaded and activated!"
+
+downloadArchive :: String -> FilePath -> IO ()
+downloadArchive version path = do
+  let url = "https://github.com/wasp-lang/wasp/releases/download/v" 
+         ++ version ++ "/" ++ getPlatformString
+  putStrLn $ "Downloading from " ++ url
+  request <- parseRequest url
+  response <- httpBS request
+  BS.writeFile path (getResponseBody response)
+
+extractArchive :: FilePath -> FilePath -> IO ()
+extractArchive archivePath destDir = do
+  putStrLn "Extracting..."
+  callProcess "tar" ["-xzf", archivePath, "-C", destDir]
+  removeFile archivePath
+
+ensureCleanInstallation :: FilePath -> IO ()
+ensureCleanInstallation path = do
+  exists <- doesDirectoryExist path
+  when exists $ do
+    putStrLn "Removing existing installation..."
+    removeDirectoryRecursive path
+
+getVersionDir :: String -> IO FilePath
+getVersionDir version = (</> version) <$> getWaspRootDir
+
+-- | Get latest release version from GitHub
+getLatestVersionFromGithub :: IO String
+getLatestVersionFromGithub = do
+  response <- httpBS =<< setRequestHeader "User-Agent" ["wasp-cli"] 
+    <$> parseRequest "https://api.github.com/repos/wasp-lang/wasp/releases/latest"
+  case decodeResponse (getResponseBody response) of
+    Just version -> return $ drop 1 version  -- Remove 'v' prefix
+    Nothing -> error "Failed to parse GitHub response"
+
+checkGitHubRelease :: String -> IO Bool
+checkGitHubRelease version = do
+  let url = "https://github.com/wasp-lang/wasp/releases/download/v" ++ version ++ "/"
+  request <- parseRequest url
+  result <- try (httpNoBody request) :: IO (Either SomeException (Response()))
+  case result of
+    Right response ->
+      let statusCode = getResponseStatusCode response
+      in return (statusCode == 200)
+    Left _ -> return False
+
+decodeResponse :: BS.ByteString -> Maybe String
+decodeResponse resp = do
+  release <- decode (LBS.fromStrict resp)
+  Aeson.parseMaybe (Aeson..: "tag_name") release
+
+-- Platform-specific configuration
+getPlatformString :: String
+getPlatformString = case os of
+  "darwin" -> "wasp-macos-x86_64.tar.gz"
+  "linux" -> "wasp-linux-x86_64.tar.gz"
+  _ -> error $ "Unsupported OS: " ++ os
+
+-- | Create or update the wrapper script
+updateWrapperScript :: FilePath -> FilePath -> FilePath -> IO ()
+updateWrapperScript name binaryPath dataPath = do
+  binDir <- getWaspBinDir
+  let wrapperPath = binDir </> name
+      wrapperContent = unlines
+        [ "#!/usr/bin/env bash"
+        , "waspc_datadir=" ++ dataPath ++ " " ++ binaryPath ++ " \"$@\""
+        ]
+  writeFile wrapperPath wrapperContent
+  setPermissions wrapperPath $ emptyPermissions { executable = True }
+
+-- | Update the main wasp binary to a specific version
+updateMainBinary :: String -> IO ()
+updateMainBinary version = do
+  (versionBin, dataDir) <- getVersionPaths version
+  binDir <- getWaspBinDir
+  let mainBinary = binDir </> "wasp"
+  
+  exists <- doesFileExist versionBin
+  if exists
+    then do
+      -- Copy the binary
+      copyFile versionBin mainBinary
+      setPermissions mainBinary $ emptyPermissions { executable = True }
+      
+      -- Update the wrapper script
+      updateWrapperScript "wasp" mainBinary dataDir
+      putStrLn "Updated wasp wrapper script"
+    else error $ "Version " ++ version ++ " binary not found"
+
+-- | Semantic version comparison
+isVersionLessThan :: String -> String -> Bool
+isVersionLessThan a b = case (parseVersion a, parseVersion b) of
+  (Just v1, Just v2) -> v1 < v2
+  _ -> False
+
+parseVersion :: String -> Maybe (Int, Int, Int)
+parseVersion v = case reads v of
+  [(major, '.':rest1)] -> case reads rest1 of
+    [(minor, '.':rest2)] -> case reads rest2 of
+      [(patch, "")] -> Just (major, minor, patch)
+      _ -> Nothing
+    _ -> Nothing
+  _ -> Nothing
+
+
+-- | Force install latest version of Wasp
+forceInstallLatest :: IO ()
+forceInstallLatest = do
+  releaseFile <- getVersionFile "release"
+  activeFile <- getVersionFile "active"
+  doesFileExist releaseFile >>= flip when (removeFile releaseFile)
+  doesFileExist activeFile >>= flip when (removeFile activeFile)
+  putStrLn "Forcing installation of the latest version of Wasp..."
+  callCommand "curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s"
+
+-- | Force install a specific version of Wasp
+forceInstallSpecific :: String -> IO ()
+forceInstallSpecific version = do
+  releaseFile <- getVersionFile "release"
+  activeFile <- getVersionFile "active"
+  doesFileExist releaseFile >>= flip when (removeFile releaseFile)
+  doesFileExist activeFile >>= flip when (removeFile activeFile)
+  putStrLn $ "Forcing installation of Wasp version " ++ version ++ "..."
+  callCommand $ "curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v " ++ version

--- a/waspc/cli/src/Wasp/Cli/Command/Version/Executor.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Version/Executor.hs
@@ -1,0 +1,97 @@
+module Wasp.Cli.Command.Version.Executor
+  ( executeWithVersion
+  , readProcessWithExitCode
+  , readProcessWithExitCodeEnv
+  ) where
+
+import System.Process (
+    proc
+  , createProcess
+  , waitForProcess
+  , StdStream(..)
+  , std_in
+  , std_out
+  , std_err
+  , env
+  )
+import qualified Data.ByteString.Char8 as BS
+import Control.Concurrent.MVar
+import Control.Monad (unless)
+import Control.Exception (evaluate)
+import Control.Concurrent (forkIO)
+import System.Environment (getEnvironment)
+import System.IO (hGetContents, hClose)
+import System.Exit (exitFailure, exitWith, ExitCode(..))
+import System.Directory (doesFileExist)
+import Wasp.Cli.Command.Version.VersionManagement (detectWrapperVersion, getActiveVersion)
+import Wasp.Cli.Command.Version.Paths (getVersionPaths, getMainBinaryPath, getVersionFile)
+
+
+-- | Execute a command using appropriate version
+executeWithVersion :: [String] -> IO ()
+executeWithVersion args = do
+  (activeVer, releaseVer) <- getInstallationVersions
+
+  if activeVer == releaseVer
+    then runMainProcess args
+    else runVersionedProcess activeVer args
+  where
+    runMainProcess args' = do
+      binPath <- getMainBinaryPath
+      (exitCode, _, _) <- readProcessWithExitCode binPath args' ""
+      exitWith exitCode
+
+    runVersionedProcess ver args' = do
+      (verBin, dataDir) <- getVersionPaths ver
+      binExists <- doesFileExist verBin
+      if binExists
+        then do
+          let envVars = [("waspc_datadir", dataDir)]
+          (exitCode, _, _) <- readProcessWithExitCodeEnv verBin args' envVars
+          exitWith exitCode
+        else do
+          putStrLn $ "Version " ++ ver ++ " not found in: " ++ verBin
+          exitFailure
+
+-- | Helper to execute process with additional environment variables
+readProcessWithExitCodeEnv :: FilePath -> [String] -> [(String, String)] -> IO (ExitCode, String, String)
+readProcessWithExitCodeEnv cmd args envVars = do
+  oldEnv <- getEnvironment
+  let newEnv = oldEnv ++ envVars
+  (_, Just outh, Just errh, ph) <- 
+    createProcess (proc cmd args) { std_out = CreatePipe, std_err = CreatePipe, env = Just newEnv }
+  out <- hGetContents outh
+  err <- hGetContents errh
+  exitCode <- waitForProcess ph
+  return (exitCode, out, err)
+
+-- Helper to read process output
+readProcessWithExitCode :: FilePath -> [String] -> String -> IO (ExitCode, String, String)
+readProcessWithExitCode cmd args stdin = do
+  (Just inh, Just outh, Just errh, ph) <- 
+    createProcess (proc cmd args){ std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe }
+  unless (null stdin) $ do
+    BS.hPutStr inh (BS.pack stdin)
+    hClose inh
+  out <- hGetContents outh
+  err <- hGetContents errh
+  outMVar <- newMVar ""
+  errMVar <- newMVar ""
+  _ <- forkIO $ evaluate (length out) >> putMVar outMVar out
+  _ <- forkIO $ evaluate (length err) >> putMVar errMVar err
+  exitCode <- waitForProcess ph
+  out' <- takeMVar outMVar
+  err' <- takeMVar errMVar
+  pure (exitCode, out', err')
+
+-- | Get both active and release versions
+getInstallationVersions :: IO (String, String)
+getInstallationVersions = do
+  active <- getActiveVersion
+  release <- getReleaseVersion
+  pure (active, release)
+  where
+    getReleaseVersion = do
+      releaseFile <- getVersionFile "release"
+      exists <- doesFileExist releaseFile
+      if exists then readFile releaseFile else detectWrapperVersion

--- a/waspc/cli/src/Wasp/Cli/Command/Version/Paths.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Version/Paths.hs
@@ -1,0 +1,48 @@
+module Wasp.Cli.Command.Version.Paths
+  ( getWaspRootDir
+  , getWaspBinDir
+  , getMainBinaryPath
+  , getVersionFile
+  , getVersionPaths
+  ) where
+
+import qualified Wasp.Cli.FileSystem as FS
+import qualified StrongPath as SP
+import System.FilePath ((</>), takeDirectory, takeFileName)
+import System.Directory (doesFileExist)
+
+-- Directory structure constants
+waspRootDirName :: FilePath
+waspRootDirName = ".local/share/wasp-lang"
+
+waspBinDirName :: FilePath
+waspBinDirName = ".local/bin"
+
+-- | Get the root directory for Wasp installations
+getWaspRootDir :: IO FilePath
+getWaspRootDir = do
+  homeDir <- SP.fromAbsDir <$> FS.getHomeDir
+  return $ homeDir </> waspRootDirName
+
+-- | Get the directory for Wasp binaries
+getWaspBinDir :: IO FilePath
+getWaspBinDir = do
+  homeDir <- SP.fromAbsDir <$> FS.getHomeDir
+  return $ homeDir </> waspBinDirName
+
+-- | Path to main wasp wrapper script
+getMainBinaryPath :: IO FilePath
+getMainBinaryPath = (</> "wasp") <$> getWaspBinDir
+
+-- | Get path to version metadata files
+getVersionFile :: String -> IO FilePath
+getVersionFile fileName = do
+  rootDir <- getWaspRootDir
+  return $ rootDir </> fileName
+
+-- | Get paths for a specific version installation
+getVersionPaths :: String -> IO (FilePath, FilePath)
+getVersionPaths version = do
+  rootDir <- getWaspRootDir
+  let versionDir = rootDir </> version
+  return (versionDir </> "wasp-bin", versionDir </> "data")

--- a/waspc/cli/src/Wasp/Cli/Command/Version/VersionManagement.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Version/VersionManagement.hs
@@ -1,0 +1,200 @@
+module Wasp.Cli.Command.Version.VersionManagement
+  ( switchVersion
+  , ensureVersionSystem
+  , getActiveVersion
+  , listVersions
+  , isVersionLessThan
+  , detectWrapperVersion
+  ) where
+
+import Control.Monad (unless, when, filterM)
+import qualified Control.Exception as E
+import Data.List (isInfixOf)
+import Data.Maybe (fromMaybe)
+import System.Directory
+  ( createDirectoryIfMissing
+  , doesFileExist
+  , doesDirectoryExist
+  , listDirectory
+  , executable
+  , setPermissions
+  , emptyPermissions
+  )
+import System.FilePath (takeFileName, takeDirectory, (</>))
+import System.Exit (exitFailure)
+import qualified Wasp.Version as WV
+import Wasp.Cli.Command.Version.Download
+  ( getLatestVersionFromGithub
+  , downloadVersion
+  , isVersionLessThan
+  )
+import Wasp.Cli.Command.Version.Paths
+  ( getVersionPaths
+  , getMainBinaryPath
+  , getVersionFile
+  , getWaspRootDir
+  )
+-- | Switch to specified version
+switchVersion :: String -> IO ()
+switchVersion version = do
+  result <- E.try (performVersionSwitch version) :: IO (Either E.SomeException ())
+  case result of
+    Left e -> do
+      putStrLn $ "Error: Failed to switch version due to: " ++ show e
+      putStrLn "Try running 'wasp version latest --force' to install the latest version."
+      exitFailure
+    Right _ -> do
+      putStrLn $ "🐝 Wasp version " ++ version ++ " is now active!"
+      return ()
+
+performVersionSwitch :: String -> IO ()
+performVersionSwitch "latest" = handleLatest
+performVersionSwitch version = handleSpecificVersion version
+
+handleLatest :: IO ()
+handleLatest = getLatestVersionFromGithub >>= switchVersion
+
+handleSpecificVersion :: String -> IO ()
+handleSpecificVersion version = do
+  (binPath, _) <- getVersionPaths version
+  binExists <- doesFileExist binPath
+  
+  unless binExists $ handleMissingVersion version
+  makeExecutable binPath
+  updateVersionMetadata version
+
+handleMissingVersion :: String -> IO ()
+handleMissingVersion version = do
+  putStrLn $ "Downloading Wasp version " ++ version ++ "..."
+  result <- E.try (downloadVersion version) :: IO (Either E.SomeException ())
+  case result of
+    Left e -> do
+      putStrLn $ "Download failed for version " ++ version
+      putStrLn "Try running 'wasp version latest --force' to install the latest version."
+      putStrLn $ "Error details: " ++ show e
+      exitFailure
+    Right _ -> return ()
+
+makeExecutable :: FilePath -> IO ()
+makeExecutable path = do
+  exists <- doesFileExist path
+  when exists $ do
+    let perms = emptyPermissions { executable = True }
+    setPermissions path perms
+
+updateVersionMetadata :: String -> IO ()
+updateVersionMetadata version = do
+  updateReleaseIfNeeded version
+  updateActiveVersion version
+
+updateReleaseIfNeeded :: String -> IO ()
+updateReleaseIfNeeded version = do
+  releaseFile <- getVersionFile "release"
+  currentRelease <- safeReadFile releaseFile
+  when (maybe False (isVersionLessThan version) currentRelease) $
+    writeFile releaseFile version
+
+updateActiveVersion :: String -> IO ()
+updateActiveVersion version = do
+  activeFile <- getVersionFile "active"
+  createParentDirectories
+  writeFile activeFile version
+  where
+    createParentDirectories = getWaspRootDir >>= createDirectoryIfMissing True
+
+-- | List all installed versions
+listVersions :: IO [String]
+listVersions = do
+  rootDir <- getWaspRootDir
+  dirs <- listDirectory rootDir
+  filterM (isValidVersion rootDir) dirs
+  where
+    isValidVersion root name = do
+      isDir <- doesDirectoryExist (root </> name)
+      return $ isDir && name `notElem` [".", "..", "active", "release"]
+
+-- | Initialize version management system
+ensureVersionSystem :: IO ()
+ensureVersionSystem = do
+  rootDir <- getWaspRootDir
+  createDirectoryIfMissing True rootDir
+  
+  releaseFile <- getVersionFile "release"
+  ensureFileExists releaseFile detectWrapperVersion
+  
+  activeFile <- getVersionFile "active"
+  ensureFileExists activeFile (getReleaseVersion releaseFile)
+
+  ensureReleaseVersionConsistency
+
+ensureFileExists :: FilePath -> IO String -> IO ()
+ensureFileExists path getDefaultContent = do
+  exists <- doesFileExist path
+  unless exists $ getDefaultContent >>= writeFile path
+
+getReleaseVersion :: FilePath -> IO String
+getReleaseVersion releaseFile = do
+  exists <- doesFileExist releaseFile
+  if exists then readFile releaseFile else detectWrapperVersion
+
+ensureReleaseVersionConsistency :: IO ()
+ensureReleaseVersionConsistency = do
+  releaseFile <- getVersionFile "release"
+  currentVer <- detectWrapperVersion
+  releaseExists <- doesFileExist releaseFile
+
+  when releaseExists $ do
+    releaseVer <- readFile releaseFile
+    unless (releaseVer == currentVer) $ do
+      writeFile releaseFile currentVer
+      syncActiveVersionIfNeeded releaseVer currentVer
+
+syncActiveVersionIfNeeded :: String -> String -> IO ()
+syncActiveVersionIfNeeded oldRelease newRelease = do
+  activeVer <- getActiveVersion
+  when (activeVer == oldRelease) $ do
+    activeFile <- getVersionFile "active"
+    writeFile activeFile newRelease
+
+-- | Get currently active version
+getActiveVersion :: IO String
+getActiveVersion = do
+  activeFile <- getVersionFile "active"
+  safeReadFile activeFile >>= maybe getFallbackVersion return
+  where
+    getFallbackVersion = do
+      releaseFile <- getVersionFile "release"
+      safeReadFile releaseFile >>= maybe (return $ show WV.waspVersion) return
+
+safeReadFile :: FilePath -> IO (Maybe String)
+safeReadFile path = do
+  exists <- doesFileExist path
+  if exists then Just <$> readFile path else return Nothing
+
+-- | Extracts the version from the wrapper script
+detectWrapperVersion :: IO String
+detectWrapperVersion = do
+  binPath <- getMainBinaryPath
+  fileExists <- doesFileExist binPath
+  if fileExists
+    then do
+      content <- readFile binPath
+      let version = extractVersionFromScript content
+      return (fromMaybe "unknown" version)
+    else return "unknown"
+
+-- | Extract version from wrapper script content
+extractVersionFromScript :: String -> Maybe String
+extractVersionFromScript script =
+  case filter ("wasp-bin" `isInfixOf`) (lines script) of
+    (line:_) -> extractVersionFromPath line
+    _        -> Nothing
+
+-- | Extract version number from the wrapper script's binary path using regex.
+extractVersionFromPath :: String -> Maybe String
+extractVersionFromPath line =
+  let parts = words line
+      maybePath = case filter ("/wasp-lang/" `isInfixOf`) parts of
+                    (p:_) -> Just p
+                    _     -> Nothing
+  in fmap (takeFileName . takeDirectory) maybePath

--- a/waspc/run
+++ b/waspc/run
@@ -19,7 +19,7 @@ RED="\033[31m"
 DEFAULT_COLOR="\033[39m"
 
 BUILD_CMD="cabal build all"
-INSTALL_CMD="${SCRIPT_DIR}/tools/install_packages_to_data_dir.sh && cabal install --overwrite-policy=always"
+INSTALL_CMD="${SCRIPT_DIR}/tools/install_and_activate.sh"
 BUILD_ALL_CMD="cabal build all --enable-tests --enable-benchmarks"
 TEST_UNIT_CMD="cabal test waspc-test"
 TEST_CLI_CMD="cabal test cli-test"
@@ -66,7 +66,7 @@ print_usage () {
                     "Builds the project."
 
     print_usage_cmd "install" \
-                    "Installs the project locally using cabal (runs '${SCRIPT_DIR}/tools/install_packages_to_data_dir.sh' and 'cabal install')."
+                    "Installs the project locally using cabal (${SCRIPT_DIR}/tools/install_and_activate.sh' manages pre- and post-installation tasks)."
     print_usage_cmd "test" \
                     "Executes all tests (unit + e2e + headless). Builds the project first if needed."
     print_usage_cmd "test:unit [pattern]" \
@@ -114,7 +114,13 @@ case $COMMAND in
         echo_and_eval "$BUILD_CMD"
         ;;
     install)
-        echo_and_eval "$INSTALL_CMD"
+        FORCE_FLAG=""
+        for arg in "${ARGS[@]}"; do
+          if [[ "$arg" == "--force" ]]; then
+            FORCE_FLAG="--force"
+          fi
+        done
+        echo_and_eval "$INSTALL_CMD $FORCE_FLAG"
         ;;
     ghcid)
         echo_and_eval "$GHCID_CMD"

--- a/waspc/tools/install_and_activate.sh
+++ b/waspc/tools/install_and_activate.sh
@@ -1,0 +1,91 @@
+#!/bin/bash -e
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HOME_DIR=$HOME
+WASP_LANG_DIR=$HOME_DIR/.local/share/wasp-lang
+ACTIVE_FILE=$WASP_LANG_DIR/active
+BIN_DIR=$HOME_DIR/.local/bin
+CABAL_ALIAS=$HOME_DIR/.cabal/bin/wasp-cli
+FORCE_INSTALL=false
+
+for arg in "$@"; do
+  if [[ "$arg" == "--force" ]]; then
+    FORCE_INSTALL=true
+  fi
+done
+
+# get version from waspc.cabal file
+WASP_VERSION=$(awk '/^version:/ {print $2}' "$SCRIPT_DIR/../waspc.cabal")
+if [[ -z "$WASP_VERSION" ]]; then
+  echo "Error: Unable to extract version from waspc.cabal"
+  exit 1
+fi
+
+TARGET_DIR="$WASP_LANG_DIR/$WASP_VERSION"
+FINAL_WASP_VERSION="$WASP_VERSION"
+
+if [[ -d "$TARGET_DIR" ]]; then
+  echo "A version directory already exists: $TARGET_DIR"
+  echo "You can add a suffix to the version or overwrite the existing version."
+
+  while true; do
+    read -p "Enter a suffix (or press Enter to overwrite): " SUFFIX
+    CLEANED_SUFFIX=$(echo "$SUFFIX" | sed 's/[^a-zA-Z0-9-]//g')
+    CLEANED_SUFFIX=$(echo "$CLEANED_SUFFIX" | sed 's/^-*//')
+
+    if [[ -z "$SUFFIX" ]]; then
+      break
+    elif [[ "$CLEANED_SUFFIX" == "$SUFFIX" ]]; then
+      break 
+    else
+      echo "Invalid suffix. Only letters, numbers, and dashes are allowed, and dashes cannot be at the beginning."
+    fi
+  done
+
+  if [[ -n "$CLEANED_SUFFIX" ]]; then
+    TARGET_DIR="$WASP_LANG_DIR/${WASP_VERSION}-${CLEANED_SUFFIX}"
+    FINAL_WASP_VERSION="${WASP_VERSION}-${CLEANED_SUFFIX}"
+  fi
+fi
+
+"$SCRIPT_DIR/install_packages_to_data_dir.sh"
+
+cabal install --overwrite-policy=always
+
+echo "Post-install: Setting up your Wasp build..."
+
+if [[ ! -f "$CABAL_ALIAS" ]]; then
+  echo "Error: Alias $CABAL_ALIAS does not exist."
+  exit 1
+fi
+
+if [[ "$FORCE_INSTALL" == true ]]; then
+  echo "Overwriting existing version..."
+  chmod -R u+w "$TARGET_DIR" || sudo chmod -R u+w "$TARGET_DIR"
+  rm -rf "$TARGET_DIR"
+fi
+
+REAL_PATH=$(realpath "$CABAL_ALIAS")
+STORE_DIR=$(dirname "$(dirname "$REAL_PATH")")
+SHARE_DIR="$STORE_DIR/share"
+
+mkdir -p "$TARGET_DIR/data"
+cp "$REAL_PATH" "$TARGET_DIR/wasp-bin"
+chmod +x "$TARGET_DIR/wasp-bin"
+cp -r "$SHARE_DIR/" "$TARGET_DIR/data/"
+echo -n "$FINAL_WASP_VERSION" | sed 's/[[:space:]]//g' > "$ACTIVE_FILE"
+mkdir -p "$BIN_DIR"
+WASP_BIN="$BIN_DIR/wasp"
+
+# Create alias script at ~/.local/bin/wasp if it does not exist OR if --force is enabled
+if [[ ! -f "$WASP_BIN" || "$FORCE_INSTALL" == true ]]; then
+  echo "Creating alias script at $WASP_BIN"
+  echo -e "#!/usr/bin/env bash\nwaspc_datadir=\"$TARGET_DIR/data\" \"$TARGET_DIR/wasp-bin\" \"\$@\"" > "$WASP_BIN"
+  chmod +x "$WASP_BIN"
+  RELEASE_FILE="$WASP_LANG_DIR/release"
+  echo -n "$FINAL_WASP_VERSION" | tr -d '[:space:]' > "$RELEASE_FILE"
+  echo "Updated release version to $FINAL_WASP_VERSION"
+fi
+
+echo "Wasp $FINAL_WASP_VERSION installed successfully and set to the active version!"
+echo "You can run it using: wasp <command>"

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -577,6 +577,10 @@ library cli-lib
     Wasp.Cli.Command.Telemetry.User
     Wasp.Cli.Command.Test
     Wasp.Cli.Command.TsConfigSetup
+    Wasp.Cli.Command.Version.Download
+    Wasp.Cli.Command.Version.Executor
+    Wasp.Cli.Command.Version.VersionManagement
+    Wasp.Cli.Command.Version.Paths
     Wasp.Cli.Command.Watch
     Wasp.Cli.Command.WaspLS
     Wasp.Cli.Common
@@ -594,6 +598,8 @@ executable wasp-cli
       base
     , async
     , waspc
+    , directory
+    , filepath
     , cli-lib
     , with-utf8 ^>= 1.0.2
   other-modules:


### PR DESCRIPTION
### Description

1. Version Switching
- `wasp version <version>` installs/switches to a new Wasp version.
- `--force` flag enables a hard install from the shell script.
- The most recent release is allowed to sit in the shell wrapper, delegating commands to other wasp binaries depending on the user selection.

2. Updating
- `wasp` update fetches and installs the latest Wasp version.
- `--force flag` does a hard install from the shell script.

3. Dev builds
- Massive improvement to the dev experience. ./run install has been overhauled, it fits by default in the new versioning system.
- With the install script, you can run your builds right off the bat on wasp, but protecting your other versions.
- The install script will detect if your build is going to overwrite something, and give you the chance to add a suffix to it (i.e. 0.16.0-dev). Upon successfully building, it automatically puts your new build as the activated wasp version.
- This way, you don't have to worry about your builds, just give them a quick suffix. Great for switching between a massive amount of branches without having to redownload release ones. If you wish, you can overwrite the binary when building
- `./run install --force` will hard install your build as the source of truth for the shell wrapper.

### Select what type of change this PR introduces:
1. [ ] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [x] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Update example apps if needed
If you did code changes and added a new feature or modified an existing feature, make sure you satisfy the following:
1. [ ] I updated `waspc/examples/todoApp` as needed (updated modified feature or added new feature) and manually checked it works correctly.
2. [ ] I updated `waspc/headless-test/examples/todoApp` and its e2e tests as needed (updated modified feature and its tests or added new feature and new tests for it).
