### PR TITLE
Updates docs to use `wasp.sh` domain

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -44,7 +44,7 @@ $ GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy
 ```
 
 This command will build the website and push it to the `gh-pages` branch,
-which will get it deployed to https://wasp-lang.dev !
+which will get it deployed to https://wasp.sh !
 
 ### Multiple documentation versions
 

--- a/web/docs/contact.md
+++ b/web/docs/contact.md
@@ -2,4 +2,5 @@
 title: Contact
 ---
 
+<!-- TODO: update the email once we setup @wasp.sh-->
 You can find us on [Discord](https://discord.gg/rzdnErX) or you can reach out to us via email at hi@wasp-lang.dev.

--- a/web/docs/data-model/backends.md
+++ b/web/docs/data-model/backends.md
@@ -132,7 +132,7 @@ To run your Wasp app in production, you'll need to switch from SQLite to Postgre
     // ...
     ```
 
-2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](https://wasp-lang.dev/docs/general/cli#project-commands):
+2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](../general/cli#project-commands):
 
     ```bash
     rm -r migrations/

--- a/web/docs/deployment/deployment-methods/paas.md
+++ b/web/docs/deployment/deployment-methods/paas.md
@@ -594,7 +594,7 @@ jobs:
           node-version: '20'
 
       - name: Install Wasp
-        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
+        run: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
 
       - name: Wasp Build
         run: wasp build
@@ -699,7 +699,7 @@ jobs:
           node-version: '20'
 
       - name: Install Wasp
-        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
+        run: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
 
       - name: Wasp Build
         run: cd ./app && wasp build

--- a/web/docs/general/cli.md
+++ b/web/docs/general/cli.md
@@ -49,9 +49,9 @@ EXAMPLES
   wasp start
   wasp db migrate-dev
 
-Docs: https://wasp-lang.dev/docs
+Docs: https://wasp.sh/docs
 Discord (chat): https://discord.gg/rzdnErX
-Newsletter: https://wasp-lang.dev/#signup
+Newsletter: https://wasp.sh/#signup
 ```
 
 ## Commands
@@ -122,7 +122,7 @@ Newsletter: https://wasp-lang.dev/#signup
   
   Read more about automatic deployment [here](../deployment/deployment-methods/cli.md).
 
- - `wasp telemetry` displays the status of [telemetry](https://wasp-lang.dev/docs/telemetry).
+ - `wasp telemetry` displays the status of [telemetry](../telemetry.md).
 
    ```
    $ wasp telemetry
@@ -130,7 +130,7 @@ Newsletter: https://wasp-lang.dev/#signup
    Telemetry is currently: ENABLED
    Telemetry cache directory: /home/user/.cache/wasp/telemetry/
    Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
-   Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details.
+   Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 
    ```
  - `wasp deps` lists the dependencies that Wasp uses in your project.
@@ -167,10 +167,10 @@ To set up Bash completion, run the `wasp completion` command and follow the inst
     0.14.0
 
     If you wish to install/switch to the latest version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s
 
     If you want specific x.y.z version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v x.y.z
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v x.y.z
 
     Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one.
     ```

--- a/web/docs/introduction/quick-start.md
+++ b/web/docs/introduction/quick-start.md
@@ -14,7 +14,7 @@ Let's create and run our first Wasp app in 3 short steps:
 1. **To install Wasp on Linux / OSX / WSL (Windows), open your terminal and run:**
 
    ```shell
-   curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+   curl -sSL https://get.wasp.sh/installer.sh | sh
    ```
 
    ℹ️ Wasp requires Node.js and will warn you if it is missing: check below for [more details](#requirements).
@@ -52,7 +52,7 @@ That's it 🎉 You have successfully created and served a new full-stack web app
  - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈
  - [ ] [Setup your editor](./editor-setup.md) for working with Wasp.
  - [ ] Join us on [Discord](https://discord.gg/rzdnErX)! Any feedback or questions you have, we are there for you.
- - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp-lang.dev/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
+ - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp.sh/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
 
 ------
 
@@ -111,7 +111,7 @@ If you need it, we recommend using [nvm](https://github.com/nvm-sh/nvm) for mana
 Open your terminal and run:
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::note Running Wasp on Mac with Mx chip (arm64)
@@ -129,7 +129,7 @@ Once Rosetta is installed, you should be able to run Wasp without any issues.
 
 With Wasp for Windows, we are almost there: Wasp is successfully compiling and running on Windows but there is a bug or two stopping it from fully working. Check it out [here](https://github.com/wasp-lang/wasp/issues/48) if you are interested in helping.
 
-In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp-lang.dev/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
+In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp.sh/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
 :::caution
   If you are using WSL2, make sure that your Wasp project is not on the Windows file system, but instead on the Linux file system. Otherwise, Wasp won't be able to detect file changes, due to the [issue in WSL2](https://github.com/microsoft/WSL/issues/4739).
 :::

--- a/web/docs/migration-guides/migrate-from-0-11-to-0-12.md
+++ b/web/docs/migration-guides/migrate-from-0-11-to-0-12.md
@@ -180,7 +180,7 @@ directory `foo`, you should:
 
 0. **Install the `0.12.x` version** of Wasp.
   ```bash
-  curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.12.4
+  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.12.4
   ```
 1. Make sure to **backup or save your project** before starting the procedure (e.g.,
    by committing it to source control or creating a copy).

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -15,7 +15,7 @@ module.exports = {
     'A simple language for developing full-stack web apps with less code.',
   // url, baseUrl, organizationName, projectName and trailingSlash are set according to the
   // instructions in https://docusaurus.io/docs/deployment#deploying-to-github-pages .
-  url: 'https://wasp-lang.dev',
+  url: 'https://wasp.sh',
   baseUrl: '/', // Should be name of repo if hosted on Github Pages, but can be just '/' if custom domain is used.
   organizationName: 'wasp-lang', // Should be GitHub org/user name if hosted on Github Pages.
   projectName: 'wasp', // Should be repo name if hosted on Github Pages.
@@ -56,7 +56,7 @@ module.exports = {
       logo: {
         alt: 'Wasp logo',
         src: 'img/wasp-logo-eqpar-circle.png',
-        href: 'https://wasp-lang.dev/',
+        href: 'https://wasp.sh/',
         target: '_self',
       },
       items: [
@@ -317,7 +317,7 @@ function getScripts() {
     scripts.push({
       src: '/waspara/wasp/script.js',
       defer: true,
-      'data-domain': 'wasp-lang.dev',
+      'data-domain': 'wasp.sh',
       'data-api': '/waspara/wasp/event',
     })
   }

--- a/web/src/components/HiddenLLMHelper.tsx
+++ b/web/src/components/HiddenLLMHelper.tsx
@@ -43,6 +43,6 @@ function removeTrailingSlash(path: string) {
 }
 
 function concatWaspUrl(path: string) {
-  const baseUrl = 'https://wasp-lang.dev'
+  const baseUrl = 'https://wasp.sh'
   return path.startsWith('/') ? baseUrl.concat(path) : baseUrl.concat('/', path)
 }

--- a/web/src/components/InstallCmd.js
+++ b/web/src/components/InstallCmd.js
@@ -7,7 +7,7 @@ const copyToClipboard = (text) => {
 }
 
 const InstallCmd = () => {
-  const code = 'curl -sSL https://get.wasp-lang.dev/installer.sh | sh'
+  const code = 'curl -sSL https://get.wasp.sh/installer.sh | sh'
 
   return (
     <div

--- a/web/src/components/Nav/Announcement.js
+++ b/web/src/components/Nav/Announcement.js
@@ -10,16 +10,6 @@ const Announcement = () => {
 
   const handleLink = () => {
     history.push('/blog/2025/01/09/wasp-launch-week-8')
-
-    // window.open('https://magic-app-generator.wasp-lang.dev/')
-    //window.open('https://www.producthunt.com/posts/open-saas')
-    //history.push('/blog/2023/06/30/tutorial-jam')
-    //history.push('/#signup')
-
-    //window.open('https://twitter.com/MatijaSosic/status/1646532181324603395')
-    //window.open('https://twitter.com/WaspLang/status/1647979490180575234')
-    //window.open('https://www.producthunt.com/posts/free-saas-template-gpt-stripe-auth')
-    // window.open("https://hackathon.wasp-lang.dev");
   }
 
   return (

--- a/web/src/pages/index.js
+++ b/web/src/pages/index.js
@@ -45,7 +45,7 @@ const Index = () => {
       <Head>
         {/* opengraph / facebook */}
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://wasp-lang.dev/" />
+        <meta property="og:url" content="https://wasp.sh/" />
         <meta
           property="og:description"
           content="Develop full-stack web apps without boilerplate."
@@ -53,7 +53,7 @@ const Index = () => {
         <meta property="og:image" content={coverPhotoAbsoluteUrl} />
         {/* twitter */}
         <meta property="twitter:card" content="summary_large_image" />
-        <meta property="twitter:url" content="https://wasp-lang.dev/" />
+        <meta property="twitter:url" content="https://wasp.sh/" />
         <meta
           property="twitter:title"
           content="Develop full-stack web apps without boilerplate."

--- a/web/static/CNAME
+++ b/web/static/CNAME
@@ -1,1 +1,0 @@
-wasp-lang.dev

--- a/web/static/js/fix-multiple-trailing-slashes.js
+++ b/web/static/js/fix-multiple-trailing-slashes.js
@@ -1,10 +1,10 @@
 if (window && window.location && window.location.pathname.endsWith('//')) {
   // If there are multiple slashes at the end of the URL, we remove redundant ones
   // so that only one is left.
-  // e.g. wasp-lang.dev/ will stay wasp-lang.dev/,
-  //      wasp-lang.dev will stay wasp-lang.dev,
-  // but  wasp-lang.dev// will become wasp-leng.dev/,
-  // and  wasp-lang.dev/// will become wasp-lang.dev/.
+  // e.g. wasp.sh/ will stay wasp.sh/,
+  //      wasp.sh will stay wasp.sh,
+  // but  wasp.sh// will become wasp-leng.dev/,
+  // and  wasp.sh/// will become wasp.sh/.
   let pathname = window.location.pathname
   let n = 0 // Num trailing slashes.
   for (; n < pathname.length && pathname[pathname.length - 1 - n] == '/'; n++);

--- a/web/versioned_docs/version-0.11.8/contact.md
+++ b/web/versioned_docs/version-0.11.8/contact.md
@@ -2,4 +2,5 @@
 title: Contact
 ---
 
+<!-- TODO: update the email once we setup @wasp.sh-->
 You can find us on [Discord](https://discord.gg/rzdnErX) or you can reach out to us via email at hi@wasp-lang.dev.

--- a/web/versioned_docs/version-0.11.8/data-model/backends.md
+++ b/web/versioned_docs/version-0.11.8/data-model/backends.md
@@ -45,7 +45,7 @@ app MyApp {
 }
 ```
 
-2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](https://wasp-lang.dev/docs/general/cli#project-commands):
+2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](../general/cli#project-commands):
 
 ```bash
 rm -r migrations/

--- a/web/versioned_docs/version-0.11.8/general/cli.md
+++ b/web/versioned_docs/version-0.11.8/general/cli.md
@@ -43,9 +43,9 @@ EXAMPLES
   wasp start
   wasp db migrate-dev
 
-Docs: https://wasp-lang.dev/docs
+Docs: https://wasp.sh/docs
 Discord (chat): https://discord.gg/rzdnErX
-Newsletter: https://wasp-lang.dev/#signup
+Newsletter: https://wasp.sh/#signup
 ```
 
 ## Commands
@@ -104,7 +104,7 @@ Newsletter: https://wasp-lang.dev/#signup
   
   Read more about automatic deployment [here](../advanced/deployment/cli).
 
- - `wasp telemetry` displays the status of [telemetry](https://wasp-lang.dev/docs/telemetry).
+ - `wasp telemetry` displays the status of [telemetry](../telemetry).
 
    ```
    $ wasp telemetry
@@ -112,7 +112,7 @@ Newsletter: https://wasp-lang.dev/#signup
    Telemetry is currently: ENABLED
    Telemetry cache directory: /home/user/.cache/wasp/telemetry/
    Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
-   Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details.
+   Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 
    ```
  - `wasp deps` lists the dependencies that Wasp uses in your project.

--- a/web/versioned_docs/version-0.11.8/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.11.8/introduction/quick-start.md
@@ -17,7 +17,7 @@ Welcome, new Waspeteer 🐝!
 To install Wasp on Linux / OSX / WSL(Win), open your terminal and run: 
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
  ℹ️ Wasp requires Node.js and will warn you if it is missing: check below for [more details](#requirements).
@@ -46,7 +46,7 @@ Check [More Details](#more-details) section below if anything went wrong, or if 
  - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈
  - [ ] [Setup your editor](./editor-setup.md) for working with Wasp.
  - [ ] Join us on [Discord](https://discord.gg/rzdnErX)! Any feedback or questions you have, we are there for you.
- - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp-lang.dev/#signup . We usually send 1 per month, and Matija does his best to unleash his creativity to make them engaging and fun to read :D!
+ - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp.sh/#signup . We usually send 1 per month, and Matija does his best to unleash his creativity to make them engaging and fun to read :D!
 
 ------
 
@@ -104,7 +104,7 @@ We recommend using [nvm](https://github.com/nvm-sh/nvm) for managing your Node.j
 Open your terminal and run:
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::note Running Wasp on Mac with Mx chip (arm64)
@@ -122,7 +122,7 @@ Once Rosetta is installed, you should be able to run Wasp without any issues.
 
 With Wasp for Windows, we are almost there: Wasp is successfully compiling and running on Windows but there is a bug or two stopping it from fully working. Check it out [here](https://github.com/wasp-lang/wasp/issues/48) if you are interested in helping.
 
-In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp-lang.dev/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
+In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp.sh/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
 :::caution
   If you are using WSL2, make sure that your Wasp project is not on the Windows file system, but instead on the Linux file system. Otherwise, Wasp won't be able to detect file changes, due to the [issue in WSL2](https://github.com/microsoft/WSL/issues/4739).
 :::

--- a/web/versioned_docs/version-0.12.0/contact.md
+++ b/web/versioned_docs/version-0.12.0/contact.md
@@ -2,4 +2,5 @@
 title: Contact
 ---
 
+<!-- TODO: update the email once we setup @wasp.sh-->
 You can find us on [Discord](https://discord.gg/rzdnErX) or you can reach out to us via email at hi@wasp-lang.dev.

--- a/web/versioned_docs/version-0.12.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.12.0/data-model/backends.md
@@ -45,7 +45,7 @@ app MyApp {
 }
 ```
 
-2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](https://wasp-lang.dev/docs/general/cli#project-commands):
+2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](../general/cli#project-commands):
 
 ```bash
 rm -r migrations/

--- a/web/versioned_docs/version-0.12.0/general/cli.md
+++ b/web/versioned_docs/version-0.12.0/general/cli.md
@@ -49,9 +49,9 @@ EXAMPLES
   wasp start
   wasp db migrate-dev
 
-Docs: https://wasp-lang.dev/docs
+Docs: https://wasp.sh/docs
 Discord (chat): https://discord.gg/rzdnErX
-Newsletter: https://wasp-lang.dev/#signup
+Newsletter: https://wasp.sh/#signup
 ```
 
 ## Commands
@@ -122,7 +122,7 @@ Newsletter: https://wasp-lang.dev/#signup
   
   Read more about automatic deployment [here](../advanced/deployment/cli).
 
- - `wasp telemetry` displays the status of [telemetry](https://wasp-lang.dev/docs/telemetry).
+ - `wasp telemetry` displays the status of [telemetry](../telemetry).
 
    ```
    $ wasp telemetry
@@ -130,7 +130,7 @@ Newsletter: https://wasp-lang.dev/#signup
    Telemetry is currently: ENABLED
    Telemetry cache directory: /home/user/.cache/wasp/telemetry/
    Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
-   Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details.
+   Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 
    ```
  - `wasp deps` lists the dependencies that Wasp uses in your project.
@@ -160,10 +160,10 @@ To set up Bash completion, run the `wasp completion` command and follow the inst
     0.12.0
 
     If you wish to install/switch to the latest version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s
 
     If you want specific x.y.z version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v x.y.z
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v x.y.z
 
     Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one.
     ```

--- a/web/versioned_docs/version-0.12.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.12.0/introduction/quick-start.md
@@ -14,7 +14,7 @@ Let's create and run our first Wasp app in 3 short steps:
 1. **To install Wasp on Linux / OSX / WSL (Windows), open your terminal and run:**
 
    ```shell
-   curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+   curl -sSL https://get.wasp.sh/installer.sh | sh
    ```
 
    ℹ️ Wasp requires Node.js and will warn you if it is missing: check below for [more details](#requirements).
@@ -52,7 +52,7 @@ That's it 🎉 You have successfully created and served a new full-stack web app
  - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈
  - [ ] [Setup your editor](./editor-setup.md) for working with Wasp.
  - [ ] Join us on [Discord](https://discord.gg/rzdnErX)! Any feedback or questions you have, we are there for you.
- - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp-lang.dev/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
+ - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp.sh/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
 
 ------
 
@@ -111,7 +111,7 @@ If you need it, we recommend using [nvm](https://github.com/nvm-sh/nvm) for mana
 Open your terminal and run:
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::note Running Wasp on Mac with Mx chip (arm64)
@@ -129,7 +129,7 @@ Once Rosetta is installed, you should be able to run Wasp without any issues.
 
 With Wasp for Windows, we are almost there: Wasp is successfully compiling and running on Windows but there is a bug or two stopping it from fully working. Check it out [here](https://github.com/wasp-lang/wasp/issues/48) if you are interested in helping.
 
-In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp-lang.dev/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
+In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp.sh/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
 :::caution
   If you are using WSL2, make sure that your Wasp project is not on the Windows file system, but instead on the Linux file system. Otherwise, Wasp won't be able to detect file changes, due to the [issue in WSL2](https://github.com/microsoft/WSL/issues/4739).
 :::

--- a/web/versioned_docs/version-0.12.0/migrate-from-0-11-to-0-12.md
+++ b/web/versioned_docs/version-0.12.0/migrate-from-0-11-to-0-12.md
@@ -172,7 +172,7 @@ directory `foo`, you should:
 
 0. **Install the latest `0.12.x` version** of Wasp.
   ```bash
-  curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s
+  curl -sSL https://get.wasp.sh/installer.sh | sh -s
   ```
 1. Make sure to **backup or save your project** before starting the procedure (e.g.,
    by committing it to source control or creating a copy).

--- a/web/versioned_docs/version-0.13.0/contact.md
+++ b/web/versioned_docs/version-0.13.0/contact.md
@@ -2,4 +2,5 @@
 title: Contact
 ---
 
+<!-- TODO: update the email once we setup @wasp.sh-->
 You can find us on [Discord](https://discord.gg/rzdnErX) or you can reach out to us via email at hi@wasp-lang.dev.

--- a/web/versioned_docs/version-0.13.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.13.0/data-model/backends.md
@@ -45,7 +45,7 @@ app MyApp {
 }
 ```
 
-2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](https://wasp-lang.dev/docs/general/cli#project-commands):
+2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](../general/cli#project-commands):
 
 ```bash
 rm -r migrations/

--- a/web/versioned_docs/version-0.13.0/general/cli.md
+++ b/web/versioned_docs/version-0.13.0/general/cli.md
@@ -49,9 +49,9 @@ EXAMPLES
   wasp start
   wasp db migrate-dev
 
-Docs: https://wasp-lang.dev/docs
+Docs: https://wasp.sh/docs
 Discord (chat): https://discord.gg/rzdnErX
-Newsletter: https://wasp-lang.dev/#signup
+Newsletter: https://wasp.sh/#signup
 ```
 
 ## Commands
@@ -122,7 +122,7 @@ Newsletter: https://wasp-lang.dev/#signup
   
   Read more about automatic deployment [here](../advanced/deployment/cli).
 
- - `wasp telemetry` displays the status of [telemetry](https://wasp-lang.dev/docs/telemetry).
+ - `wasp telemetry` displays the status of [telemetry](../telemetry).
 
    ```
    $ wasp telemetry
@@ -130,7 +130,7 @@ Newsletter: https://wasp-lang.dev/#signup
    Telemetry is currently: ENABLED
    Telemetry cache directory: /home/user/.cache/wasp/telemetry/
    Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
-   Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details.
+   Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 
    ```
  - `wasp deps` lists the dependencies that Wasp uses in your project.
@@ -160,10 +160,10 @@ To set up Bash completion, run the `wasp completion` command and follow the inst
     0.12.0
 
     If you wish to install/switch to the latest version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s
 
     If you want specific x.y.z version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v x.y.z
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v x.y.z
 
     Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one.
     ```

--- a/web/versioned_docs/version-0.13.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.13.0/introduction/quick-start.md
@@ -14,7 +14,7 @@ Let's create and run our first Wasp app in 3 short steps:
 1. **To install Wasp on Linux / OSX / WSL (Windows), open your terminal and run:**
 
    ```shell
-   curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+   curl -sSL https://get.wasp.sh/installer.sh | sh
    ```
 
    ℹ️ Wasp requires Node.js and will warn you if it is missing: check below for [more details](#requirements).
@@ -52,7 +52,7 @@ That's it 🎉 You have successfully created and served a new full-stack web app
  - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈
  - [ ] [Setup your editor](./editor-setup.md) for working with Wasp.
  - [ ] Join us on [Discord](https://discord.gg/rzdnErX)! Any feedback or questions you have, we are there for you.
- - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp-lang.dev/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
+ - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp.sh/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
 
 ------
 
@@ -111,7 +111,7 @@ If you need it, we recommend using [nvm](https://github.com/nvm-sh/nvm) for mana
 Open your terminal and run:
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::note Running Wasp on Mac with Mx chip (arm64)
@@ -129,7 +129,7 @@ Once Rosetta is installed, you should be able to run Wasp without any issues.
 
 With Wasp for Windows, we are almost there: Wasp is successfully compiling and running on Windows but there is a bug or two stopping it from fully working. Check it out [here](https://github.com/wasp-lang/wasp/issues/48) if you are interested in helping.
 
-In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp-lang.dev/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
+In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp.sh/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
 :::caution
   If you are using WSL2, make sure that your Wasp project is not on the Windows file system, but instead on the Linux file system. Otherwise, Wasp won't be able to detect file changes, due to the [issue in WSL2](https://github.com/microsoft/WSL/issues/4739).
 :::

--- a/web/versioned_docs/version-0.13.0/migrate-from-0-11-to-0-12.md
+++ b/web/versioned_docs/version-0.13.0/migrate-from-0-11-to-0-12.md
@@ -180,7 +180,7 @@ directory `foo`, you should:
 
 0. **Install the `0.12.x` version** of Wasp.
   ```bash
-  curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.12.4
+  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.12.4
   ```
 1. Make sure to **backup or save your project** before starting the procedure (e.g.,
    by committing it to source control or creating a copy).

--- a/web/versioned_docs/version-0.14.0/contact.md
+++ b/web/versioned_docs/version-0.14.0/contact.md
@@ -2,4 +2,5 @@
 title: Contact
 ---
 
+<!-- TODO: update the email once we setup @wasp.sh-->
 You can find us on [Discord](https://discord.gg/rzdnErX) or you can reach out to us via email at hi@wasp-lang.dev.

--- a/web/versioned_docs/version-0.14.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.14.0/data-model/backends.md
@@ -132,7 +132,7 @@ To run your Wasp app in production, you'll need to switch from SQLite to Postgre
     // ...
     ```
 
-2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](https://wasp-lang.dev/docs/general/cli#project-commands):
+2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](../general/cli#project-commands):
 
     ```bash
     rm -r migrations/

--- a/web/versioned_docs/version-0.14.0/general/cli.md
+++ b/web/versioned_docs/version-0.14.0/general/cli.md
@@ -49,9 +49,9 @@ EXAMPLES
   wasp start
   wasp db migrate-dev
 
-Docs: https://wasp-lang.dev/docs
+Docs: https://wasp.sh/docs
 Discord (chat): https://discord.gg/rzdnErX
-Newsletter: https://wasp-lang.dev/#signup
+Newsletter: https://wasp.sh/#signup
 ```
 
 ## Commands
@@ -122,7 +122,7 @@ Newsletter: https://wasp-lang.dev/#signup
   
   Read more about automatic deployment [here](../advanced/deployment/cli).
 
- - `wasp telemetry` displays the status of [telemetry](https://wasp-lang.dev/docs/telemetry).
+ - `wasp telemetry` displays the status of [telemetry](../telemetry).
 
    ```
    $ wasp telemetry
@@ -130,7 +130,7 @@ Newsletter: https://wasp-lang.dev/#signup
    Telemetry is currently: ENABLED
    Telemetry cache directory: /home/user/.cache/wasp/telemetry/
    Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
-   Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details.
+   Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 
    ```
  - `wasp deps` lists the dependencies that Wasp uses in your project.
@@ -167,10 +167,10 @@ To set up Bash completion, run the `wasp completion` command and follow the inst
     0.14.0
 
     If you wish to install/switch to the latest version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s
 
     If you want specific x.y.z version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v x.y.z
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v x.y.z
 
     Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one.
     ```

--- a/web/versioned_docs/version-0.14.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.14.0/introduction/quick-start.md
@@ -14,7 +14,7 @@ Let's create and run our first Wasp app in 3 short steps:
 1. **To install Wasp on Linux / OSX / WSL (Windows), open your terminal and run:**
 
    ```shell
-   curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+   curl -sSL https://get.wasp.sh/installer.sh | sh
    ```
 
    ℹ️ Wasp requires Node.js and will warn you if it is missing: check below for [more details](#requirements).
@@ -52,7 +52,7 @@ That's it 🎉 You have successfully created and served a new full-stack web app
  - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈
  - [ ] [Setup your editor](./editor-setup.md) for working with Wasp.
  - [ ] Join us on [Discord](https://discord.gg/rzdnErX)! Any feedback or questions you have, we are there for you.
- - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp-lang.dev/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
+ - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp.sh/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
 
 ------
 
@@ -111,7 +111,7 @@ If you need it, we recommend using [nvm](https://github.com/nvm-sh/nvm) for mana
 Open your terminal and run:
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::note Running Wasp on Mac with Mx chip (arm64)
@@ -129,7 +129,7 @@ Once Rosetta is installed, you should be able to run Wasp without any issues.
 
 With Wasp for Windows, we are almost there: Wasp is successfully compiling and running on Windows but there is a bug or two stopping it from fully working. Check it out [here](https://github.com/wasp-lang/wasp/issues/48) if you are interested in helping.
 
-In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp-lang.dev/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
+In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp.sh/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
 :::caution
   If you are using WSL2, make sure that your Wasp project is not on the Windows file system, but instead on the Linux file system. Otherwise, Wasp won't be able to detect file changes, due to the [issue in WSL2](https://github.com/microsoft/WSL/issues/4739).
 :::

--- a/web/versioned_docs/version-0.14.0/migrate-from-0-11-to-0-12.md
+++ b/web/versioned_docs/version-0.14.0/migrate-from-0-11-to-0-12.md
@@ -180,7 +180,7 @@ directory `foo`, you should:
 
 0. **Install the `0.12.x` version** of Wasp.
   ```bash
-  curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.12.4
+  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.12.4
   ```
 1. Make sure to **backup or save your project** before starting the procedure (e.g.,
    by committing it to source control or creating a copy).

--- a/web/versioned_docs/version-0.15.0/contact.md
+++ b/web/versioned_docs/version-0.15.0/contact.md
@@ -2,4 +2,5 @@
 title: Contact
 ---
 
+<!-- TODO: update the email once we setup @wasp.sh-->
 You can find us on [Discord](https://discord.gg/rzdnErX) or you can reach out to us via email at hi@wasp-lang.dev.

--- a/web/versioned_docs/version-0.15.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.15.0/data-model/backends.md
@@ -132,7 +132,7 @@ To run your Wasp app in production, you'll need to switch from SQLite to Postgre
     // ...
     ```
 
-2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](https://wasp-lang.dev/docs/general/cli#project-commands):
+2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](../general/cli#project-commands):
 
     ```bash
     rm -r migrations/

--- a/web/versioned_docs/version-0.15.0/general/cli.md
+++ b/web/versioned_docs/version-0.15.0/general/cli.md
@@ -49,9 +49,9 @@ EXAMPLES
   wasp start
   wasp db migrate-dev
 
-Docs: https://wasp-lang.dev/docs
+Docs: https://wasp.sh/docs
 Discord (chat): https://discord.gg/rzdnErX
-Newsletter: https://wasp-lang.dev/#signup
+Newsletter: https://wasp.sh/#signup
 ```
 
 ## Commands
@@ -122,7 +122,7 @@ Newsletter: https://wasp-lang.dev/#signup
   
   Read more about automatic deployment [here](../advanced/deployment/cli).
 
- - `wasp telemetry` displays the status of [telemetry](https://wasp-lang.dev/docs/telemetry).
+ - `wasp telemetry` displays the status of [telemetry](../telemetry).
 
    ```
    $ wasp telemetry
@@ -130,7 +130,7 @@ Newsletter: https://wasp-lang.dev/#signup
    Telemetry is currently: ENABLED
    Telemetry cache directory: /home/user/.cache/wasp/telemetry/
    Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
-   Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details.
+   Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 
    ```
  - `wasp deps` lists the dependencies that Wasp uses in your project.
@@ -167,10 +167,10 @@ To set up Bash completion, run the `wasp completion` command and follow the inst
     0.14.0
 
     If you wish to install/switch to the latest version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s
 
     If you want specific x.y.z version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v x.y.z
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v x.y.z
 
     Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one.
     ```

--- a/web/versioned_docs/version-0.15.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.15.0/introduction/quick-start.md
@@ -14,7 +14,7 @@ Let's create and run our first Wasp app in 3 short steps:
 1. **To install Wasp on Linux / OSX / WSL (Windows), open your terminal and run:**
 
    ```shell
-   curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+   curl -sSL https://get.wasp.sh/installer.sh | sh
    ```
 
    ℹ️ Wasp requires Node.js and will warn you if it is missing: check below for [more details](#requirements).
@@ -52,7 +52,7 @@ That's it 🎉 You have successfully created and served a new full-stack web app
  - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈
  - [ ] [Setup your editor](./editor-setup.md) for working with Wasp.
  - [ ] Join us on [Discord](https://discord.gg/rzdnErX)! Any feedback or questions you have, we are there for you.
- - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp-lang.dev/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
+ - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp.sh/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
 
 ------
 
@@ -111,7 +111,7 @@ If you need it, we recommend using [nvm](https://github.com/nvm-sh/nvm) for mana
 Open your terminal and run:
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::note Running Wasp on Mac with Mx chip (arm64)
@@ -129,7 +129,7 @@ Once Rosetta is installed, you should be able to run Wasp without any issues.
 
 With Wasp for Windows, we are almost there: Wasp is successfully compiling and running on Windows but there is a bug or two stopping it from fully working. Check it out [here](https://github.com/wasp-lang/wasp/issues/48) if you are interested in helping.
 
-In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp-lang.dev/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
+In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp.sh/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
 :::caution
   If you are using WSL2, make sure that your Wasp project is not on the Windows file system, but instead on the Linux file system. Otherwise, Wasp won't be able to detect file changes, due to the [issue in WSL2](https://github.com/microsoft/WSL/issues/4739).
 :::

--- a/web/versioned_docs/version-0.15.0/migration-guides/migrate-from-0-11-to-0-12.md
+++ b/web/versioned_docs/version-0.15.0/migration-guides/migrate-from-0-11-to-0-12.md
@@ -180,7 +180,7 @@ directory `foo`, you should:
 
 0. **Install the `0.12.x` version** of Wasp.
   ```bash
-  curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.12.4
+  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.12.4
   ```
 1. Make sure to **backup or save your project** before starting the procedure (e.g.,
    by committing it to source control or creating a copy).

--- a/web/versioned_docs/version-0.16.0/contact.md
+++ b/web/versioned_docs/version-0.16.0/contact.md
@@ -2,4 +2,5 @@
 title: Contact
 ---
 
+<!-- TODO: update the email once we setup @wasp.sh-->
 You can find us on [Discord](https://discord.gg/rzdnErX) or you can reach out to us via email at hi@wasp-lang.dev.

--- a/web/versioned_docs/version-0.16.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.16.0/data-model/backends.md
@@ -132,7 +132,7 @@ To run your Wasp app in production, you'll need to switch from SQLite to Postgre
     // ...
     ```
 
-2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](https://wasp-lang.dev/docs/general/cli#project-commands):
+2. Delete all the old migrations, since they are SQLite migrations and can't be used with PostgreSQL, as well as the SQLite database by running [`wasp clean`](../general/cli#project-commands):
 
     ```bash
     rm -r migrations/

--- a/web/versioned_docs/version-0.16.0/deployment/deployment-methods/paas.md
+++ b/web/versioned_docs/version-0.16.0/deployment/deployment-methods/paas.md
@@ -594,7 +594,7 @@ jobs:
           node-version: '20'
 
       - name: Install Wasp
-        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
+        run: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
 
       - name: Wasp Build
         run: wasp build
@@ -699,7 +699,7 @@ jobs:
           node-version: '20'
 
       - name: Install Wasp
-        run: curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
+        run: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.16.0 # Change to your Wasp version
 
       - name: Wasp Build
         run: cd ./app && wasp build

--- a/web/versioned_docs/version-0.16.0/general/cli.md
+++ b/web/versioned_docs/version-0.16.0/general/cli.md
@@ -49,9 +49,9 @@ EXAMPLES
   wasp start
   wasp db migrate-dev
 
-Docs: https://wasp-lang.dev/docs
+Docs: https://wasp.sh/docs
 Discord (chat): https://discord.gg/rzdnErX
-Newsletter: https://wasp-lang.dev/#signup
+Newsletter: https://wasp.sh/#signup
 ```
 
 ## Commands
@@ -122,7 +122,7 @@ Newsletter: https://wasp-lang.dev/#signup
   
   Read more about automatic deployment [here](../deployment/deployment-methods/cli.md).
 
- - `wasp telemetry` displays the status of [telemetry](https://wasp-lang.dev/docs/telemetry).
+ - `wasp telemetry` displays the status of [telemetry](https://wasp.sh/docs/telemetry).
 
    ```
    $ wasp telemetry
@@ -130,7 +130,7 @@ Newsletter: https://wasp-lang.dev/#signup
    Telemetry is currently: ENABLED
    Telemetry cache directory: /home/user/.cache/wasp/telemetry/
    Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
-   Our telemetry is anonymized and very limited in its scope: check https://wasp-lang.dev/docs/telemetry for more details.
+   Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 
    ```
  - `wasp deps` lists the dependencies that Wasp uses in your project.
@@ -167,10 +167,10 @@ To set up Bash completion, run the `wasp completion` command and follow the inst
     0.14.0
 
     If you wish to install/switch to the latest version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s
 
     If you want specific x.y.z version of Wasp, do:
-    curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v x.y.z
+    curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v x.y.z
 
     Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one.
     ```

--- a/web/versioned_docs/version-0.16.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.16.0/introduction/quick-start.md
@@ -14,7 +14,7 @@ Let's create and run our first Wasp app in 3 short steps:
 1. **To install Wasp on Linux / OSX / WSL (Windows), open your terminal and run:**
 
    ```shell
-   curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+   curl -sSL https://get.wasp.sh/installer.sh | sh
    ```
 
    ℹ️ Wasp requires Node.js and will warn you if it is missing: check below for [more details](#requirements).
@@ -52,7 +52,7 @@ That's it 🎉 You have successfully created and served a new full-stack web app
  - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈
  - [ ] [Setup your editor](./editor-setup.md) for working with Wasp.
  - [ ] Join us on [Discord](https://discord.gg/rzdnErX)! Any feedback or questions you have, we are there for you.
- - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp-lang.dev/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
+ - [ ] Follow Wasp development by subscribing to our newsletter: https://wasp.sh/#signup . We usually send 1 per month, and [Matija](https://github.com/matijaSos) does his best to unleash his creativity to make them engaging and fun to read :D!
 
 ------
 
@@ -111,7 +111,7 @@ If you need it, we recommend using [nvm](https://github.com/nvm-sh/nvm) for mana
 Open your terminal and run:
 
 ```shell
-curl -sSL https://get.wasp-lang.dev/installer.sh | sh
+curl -sSL https://get.wasp.sh/installer.sh | sh
 ```
 
 :::note Running Wasp on Mac with Mx chip (arm64)
@@ -129,7 +129,7 @@ Once Rosetta is installed, you should be able to run Wasp without any issues.
 
 With Wasp for Windows, we are almost there: Wasp is successfully compiling and running on Windows but there is a bug or two stopping it from fully working. Check it out [here](https://github.com/wasp-lang/wasp/issues/48) if you are interested in helping.
 
-In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp-lang.dev/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
+In the meantime, the best way to start using Wasp on Windows is by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Once you set up Ubuntu on WSL, just follow Linux instructions for installing Wasp. You can refer to this [article](https://wasp.sh/blog/2023/11/21/guide-windows-development-wasp-wsl) if you prefer a step by step guide to using Wasp in WSL environment. If you need further help, reach out to us on [Discord](https://discord.gg/rzdnErX) - we have some community members using WSL that might be able to help you.
 :::caution
   If you are using WSL2, make sure that your Wasp project is not on the Windows file system, but instead on the Linux file system. Otherwise, Wasp won't be able to detect file changes, due to the [issue in WSL2](https://github.com/microsoft/WSL/issues/4739).
 :::

--- a/web/versioned_docs/version-0.16.0/migration-guides/migrate-from-0-11-to-0-12.md
+++ b/web/versioned_docs/version-0.16.0/migration-guides/migrate-from-0-11-to-0-12.md
@@ -180,7 +180,7 @@ directory `foo`, you should:
 
 0. **Install the `0.12.x` version** of Wasp.
   ```bash
-  curl -sSL https://get.wasp-lang.dev/installer.sh | sh -s -- -v 0.12.4
+  curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.12.4
   ```
 1. Make sure to **backup or save your project** before starting the procedure (e.g.,
    by committing it to source control or creating a copy).


### PR DESCRIPTION
I'll merge this tomorrow and deploy to _wasp.sh only_ before I turn on the redirect from wasp-lang.dev -> wasp.sh