### PR TITLE
Update outdated docs, improve naming, prefer user props over auth hook in docs

### DIFF
--- a/web/docs/advanced/jobs.md
+++ b/web/docs/advanced/jobs.md
@@ -233,7 +233,7 @@ The Job declaration has the following fields:
   :::note Job executors
   Our jobs need job executors to handle the _scheduling, monitoring, and execution_.
 
-  `PgBoss` is currently our only job executor, and is recommended for low-volume production use cases. It requires that your database provider is set to `"postgresql"` in your `schema.prisma` file. Read more about setting the provider [here](../data-model/backends.md#postgresql).
+  `PgBoss` is currently our only job executor, and is recommended for low-volume production use cases. It requires that your database provider is set to `"postgresql"` in your `schema.prisma` file. Read more about setting the provider [here](../data-model/databases.md#postgresql).
   :::
 
   We have selected [pg-boss](https://github.com/timgit/pg-boss/) as our first job executor to handle the low-volume, basic job queue workloads many web applications have. By using PostgreSQL (and [SKIP LOCKED](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/)) as its storage and synchronization mechanism, it allows us to provide many job queue pros without any additional infrastructure or complex management.

--- a/web/docs/auth/overview.md
+++ b/web/docs/auth/overview.md
@@ -184,7 +184,7 @@ There are two ways to access the `user` object on the client:
 
 #### Using the `user` prop
 
-If the page's declaration sets `authRequired` to `true`, the page's React component receives the `user` object as a prop:
+The preferred way to fetch user data on authenticated pages is by using the `user` prop. If the page's declaration sets `authRequired` to `true`, the page's React component receives the `user` object as a prop:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
@@ -313,7 +313,7 @@ export function Main() {
 </Tabs>
 
 :::tip
-Since the `user` prop is only available in a page's React component: use the `user` prop in the page's React component and the `useAuth` hook in any other React component.
+While the `user` prop is only available in an authenticated page's React component, it is the preferred option because we can be certain that the user exists on that page. On the other hand, `useAuth` can be used when the user might not exist, making it better suited for non-authenticated components.
 :::
 
 ### On the server

--- a/web/docs/auth/social-auth/overview.md
+++ b/web/docs/auth/social-auth/overview.md
@@ -215,7 +215,7 @@ export const userSignupFields = defineUserSignupFields({
 
 #### 3. Showing the Correct State on the Client
 
-You can query the user's `isSignupComplete` flag on the client with the [`useAuth()`](../../auth/overview) hook.
+You can check the `isSignupComplete` flag on the `user` object.
 Depending on the flag's value, you can redirect users to the appropriate signup step.
 
 For example:
@@ -227,12 +227,9 @@ For example:
 <TabItem value="js" label="JavaScript">
 
 ```jsx title=src/HomePage.jsx
-import { useAuth } from 'wasp/client/auth'
 import { Navigate } from 'react-router-dom'
 
-export function HomePage() {
-  const { data: user } = useAuth()
-
+export function HomePage({ user }) {
   if (user.isSignupComplete === false) {
     return <Navigate to="/edit-user-details" />
   }
@@ -245,12 +242,9 @@ export function HomePage() {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title=src/HomePage.tsx
-import { useAuth } from 'wasp/client/auth'
 import { Navigate } from 'react-router-dom'
 
-export function HomePage() {
-  const { data: user } = useAuth()
-
+export function HomePage({ user }: { user: AuthUser }) {
   if (user.isSignupComplete === false) {
     return <Navigate to="/edit-user-details" />
   }

--- a/web/docs/data-model/databases.md
+++ b/web/docs/data-model/databases.md
@@ -225,7 +225,7 @@ async function createUser(prisma, data) {
             create: {
               providerName: 'username',
               providerUserId: data.username,
-              providerData: sanitizeAndSerializeProviderData({
+              providerData: await sanitizeAndSerializeProviderData({
                 hashedPassword: data.password
               }),
             },
@@ -273,7 +273,7 @@ async function createUser(
             create: {
               providerName: 'username',
               providerUserId: data.username,
-              providerData: sanitizeAndSerializeProviderData<'username'>({
+              providerData: await sanitizeAndSerializeProviderData<'username'>({
                 hashedPassword: data.password
               }),
             },

--- a/web/static/_redirects
+++ b/web/static/_redirects
@@ -8,6 +8,7 @@
 /docs/deploying                    /docs/deployment/intro                    301
 /docs/advanced/deployment/overview /docs/deployment/intro                    301
 /docs/integrations/css-frameworks  /docs/project/css-frameworks             301
+/docs/data-model/backends          /docs/data-model/databases               301
 /docs/guides/websockets            /docs/advanced/web-sockets               301
 /docs/guides/testing               /docs/project/testing                    301
 /docs/guides/middleware-customization /docs/advanced/middleware-config       301


### PR DESCRIPTION
- Adds `await` for `sanitizeAndSerializeProviderData` calls
- Renames `data-model/backends` to `data-model/databases` 
- Docs guide users to use `user` props rather than `useAuth()`, also reflected on examples

Related issues: https://github.com/wasp-lang/wasp/issues/2514, https://github.com/wasp-lang/wasp/issues/1071
