### PR TITLE
Fix 0.16.0 version number in changelog

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -18,7 +18,7 @@
 - Session ID is no longer removed when the user logs out from a different tab ([#2075](https://github.com/wasp-lang/wasp/issues/2075)).
 - Using operations on the server no longer breaks relative extensionless imports ([#2492](https://github.com/wasp-lang/wasp/issues/2492)).
 
-## 1.16.0
+## 0.16.0
 
 ### 🎉 New Features and improvements
 


### PR DESCRIPTION
### Description

Version number in the changelog is wrong: It's 1.16.0, and it should be 0.16.0

### Select what type of change this PR introduces:
1. [X] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).
