### PR TITLE
Remove hardcoded `theme-color` meta attribute

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -4,7 +4,7 @@
 
 ### 🎉 New Features and improvements
 
-- A custom `theme-color` can now be defined by the app ([#2546](https://github.com/wasp-lang/wasp/pull/2546)).
+- Custom values for `theme-color` are now supported ([#2546](https://github.com/wasp-lang/wasp/pull/2546)).
 
 ## 0.16.2
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.3
+
+### 🎉 New Features and improvements
+
+- A custom `theme-color` can now be defined by the app ([#2546](https://github.com/wasp-lang/wasp/pull/2546)).
+
 ## 0.16.2
 
 ### 🎉 New Features and improvements

--- a/waspc/data/Generator/templates/react-app/index.html
+++ b/waspc/data/Generator/templates/react-app/index.html
@@ -8,7 +8,6 @@
             name="viewport"
             content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
         />
-        <meta name="theme-color" content="#000000" />
 
         <link rel="manifest" href="/manifest.json" />
 

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -550,7 +550,7 @@
             "file",
             "web-app/index.html"
         ],
-        "503f37673a444e70b8954eec7efb5365d5e80971de0a5bee9cba56f73bbbd83c"
+        "8cc6168f652b825015918a0d2e82a2c0ad3126e1dd39662b0a49a38f9818e5a1"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/index.html
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/index.html
@@ -7,7 +7,6 @@
             name="viewport"
             content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
         />
-        <meta name="theme-color" content="#000000" />
 
         <link rel="manifest" href="/manifest.json" />
 

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -564,7 +564,7 @@
             "file",
             "web-app/index.html"
         ],
-        "f38792224e7db1569c41ec117a2cb211dec4620b8b4302c47ff7fc8f58ce3647"
+        "e87f539b3de57d569c5984c8edca0026a939634312b5b1f0163bd34f426846e5"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/index.html
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/index.html
@@ -7,7 +7,6 @@
             name="viewport"
             content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
         />
-        <meta name="theme-color" content="#000000" />
 
         <link rel="manifest" href="/manifest.json" />
 

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -1187,7 +1187,7 @@
             "file",
             "web-app/index.html"
         ],
-        "f1ca90861003c568c2670b0064f15431cfc45a68b23ffd890b1187af588a76d9"
+        "04e67239005c3ec39463778c9d0d4abc2addd8a30b295390619e494a84f96103"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/index.html
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/index.html
@@ -7,7 +7,6 @@
             name="viewport"
             content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
         />
-        <meta name="theme-color" content="#000000" />
 
         <link rel="manifest" href="/manifest.json" />
 

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -662,7 +662,7 @@
             "file",
             "web-app/index.html"
         ],
-        "22a3affb86f8ca588469315523df9116dc9afb0265e2df8d861f2066c960a333"
+        "697e9b92b49353765357b3ec2607868096effc39c5de83ed11fe59fde47d9cf3"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/index.html
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/index.html
@@ -7,7 +7,6 @@
             name="viewport"
             content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
         />
-        <meta name="theme-color" content="#000000" />
 
         <link rel="manifest" href="/manifest.json" />
 

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -564,7 +564,7 @@
             "file",
             "web-app/index.html"
         ],
-        "be16520d0a664cda0212f52f7d42d5839415e8dd4a6ff025f6063e5b4b1f852d"
+        "309599f7e420c3310c1464a8548ff0326de23726837c4341d245bbe411459e41"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/index.html
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/index.html
@@ -7,7 +7,6 @@
             name="viewport"
             content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
         />
-        <meta name="theme-color" content="#000000" />
 
         <link rel="manifest" href="/manifest.json" />
 

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.16.3
+version:        0.16.2
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.16.2
+version:        0.16.3
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues


### PR DESCRIPTION
### Description

This PR removes the `theme-color` attributed hardcoded in the wasp template for React, so that it can be overridden by the app. Fixes #2545

**Screenshots**

**Desktop**
 - OS: MacOS Sequoia 15.3.1
 - Browser: Safari
 - Version: (Applies to any)

| `master` | [This branch](https://github.com/wasp-lang/wasp/pull/2546) |
| - | - |
| <img width="1832" alt="image" src="https://github.com/user-attachments/assets/7f8a58c0-bcf0-4724-af3c-db7c5734798f" /> | <img width="1832" alt="image" src="https://github.com/user-attachments/assets/7f00ebbf-3f98-4b2c-8090-d3c21f620180" /> |


**Smartphone**
 - Device: iPhone 16 Pro
 - OS: iOS 18.3.1
 - Browser: Safari
 - Version: (Applies to any)

| `master` | [This branch](https://github.com/wasp-lang/wasp/pull/2546) |
| - | - |
| ![Image](https://github.com/user-attachments/assets/0e1d9de6-960c-45ca-ae78-7c8d3eaf7dd8) | ![Image](https://github.com/user-attachments/assets/79f7fd10-d993-47b6-ae12-08254847cba4) |
### Select what type of change this PR introduces:
1. [ ] **Just code/docs improvement** (no functional change).
2. [X] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [x] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [x] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Update example apps if needed
If you did code changes and added a new feature or modified an existing feature, make sure you satisfy the following:
1. [x] I updated `waspc/examples/todoApp` as needed (updated modified feature or added new feature) and manually checked it works correctly.
2. [x] I updated `waspc/headless-test/examples/todoApp` and its e2e tests as needed (updated modified feature and its tests or added new feature and new tests for it).
