### PR TITLE
Convert hardcoded strings to variables

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -7,6 +7,7 @@
 - Custom values for `theme-color` are now supported ([#2546](https://github.com/wasp-lang/wasp/pull/2546) by @andrsdt).
 - Increased the minimum Node version to 20.0.0 ( [#2537](https://github.com/wasp-lang/wasp/pull/2537) )
 - Invalid CLI commands now properly return non-zero exit code ( [#2522](https://github.com/wasp-lang/wasp/pull/2552) )
+- Prisma's datasource database provider string literals are now variablized ( [#2548](https://github.com/wasp-lang/wasp/pull/2548) )
 
 ### Bug fixes
 

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -40,6 +40,7 @@ import Wasp.Generator.Crud (crudDeclarationToOperationsList)
 import Wasp.Node.Version (oldestWaspSupportedNodeVersion)
 import qualified Wasp.Node.Version as V
 import qualified Wasp.Psl.Ast.Model as Psl.Model
+import qualified Wasp.Psl.Db as Psl.Db
 import qualified Wasp.Psl.Util as Psl.Util
 import Wasp.Psl.Valid (getValidDbSystemFromPrismaSchema)
 import qualified Wasp.SemanticVersion as SV
@@ -165,7 +166,7 @@ validateOnlyEmailOrUsernameAndPasswordAuthIsUsed spec =
 validateDbIsPostgresIfPgBossUsed :: AppSpec -> [ValidationError]
 validateDbIsPostgresIfPgBossUsed spec =
   [ GenericValidationError
-      "The database provider in the schema.prisma file must be \"postgresql\" since there are jobs with executor set to PgBoss."
+      ("The database provider in the schema.prisma file must be \"" ++ Psl.Db.pslPostgresqlKeyword ++ "\" since there are jobs with executor set to PgBoss.")
     | isPgBossJobExecutorUsed spec && not (isPostgresUsed spec)
   ]
 

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -166,7 +166,7 @@ validateOnlyEmailOrUsernameAndPasswordAuthIsUsed spec =
 validateDbIsPostgresIfPgBossUsed :: AppSpec -> [ValidationError]
 validateDbIsPostgresIfPgBossUsed spec =
   [ GenericValidationError
-      ("The database provider in the schema.prisma file must be \"" ++ Psl.Db.pslPostgresqlKeyword ++ "\" since there are jobs with executor set to PgBoss.")
+      ("The database provider in the schema.prisma file must be \"" ++ Psl.Db.dbProviderPostgresqlStringLiteral ++ "\" since there are jobs with executor set to PgBoss.")
     | isPgBossJobExecutorUsed spec && not (isPostgresUsed spec)
   ]
 

--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -64,11 +64,11 @@ genPrismaSchema ::
   Generator FileDraft
 genPrismaSchema spec = do
   (datasourceProvider :: String) <- case dbSystem of
-    AS.Db.PostgreSQL -> return Pls.Db.pslPostgresqlKeyword
+    AS.Db.PostgreSQL -> return Pls.Db.dbProviderPostgresqlStringLiteral
     AS.Db.SQLite ->
       if AS.isBuild spec
         then logAndThrowGeneratorError $ GenericGeneratorError "SQLite (a default database) is not supported in production. To build your Wasp app for production, switch to a different database. Switching to PostgreSQL: https://wasp.sh/docs/data-model/backends#migrating-from-sqlite-to-postgresql ."
-        else return Pls.Db.pslSqliteKeyword
+        else return Pls.Db.dbProviderSqliteStringLiteral
 
   entities <- getEntitiesForPrismaSchema spec
 

--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -48,6 +48,7 @@ import qualified Wasp.Psl.Ast.Argument as Psl.Argument
 import qualified Wasp.Psl.Ast.ConfigBlock as Psl.Ast.ConfigBlock
 import qualified Wasp.Psl.Ast.Model as Psl.Model
 import qualified Wasp.Psl.Ast.Schema as Psl.Schema
+import qualified Wasp.Psl.Db as Pls.Db
 import qualified Wasp.Psl.Format as Psl.Format
 import qualified Wasp.Psl.Generator.Schema as Psl.Generator.Schema
 import Wasp.Util (checksumFromFilePath, hexToString, ifM, (<:>))
@@ -63,11 +64,11 @@ genPrismaSchema ::
   Generator FileDraft
 genPrismaSchema spec = do
   (datasourceProvider :: String) <- case dbSystem of
-    AS.Db.PostgreSQL -> return "postgresql"
+    AS.Db.PostgreSQL -> return Pls.Db.pslPostgresqlKeyword
     AS.Db.SQLite ->
       if AS.isBuild spec
         then logAndThrowGeneratorError $ GenericGeneratorError "SQLite (a default database) is not supported in production. To build your Wasp app for production, switch to a different database. Switching to PostgreSQL: https://wasp.sh/docs/data-model/backends#migrating-from-sqlite-to-postgresql ."
-        else return "sqlite"
+        else return Pls.Db.pslSqliteKeyword
 
   entities <- getEntitiesForPrismaSchema spec
 

--- a/waspc/src/Wasp/Project/Db.hs
+++ b/waspc/src/Wasp/Project/Db.hs
@@ -11,7 +11,6 @@ where
 
 import StrongPath (Abs, Dir, Path')
 import qualified Wasp.AppSpec as AS
-import qualified Wasp.AppSpec.App.Db as AS.App.Db
 import qualified Wasp.AppSpec.App.Db as AS.Db
 import Wasp.Project.Common (WaspProjectDir)
 import qualified Wasp.Project.Db.Dev.Postgres as DevPostgres
@@ -19,6 +18,7 @@ import qualified Wasp.Project.Db.Dev.Sqlite as DevSqlite
 import qualified Wasp.Psl.Ast.Argument as Psl.Argument
 import qualified Wasp.Psl.Ast.ConfigBlock as Psl.ConfigBlock
 import qualified Wasp.Psl.Ast.Schema as Psl.Schema
+import qualified Wasp.Psl.Db as Psl.Db
 import Wasp.Psl.Generator.Argument (generateExpression)
 import Wasp.Psl.Util (findPrismaConfigBlockKeyValuePair)
 
@@ -30,8 +30,8 @@ makeDevDatabaseUrl ::
 makeDevDatabaseUrl waspProjectDir dbSystem decls = do
   (appName, _) <- AS.getApp decls
   case dbSystem of
-    AS.App.Db.PostgreSQL -> Just $ DevPostgres.makeDevConnectionUrl waspProjectDir appName
-    AS.App.Db.SQLite -> Just DevSqlite.defaultDevDbFile
+    AS.Db.PostgreSQL -> Just $ DevPostgres.makeDevConnectionUrl waspProjectDir appName
+    AS.Db.SQLite -> Just DevSqlite.defaultDevDbFile
 
 databaseUrlEnvVarName :: String
 databaseUrlEnvVarName = "DATABASE_URL"
@@ -50,8 +50,9 @@ data DbSystemParseError = UnsupportedDbSystem String | MissingDbSystem
 getDbSystemFromPrismaSchema :: Psl.Schema.Schema -> Either DbSystemParseError AS.Db.DbSystem
 getDbSystemFromPrismaSchema prismaSchema =
   case getDbProviderFromPrismaSchema prismaSchema of
-    Just (Psl.Argument.StringExpr "postgresql") -> Right AS.App.Db.PostgreSQL
-    Just (Psl.Argument.StringExpr "sqlite") -> Right AS.App.Db.SQLite
+    Just (Psl.Argument.StringExpr provider)
+      | provider == Psl.Db.pslPostgresqlKeyword -> Right AS.Db.PostgreSQL
+      | provider == Psl.Db.pslSqliteKeyword -> Right AS.Db.SQLite
     Just anyOtherExpression -> Left $ UnsupportedDbSystem $ generateExpression anyOtherExpression
     Nothing -> Left MissingDbSystem
 

--- a/waspc/src/Wasp/Project/Db.hs
+++ b/waspc/src/Wasp/Project/Db.hs
@@ -51,8 +51,8 @@ getDbSystemFromPrismaSchema :: Psl.Schema.Schema -> Either DbSystemParseError AS
 getDbSystemFromPrismaSchema prismaSchema =
   case getDbProviderFromPrismaSchema prismaSchema of
     Just (Psl.Argument.StringExpr provider)
-      | provider == Psl.Db.pslPostgresqlKeyword -> Right AS.Db.PostgreSQL
-      | provider == Psl.Db.pslSqliteKeyword -> Right AS.Db.SQLite
+      | provider == Psl.Db.dbProviderPostgresqlStringLiteral -> Right AS.Db.PostgreSQL
+      | provider == Psl.Db.dbProviderSqliteStringLiteral -> Right AS.Db.SQLite
     Just anyOtherExpression -> Left $ UnsupportedDbSystem $ generateExpression anyOtherExpression
     Nothing -> Left MissingDbSystem
 

--- a/waspc/src/Wasp/Psl/Db.hs
+++ b/waspc/src/Wasp/Psl/Db.hs
@@ -1,11 +1,11 @@
 module Wasp.Psl.Db
-  ( pslPostgresqlKeyword,
-    pslSqliteKeyword,
+  ( dbProviderPostgresqlStringLiteral,
+    dbProviderSqliteStringLiteral,
   )
 where
 
-pslPostgresqlKeyword :: String
-pslPostgresqlKeyword = "postgresql"
+dbProviderPostgresqlStringLiteral :: String
+dbProviderPostgresqlStringLiteral = "postgresql"
 
-pslSqliteKeyword :: String
-pslSqliteKeyword = "sqlite"
+dbProviderSqliteStringLiteral :: String
+dbProviderSqliteStringLiteral = "sqlite"

--- a/waspc/src/Wasp/Psl/Db.hs
+++ b/waspc/src/Wasp/Psl/Db.hs
@@ -1,0 +1,11 @@
+module Wasp.Psl.Db
+  ( pslPostgresqlKeyword,
+    pslSqliteKeyword,
+  )
+where
+
+pslPostgresqlKeyword :: String
+pslPostgresqlKeyword = "postgresql"
+
+pslSqliteKeyword :: String
+pslSqliteKeyword = "sqlite"

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -417,6 +417,7 @@ library
     Wasp.Psl.Parser.View
     Wasp.Psl.Util
     Wasp.Psl.Valid
+    Wasp.Psl.Db
     Wasp.SemanticVersion
     Wasp.SemanticVersion.VersionBound
     Wasp.SemanticVersion.Version


### PR DESCRIPTION
Converts all hardcoded strings ("postgresql" and "sqlite) to variable alternatives.

Left out strings include:
1. Filepath strings e.g. `"-v %s:/var/lib/postgresql/data"`, `"postgresql://%s:%s@localhost:%d/%s"`
2. Test `Text` strings e.g.
```hs
getPrismaSchemaWithConfig restOfPrismaSource =
  Util.getPrismaSchema
    [trimming|
      datasource db {
        provider = "postgresql"
        url      = env("DATABASE_URL")
      }
      generator client {
        provider = "prisma-client-js"
      }
      ${restOfPrismaSource}
    |]
```

If we wish to also include variables in tests `Text` strings I can change that.

Fixes #2220 
