### PR TITLE
Invalid CLI commands should return non-zero exit code

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -6,6 +6,7 @@
 
 - Custom values for `theme-color` are now supported ([#2546](https://github.com/wasp-lang/wasp/pull/2546) by @andrsdt).
 - Increased the minimum Node version to 20.0.0 ( [#2537](https://github.com/wasp-lang/wasp/pull/2537) )
+- Invalid CLI commands now properly return non-zero exit code ( [#2522](https://github.com/wasp-lang/wasp/pull/2552) )
 
 ### Bug fixes
 

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -100,7 +100,9 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
             projectName
             appDescription
             projectConfigJson
-      _unknownCommand -> printWaspNewAiUsage
+      _unknownCommand -> do
+        printWaspNewAiUsage
+        exitFailure
     Command.Call.Start -> runCommand start
     Command.Call.StartDb -> runCommand Command.Start.Db.start
     Command.Call.Clean -> runCommand clean
@@ -118,11 +120,12 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
     Command.Call.PrintBashCompletionInstruction -> runCommand printBashCompletionInstruction
     Command.Call.GenerateBashCompletionScript -> runCommand generateBashCompletionScript
     Command.Call.BashCompletionListCommands -> runCommand bashCompletion
-    Command.Call.Unknown _ -> printUsage
     Command.Call.WaspLS -> runWaspLS
     Command.Call.Deploy deployArgs -> runCommand $ deploy deployArgs
     Command.Call.Test testArgs -> runCommand $ test testArgs
-
+    Command.Call.Unknown _ -> do
+      printUsage
+      exitFailure
   -- If sending of telemetry data is still not done 1 second since commmand finished, abort it.
   -- We also make sure here to catch all errors that might get thrown and silence them.
   void $ Async.race (threadDelaySeconds 1) (Async.waitCatch telemetryThread)
@@ -225,7 +228,9 @@ dbCli args = case args of
   ["seed"] -> runCommandThatRequiresDbRunning $ Command.Db.Seed.seed Nothing
   ["seed", seedName] -> runCommandThatRequiresDbRunning $ Command.Db.Seed.seed $ Just seedName
   ["studio"] -> runCommandThatRequiresDbRunning Command.Db.Studio.studio
-  _unknownDbCommand -> printDbUsage
+  _unknownDbCommand -> do
+    printDbUsage
+    exitFailure
 
 {- ORMOLU_DISABLE -}
 printDbUsage :: IO ()

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -100,9 +100,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
             projectName
             appDescription
             projectConfigJson
-      _unknownCommand -> do
-        printWaspNewAiUsage
-        exitFailure
+      _unknownCommand -> printWaspNewAiUsage >> exitFailure
     Command.Call.Start -> runCommand start
     Command.Call.StartDb -> runCommand Command.Start.Db.start
     Command.Call.Clean -> runCommand clean
@@ -123,9 +121,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
     Command.Call.WaspLS -> runWaspLS
     Command.Call.Deploy deployArgs -> runCommand $ deploy deployArgs
     Command.Call.Test testArgs -> runCommand $ test testArgs
-    Command.Call.Unknown _ -> do
-      printUsage
-      exitFailure
+    Command.Call.Unknown _ -> printUsage >> exitFailure
   -- If sending of telemetry data is still not done 1 second since commmand finished, abort it.
   -- We also make sure here to catch all errors that might get thrown and silence them.
   void $ Async.race (threadDelaySeconds 1) (Async.waitCatch telemetryThread)
@@ -228,9 +224,7 @@ dbCli args = case args of
   ["seed"] -> runCommandThatRequiresDbRunning $ Command.Db.Seed.seed Nothing
   ["seed", seedName] -> runCommandThatRequiresDbRunning $ Command.Db.Seed.seed $ Just seedName
   ["studio"] -> runCommandThatRequiresDbRunning Command.Db.Studio.studio
-  _unknownDbCommand -> do
-    printDbUsage
-    exitFailure
+  _unknownDbCommand -> printDbUsage >> exitFailure
 
 {- ORMOLU_DISABLE -}
 printDbUsage :: IO ()


### PR DESCRIPTION
Add exitFailure to invalid wasp-cli usages

As far as I can see it works.

```bash
➜  waspc git:(bf/franjo/wasp-cli-exit-code) ✗ cabal run wasp-cli asdasdasdasdasd
USAGE
  wasp <command> [command-args]
...

➜  waspc git:(bf/franjo/wasp-cli-exit-code) ✗ echo $?
1
➜  waspc git:(bf/franjo/wasp-cli-exit-code) ✗ cabal run wasp-cli db migrate
USAGE
  wasp db <command> [command-args]
...

➜  waspc git:(bf/franjo/wasp-cli-exit-code) ✗ echo $?
1
```

Side note: 
I think `Main.hs` is a bit messy currently with the file doing too much work.
There is this note:
```hs
-- TODO: maybe extract to a separate module, e.g. DbCli.hs?
dbCli :: [String] -> IO ()
```
Same should probably be done for AI part.


Fixes #2491