### PR TITLE
waspc/run script can now run wasp-cli from anywhere, not just from waspc/ dir

### DIFF
--- a/waspc/run
+++ b/waspc/run
@@ -28,7 +28,7 @@ TEST_E2E_DELETE_GOLDENS="rm -rf $PROJECT_ROOT/e2e-test/test-outputs/*-golden"
 TEST_E2E_ACCEPT_ALL_CMD="$TEST_E2E_DELETE_GOLDENS && $TEST_E2E_CMD"
 TEST_HEADLESS_CMD="cd headless-test && npm install && npx playwright test"
 TEST_CMD="cabal test && echo 'Running headless tests' && $TEST_HEADLESS_CMD && echo 'ALL TESTS PASSED' || { echo 'SOME TESTS FAILED'; exit 1; }"
-RUN_CMD="cabal run wasp-cli ${ARGS[@]}"
+RUN_CMD="cabal --project-dir=${PROJECT_ROOT} run wasp-cli ${ARGS[@]}"
 GHCID_CMD="ghcid --command=cabal repl"
 GHCUP_SET="ghcup set ghc 8.10.7 && ghcup set hls 2.2.0"
 
@@ -80,7 +80,7 @@ print_usage () {
     print_usage_cmd "test:headless" \
                     "Executes headless tests, where example wasp apps are e2e tested using Playwright."
     print_usage_cmd "wasp-cli <args>" \
-                    "Runs the wasp executable while forwarding arguments. Builds the project first if needed."
+                    "Runs the wasp executable while forwarding arguments. Builds the project first if needed. Doesn't require you to be in the waspc project to run it."
     print_usage_cmd "ghcid" \
                     "Runs ghcid, which watches source file changes and reports errors. Does not watch tests."
     print_usage_cmd "ghcid-test" \


### PR DESCRIPTION
I was considering if I should add the `--project-dir` flag to the other `cabal` commands in the `run` script, but I decided against it at the end: it doesnt' make much sense for them, they are all development commands that you are running when doing changes in the waspc/ dir, and it would just unneccesarily complicate the `run` script.