### PR TITLE
docs: add TypeScript packages compilation step before running tests

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -12,7 +12,6 @@
 ### Bug fixes
 
 - CRUD operations can now have their return types inferred like regular operations ([#2541](https://github.com/wasp-lang/wasp/issues/2541) by @Genyus).
-- Package names in package.json are now properly lowercase to comply with npm conventions ([#2572] by @cprecioso).
 - Added documentation about npm package name requirements in README ([#issue_number] by @0xTaneja).
 
 ## 0.16.2

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -12,7 +12,7 @@
 ### Bug fixes
 
 - CRUD operations can now have their return types inferred like regular operations ([#2541](https://github.com/wasp-lang/wasp/issues/2541) by @Genyus).
-- Added documentation about npm package name requirements in README ([#2575] by @0xTaneja).
+
 
 ## 0.16.2
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -37,9 +37,9 @@
 
 #### Env variables validation with Zod
 
-Wasp now uses Zod to validate environment variables, allowing it to fail faster if something is misconfigured. This means you'll get more relevant error messages when running your app with incorrect env variables.
+Wasp now uses Zod to validate environment variables, allowing it to fail faster if something is misconfigured. This means you’ll get more relevant error messages when running your app with incorrect env variables.
 
-You can also use Zod to validate your own environment variables. Here's an example:
+You can also use Zod to validate your own environment variables. Here’s an example:
 
 ```ts
 // src/env.ts
@@ -66,7 +66,7 @@ app myApp {
 
 ### Deployment docs upgrade
 
-Based on feedback from our Discord community, we've revamped our deployment docs to make it simpler to deploy your app to production. We focused on explaining key deployment concepts, regardless of the deployment method you choose. We've added guides on hosting Wasp apps on your own servers, for example, how to use Coolify and Caprover for self-hosting. The Env Variables section now includes a comprehensive list of all available Wasp env variables and provides clearer instructions on how to set them up in a deployed app.
+Based on feedback from our Discord community, we’ve revamped our deployment docs to make it simpler to deploy your app to production. We focused on explaining key deployment concepts, regardless of the deployment method you choose. We’ve added guides on hosting Wasp apps on your own servers, for example, how to use Coolify and Caprover for self-hosting. The Env Variables section now includes a comprehensive list of all available Wasp env variables and provides clearer instructions on how to set them up in a deployed app.
 
 Check the updated deployment docs here: https://wasp.sh/docs/deployment/intro
 
@@ -869,7 +869,7 @@ Check below for details on each of them!
 
 ### ⚠️ Breaking changes
 
-- Wasp's **signup action** `import signup from '@wasp/auth/signup'` now accepts only the user entity fields relevant to the auth process (e.g. `username` and `password`).
+- Wasp's **signup action** `import signup from '@wasp/auth/signup` now accepts only the user entity fields relevant to the auth process (e.g. `username` and `password`).
   This ensures no unexpected data can be inserted into the database during signup, but it also means you can't any more set any user entity fields via signup action (e.g. `age` or `address`).
   Instead, those should be set in the separate step after signup, or via a custom signup action of your own.
 - Wasp now uses **React 18**! Check the following upgrade guide for details: https://react.dev/blog/2022/03/08/react-18-upgrade-guide .

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -12,7 +12,7 @@
 ### Bug fixes
 
 - CRUD operations can now have their return types inferred like regular operations ([#2541](https://github.com/wasp-lang/wasp/issues/2541) by @Genyus).
-- Added documentation about npm package name requirements in README ([#issue_number] by @0xTaneja).
+- Added documentation about npm package name requirements in README ([#2575] by @0xTaneja).
 
 ## 0.16.2
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -12,6 +12,8 @@
 ### Bug fixes
 
 - CRUD operations can now have their return types inferred like regular operations ([#2541](https://github.com/wasp-lang/wasp/issues/2541) by @Genyus).
+- Package names in package.json are now properly lowercase to comply with npm conventions ([#2572] by @cprecioso).
+- Added documentation about npm package name requirements in README ([#issue_number] by @0xTaneja).
 
 ## 0.16.2
 
@@ -37,9 +39,9 @@
 
 #### Env variables validation with Zod
 
-Wasp now uses Zod to validate environment variables, allowing it to fail faster if something is misconfigured. This means you’ll get more relevant error messages when running your app with incorrect env variables.
+Wasp now uses Zod to validate environment variables, allowing it to fail faster if something is misconfigured. This means you'll get more relevant error messages when running your app with incorrect env variables.
 
-You can also use Zod to validate your own environment variables. Here’s an example:
+You can also use Zod to validate your own environment variables. Here's an example:
 
 ```ts
 // src/env.ts
@@ -66,7 +68,7 @@ app myApp {
 
 ### Deployment docs upgrade
 
-Based on feedback from our Discord community, we’ve revamped our deployment docs to make it simpler to deploy your app to production. We focused on explaining key deployment concepts, regardless of the deployment method you choose. We’ve added guides on hosting Wasp apps on your own servers, for example, how to use Coolify and Caprover for self-hosting. The Env Variables section now includes a comprehensive list of all available Wasp env variables and provides clearer instructions on how to set them up in a deployed app.
+Based on feedback from our Discord community, we've revamped our deployment docs to make it simpler to deploy your app to production. We focused on explaining key deployment concepts, regardless of the deployment method you choose. We've added guides on hosting Wasp apps on your own servers, for example, how to use Coolify and Caprover for self-hosting. The Env Variables section now includes a comprehensive list of all available Wasp env variables and provides clearer instructions on how to set them up in a deployed app.
 
 Check the updated deployment docs here: https://wasp.sh/docs/deployment/intro
 
@@ -869,7 +871,7 @@ Check below for details on each of them!
 
 ### ⚠️ Breaking changes
 
-- Wasp's **signup action** `import signup from '@wasp/auth/signup` now accepts only the user entity fields relevant to the auth process (e.g. `username` and `password`).
+- Wasp's **signup action** `import signup from '@wasp/auth/signup'` now accepts only the user entity fields relevant to the auth process (e.g. `username` and `password`).
   This ensures no unexpected data can be inserted into the database during signup, but it also means you can't any more set any user entity fields via signup action (e.g. `age` or `address`).
   Instead, those should be set in the separate step after signup, or via a custom signup action of your own.
 - Wasp now uses **React 18**! Check the following upgrade guide for details: https://react.dev/blog/2022/03/08/react-18-upgrade-guide .

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -13,7 +13,6 @@
 
 - CRUD operations can now have their return types inferred like regular operations ([#2541](https://github.com/wasp-lang/wasp/issues/2541) by @Genyus).
 
-
 ## 0.16.2
 
 ### 🎉 New Features and improvements

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -75,13 +75,13 @@ If that is the case, relax and feel free to get yourself a cup of coffee! When s
 
 :warning: If the LLVM error persists even after its installation, you may need to manually add it your PATH. To do this, you should add the following to end of your shell rc file (e.g. _~/.bashrc_ or _~/.zshrc_): `export PATH="/opt/homebrew/Cellar/llvm@13/13.0.1_2/bin/:$PATH"`.
 
-### Compiling TypeScript Packages (Required)
+### Compiling TypeScript Packages
 
-Before running wasp-cli, examples, or tests locally, you must compile the bundled TypeScript packages used by the CLI.
+Before running `wasp-cli`, examples, or tests locally, you must compile the bundled TypeScript packages used by the CLI.
 
-Wasp bundles some TypeScript packages into the installation artifact (eg: deployment scripts), which end up in the installed version's waspc_datadir. To do so in CI, it runs ./tools/install_packages_to_data_dir.sh.
+Wasp bundles some TypeScript packages into the installation artifact (eg: deployment scripts), which end up in the installed version's `waspc_datadir`. To do so in CI, it runs `./tools/install_packages_to_data_dir.sh`.
 
-For more details about TypeScript packages in Wasp, see [TypeScript Packages section](https://github.com/wasp-lang/wasp/blob/main/waspc/README.md#typescript-packages).
+For more details about TypeScript packages in Wasp, see [TypeScript Packages section](#typescript-packages).
 
 Run this once after cloning:
 
@@ -89,13 +89,13 @@ Run this once after cloning:
 ./run wasp-packages:compile
 ```
 
-If you skip this step, commands like wasp-cli compile, running examples like todoApp, or even cabal test may fail with errors such as:
+If you skip this step, commands like `wasp-cli` compile, running examples like `todoApp`, or even `cabal test` may fail with errors such as:
 
 ```bash
 wasp-cli: npm: readCreateProcessWithExitCode: chdir: invalid argument (Bad file descriptor)
 ```
 
-You also need to re-run this if you make any changes to files inside the packages/ directory.
+You also need to re-run this if you make any changes to files inside the `packages/` directory.
 
 ### Test
 

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -75,6 +75,28 @@ If that is the case, relax and feel free to get yourself a cup of coffee! When s
 
 :warning: If the LLVM error persists even after its installation, you may need to manually add it your PATH. To do this, you should add the following to end of your shell rc file (e.g. _~/.bashrc_ or _~/.zshrc_): `export PATH="/opt/homebrew/Cellar/llvm@13/13.0.1_2/bin/:$PATH"`.
 
+### Compiling TypeScript Packages (Required)
+
+Before running wasp-cli, examples, or tests locally, you must compile the bundled TypeScript packages used by the CLI.
+
+Wasp bundles some TypeScript packages into the installation artifact (eg: deployment scripts), which end up in the installed version's waspc_datadir. To do so in CI, it runs ./tools/install_packages_to_data_dir.sh.
+
+For more details about TypeScript packages in Wasp, see [TypeScript Packages section](https://github.com/wasp-lang/wasp/blob/main/waspc/README.md#typescript-packages).
+
+Run this once after cloning:
+
+```bash
+./run wasp-packages:compile
+```
+
+If you skip this step, commands like wasp-cli compile, running examples like todoApp, or even cabal test may fail with errors such as:
+
+```bash
+wasp-cli: npm: readCreateProcessWithExitCode: chdir: invalid argument (Bad file descriptor)
+```
+
+You also need to re-run this if you make any changes to files inside the packages/ directory.
+
 ### Test
 
 ```


### PR DESCRIPTION
### Description

Fixes #2575

Added the TypeScript packages compilation step in the README.md before running tests. This step is required to compile the bundled TypeScript packages used by the CLI before running tests, examples, or wasp-cli commands.

The added section includes:
- The command to run (`./run wasp-packages:compile`)
- Warning about potential errors if this step is skipped
- Note about re-running when changes are made to packages

This change helps prevent common errors like:
```bash
wasp-cli: npm: readCreateProcessWithExitCode: chdir: invalid argument (Bad file descriptor)
```

The section was added in the correct location - right before the `cabal test` command in the Test section of the README.

### Select what type of change this PR introduces:
1. [x] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [x] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.
