### PR TITLE
Typescript application specification http route changes

### DIFF
--- a/waspc/packages/wasp-config/eslint.config.js
+++ b/waspc/packages/wasp-config/eslint.config.js
@@ -1,5 +1,5 @@
-import globals from 'globals'
 import pluginJs from '@eslint/js'
+import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default [
@@ -16,7 +16,18 @@ export default [
   },
   {
     rules: {
-      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
       '@typescript-eslint/no-empty-function': 'warn',
       'no-empty': 'warn',
       'no-constant-condition': 'warn',

--- a/waspc/packages/wasp-config/src/mapUserSpecToAppSpecDecls.ts
+++ b/waspc/packages/wasp-config/src/mapUserSpecToAppSpecDecls.ts
@@ -142,6 +142,10 @@ function mapExtImport(extImport: User.ExtImport): AppSpec.ExtImport {
   }
 }
 
+function mapHttpRoute(httpRoute: User.HttpRoute): AppSpec.HttpRoute {
+  return [httpRoute.method, httpRoute.route]
+}
+
 function mapApiConfig(
   config: User.ApiConfig,
   parseEntityRef: RefParser<'Entity'>
@@ -151,7 +155,7 @@ function mapApiConfig(
     fn: mapExtImport(fn),
     middlewareConfigFn: middlewareConfigFn && mapExtImport(middlewareConfigFn),
     entities: entities && entities.map(parseEntityRef),
-    httpRoute,
+    httpRoute: mapHttpRoute(httpRoute),
     auth,
   }
 }
@@ -333,7 +337,8 @@ function mapServer(server: User.ServerConfig): AppSpec.Server {
   return {
     setupFn: setupFn && mapExtImport(setupFn),
     middlewareConfigFn: middlewareConfigFn && mapExtImport(middlewareConfigFn),
-    envValidationSchema: envValidationSchema && mapExtImport(envValidationSchema),
+    envValidationSchema:
+      envValidationSchema && mapExtImport(envValidationSchema),
   }
 }
 
@@ -343,7 +348,8 @@ function mapClient(client: User.ClientConfig): AppSpec.Client {
     setupFn: setupFn && mapExtImport(setupFn),
     rootComponent: rootComponent && mapExtImport(rootComponent),
     baseDir,
-    envValidationSchema: envValidationSchema && mapExtImport(envValidationSchema),
+    envValidationSchema:
+      envValidationSchema && mapExtImport(envValidationSchema),
   }
 }
 

--- a/waspc/packages/wasp-config/src/userApi.ts
+++ b/waspc/packages/wasp-config/src/userApi.ts
@@ -1,7 +1,7 @@
 /** This module defines the user-facing API for defining a Wasp app.
  */
-import * as AppSpec from './appSpec.js'
 import { GET_USER_SPEC } from './_private.js'
+import * as AppSpec from './appSpec.js'
 
 export class App {
   #userSpec: UserSpec;
@@ -153,11 +153,16 @@ export type ApiNamespaceConfig = {
   path: string
 }
 
+export type HttpRoute = {
+  method: AppSpec.HttpMethod
+  route: string
+}
+
 export type ApiConfig = {
   fn: ExtImport
   middlewareConfigFn?: ExtImport
   entities?: string[]
-  httpRoute: AppSpec.HttpRoute
+  httpRoute: HttpRoute
   auth?: boolean
 }
 

--- a/waspc/src/Wasp/Generator/ExternalConfig/TsConfig.hs
+++ b/waspc/src/Wasp/Generator/ExternalConfig/TsConfig.hs
@@ -59,10 +59,10 @@ validateCompilerOptions compilerOptions =
 
 validateRequiredField :: (Eq a, JsonValue a) => FullyQualifiedFieldName -> Maybe a -> a -> [String]
 validateRequiredField fullyQualifiedFieldName fieldValue expectedValue =
-  validateFieldValue fullyQualifiedFieldName (Just expectedValue) fieldValue
+  validateFieldValue fullyQualifiedFieldName fieldValue (Just expectedValue)
 
 validateFieldValue :: (Eq a, JsonValue a) => FullyQualifiedFieldName -> Maybe a -> Maybe a -> [String]
-validateFieldValue fullyQualifiedFieldName expectedValue actualValue =
+validateFieldValue fullyQualifiedFieldName actualValue expectedValue =
   case (expectedValue, actualValue) of
     (Nothing, Nothing) -> []
     (Just expected, Just actual) -> [makeInvalidValueErrorMessage expected | actual /= expected]

--- a/waspc/src/Wasp/Generator/ExternalConfig/TsConfig.hs
+++ b/waspc/src/Wasp/Generator/ExternalConfig/TsConfig.hs
@@ -59,10 +59,10 @@ validateCompilerOptions compilerOptions =
 
 validateRequiredField :: (Eq a, JsonValue a) => FullyQualifiedFieldName -> Maybe a -> a -> [String]
 validateRequiredField fullyQualifiedFieldName fieldValue expectedValue =
-  validateFieldValue fullyQualifiedFieldName fieldValue (Just expectedValue)
+  validateFieldValue fullyQualifiedFieldName (Just expectedValue) fieldValue
 
 validateFieldValue :: (Eq a, JsonValue a) => FullyQualifiedFieldName -> Maybe a -> Maybe a -> [String]
-validateFieldValue fullyQualifiedFieldName actualValue expectedValue =
+validateFieldValue fullyQualifiedFieldName expectedValue actualValue =
   case (expectedValue, actualValue) of
     (Nothing, Nothing) -> []
     (Just expected, Just actual) -> [makeInvalidValueErrorMessage expected | actual /= expected]

--- a/web/docs/general/wasp-ts-config.md
+++ b/web/docs/general/wasp-ts-config.md
@@ -233,7 +233,10 @@ app.api('barBaz', {
   fn: { import: 'barBaz', from: '@src/apis' },
   auth: false,
   entities: ['Task'],
-  httpRoute: ['GET', '/bar/baz']
+  httpRoute: {
+    method: 'GET',
+    route: '/bar/baz',
+  },
 });
 
 app.job('mySpecialJob', {


### PR DESCRIPTION
Makes the user API `HttpRoute` of type

```ts
export type HttpRoute = {
  method: AppSpec.HttpMethod
  route: string
}
```

which works better with Typescript, instead of the app spec API

```ts
export type HttpRoute = [HttpMethod, string]
```

Also fixes the eslint to work properly with the `_` prefix for unused vars.

Fixes #2532