### PR TITLE
Add extra indexes to optimize Mage DB queries

### DIFF
--- a/mage/migrations/20250407104255_add_files_and_logs_indexes/migration.sql
+++ b/mage/migrations/20250407104255_add_files_and_logs_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "File_projectId_idx" ON "File"("projectId");
+
+-- CreateIndex
+CREATE INDEX "Log_projectId_createdAt_idx" ON "Log"("projectId", "createdAt");

--- a/mage/schema.prisma
+++ b/mage/schema.prisma
@@ -53,6 +53,7 @@ model File {
   project   Project  @relation(fields: [projectId], references: [id])
 
   @@index([name, projectId])
+  @@index([projectId])
 }
 
 model Log {
@@ -61,4 +62,6 @@ model Log {
   createdAt DateTime @default(now())
   projectId String
   project   Project  @relation(fields: [projectId], references: [id])
+
+  @@index([projectId, createdAt])
 }


### PR DESCRIPTION
I've noticed that loading projects on Mage is extremely slow (20+ seconds). I timed some of the queries. Added Prisma SQL logging with timing. Asked an LLM (Gemini 2.5 Pro) for an analysis of the SQL statements that Prisma was executing. 

Summary:
*   **Problem:** Fetching a `Project` with related `File` and `Log` data (`Project.findUniqueOrThrow` with includes) was taking over 20 seconds.
*   **Diagnosis:** Query logging revealed extremely slow lookups for related records:
    *   Fetching `File` records by `projectId` took ~5 seconds.
    *   Fetching `Log` records by `projectId` and sorting by `createdAt` took ~17 seconds.
    *   This indicated missing database indexes on `File.projectId` and `Log.projectId`.

So, I added the required indexes to the Prisma models.

Summary:
*   **Fix:** Added database indexes via `@@index` directives in `schema.prisma`:
    *   Added `@@index([projectId])` to the `File` model.
    *   Added `@@index([projectId, createdAt])` to the `Log` model to optimize both filtering by project and sorting by creation date.