### PR TITLE
Remove `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "wasp",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
There's no `package.json` at the top level so there shouldn't be a `package-lock.json`.