### PR TITLE
WIP: Add Turso Support to Wasp

### DIFF
--- a/wasp-app-runner/package-lock.json
+++ b/wasp-app-runner/package-lock.json
@@ -16,7 +16,7 @@
         "wasp-app-runner": "bin/index.js"
       },
       "devDependencies": {
-        "@types/node": "^22.10.10",
+        "@types/node": "^22.14.1",
         "@types/yargs": "^17.0.33"
       }
     },
@@ -339,12 +339,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-      "integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/yargs": {
@@ -603,10 +604,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "devOptional": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/wasp-app-runner/package.json
+++ b/wasp-app-runner/package.json
@@ -17,7 +17,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@types/node": "^22.10.10",
+    "@types/node": "^22.14.1",
     "@types/yargs": "^17.0.33"
   }
 }

--- a/wasp-app-runner/src/db/index.ts
+++ b/wasp-app-runner/src/db/index.ts
@@ -1,10 +1,12 @@
 import { setupPostgres } from "./postgres.js";
 import { setupSqlite } from "./sqlite.js";
+import { setupLibsql } from "./libsql.js";
 import type { SetupDbFn } from "./types.js";
 
 export enum DbType {
   Sqlite = "sqlite",
   Postgres = "postgres",
+  Libsql = "libsql",
 }
 
 export function setupDb({
@@ -21,6 +23,8 @@ export function setupDb({
       return setupSqlite({ appName, pathToApp });
     case DbType.Postgres:
       return setupPostgres({ appName, pathToApp });
+    case DbType.Libsql:
+      return setupLibsql({ appName, pathToApp });
     default:
       dbType satisfies never;
       throw new Error(`Unknown database type: ${dbType}`);

--- a/wasp-app-runner/src/db/libsql.ts
+++ b/wasp-app-runner/src/db/libsql.ts
@@ -1,0 +1,33 @@
+import type { SetupDbFn } from "./types.js";
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      TURSO_DATABASE_URL?: string;
+      TURSO_AUTH_TOKEN?: string;
+    }
+  }
+}
+
+export const setupLibsql: SetupDbFn = async ({ appName, pathToApp }) => {
+  const databaseUrl = process.env.DATABASE_URL;
+  const authToken = process.env.AUTH_TOKEN;
+
+  if (!databaseUrl || !authToken) {
+    throw new Error(
+      "DATABASE_URL and AUTH_TOKEN environment variables must be set for Turso database"
+    );
+  }
+
+  // Ensure the URL is in the correct format for Prisma
+  const prismaUrl = databaseUrl.startsWith("libsql://") 
+    ? databaseUrl 
+    : `libsql://${databaseUrl}`;
+
+  return {
+    dbEnvVars: {
+      DATABASE_URL: prismaUrl,
+      AUTH_TOKEN: authToken,
+    },
+  };
+}; 

--- a/wasp-app-runner/src/db/libsql.ts
+++ b/wasp-app-runner/src/db/libsql.ts
@@ -3,19 +3,19 @@ import type { SetupDbFn } from "./types.js";
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      TURSO_DATABASE_URL?: string;
-      TURSO_AUTH_TOKEN?: string;
+      DATABASE_URL?: string;
+      DATABASE_AUTH_TOKEN?: string;
     }
   }
 }
 
 export const setupLibsql: SetupDbFn = async ({ appName, pathToApp }) => {
   const databaseUrl = process.env.DATABASE_URL;
-  const authToken = process.env.AUTH_TOKEN;
+  const authToken = process.env.DATABASE_AUTH_TOKEN;
 
   if (!databaseUrl || !authToken) {
     throw new Error(
-      "DATABASE_URL and AUTH_TOKEN environment variables must be set for Turso database"
+      "DATABASE_URL and DATABASE_AUTH_TOKEN environment variables must be set for Turso database"
     );
   }
 
@@ -27,7 +27,7 @@ export const setupLibsql: SetupDbFn = async ({ appName, pathToApp }) => {
   return {
     dbEnvVars: {
       DATABASE_URL: prismaUrl,
-      AUTH_TOKEN: authToken,
+      DATABASE_AUTH_TOKEN: authToken,
     },
   };
 }; 

--- a/wasp-app-runner/src/waspCli.ts
+++ b/wasp-app-runner/src/waspCli.ts
@@ -88,10 +88,10 @@ export async function getAppInfo({
 
   if (dbTypeMatchStr === "PostgreSQL") {
     dbType = DbType.Postgres;
-  } else if (dbTypeMatchStr === "LibSQL") {
-    dbType = DbType.Libsql;
   } else if (dbTypeMatchStr === "SQLite") {
     dbType = DbType.Sqlite;
+  } else if (dbTypeMatchStr === "SQLite" && process.env.DATABASE_URL?.startsWith('libsql://')) {
+    dbType = DbType.Libsql;
   } else {
     log("get-app-info", "error", `Unknown database type: ${dbTypeMatchStr}`);
     process.exit(1);

--- a/wasp-app-runner/src/waspCli.ts
+++ b/wasp-app-runner/src/waspCli.ts
@@ -88,10 +88,10 @@ export async function getAppInfo({
 
   if (dbTypeMatchStr === "PostgreSQL") {
     dbType = DbType.Postgres;
-  } else if (dbTypeMatchStr === "SQLite") {
-    dbType = DbType.Sqlite;
   } else if (dbTypeMatchStr === "SQLite" && process.env.DATABASE_URL?.startsWith('libsql://')) {
     dbType = DbType.Libsql;
+  } else if (dbTypeMatchStr === "SQLite") {
+    dbType = DbType.Sqlite;
   } else {
     log("get-app-info", "error", `Unknown database type: ${dbTypeMatchStr}`);
     process.exit(1);

--- a/wasp-app-runner/src/waspCli.ts
+++ b/wasp-app-runner/src/waspCli.ts
@@ -83,12 +83,23 @@ export async function getAppInfo({
     process.exit(1);
   }
 
+  let dbType: DbType;
+  const dbTypeMatchStr = ensureRegexMatch(dbTypeMatch, "db type");
+
+  if (dbTypeMatchStr === "PostgreSQL") {
+    dbType = DbType.Postgres;
+  } else if (dbTypeMatchStr === "LibSQL") {
+    dbType = DbType.Libsql;
+  } else if (dbTypeMatchStr === "SQLite") {
+    dbType = DbType.Sqlite;
+  } else {
+    log("get-app-info", "error", `Unknown database type: ${dbTypeMatchStr}`);
+    process.exit(1);
+  }
+
   return {
     appName: ensureRegexMatch(appNameMatch, "app name"),
-    dbType:
-      ensureRegexMatch(dbTypeMatch, "db type") === "PostgreSQL"
-        ? DbType.Postgres
-        : DbType.Sqlite,
+    dbType,
   };
 }
 

--- a/waspc/cli/src/Wasp/Cli/Command/Start/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start/Db.hs
@@ -44,10 +44,15 @@ start = do
   case ASV.getValidDbSystem appSpec of
     AS.App.Db.SQLite -> noteSQLiteDoesntNeedStart
     AS.App.Db.PostgreSQL -> startPostgreDevDb waspProjectDir appName
+    AS.App.Db.LibSQL -> noteLibSQLDoesntNeedStart
   where
     noteSQLiteDoesntNeedStart =
       cliSendMessageC . Msg.Info $
         "Nothing to do! You are all good, you are using SQLite which doesn't need to be started."
+    
+    noteLibSQLDoesntNeedStart =
+      cliSendMessageC . Msg.Info $
+        "Nothing to do! You are all good, you are using libSQL (Turso) which doesn't need to be started."
 
 throwIfCustomDbAlreadyInUse :: AS.AppSpec -> Command ()
 throwIfCustomDbAlreadyInUse spec = do

--- a/waspc/data/Generator/templates/sdk/wasp/server/dbClient.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/dbClient.ts
@@ -1,8 +1,25 @@
 {{={= =}=}}
 {=# areThereAnyEntitiesDefined =}
 import Prisma from '@prisma/client'
+import { PrismaLibSQL } from '@prisma/adapter-libsql'
 
 function createDbClient(): Prisma.PrismaClient {
+  const connectionString = `${process.env.DATABASE_URL}`
+  const authToken = `${process.env.DATABASE_AUTH_TOKEN}`
+
+  // Only use libSQL adapter if we're using Turso/libSQL
+  if (connectionString.startsWith('libsql://')) {
+    const adapter = new PrismaLibSQL({
+      url: connectionString,
+      authToken,
+    })
+
+    return new Prisma.PrismaClient({
+      adapter,
+    })
+  }
+
+  // Default to regular Prisma client for SQLite/PostgreSQL
   return new Prisma.PrismaClient()
 }
 {=/ areThereAnyEntitiesDefined =}

--- a/waspc/src/Wasp/AppSpec/App/Db.hs
+++ b/waspc/src/Wasp/AppSpec/App/Db.hs
@@ -18,5 +18,5 @@ data Db = Db
   }
   deriving (Show, Eq, Data, Generic, FromJSON)
 
-data DbSystem = PostgreSQL | SQLite
+data DbSystem = PostgreSQL | SQLite | LibSQL
   deriving (Show, Eq, Data, Generic, FromJSON)

--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -69,6 +69,7 @@ genPrismaSchema spec = do
       if AS.isBuild spec
         then logAndThrowGeneratorError $ GenericGeneratorError "SQLite (a default database) is not supported in production. To build your Wasp app for production, switch to a different database. Switching to PostgreSQL: https://wasp.sh/docs/data-model/databases#migrating-from-sqlite-to-postgresql ."
         else return Pls.Db.dbProviderSqliteStringLiteral
+    AS.Db.LibSQL -> return Pls.Db.dbProviderLibsqlStringLiteral
 
   entities <- getEntitiesForPrismaSchema spec
 

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -193,6 +193,7 @@ npmDepsForSdk spec =
     { N.dependencies =
         Npm.Dependency.fromList
           [ ("@prisma/client", show prismaVersion),
+            ("@prisma/adapter-libsql", "6.6.0"),
             ("prisma", show prismaVersion),
             ("@tanstack/react-query", show reactQueryVersion),
             ("axios", show axiosVersion),

--- a/waspc/src/Wasp/Project/Db.hs
+++ b/waspc/src/Wasp/Project/Db.hs
@@ -53,6 +53,7 @@ getDbSystemFromPrismaSchema prismaSchema =
     Just (Psl.Argument.StringExpr provider)
       | provider == Psl.Db.dbProviderPostgresqlStringLiteral -> Right AS.Db.PostgreSQL
       | provider == Psl.Db.dbProviderSqliteStringLiteral -> Right AS.Db.SQLite
+      | provider == Psl.Db.dbProviderLibsqlStringLiteral -> Right AS.Db.LibSQL
     Just anyOtherExpression -> Left $ UnsupportedDbSystem $ generateExpression anyOtherExpression
     Nothing -> Left MissingDbSystem
 

--- a/waspc/src/Wasp/Psl/Db.hs
+++ b/waspc/src/Wasp/Psl/Db.hs
@@ -9,3 +9,7 @@ dbProviderPostgresqlStringLiteral = "postgresql"
 
 dbProviderSqliteStringLiteral :: String
 dbProviderSqliteStringLiteral = "sqlite"
+
+dbProviderLibsqlStringLiteral :: String
+-- While it's called libSQL, Prisma calls it "sqlite". libSQL is a fork of SQLite.
+dbProviderLibsqlStringLiteral = "sqlite"

--- a/waspc/src/Wasp/Psl/Valid.hs
+++ b/waspc/src/Wasp/Psl/Valid.hs
@@ -20,7 +20,7 @@ import qualified Wasp.Valid as Valid
 
 -- Wasp expects the Prisma schema to be written in certain way:
 
--- * The DB providers that Wasp supports are PostgreSQL and SQLite.
+-- * The DB providers that Wasp supports are PostgreSQL, SQLite, and libSQL.
 
 -- * The DB url must be provided via the DATABASE_URL environment variable.
 


### PR DESCRIPTION
### Description

I want to use Turso's libSQL with Wasp. [It appears that Turso is supported in beta for Prisma](https://www.prisma.io/docs/orm/overview/databases/turso), so I wanted to give a concerted effort at seeing what's possible to get it to work.

This is still a work in progress, and I could use any help I can get. I do not truly understand Haskell at this point, but it's been fun poking around.

### Why Turso?

Since Wasp is a Rails-like framework and utilizes Prisma, it insinuates the ability or one day hope to be able to easily swap database providers. [Laravel provides first-party support for five databases](https://laravel.com/docs/11.x/database). Not sure the how many db's Rails supports first-party. 

Turso's libSQL has been my go-to database, mainly because it's incredibly affordable, simple, and rather fast. _"[libSQL](https://docs.turso.tech/libsql) is a fork of SQLite that aims to be a modern database, with a focus on low query latency and high availability. It’s designed to be a drop-in replacement for SQLite, and scales globally with Turso over HTTP."_

I imagine Turso's libSQL what Wasp wanted SQLite to be, so that it (SQLite) could be deployable. 

It's increasingly growing in popularity. See the star chart as of 2025-04-16:
![star-history-2025416](https://github.com/user-attachments/assets/6f604cba-4249-4df5-b60c-23308ea81143)

I think it would be a smart decision for Wasp to consider supporting alternative databases than Postgres to become more and more of a true Rails-like framework JS-alternative.

Turso's libSQL is supported by [Rails](https://docs.turso.tech/sdk/activerecord/guides/rails)
and [Laravel](https://docs.turso.tech/sdk/php/guides/laravel). 

Related to: 
- https://github.com/wasp-lang/wasp/issues/2536
- https://github.com/wasp-lang/wasp/issues/1261
- https://github.com/wasp-lang/wasp/issues/1265

### Select what type of change this PR introduces:
1. [ ] **Just code/docs improvement** (no functional change).
2. [ ] **Bug fix** (non-breaking change which fixes an issue).
3. [x] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed
If you did a bug fix, new feature, or breaking change, that affects waspc, make sure you satisfy the following:
1. [ ] I updated [ChangeLog.md](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [ ] I bumped waspc version in [waspc.cabal](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.

### Update example apps if needed
If you did code changes and added a new feature or modified an existing feature, make sure you satisfy the following:
1. [ ] I updated `waspc/examples/todoApp` as needed (updated modified feature or added new feature) and manually checked it works correctly.
2. [ ] I updated `waspc/headless-test/examples/todoApp` and its e2e tests as needed (updated modified feature and its tests or added new feature and new tests for it).
