### PR TITLE
Add manual workflow running

### DIFF
--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -1,6 +1,7 @@
 name: WASPC-CI
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - "waspc/**"


### PR DESCRIPTION
Just adds the ability for running the workflow manually, since it might not be ran on certain cases (check my latest push to https://github.com/wasp-lang/wasp/pull/2685/commits).

GitHub Docs: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow

This doesn't allow _anyone_ to run them, as it says in the docs:
> Write access to the repository is required to perform these steps.