### PR TITLE
Cleanup Tailwind validation PR

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -7,7 +7,6 @@
 Follow the [the official migration guide](https://wasp.sh/docs/migration-guides/migrate-from-0-16-to-0-17) to address all the breaking changes. Here's a short overview:
 
 - In the `usernameAndPassword` authentication method, the function `login()` imported from `wasp/client/auth` now accepts an object with `username` and `password` instead of two separate arguments ([#2598](https://github.com/wasp-lang/wasp/pull/2598))
-- Wasp requires that projects have `tailwindcss@^3.2.7` dependency specified in their `devDependencies` in `package.json`. ([#2465](https://github.com/wasp-lang/wasp/pull/2465))
 - We've made some improvements to our TypeScript setup that require you to
   update the `tsconfig.json` file. The migration guide will lead you through
   them, but here are all the non-cosmetic ones:

--- a/web/docs/project/css-frameworks.md
+++ b/web/docs/project/css-frameworks.md
@@ -6,39 +6,21 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ## Tailwind
 
-To enable support for Tailwind in your project, you need to add two config files — [`tailwind.config.cjs`](https://tailwindcss.com/docs/configuration#configuration-options) and `postcss.config.cjs` — to the root directory.
+Wasp works great with [Tailwind CSS](https://v3.tailwindcss.com/), a utility-first CSS framework. Currently, Wasp supports Tailwind CSS v3, but we are [working on supporting v4](https://github.com/wasp-lang/wasp/issues/2483) as well. You can use Tailwind CSS in your Wasp project by following the steps below.
 
-With these files present, Wasp installs the necessary dependencies and copies your configuration to the generated project. You can then use [Tailwind CSS directives](https://tailwindcss.com/docs/functions-and-directives#directives) in your CSS and Tailwind classes on your React components.
-
-```bash title="tree ."
-.
-├── main.wasp
-├── package.json
-├── src
-│   ├── Main.css
-│   ├── MainPage.jsx
-│   ├── vite-env.d.ts
-│   └── waspLogo.png
-├── public
-├── tsconfig.json
-├── vite.config.ts
-# highlight-start
-├── postcss.config.cjs
-└── tailwind.config.cjs
-# highlight-end
-```
-
-:::tip Tailwind not working?
-If you can not use Tailwind after adding the required config files, make sure to restart `wasp start`. This is sometimes needed to ensure that Wasp picks up the changes and enables Tailwind integration.
-:::
-
-### Enabling Tailwind Step-by-Step
+### Adding Tailwind to your Wasp project
 
 :::caution
-Make sure to use the `.cjs` extension for these config files, if you name them with a `.js` extension, Wasp will not detect them.
+Make sure to use the `.cjs` extension for the Tailwind CSS and PostCSS config files, if you name them with a `.js` extension, Wasp will not detect them.
 :::
 
-1. Add `./tailwind.config.cjs`.
+1. Install Tailwind as a development dependency.
+
+```bash
+npm install -D tailwindcss@3.2.7
+```
+
+2. Add `./tailwind.config.cjs`.
 
 ```js title="./tailwind.config.cjs"
 const { resolveProjectPath } = require('wasp/dev')
@@ -53,7 +35,13 @@ module.exports = {
 }
 ```
 
-2. Add `./postcss.config.cjs`.
+:::note The `resolveProjectPath` function
+
+Because Wasp copies the configuration files to the generated project, you must wrap any paths in the `content` array with the `resolveProjectPath` function. This function resolves the path to the generated project, so that Tailwind can find your source files.
+
+:::
+
+3. Add `./postcss.config.cjs`.
 
 ```js title="./postcss.config.cjs"
 module.exports = {
@@ -64,7 +52,7 @@ module.exports = {
 }
 ```
 
-3. Import Tailwind into your CSS file. For example, in a new project you might import Tailwind into `Main.css`.
+4. Import Tailwind into your CSS file. For example, in a new project you might import Tailwind into `Main.css`.
 
 ```css title="./src/Main.css" {1-3}
 @tailwind base;
@@ -74,7 +62,7 @@ module.exports = {
 /* ... */
 ```
 
-4. Start using Tailwind 🥳
+5. Start using Tailwind 🥳
 
 ```jsx title="./src/MainPage.jsx"
 // ...
@@ -91,9 +79,6 @@ module.exports = {
 To add Tailwind plugins, install them as npm development [dependencies](../project/dependencies) and add them to the plugins list in your `tailwind.config.cjs` file:
 
 ```shell
-# Wasp requires you to have Tailwind ^3.2.7 written in your package.json, you
-# must explicitly install it.
-npm install -D tailwindcss@3.2.7
 npm install -D @tailwindcss/forms
 npm install -D @tailwindcss/typography
 ```


### PR DESCRIPTION
- Cleans up `Changelog` after #2465 (that PR initially wanted to validate `tailwindcss` version, but we dropped it to keep things simple since we want to move Tailwind to user-land).
- Updates the docs to better explain how to set up Tailwind in a project.