### PR TITLE
Add instructions on e2e tests to README

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -153,19 +153,21 @@ When done, new tab in your browser should open and you will see a Todo App!
 1. Create a new feature branch from `main`.
 2. If you don't have a good/reliable working HLS (Haskell Language Server) connected to your IDE (which we strongly recommend), you will want to instead run `./run ghcid` from the root of the `waspc` project: this will run a process that watches the Haskell project and reports any Haskell compiler errors. Leave it running.
     -  NOTE: You will need to install `ghcid` globally first. You can do it with `cabal install ghcid`.
-3. Do a change in the codebase (most often in `src/` or `cli/src/` or `data/`) (also update tests if that makes sense: see "Tests").
+3. Do a change in the codebase (most often in `src/` or `cli/src/` or `data/`), and update tests if that makes sense (see [Test](#tests)).
    Fix any errors shown by HLS/`ghcid`.
-   Rinse and repeat.
+   Rinse and repeat. If you're an internal team member, posptpone updating e2e tests until approval (see [here](#note-for-team-members)).
 4. Use `./run build` to build the Haskell/cabal project, and `./run wasp-cli` to both build and run it. If you changed code in `packages/`, you will also need to run `./run build:packages` (check [TypeScript Packages section](#typescript-packages) for more details). Alternatively, you can also run slower `./run build:all` to at the same time build Haskell, TS packages, and any other piece of the project in one command.
 5. For easier manual testing of the changes you did on a Wasp app, you have the `examples/todoApp` app, which we always keep updated. Also, if you added a new feature, add it to this app (+ tests) if needed. Check its README for more details (including how to run it).
-6. Run `./run test` to confirm that all the tests (unit + integration + e2e) are passing. If needed, accept changes in the e2e golden/snapshot tests with `./run test:e2e:accept-all`. Check "Tests" for more info.
+6. Run `./run test` to confirm that all the tests are passing (unit + integration + e2e). If needed, accept changes in the e2e golden/snapshot tests with `./run test:e2e:accept-all`. Check "Tests" for more info.
 7. If you did a bug fix, added new feature or did a breaking change, add short info about it to `Changelog.md`. Also, bump version in `waspc.cabal` and `ChangeLog.md` if needed. If you are not sure how to decide which version to go with, check out [how we determine the next version](#determining-next-version).
-8. Squash all the commits into a single commit (or a few in case it makes more sense) and create a PR.
-   Keep an eye on CI tests -> they should all be passing, if not, look into it.
+8. Create a PR. Keep an eye on CI tests -> Everything must pass. If it doesn't, look into it.
 9. If your PR changes how users(Waspers) use Wasp, make sure to also update the documentation, which is in this same repo, but under `/web/docs`.
-10. Work with reviewer(s) to get the PR approved.
-    Keep adding "fix" commits until PR is approved, then again squash them all into one commit.
+10. Work with reviewer(s) to get the PR approved, keep committing until the PR is approved.
 11. Reviewer will merge the branch into `main`. Yay!
+
+### Note for team members 
+
+Don't update e2e tests until someone approves the PR. They slow down the UI and create noise for the reviewers.
 
 ## Design docs (aka RFCs)
 


### PR DESCRIPTION
- Added a note that tells us (team members) not to update e2e tests until approval
- Removed other seemingly outdated instructions