### PR TITLE
Use branded types for `wasp-app-runner`

### DIFF
--- a/wasp-app-runner/src/args.ts
+++ b/wasp-app-runner/src/args.ts
@@ -1,0 +1,40 @@
+import { Command, Argument } from "@commander-js/extra-typings";
+import { Branded } from "./types.js";
+
+export type Mode = "dev" | "build";
+export type PathToApp = Branded<string, "PathToApp">;
+export type WaspCliCmd = Branded<string, "WaspCliCmd">;
+
+export function parseArgs(): {
+  mode: Mode;
+  pathToApp: PathToApp;
+  waspCliCmd: WaspCliCmd;
+} {
+  const program = new Command();
+
+  program.name("wasp-app-runner");
+
+  const runCommand = program
+    .command("run")
+    .description("Run the Wasp application")
+    .addArgument(
+      new Argument("<mode>", "The run mode").choices(["dev", "build"])
+    )
+    .option("--path-to-app <path>", "Path to the Wasp application", ".")
+    .option("--wasp-cli-cmd <command>", "Wasp CLI command to use", "wasp");
+
+  if (process.argv.length === 2) {
+    program.help();
+  }
+
+  program.parse();
+
+  const options = runCommand.opts();
+  const args = runCommand.processedArgs;
+
+  return {
+    mode: args[0],
+    pathToApp: options.pathToApp as PathToApp,
+    waspCliCmd: options.waspCliCmd as WaspCliCmd,
+  };
+}

--- a/wasp-app-runner/src/build/client.ts
+++ b/wasp-app-runner/src/build/client.ts
@@ -6,11 +6,12 @@ import { log } from "../logging.js";
 import { EnvVars } from "../types.js";
 import { parse } from "dotenv";
 import { doesFileExits } from "../files.js";
+import type { PathToApp } from "../args.js";
 
 export async function buildAndStartClientApp({
   pathToApp,
 }: {
-  pathToApp: string;
+  pathToApp: PathToApp;
 }): Promise<void> {
   const { exitCode: buildExitCode } = await buildClientApp({ pathToApp });
   if (buildExitCode !== 0) {
@@ -30,7 +31,7 @@ export async function buildAndStartClientApp({
 async function buildClientApp({
   pathToApp,
 }: {
-  pathToApp: string;
+  pathToApp: PathToApp;
 }): Promise<{ exitCode: number | null }> {
   const defaultRequiredEnv = {
     REACT_APP_API_URL: "http://localhost:3001",
@@ -51,7 +52,11 @@ async function buildClientApp({
   });
 }
 
-async function startClientApp({ pathToApp }: { pathToApp: string }): Promise<{
+async function startClientApp({
+  pathToApp,
+}: {
+  pathToApp: PathToApp;
+}): Promise<{
   exitCode: number | null;
 }> {
   return spawnWithLog({
@@ -65,7 +70,7 @@ async function startClientApp({ pathToApp }: { pathToApp: string }): Promise<{
 async function getDevEnvVars({
   pathToApp,
 }: {
-  pathToApp: string;
+  pathToApp: PathToApp;
 }): Promise<EnvVars> {
   const envVarsPath = path.join(pathToApp, ".env.client");
 

--- a/wasp-app-runner/src/build/index.ts
+++ b/wasp-app-runner/src/build/index.ts
@@ -1,5 +1,6 @@
+import type { PathToApp, WaspCliCmd } from "../args.js";
 import { DbType, setupDb } from "../db/index.js";
-import { buildApp } from "../waspCli.js";
+import { type AppName, buildApp } from "../waspCli.js";
 import { buildAndStartClientApp } from "./client.js";
 import { buildAndRunServerAppContainer } from "./server.js";
 
@@ -9,9 +10,9 @@ export async function startAppInBuildMode({
   appName,
   dbType,
 }: {
-  waspCliCmd: string;
-  pathToApp: string;
-  appName: string;
+  waspCliCmd: WaspCliCmd;
+  pathToApp: PathToApp;
+  appName: AppName;
   dbType: DbType;
 }) {
   await buildApp({

--- a/wasp-app-runner/src/build/server.ts
+++ b/wasp-app-runner/src/build/server.ts
@@ -9,14 +9,16 @@ import {
 import { EnvVars } from "../types.js";
 import { log } from "../logging.js";
 import { doesFileExits } from "../files.js";
+import type { AppName } from "../waspCli.js";
+import type { PathToApp } from "../args.js";
 
 export async function buildAndRunServerAppContainer({
   appName,
   pathToApp,
   extraEnv,
 }: {
-  appName: string;
-  pathToApp: string;
+  appName: AppName;
+  pathToApp: PathToApp;
   extraEnv: EnvVars;
 }): Promise<void> {
   const { imageName, containerName } = createAppSpecificServerBuildDockerNames({
@@ -60,7 +62,7 @@ function buildServerAppContainer({
   pathToApp,
   imageName,
 }: {
-  pathToApp: string;
+  pathToApp: PathToApp;
   imageName: ServerBuildImageName;
 }): Promise<{ exitCode: number | null }> {
   return spawnWithLog({
@@ -77,7 +79,7 @@ function runServerAppContainer({
   containerName,
   extraEnv,
 }: {
-  pathToApp: string;
+  pathToApp: PathToApp;
   imageName: ServerBuildImageName;
   containerName: ServerBuildContainerName;
   extraEnv: EnvVars;
@@ -105,7 +107,7 @@ function getDockerEnvVarsArgs({
   pathToApp,
   extraEnv,
 }: {
-  pathToApp: string;
+  pathToApp: PathToApp;
   extraEnv: EnvVars;
 }): string[] {
   const defaultRequiredEnv: EnvVars = {
@@ -130,7 +132,7 @@ function getEnvVarsDockerArgs(envVars: EnvVars): string[] {
 function getDevEnvFileDockerArg({
   pathToApp,
 }: {
-  pathToApp: string;
+  pathToApp: PathToApp;
 }): [string, string] | [] {
   const envFilePath = path.resolve(pathToApp, ".env.server");
 

--- a/wasp-app-runner/src/db/index.ts
+++ b/wasp-app-runner/src/db/index.ts
@@ -1,3 +1,5 @@
+import type { PathToApp } from "../args.js";
+import type { AppName } from "../waspCli.js";
 import { setupPostgres } from "./postgres.js";
 import { setupSqlite } from "./sqlite.js";
 import type { SetupDbFn } from "./types.js";
@@ -13,8 +15,8 @@ export function setupDb({
   pathToApp,
 }: {
   dbType: DbType;
-  appName: string;
-  pathToApp: string;
+  appName: AppName;
+  pathToApp: PathToApp;
 }): ReturnType<SetupDbFn> {
   switch (dbType) {
     case DbType.Sqlite:

--- a/wasp-app-runner/src/db/postgres.ts
+++ b/wasp-app-runner/src/db/postgres.ts
@@ -6,6 +6,8 @@ import {
   DbContainerName,
   createAppSpecificDbContainerName,
 } from "../docker.js";
+import type { AppName } from "../waspCli.js";
+import type { PathToApp } from "../args.js";
 
 type DatabaseConnectionUrl = Branded<string, "DatabaseConnectionUrl">;
 
@@ -28,8 +30,8 @@ async function startPostgresContainerForApp({
   appName,
   pathToApp,
 }: {
-  appName: string;
-  pathToApp: string;
+  appName: AppName;
+  pathToApp: PathToApp;
 }): Promise<DatabaseConnectionUrl> {
   const containerName = createAppSpecificDbContainerName({
     appName,

--- a/wasp-app-runner/src/db/types.ts
+++ b/wasp-app-runner/src/db/types.ts
@@ -1,6 +1,9 @@
+import type { PathToApp } from "../args.js";
+import type { AppName } from "../waspCli.js";
+
 export type SetupDbFn = (options: {
-  appName: string;
-  pathToApp: string;
+  appName: AppName;
+  pathToApp: PathToApp;
 }) => Promise<{
   dbEnvVars: { [envVarName: string]: string };
 }>;

--- a/wasp-app-runner/src/dev/index.ts
+++ b/wasp-app-runner/src/dev/index.ts
@@ -1,5 +1,6 @@
+import type { PathToApp, WaspCliCmd } from "../args.js";
 import { DbType, setupDb } from "../db/index.js";
-import { migrateDb, startApp } from "../waspCli.js";
+import { type AppName, migrateDb, startApp } from "../waspCli.js";
 
 export async function startAppInDevMode({
   waspCliCmd,
@@ -7,9 +8,9 @@ export async function startAppInDevMode({
   appName,
   dbType,
 }: {
-  waspCliCmd: string;
-  pathToApp: string;
-  appName: string;
+  waspCliCmd: WaspCliCmd;
+  pathToApp: PathToApp;
+  appName: AppName;
   dbType: DbType;
 }): Promise<void> {
   const { dbEnvVars } = await setupDb({

--- a/wasp-app-runner/src/docker.ts
+++ b/wasp-app-runner/src/docker.ts
@@ -1,5 +1,7 @@
 import { createHash } from "crypto";
 import { Branded } from "./types.js";
+import type { PathToApp } from "./args.js";
+import type { AppName } from "./waspCli.js";
 
 export type DbContainerName = Branded<string, "ContainerName">;
 export type ServerBuildContainerName = Branded<
@@ -12,8 +14,8 @@ export function createAppSpecificDbContainerName({
   appName,
   pathToApp,
 }: {
-  appName: string;
-  pathToApp: string;
+  appName: AppName;
+  pathToApp: PathToApp;
 }): DbContainerName {
   const prefix = createAppSpecificPrefix({
     appName,
@@ -26,8 +28,8 @@ export function createAppSpecificServerBuildDockerNames({
   appName,
   pathToApp,
 }: {
-  appName: string;
-  pathToApp: string;
+  appName: AppName;
+  pathToApp: PathToApp;
 }): {
   imageName: ServerBuildImageName;
   containerName: ServerBuildContainerName;
@@ -46,8 +48,8 @@ function createAppSpecificPrefix({
   appName,
   pathToApp,
 }: {
-  appName: string;
-  pathToApp: string;
+  appName: AppName;
+  pathToApp: PathToApp;
 }): string {
   const appPathHash = createHash("md5")
     .update(pathToApp)

--- a/wasp-app-runner/src/index.ts
+++ b/wasp-app-runner/src/index.ts
@@ -1,12 +1,10 @@
-import { Command, Argument } from "@commander-js/extra-typings";
 import { log } from "./logging.js";
 import { checkDependencies } from "./dependencies.js";
 import { DbType } from "./db/index.js";
 import { getAppInfo } from "./waspCli.js";
 import { startAppInDevMode } from "./dev/index.js";
 import { startAppInBuildMode } from "./build/index.js";
-
-type Mode = "dev" | "build";
+import { type Mode, parseArgs, PathToApp, WaspCliCmd } from "./args.js";
 
 export async function main(): Promise<void> {
   const { mode, waspCliCmd, pathToApp } = parseArgs();
@@ -33,8 +31,8 @@ async function runWaspApp({
   pathToApp,
 }: {
   mode: Mode;
-  waspCliCmd: string;
-  pathToApp: string;
+  waspCliCmd: WaspCliCmd;
+  pathToApp: PathToApp;
 }): Promise<void> {
   await checkDependencies();
 
@@ -73,38 +71,4 @@ async function runWaspApp({
       dbType,
     });
   }
-}
-
-function parseArgs(): {
-  mode: Mode;
-  pathToApp: string;
-  waspCliCmd: string;
-} {
-  const program = new Command();
-
-  program.name("wasp-app-runner");
-
-  const runCommand = program
-    .command("run")
-    .description("Run the Wasp application")
-    .addArgument(
-      new Argument("<mode>", "The run mode").choices(["dev", "build"])
-    )
-    .option("--path-to-app <path>", "Path to the Wasp application", ".")
-    .option("--wasp-cli-cmd <command>", "Wasp CLI command to use", "wasp");
-
-  if (process.argv.length === 2) {
-    program.help();
-  }
-
-  program.parse();
-
-  const options = runCommand.opts();
-  const args = runCommand.processedArgs;
-
-  return {
-    mode: args[0],
-    pathToApp: options.pathToApp,
-    waspCliCmd: options.waspCliCmd,
-  };
 }

--- a/wasp-app-runner/src/waspCli.ts
+++ b/wasp-app-runner/src/waspCli.ts
@@ -3,15 +3,18 @@ import { stripVTControlCharacters } from "node:util";
 import { log } from "./logging.js";
 import { spawnWithLog, spawnAndCollectOutput } from "./process.js";
 import { DbType } from "./db/index.js";
-import type { EnvVars } from "./types.js";
+import type { Branded, EnvVars } from "./types.js";
+import type { PathToApp, WaspCliCmd } from "./args.js";
+
+export type AppName = Branded<string, "AppName">;
 
 export function migrateDb({
   waspCliCmd,
   pathToApp,
   extraEnv,
 }: {
-  waspCliCmd: string;
-  pathToApp: string;
+  waspCliCmd: WaspCliCmd;
+  pathToApp: PathToApp;
   extraEnv: EnvVars;
 }): Promise<{ exitCode: number | null }> {
   return spawnWithLog({
@@ -28,8 +31,8 @@ export function startApp({
   pathToApp,
   extraEnv,
 }: {
-  waspCliCmd: string;
-  pathToApp: string;
+  waspCliCmd: WaspCliCmd;
+  pathToApp: PathToApp;
   extraEnv: EnvVars;
 }): Promise<{ exitCode: number | null }> {
   return spawnWithLog({
@@ -45,8 +48,8 @@ export function buildApp({
   waspCliCmd,
   pathToApp,
 }: {
-  waspCliCmd: string;
-  pathToApp: string;
+  waspCliCmd: WaspCliCmd;
+  pathToApp: PathToApp;
 }): Promise<{ exitCode: number | null }> {
   return spawnWithLog({
     name: "build-app",
@@ -60,10 +63,10 @@ export async function getAppInfo({
   waspCliCmd,
   pathToApp,
 }: {
-  waspCliCmd: string;
-  pathToApp: string;
+  waspCliCmd: WaspCliCmd;
+  pathToApp: PathToApp;
 }): Promise<{
-  appName: string;
+  appName: AppName;
   dbType: DbType;
 }> {
   const { stdoutData, exitCode } = await spawnAndCollectOutput({
@@ -99,7 +102,7 @@ export async function getAppInfo({
   }
 
   return {
-    appName: ensureRegexMatch(appNameMatch, "app name"),
+    appName: ensureRegexMatch(appNameMatch, "app name") as AppName,
     dbType:
       ensureRegexMatch(dbTypeMatch, "db type") === "PostgreSQL"
         ? DbType.Postgres


### PR DESCRIPTION
Moves CLI args parsing into `args.ts` and uses branded types for all the CLI args. It also uses branded type for the app name value. 