### PR TITLE
Use regular GitHub Actions concurrency

### DIFF
--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -25,16 +25,11 @@ defaults:
     shell: bash
     working-directory: waspc
 
-jobs:
-  cancel:
-    name: Cancel redundant actions already in progress
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Cancel actions in progress of same workflow and same branch
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Build Wasp
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Just use the native GitHub facilities to only have a single job running for each workflow and branch. This means we use one fewer job on each run. (And we depend on one fewer 3rd party action)

Docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow