### PR TITLE
Quote all titles

### DIFF
--- a/web/blog/2022-06-15-jobs-feature-announcement.md
+++ b/web/blog/2022-06-15-jobs-feature-announcement.md
@@ -37,7 +37,7 @@ You wouldn’t want the server to delay sending its HTTP response until those ar
 
 The typical solution here is to use a job queue of some kind. They are not impossible to set up, of course, but there is a fair amount of boilerplate involved, some operational expertise/overhead required, and moving from one system to another when you outgrow it is usually a challenge. These are the exact areas where we feel Wasp can provide real value, so we are happy to introduce Wasp Jobs to help out with this!
 
-```js title=src/server/workers/github.js
+```js title="src/server/workers/github.js"
 import axios from 'axios'
 import { upsertMetric } from './utils.js'
 
@@ -81,7 +81,7 @@ However, we will also continue to expand the number of job execution runtimes we
 
 If you are a regular reader of this blog (thank you, you deserve a raise! 😊), you may recall we created an example app of a metrics dashboard called [Waspleau](https://wasp.sh/blog/2022/01/27/waspleau) that used workers in the background to make periodic HTTP calls for data. In that example, we didn’t yet have access to recurring jobs in Wasp, so we used Bull for scheduled jobs instead. To set up our queue-related logic we had to have this huge `setupFn` wiring it all up; but now, we can remove all that code and simply use jobs instead! Here is what the new DSL looks like:
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 // A cron job for fetching GitHub stats
 job getGithubStats {
   executor: PgBoss,
@@ -111,7 +111,7 @@ job calcPageLoadTime {
 
 And here is an example of how you can reference and invoke jobs on the server. _Note: We did not even need to do this step since jobs with a schedule are automatically configured to run at the desired time._
 
-```js title=src/server/serverSetup.js
+```js title="src/server/serverSetup.js"
 /**
 * These Jobs are automatically scheduled by Wasp.
 * However, let's kick them off on server setup to ensure we have data right away.

--- a/web/blog/2022-11-30-optimistic-update-feature-announcement.md
+++ b/web/blog/2022-11-30-optimistic-update-feature-announcement.md
@@ -46,7 +46,7 @@ Before looking at our todo app in action, let's see how we've implemented it in 
 
 These are the relevant declarations in our `.wasp` file:
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 entity Task {=psl
     id          Int     @id @default(autoincrement())
     description String
@@ -69,7 +69,7 @@ action updateTask {
 
 This is the query we use to fetch the tasks (together with their statuses):
 
-```js title=queries.js
+```js title="queries.js"
 export const getTasks = async (args, context) => {
   return context.entities.Task.findMany()
 }
@@ -77,7 +77,7 @@ export const getTasks = async (args, context) => {
 
 Here's the action we use to update a task’s status:
 
-```js title=actions.js
+```js title="actions.js"
 export const updateTask = async ({ id, isDone }, context) => {
   return context.entities.Task.updateMany({
     where: { id },
@@ -88,7 +88,7 @@ export const updateTask = async ({ id, isDone }, context) => {
 
 Finally, this is how our client uses this action to update a task:
 
-```jsx title=MainPage.js
+```jsx title="MainPage.js"
 import updateTask from '@wasp/queries'
 
 // ...
@@ -126,7 +126,7 @@ How can we improve it? Well, of course, we can optimistically update the checkbo
 
 To perform the `updateTask` action optimistically, all we need to do is decorate the calling code on the client:
 
-```jsx {6-16,25} title=MainPage.js
+```jsx {6-16,25} title="MainPage.js"
 import updateTask from '@wasp/queries'
 
 // ...

--- a/web/docs/advanced/middleware-config.md
+++ b/web/docs/advanced/middleware-config.md
@@ -82,7 +82,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -92,7 +92,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.js
+    ```ts title="src/serverSetup.js"
     import cors from 'cors'
     import { config } from 'wasp/server'
 
@@ -105,7 +105,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -115,7 +115,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.ts
+    ```ts title="src/serverSetup.ts"
     import cors from 'cors'
     import { config, type MiddlewareConfigFn } from 'wasp/server'
 
@@ -134,7 +134,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -145,7 +145,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     import express from 'express'
 
     export const webhookCallback = (req, res, _context) => {
@@ -165,7 +165,7 @@ If you would like to modify the middleware for a single API, you can do somethin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -176,7 +176,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type WebhookCallback } from 'wasp/server/api'
     import { type MiddlewareConfigFn } from 'wasp/server'
@@ -213,7 +213,7 @@ If you would like to modify the middleware for all API routes under some common 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -222,7 +222,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     export const fooBarNamespaceMiddlewareFn = (middlewareConfig) => {
       const customMiddleware = (_req, _res, next) => {
         console.log('fooBarNamespaceMiddlewareFn: custom middleware')
@@ -237,7 +237,7 @@ If you would like to modify the middleware for all API routes under some common 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -246,7 +246,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type MiddlewareConfigFn } from 'wasp/server'
 

--- a/web/docs/advanced/web-sockets.md
+++ b/web/docs/advanced/web-sockets.md
@@ -25,7 +25,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -38,7 +38,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -71,7 +71,7 @@ This is how we can define our `webSocketFn` function:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title=src/webSocket.js
+    ```ts title="src/webSocket.js"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
 
@@ -92,7 +92,7 @@ This is how we can define our `webSocketFn` function:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/webSocket.ts
+    ```ts title="src/webSocket.ts"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
     import { type WebSocketDefinition, type WaspSocketData } from 'wasp/server/webSocket'
@@ -164,7 +164,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title=src/ChatPage.jsx
+    ```tsx title="src/ChatPage.jsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -226,7 +226,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
     You can additionally use the `ClientToServerPayload` and `ServerToClientPayload` helper types to get the payload type for a specific event.
 
-    ```tsx title=src/ChatPage.tsx
+    ```tsx title="src/ChatPage.tsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -299,7 +299,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -312,7 +312,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 

--- a/web/docs/auth/entities/entities.md
+++ b/web/docs/auth/entities/entities.md
@@ -142,7 +142,7 @@ This can be useful if you support multiple authentication methods and you need _
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     export const createTask = async (args, context) => {
       const userId = context.user.getFirstProviderUserId()
       // ...
@@ -160,7 +160,7 @@ This can be useful if you support multiple authentication methods and you need _
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     export const createTask: CreateTask<...>  = async (args, context) => {
       const userId = context.user.getFirstProviderUserId()
       // ...

--- a/web/docs/auth/social-auth/create-your-own-ui.md
+++ b/web/docs/auth/social-auth/create-your-own-ui.md
@@ -13,7 +13,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/LoginPage.jsx
+    ```jsx title="src/LoginPage.jsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,
@@ -36,7 +36,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/LoginPage.tsx
+    ```tsx title="src/LoginPage.tsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,

--- a/web/docs/auth/social-auth/discord.md
+++ b/web/docs/auth/social-auth/discord.md
@@ -257,7 +257,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -276,7 +276,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -369,7 +369,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/discord.js
+    ```js title="src/auth/discord.js"
     export const userSignupFields = {
       username: (data) => data.profile.global_name,
       avatarUrl: (data) => data.profile.avatar,
@@ -415,7 +415,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/discord.ts
+    ```ts title="src/auth/discord.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -504,7 +504,7 @@ The `discord` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/discord.js
+      ```js title="src/auth/discord.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -514,7 +514,7 @@ The `discord` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/discord.ts
+      ```ts title="src/auth/discord.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/docs/auth/social-auth/github.md
+++ b/web/docs/auth/social-auth/github.md
@@ -257,7 +257,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -382,7 +382,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```js title=src/auth/github.js
+    ```js title="src/auth/github.js"
     export const userSignupFields = {
       username: () => 'hardcoded-username',
       displayName: (data) => data.profile.name,
@@ -428,7 +428,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```ts title=src/auth/github.ts
+    ```ts title="src/auth/github.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -517,7 +517,7 @@ The `gitHub` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/github.js
+      ```js title="src/auth/github.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -527,7 +527,7 @@ The `gitHub` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/github.ts
+      ```ts title="src/auth/github.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/docs/auth/social-auth/google.md
+++ b/web/docs/auth/social-auth/google.md
@@ -303,7 +303,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -322,7 +322,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -411,7 +411,7 @@ model User {
 // ...
 ```
 
-```ts title=src/auth/google.ts auto-js
+```ts title="src/auth/google.ts" auto-js
 import { defineUserSignupFields } from 'wasp/server/auth'
 
 export const userSignupFields = defineUserSignupFields({
@@ -498,7 +498,7 @@ The `google` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/google.js
+      ```js title="src/auth/google.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -508,7 +508,7 @@ The `google` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/google.ts
+      ```ts title="src/auth/google.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/docs/auth/social-auth/keycloak.md
+++ b/web/docs/auth/social-auth/keycloak.md
@@ -267,7 +267,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -286,7 +286,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -370,7 +370,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/keycloak.js
+    ```js title="src/auth/keycloak.js"
     export const userSignupFields = {
       username: () => 'hardcoded-username',
       displayName: (data) => data.profile.name,
@@ -416,7 +416,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/keycloak.ts
+    ```ts title="src/auth/keycloak.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -505,7 +505,7 @@ The `keycloak` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/keycloak.js
+      ```js title="src/auth/keycloak.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -515,7 +515,7 @@ The `keycloak` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/keycloak.ts
+      ```ts title="src/auth/keycloak.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/docs/auth/social-auth/overview.md
+++ b/web/docs/auth/social-auth/overview.md
@@ -32,7 +32,7 @@ Here's what the full setup looks like:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -58,7 +58,7 @@ Here's what the full setup looks like:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -110,7 +110,7 @@ Let's go through both steps in more detail.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```prisma title=schema.prisma
+    ```prisma title="schema.prisma"
     model User {
       id               Int     @id @default(autoincrement())
       username         String? @unique
@@ -121,7 +121,7 @@ Let's go through both steps in more detail.
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```prisma title=schema.prisma
+    ```prisma title="schema.prisma"
     model User {
       id               Int     @id @default(autoincrement())
       username         String? @unique
@@ -138,7 +138,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -161,7 +161,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function.
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       isSignupComplete: () => false,
     }
@@ -169,7 +169,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -192,7 +192,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function:
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -218,7 +218,7 @@ For example:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/HomePage.jsx
+    ```jsx title="src/HomePage.jsx"
     import { Navigate } from 'react-router-dom'
 
     export function HomePage({ user }) {
@@ -232,7 +232,7 @@ For example:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/HomePage.tsx
+    ```tsx title="src/HomePage.tsx"
     import { Navigate } from 'react-router-dom'
     import { AuthUser } from 'wasp/auth'
 

--- a/web/docs/data-model/crud.md
+++ b/web/docs/data-model/crud.md
@@ -157,7 +157,7 @@ Here's the `src/tasks.{js,ts}` file:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -187,7 +187,7 @@ Here's the `src/tasks.{js,ts}` file:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { type Tasks } from 'wasp/server/crud'
     import { type Task } from 'wasp/entities'
     import { HttpError } from 'wasp/server'

--- a/web/docs/data-model/databases.md
+++ b/web/docs/data-model/databases.md
@@ -157,7 +157,7 @@ You can define as many **seed functions** as you want in an array under the `app
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -171,7 +171,7 @@ You can define as many **seed functions** as you want in an array under the `app
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -314,7 +314,7 @@ You'll often want to call `wasp db seed` right after you run `wasp db reset`, as
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -328,7 +328,7 @@ You'll often want to call `wasp db seed` right after you run `wasp db reset`, as
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -364,7 +364,7 @@ Use one of the following commands to run the seed functions:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {
@@ -378,7 +378,7 @@ Use one of the following commands to run the seed functions:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {

--- a/web/docs/data-model/operations/actions.md
+++ b/web/docs/data-model/operations/actions.md
@@ -293,7 +293,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -327,7 +327,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -413,7 +413,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/actions.js
+    ```js title="src/actions.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -427,7 +427,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/actions.ts
+    ```ts title="src/actions.ts"
     import { type CreateTask } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -685,7 +685,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `createfoo` from the file `src/actions.js`
 
-    ```js title=actions.js
+    ```js title="actions.js"
     export const createFoo = (args, context) => {
       // implementation
     }
@@ -706,7 +706,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `CreateFoo` and specify the Action's inputs and outputs using its type arguments.
 
-    ```ts title=actions.ts
+    ```ts title="actions.ts"
     import { type CreateFoo } from 'wasp/server/operations'
 
     type Foo = // ...
@@ -764,7 +764,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     import {
       useQuery,
@@ -815,7 +815,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     import {
       useQuery,

--- a/web/docs/data-model/operations/queries.md
+++ b/web/docs/data-model/operations/queries.md
@@ -311,7 +311,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/MainPage.jsx
+    ```jsx title="src/MainPage.jsx"
     import React from 'react'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
 
@@ -360,7 +360,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/MainPage.tsx
+    ```tsx title="src/MainPage.tsx"
     import React from 'react'
     import { type Task } from 'wasp/entities'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
@@ -426,7 +426,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/queries.js
+    ```js title="src/queries.js"
     import { HttpError } from 'wasp/server'
 
     export const getAllTasks = async (args, context) => {
@@ -440,7 +440,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/queries.ts
+    ```ts title="src/queries.ts"
     import { type GetAllTasks } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -656,7 +656,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `getFoo` from the file `src/queries.js`
 
-    ```js title=queries.js
+    ```js title="queries.js"
     export const getFoo = (args, context) => {
       // implementation
     }
@@ -677,7 +677,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `GetFoo` and specify the Query's inputs and outputs using its type arguments.
 
-    ```ts title=queries.ts
+    ```ts title="queries.ts"
     import { type GetFoo } from 'wasp/server/operations'
 
     type Foo = // ...

--- a/web/docs/general/typescript.md
+++ b/web/docs/general/typescript.md
@@ -43,7 +43,7 @@ model Task {
 
 And your `main.wasp` file defines the `getTaskInfo` query:
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 query getTaskInfo {
   fn: import { getTaskInfo } from "@src/queries",
   entities: [Task]
@@ -97,7 +97,7 @@ To migrate this file to TypeScript, all you have to do is:
   </TabItem>
 
   <TabItem value="after" label="After">
-    ```typescript title=src/queries.ts
+    ```typescript title="src/queries.ts"
     import HttpError from 'wasp/server'
     // highlight-next-line
     import { type Task } from '@wasp/entities'

--- a/web/docs/migration-guides/migrate-from-0-13-to-0-14.md
+++ b/web/docs/migration-guides/migrate-from-0-13-to-0-14.md
@@ -117,7 +117,7 @@ new version of the file and reapplying them.
 
 Here's the new version of the `tsconfig.json` file:
 
-```json title=tsconfig.json
+```json title="tsconfig.json"
 // =============================== IMPORTANT =================================
 //
 // This file is only used for Wasp IDE support. You can change it to configure
@@ -409,7 +409,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getUsername } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -429,7 +429,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const username = context.user.identities.username?.id
            // ...
@@ -455,7 +455,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getEmail } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -475,7 +475,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const email = context.user.identities.email?.id
            // ...
@@ -541,7 +541,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getFirstProviderUserId } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -561,7 +561,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const userId = user.getFirstProviderUserId()
            // ...
@@ -589,7 +589,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { findUserIdentity } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -612,7 +612,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            if (context.user.identities.username) {
                // ...

--- a/web/docs/migration-guides/migrate-from-0-16-to-0-17.md
+++ b/web/docs/migration-guides/migrate-from-0-16-to-0-17.md
@@ -38,10 +38,10 @@ await login({ username: usernameValue, password: passwordValue })
 This is to make it consistent with the `login` and `signup` calls in other
 authentication methods, which were already using this convention.
 
-### Wasp no longer generates a default `favicon.ico` 
+### Wasp no longer generates a default `favicon.ico`
 
 Wasp will no longer generate `favicon.ico` if there isn't one in the `public` directory.
-Also, Wasp will no longer generate a `<link>` meta tag in `index.html`. You'll need to define it yourself explicitly. 
+Also, Wasp will no longer generate a `<link>` meta tag in `index.html`. You'll need to define it yourself explicitly.
 
 New Wasp projects come with a default `favicon.ico` in the `public` directory and the `<link>` meta tag in the `main.wasp` file.
 
@@ -121,7 +121,7 @@ If you have made changes to your `tsconfig.json` file, we recommend taking the
 new version of the file and reapplying them.
 
 Here's the new version of `tsconfig.json`:
-```json title=tsconfig.json
+```json title="tsconfig.json"
 // =============================== IMPORTANT =================================
 // This file is mainly used for Wasp IDE support.
 //
@@ -175,7 +175,7 @@ import '@testing-library/jest-dom'
 ### 4. Add a `favicon.ico` to the `public` directory
 
 This step is necessary only if you don't have a `favicon.ico` in your `public` folder.
-If so, you should add a `favicon.ico` to your `public` folder. 
+If so, you should add a `favicon.ico` to your `public` folder.
 
 If you want to keep the default, you can [download it here](https://github.com/wasp-lang/wasp/tree/main/waspc/data/Cli/templates/skeleton/public/favicon.ico).
 

--- a/web/docs/project/testing.md
+++ b/web/docs/project/testing.md
@@ -161,7 +161,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```js title=src/Todo.test.jsx
+    ```js title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -215,7 +215,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -280,7 +280,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```jsx title=src/Todo.test.jsx
+    ```jsx title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -341,7 +341,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 

--- a/web/versioned_docs/version-0.11.8/advanced/middleware-config.md
+++ b/web/versioned_docs/version-0.11.8/advanced/middleware-config.md
@@ -82,7 +82,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -93,7 +93,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/server/serverSetup.js
+    ```ts title="src/server/serverSetup.js"
     import cors from 'cors'
     import config from '@wasp/config.js'
 
@@ -106,7 +106,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -117,7 +117,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/server/serverSetup.ts
+    ```ts title="src/server/serverSetup.ts"
     import cors from 'cors'
     import type { MiddlewareConfigFn } from '@wasp/middleware'
     import config from '@wasp/config.js'
@@ -137,7 +137,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -148,7 +148,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/server/apis.js
+    ```ts title="src/server/apis.js"
     import express from 'express'
 
     export const webhookCallback = (req, res, _context) => {
@@ -157,7 +157,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
     export const webhookCallbackMiddlewareFn = (middlewareConfig) => {
       console.log('webhookCallbackMiddlewareFn: Swap express.json for express.raw')
-      
+
       middlewareConfig.delete('express.json')
       middlewareConfig.set('express.raw', express.raw({ type: '*/*' }))
 
@@ -168,7 +168,7 @@ If you would like to modify the middleware for a single API, you can do somethin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -179,7 +179,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/server/apis.ts
+    ```ts title="src/server/apis.ts"
     import express from 'express'
     import { WebhookCallback } from '@wasp/apis/types'
     import type { MiddlewareConfigFn } from '@wasp/middleware'
@@ -190,7 +190,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
     export const webhookCallbackMiddlewareFn: MiddlewareConfigFn = (middlewareConfig) => {
       console.log('webhookCallbackMiddlewareFn: Swap express.json for express.raw')
-      
+
       middlewareConfig.delete('express.json')
       middlewareConfig.set('express.raw', express.raw({ type: '*/*' }))
 
@@ -216,7 +216,7 @@ If you would like to modify the middleware for all API routes under some common 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -225,7 +225,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/server/apis.js
+    ```ts title="src/server/apis.js"
     export const fooBarNamespaceMiddlewareFn = (middlewareConfig) => {
       const customMiddleware = (_req, _res, next) => {
         console.log('fooBarNamespaceMiddlewareFn: custom middleware')
@@ -240,7 +240,7 @@ If you would like to modify the middleware for all API routes under some common 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -249,7 +249,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/server/apis.ts
+    ```ts title="src/server/apis.ts"
     import express from 'express'
     import type { MiddlewareConfigFn } from '@wasp/middleware'
 

--- a/web/versioned_docs/version-0.11.8/advanced/web-sockets.md
+++ b/web/versioned_docs/version-0.11.8/advanced/web-sockets.md
@@ -25,7 +25,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -38,7 +38,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -71,7 +71,7 @@ This is how we can define our `webSocketFn` function:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title=src/server/webSocket.js
+    ```ts title="src/server/webSocket.js"
     import { v4 as uuidv4 } from 'uuid'
 
     export const webSocketFn = (io, context) => {
@@ -91,7 +91,7 @@ This is how we can define our `webSocketFn` function:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/server/webSocket.ts
+    ```ts title="src/server/webSocket.ts"
     import type { WebSocketDefinition, WaspSocketData } from '@wasp/webSocket'
     import { v4 as uuidv4 } from 'uuid'
 
@@ -162,7 +162,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title=src/client/ChatPage.jsx
+    ```tsx title="src/client/ChatPage.jsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -224,7 +224,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
     You can additionally use the `ClientToServerPayload` and `ServerToClientPayload` helper types to get the payload type for a specific event.
 
-    ```tsx title=src/client/ChatPage.tsx
+    ```tsx title="src/client/ChatPage.tsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -297,7 +297,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -310,7 +310,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 

--- a/web/versioned_docs/version-0.11.8/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.11.8/auth/social-auth/github.md
@@ -297,7 +297,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp {10}
+    ```wasp title="main.wasp" {10}
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -316,7 +316,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp {10}
+    ```wasp title="main.wasp" {10}
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -376,7 +376,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
     // ...
     ```
 
-    ```js title=src/server/auth/github.js
+    ```js title="src/server/auth/github.js"
     import { generateAvailableDictionaryUsername } from "@wasp/core/auth.js";
 
     export const getUserFields = async (_context, args) => {
@@ -425,7 +425,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
     // ...
     ```
 
-    ```ts title=src/server/auth/github.ts
+    ```ts title="src/server/auth/github.ts"
     import type { GetUserFieldsFn } from '@wasp/types'
     import { generateAvailableDictionaryUsername } from '@wasp/core/auth.js'
 
@@ -510,7 +510,7 @@ The `gitHub` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/server/auth/github.js
+      ```js title="src/server/auth/github.js"
       export function getConfig() {
         return {
           clientID, // look up from env or elsewhere
@@ -522,7 +522,7 @@ The `gitHub` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/server/auth/github.ts
+      ```ts title="src/server/auth/github.ts"
       export function getConfig() {
         return {
           clientID, // look up from env or elsewhere
@@ -545,7 +545,7 @@ The `gitHub` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/server/auth/github.js
+      ```js title="src/server/auth/github.js"
       import { generateAvailableUsername } from '@wasp/core/auth.js'
 
       export const getUserFields = async (_context, args) => {
@@ -559,7 +559,7 @@ The `gitHub` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/server/auth/github.ts
+      ```ts title="src/server/auth/github.ts"
       import type { GetUserFieldsFn } from '@wasp/types'
       import { generateAvailableUsername } from '@wasp/core/auth.js'
 

--- a/web/versioned_docs/version-0.11.8/auth/social-auth/google.md
+++ b/web/versioned_docs/version-0.11.8/auth/social-auth/google.md
@@ -344,7 +344,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp {10}
+    ```wasp title="main.wasp" {10}
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -363,7 +363,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp {10}
+    ```wasp title="main.wasp" {10}
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -423,7 +423,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
     // ...
     ```
 
-    ```js title=src/server/auth/google.js
+    ```js title="src/server/auth/google.js"
     import { generateAvailableDictionaryUsername } from '@wasp/core/auth.js'
 
     export const getUserFields = async (_context, args) => {
@@ -472,7 +472,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
     // ...
     ```
 
-    ```ts title=src/server/auth/google.ts
+    ```ts title="src/server/auth/google.ts"
     import type { GetUserFieldsFn } from '@wasp/types'
     import { generateAvailableDictionaryUsername } from '@wasp/core/auth.js'
 
@@ -557,7 +557,7 @@ The `google` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/server/auth/google.js
+      ```js title="src/server/auth/google.js"
       export function getConfig() {
         return {
           clientID, // look up from env or elsewhere
@@ -569,7 +569,7 @@ The `google` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/server/auth/google.ts
+      ```ts title="src/server/auth/google.ts"
       export function getConfig() {
         return {
           clientID, // look up from env or elsewhere
@@ -592,7 +592,7 @@ The `google` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/server/auth/google.js
+      ```js title="src/server/auth/google.js"
       import { generateAvailableUsername } from '@wasp/core/auth.js'
 
       export const getUserFields = async (_context, args) => {
@@ -606,7 +606,7 @@ The `google` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/server/auth/google.ts
+      ```ts title="src/server/auth/google.ts"
       import type { GetUserFieldsFn } from '@wasp/types'
       import { generateAvailableUsername } from '@wasp/core/auth.js'
 

--- a/web/versioned_docs/version-0.11.8/auth/social-auth/overview.md
+++ b/web/versioned_docs/version-0.11.8/auth/social-auth/overview.md
@@ -35,7 +35,7 @@ Both fields fall under `app.auth`. Here's what the full setup looks like:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -74,7 +74,7 @@ Both fields fall under `app.auth`. Here's what the full setup looks like:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -143,7 +143,7 @@ Let's go through both steps in more detail.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     entity User {=psl
         id                        Int           @id @default(autoincrement())
         username                  String?       @unique
@@ -155,7 +155,7 @@ Let's go through both steps in more detail.
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     entity User {=psl
         id                        Int           @id @default(autoincrement())
         username                  String?       @unique
@@ -173,7 +173,7 @@ Declare an import under `app.auth.methods.google.getUserFieldsFn` (the example a
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -197,7 +197,7 @@ Declare an import under `app.auth.methods.google.getUserFieldsFn` (the example a
 
     And implement the imported function.
 
-    ```js title=src/server/auth/google.js
+    ```js title="src/server/auth/google.js"
     export const getUserFields = async (_context, _args) => {
       return {
         isSignupComplete: false,
@@ -207,7 +207,7 @@ Declare an import under `app.auth.methods.google.getUserFieldsFn` (the example a
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -231,7 +231,7 @@ Declare an import under `app.auth.methods.google.getUserFieldsFn` (the example a
 
     And implement the imported function:
 
-    ```ts title=src/server/auth/google.ts
+    ```ts title="src/server/auth/google.ts"
     import { GetUserFieldsFn } from '@wasp/types'
 
     export const getUserFields: GetUserFieldsFn = async (_context, _args) => {
@@ -257,7 +257,7 @@ For example:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=client/HomePage.jsx
+    ```jsx title="client/HomePage.jsx"
     import useAuth from '@wasp/auth/useAuth'
     import { Redirect } from 'react-router-dom'
 
@@ -274,7 +274,7 @@ For example:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=client/HomePage.tsx
+    ```tsx title="client/HomePage.tsx"
     import useAuth from '@wasp/auth/useAuth'
     import { Redirect } from 'react-router-dom'
 
@@ -315,7 +315,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=client/LoginPage.jsx
+    ```jsx title="client/LoginPage.jsx"
     import {
       SignInButton as GoogleSignInButton,
       signInUrl as googleSignInUrl,
@@ -340,7 +340,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=client/LoginPage.tsx
+    ```tsx title="client/LoginPage.tsx"
     import {
       SignInButton as GoogleSignInButton,
       signInUrl as googleSignInUrl,
@@ -388,7 +388,7 @@ All social providers share the same Entity.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp {4-10}
+    ```wasp title="main.wasp" {4-10}
     // ...
 
     entity SocialLogin {=psl
@@ -406,7 +406,7 @@ All social providers share the same Entity.
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp {4-10}
+    ```wasp title="main.wasp" {4-10}
     // ...
 
     entity SocialLogin {=psl
@@ -445,7 +445,7 @@ Using Social login providers requires you to add one extra field to the Entity a
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp {6}
+    ```wasp title="main.wasp" {6}
     // ...
 
     entity User {=psl
@@ -459,7 +459,7 @@ Using Social login providers requires you to add one extra field to the Entity a
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp {6}
+    ```wasp title="main.wasp" {6}
     // ...
 
     entity User {=psl

--- a/web/versioned_docs/version-0.11.8/data-model/backends.md
+++ b/web/versioned_docs/version-0.11.8/data-model/backends.md
@@ -34,7 +34,7 @@ To run your Wasp app in production, you'll need to switch from SQLite to Postgre
 
 1. Set the `app.db.system` field to PostgreSQL.
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 app MyApp {
   title: "My app",
   // ...
@@ -111,7 +111,7 @@ You can define as many **seed functions** as you want in an array under the `app
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -126,7 +126,7 @@ You can define as many **seed functions** as you want in an array under the `app
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -280,7 +280,7 @@ Here's an example that uses the `app.db` field to its full potential:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -298,7 +298,7 @@ Here's an example that uses the `app.db` field to its full potential:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -404,7 +404,7 @@ Use one of the following commands to run the seed functions:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {
@@ -419,7 +419,7 @@ Use one of the following commands to run the seed functions:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {

--- a/web/versioned_docs/version-0.11.8/data-model/crud.md
+++ b/web/versioned_docs/version-0.11.8/data-model/crud.md
@@ -151,7 +151,7 @@ Here's the `src/server/tasks.{js,ts}` file:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/server/tasks.js {15-20}
+    ```js title="src/server/tasks.js" {15-20}
     import HttpError from '@wasp/core/HttpError.js'
 
     export const createTask = async (args, context) => {
@@ -179,7 +179,7 @@ Here's the `src/server/tasks.{js,ts}` file:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/server/tasks.ts {23-28}
+    ```ts title="src/server/tasks.ts" {23-28}
     import type { CreateAction } from '@wasp/crud/Tasks'
     import type { Task } from '@wasp/entities'
     import HttpError from '@wasp/core/HttpError.js'

--- a/web/versioned_docs/version-0.11.8/data-model/operations/actions.md
+++ b/web/versioned_docs/version-0.11.8/data-model/operations/actions.md
@@ -244,7 +244,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx {4,25} title=src/client/pages/Task.jsx
+    ```jsx {4,25} title="src/client/pages/Task.jsx"
     import React from 'react'
     import { useQuery } from '@wasp/queries'
     import getTask from '@wasp/queries/getTask'
@@ -278,7 +278,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx {4,25} title=src/client/pages/Task.tsx
+    ```tsx {4,25} title="src/client/pages/Task.tsx"
     import React from 'react'
     import { useQuery } from '@wasp/queries'
     import getTask from '@wasp/queries/getTask'
@@ -323,7 +323,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/server/actions.js
+    ```js title="src/server/actions.js"
     import HttpError from '@wasp/core/HttpError.js'
 
     export const createTask = async (args, context) => {
@@ -337,7 +337,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/server/actions.ts
+    ```ts title="src/server/actions.ts"
     import { CreateTask } from '@wasp/actions/types'
     import HttpError from '@wasp/core/HttpError.js'
 
@@ -633,7 +633,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `createfoo` from the file `src/server/actions.js`
 
-    ```js title=actions.js
+    ```js title="actions.js"
     export const createFoo = (args, context) => {
       // implementation
     }
@@ -652,7 +652,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `CreateFoo` and specify the Action's inputs and outputs using its type arguments.
 
-    ```ts title=actions.ts
+    ```ts title="actions.ts"
     import { CreateFoo } from "@wasp/actions/types";
 
     type Foo = // ...
@@ -710,7 +710,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx {3,9,10,11,12,13,14,15,16,34} title=src/client/pages/Task.jsx
+    ```jsx {3,9,10,11,12,13,14,15,16,34} title="src/client/pages/Task.jsx"
     import React from 'react'
     import { useQuery } from '@wasp/queries'
     import { useAction } from '@wasp/actions'
@@ -757,7 +757,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```jsx {2,4,8,12,13,14,15,16,17,18,19,37} title=src/client/pages/Task.js
+    ```jsx {2,4,8,12,13,14,15,16,17,18,19,37} title="src/client/pages/Task.js"
     import React from "react";
     import { useQuery } from "@wasp/queries";
     import { useAction, OptimisticUpdateDefinition } from "@wasp/actions";

--- a/web/versioned_docs/version-0.11.8/data-model/operations/queries.md
+++ b/web/versioned_docs/version-0.11.8/data-model/operations/queries.md
@@ -221,7 +221,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/client/MainPage.jsx
+    ```jsx title="src/client/MainPage.jsx"
     import React from 'react'
     import { useQuery } from '@wasp/queries'
     import getAllTasks from '@wasp/queries/getAllTasks'
@@ -272,7 +272,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/client/MainPage.tsx
+    ```tsx title="src/client/MainPage.tsx"
     import React from 'react'
     import { Task } from '@wasp/entities'
     import { useQuery } from '@wasp/queries'
@@ -340,7 +340,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/server/queries.js
+    ```js title="src/server/queries.js"
     import HttpError from '@wasp/core/HttpError.js'
 
     export const getAllTasks = async (args, context) => {
@@ -354,7 +354,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/server/queries.ts
+    ```ts title="src/server/queries.ts"
     import { GetAllTasks } from '@wasp/queries/types'
     import HttpError from '@wasp/core/HttpError.js'
 
@@ -560,7 +560,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `getFoo` from the file `src/server/queries.js`
 
-    ```js title=queries.js
+    ```js title="queries.js"
     export const getFoo = (args, context) => {
       // implementation
     }
@@ -581,7 +581,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `GetFoo` and specify the Query's inputs and outputs using its type arguments.
 
-    ```ts title=queries.ts
+    ```ts title="queries.ts"
     import { GetFoo } from "@wasp/queries/types";
 
     type Foo = // ...

--- a/web/versioned_docs/version-0.11.8/project/testing.md
+++ b/web/versioned_docs/version-0.11.8/project/testing.md
@@ -162,7 +162,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```js title=src/client/Todo.test.jsx
+    ```js title="src/client/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -217,7 +217,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/client/Todo.test.tsx
+    ```tsx title="src/client/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -282,7 +282,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```jsx title=src/client/Todo.test.jsx
+    ```jsx title="src/client/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -343,7 +343,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/client/Todo.test.tsx
+    ```tsx title="src/client/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 

--- a/web/versioned_docs/version-0.12.0/advanced/middleware-config.md
+++ b/web/versioned_docs/version-0.12.0/advanced/middleware-config.md
@@ -82,7 +82,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -93,7 +93,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.js
+    ```ts title="src/serverSetup.js"
     import cors from 'cors'
     import { config } from 'wasp/server'
 
@@ -106,7 +106,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -117,7 +117,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.ts
+    ```ts title="src/serverSetup.ts"
     import cors from 'cors'
     import { config, type MiddlewareConfigFn } from 'wasp/server'
 
@@ -136,7 +136,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -147,7 +147,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     import express from 'express'
 
     export const webhookCallback = (req, res, _context) => {
@@ -167,7 +167,7 @@ If you would like to modify the middleware for a single API, you can do somethin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -178,7 +178,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type WebhookCallback } from 'wasp/server/api'
     import { type MiddlewareConfigFn } from 'wasp/server'
@@ -215,7 +215,7 @@ If you would like to modify the middleware for all API routes under some common 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -224,7 +224,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     export const fooBarNamespaceMiddlewareFn = (middlewareConfig) => {
       const customMiddleware = (_req, _res, next) => {
         console.log('fooBarNamespaceMiddlewareFn: custom middleware')
@@ -239,7 +239,7 @@ If you would like to modify the middleware for all API routes under some common 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -248,7 +248,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type MiddlewareConfigFn } from 'wasp/server'
 

--- a/web/versioned_docs/version-0.12.0/advanced/web-sockets.md
+++ b/web/versioned_docs/version-0.12.0/advanced/web-sockets.md
@@ -25,7 +25,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -38,7 +38,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -71,7 +71,7 @@ This is how we can define our `webSocketFn` function:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title=src/webSocket.js
+    ```ts title="src/webSocket.js"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
 
@@ -92,7 +92,7 @@ This is how we can define our `webSocketFn` function:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/webSocket.ts
+    ```ts title="src/webSocket.ts"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
     import { type WebSocketDefinition, type WaspSocketData } from 'wasp/server/webSocket'
@@ -164,7 +164,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title=src/ChatPage.jsx
+    ```tsx title="src/ChatPage.jsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -226,7 +226,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
     You can additionally use the `ClientToServerPayload` and `ServerToClientPayload` helper types to get the payload type for a specific event.
 
-    ```tsx title=src/ChatPage.tsx
+    ```tsx title="src/ChatPage.tsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -299,7 +299,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -312,7 +312,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 

--- a/web/versioned_docs/version-0.12.0/auth/entities/_get-email.md
+++ b/web/versioned_docs/version-0.12.0/auth/entities/_get-email.md
@@ -11,7 +11,7 @@ The `getEmail` helper returns the user's email or `null` if the user doesn't hav
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { getEmail } from 'wasp/auth'
 
     export const createTask = async (args, context) => {
@@ -31,7 +31,7 @@ The `getEmail` helper returns the user's email or `null` if the user doesn't hav
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { getEmail } from 'wasp/auth'
 
     export const createTask: CreateTask<...>  = async (args, context) => {

--- a/web/versioned_docs/version-0.12.0/auth/entities/_get-username.md
+++ b/web/versioned_docs/version-0.12.0/auth/entities/_get-username.md
@@ -11,7 +11,7 @@ The `getUsername` helper returns the user's username or `null` if the user doesn
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { getUsername } from 'wasp/auth'
 
     export const createTask = async (args, context) => {
@@ -31,7 +31,7 @@ The `getUsername` helper returns the user's username or `null` if the user doesn
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { getUsername } from 'wasp/auth'
 
     export const createTask: CreateTask<...>  = async (args, context) => {

--- a/web/versioned_docs/version-0.12.0/auth/entities/entities.md
+++ b/web/versioned_docs/version-0.12.0/auth/entities/entities.md
@@ -67,7 +67,7 @@ entity Auth {=psl
   id         String         @id @default(uuid())
   userId     Int?           @unique
   // Wasp injects this relation on the User entity as well
-  user       User?          @relation(fields: [userId], references: [id], onDelete: Cascade) 
+  user       User?          @relation(fields: [userId], references: [id], onDelete: Cascade)
   identities AuthIdentity[]
   sessions   Session[]
 psl=}
@@ -95,7 +95,7 @@ entity AuthIdentity {=psl
   authId         String
   auth           Auth   @relation(fields: [authId], references: [id], onDelete: Cascade)
 
-  @@id([providerName, providerUserId])  
+  @@id([providerName, providerUserId])
 psl=}
 ```
 
@@ -168,7 +168,7 @@ The `getFirstProviderUserId` helper returns the first user ID (e.g. `username` o
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { getFirstProviderUserId } from 'wasp/auth'
 
     export const createTask = async (args, context) => {
@@ -188,7 +188,7 @@ The `getFirstProviderUserId` helper returns the first user ID (e.g. `username` o
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { getFirstProviderUserId } from 'wasp/auth'
 
     export const createTask: CreateTask<...>  = async (args, context) => {
@@ -229,7 +229,7 @@ This can be useful if you want to check if the user has a specific auth identity
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { findUserIdentity } from 'wasp/client/auth'
 
     export const createTask = async (args, context) => {
@@ -261,7 +261,7 @@ This can be useful if you want to check if the user has a specific auth identity
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { findUserIdentity } from 'wasp/client/auth'
 
     export const createTask: CreateTask<...>  = async (args, context) => {

--- a/web/versioned_docs/version-0.12.0/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.12.0/auth/social-auth/github.md
@@ -257,7 +257,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -336,7 +336,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
     // ...
     ```
 
-    ```js title=src/auth/github.js
+    ```js title="src/auth/github.js"
     export const userSignupFields = {
       username: () => "hardcoded-username",
       displayName: (data) => data.profile.displayName,
@@ -382,7 +382,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
     // ...
     ```
 
-    ```ts title=src/auth/github.ts
+    ```ts title="src/auth/github.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -467,7 +467,7 @@ The `gitHub` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/github.js
+      ```js title="src/auth/github.js"
       export function getConfig() {
         return {
           clientID, // look up from env or elsewhere
@@ -479,7 +479,7 @@ The `gitHub` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/github.ts
+      ```ts title="src/auth/github.ts"
       export function getConfig() {
         return {
           clientID, // look up from env or elsewhere

--- a/web/versioned_docs/version-0.12.0/auth/social-auth/google.md
+++ b/web/versioned_docs/version-0.12.0/auth/social-auth/google.md
@@ -302,7 +302,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -321,7 +321,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -381,7 +381,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
     // ...
     ```
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       username: () => "hardcoded-username",
       displayName: (data) => data.profile.displayName,
@@ -427,7 +427,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
     // ...
     ```
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -512,7 +512,7 @@ The `google` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/google.js
+      ```js title="src/auth/google.js"
       export function getConfig() {
         return {
           clientID, // look up from env or elsewhere
@@ -524,7 +524,7 @@ The `google` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/google.ts
+      ```ts title="src/auth/google.ts"
       export function getConfig() {
         return {
           clientID, // look up from env or elsewhere

--- a/web/versioned_docs/version-0.12.0/auth/social-auth/overview.md
+++ b/web/versioned_docs/version-0.12.0/auth/social-auth/overview.md
@@ -32,7 +32,7 @@ Here's what the full setup looks like:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -57,7 +57,7 @@ Here's what the full setup looks like:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -112,7 +112,7 @@ Let's go through both steps in more detail.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     entity User {=psl
         id                        Int           @id @default(autoincrement())
         username                  String?       @unique
@@ -123,7 +123,7 @@ Let's go through both steps in more detail.
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     entity User {=psl
         id                        Int           @id @default(autoincrement())
         username                  String?       @unique
@@ -140,7 +140,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -163,7 +163,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function.
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       isSignupComplete: () => false,
     }
@@ -171,7 +171,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.11.0"
@@ -194,7 +194,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function:
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -218,7 +218,7 @@ For example:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/HomePage.jsx
+    ```jsx title="src/HomePage.jsx"
     import { useAuth } from 'wasp/client/auth'
     import { Redirect } from 'react-router-dom'
 
@@ -235,7 +235,7 @@ For example:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/HomePage.tsx
+    ```tsx title="src/HomePage.tsx"
     import { useAuth } from 'wasp/client/auth'
     import { Redirect } from 'react-router-dom'
 
@@ -276,7 +276,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/LoginPage.jsx
+    ```jsx title="src/LoginPage.jsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,
@@ -299,7 +299,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/LoginPage.tsx
+    ```tsx title="src/LoginPage.tsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,

--- a/web/versioned_docs/version-0.12.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.12.0/data-model/backends.md
@@ -34,7 +34,7 @@ To run your Wasp app in production, you'll need to switch from SQLite to Postgre
 
 1. Set the `app.db.system` field to PostgreSQL.
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 app MyApp {
   title: "My app",
   // ...
@@ -111,7 +111,7 @@ You can define as many **seed functions** as you want in an array under the `app
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -126,7 +126,7 @@ You can define as many **seed functions** as you want in an array under the `app
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -314,7 +314,7 @@ Here's an example that uses the `app.db` field to its full potential:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -332,7 +332,7 @@ Here's an example that uses the `app.db` field to its full potential:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -438,7 +438,7 @@ Use one of the following commands to run the seed functions:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {
@@ -453,7 +453,7 @@ Use one of the following commands to run the seed functions:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {

--- a/web/versioned_docs/version-0.12.0/data-model/crud.md
+++ b/web/versioned_docs/version-0.12.0/data-model/crud.md
@@ -149,7 +149,7 @@ Here's the `src/tasks.{js,ts}` file:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -179,7 +179,7 @@ Here's the `src/tasks.{js,ts}` file:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { type Tasks } from 'wasp/server/crud'
     import { type Task } from 'wasp/entities'
     import { HttpError } from 'wasp/server'

--- a/web/versioned_docs/version-0.12.0/data-model/operations/actions.md
+++ b/web/versioned_docs/version-0.12.0/data-model/operations/actions.md
@@ -236,7 +236,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -270,7 +270,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -315,7 +315,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/actions.js
+    ```js title="src/actions.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -329,7 +329,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/actions.ts
+    ```ts title="src/actions.ts"
     import { type CreateTask } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -583,7 +583,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `createfoo` from the file `src/actions.js`
 
-    ```js title=actions.js
+    ```js title="actions.js"
     export const createFoo = (args, context) => {
       // implementation
     }
@@ -604,7 +604,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `CreateFoo` and specify the Action's inputs and outputs using its type arguments.
 
-    ```ts title=actions.ts
+    ```ts title="actions.ts"
     import { type CreateFoo } from 'wasp/server/operations'
 
     type Foo = // ...
@@ -662,7 +662,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     import {
       useQuery,
@@ -713,7 +713,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     import {
       useQuery,

--- a/web/versioned_docs/version-0.12.0/data-model/operations/queries.md
+++ b/web/versioned_docs/version-0.12.0/data-model/operations/queries.md
@@ -213,7 +213,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/MainPage.jsx
+    ```jsx title="src/MainPage.jsx"
     import React from 'react'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
 
@@ -262,7 +262,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/MainPage.tsx
+    ```tsx title="src/MainPage.tsx"
     import React from 'react'
     import { type Task } from 'wasp/entities'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
@@ -328,7 +328,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/queries.js
+    ```js title="src/queries.js"
     import { HttpError } from 'wasp/server'
 
     export const getAllTasks = async (args, context) => {
@@ -342,7 +342,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/queries.ts
+    ```ts title="src/queries.ts"
     import { type GetAllTasks } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -552,7 +552,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `getFoo` from the file `src/queries.js`
 
-    ```js title=queries.js
+    ```js title="queries.js"
     export const getFoo = (args, context) => {
       // implementation
     }
@@ -573,7 +573,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `GetFoo` and specify the Query's inputs and outputs using its type arguments.
 
-    ```ts title=queries.ts
+    ```ts title="queries.ts"
     import { type GetFoo } from 'wasp/server/operations'
 
     type Foo = // ...

--- a/web/versioned_docs/version-0.12.0/project/testing.md
+++ b/web/versioned_docs/version-0.12.0/project/testing.md
@@ -161,7 +161,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```js title=src/Todo.test.jsx
+    ```js title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -215,7 +215,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -280,7 +280,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```jsx title=src/Todo.test.jsx
+    ```jsx title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -341,7 +341,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 

--- a/web/versioned_docs/version-0.13.0/advanced/middleware-config.md
+++ b/web/versioned_docs/version-0.13.0/advanced/middleware-config.md
@@ -82,7 +82,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -93,7 +93,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.js
+    ```ts title="src/serverSetup.js"
     import cors from 'cors'
     import { config } from 'wasp/server'
 
@@ -106,7 +106,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -117,7 +117,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.ts
+    ```ts title="src/serverSetup.ts"
     import cors from 'cors'
     import { config, type MiddlewareConfigFn } from 'wasp/server'
 
@@ -136,7 +136,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -147,7 +147,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     import express from 'express'
 
     export const webhookCallback = (req, res, _context) => {
@@ -167,7 +167,7 @@ If you would like to modify the middleware for a single API, you can do somethin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -178,7 +178,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type WebhookCallback } from 'wasp/server/api'
     import { type MiddlewareConfigFn } from 'wasp/server'
@@ -215,7 +215,7 @@ If you would like to modify the middleware for all API routes under some common 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -224,7 +224,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     export const fooBarNamespaceMiddlewareFn = (middlewareConfig) => {
       const customMiddleware = (_req, _res, next) => {
         console.log('fooBarNamespaceMiddlewareFn: custom middleware')
@@ -239,7 +239,7 @@ If you would like to modify the middleware for all API routes under some common 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -248,7 +248,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type MiddlewareConfigFn } from 'wasp/server'
 

--- a/web/versioned_docs/version-0.13.0/advanced/web-sockets.md
+++ b/web/versioned_docs/version-0.13.0/advanced/web-sockets.md
@@ -25,7 +25,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -38,7 +38,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -71,7 +71,7 @@ This is how we can define our `webSocketFn` function:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title=src/webSocket.js
+    ```ts title="src/webSocket.js"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
 
@@ -92,7 +92,7 @@ This is how we can define our `webSocketFn` function:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/webSocket.ts
+    ```ts title="src/webSocket.ts"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
     import { type WebSocketDefinition, type WaspSocketData } from 'wasp/server/webSocket'
@@ -164,7 +164,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title=src/ChatPage.jsx
+    ```tsx title="src/ChatPage.jsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -226,7 +226,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
     You can additionally use the `ClientToServerPayload` and `ServerToClientPayload` helper types to get the payload type for a specific event.
 
-    ```tsx title=src/ChatPage.tsx
+    ```tsx title="src/ChatPage.tsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -299,7 +299,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -312,7 +312,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 

--- a/web/versioned_docs/version-0.13.0/auth/entities/_get-email.md
+++ b/web/versioned_docs/version-0.13.0/auth/entities/_get-email.md
@@ -11,7 +11,7 @@ The `getEmail` helper returns the user's email or `null` if the user doesn't hav
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { getEmail } from 'wasp/auth'
 
     export const createTask = async (args, context) => {
@@ -31,7 +31,7 @@ The `getEmail` helper returns the user's email or `null` if the user doesn't hav
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { getEmail } from 'wasp/auth'
 
     export const createTask: CreateTask<...>  = async (args, context) => {

--- a/web/versioned_docs/version-0.13.0/auth/entities/_get-username.md
+++ b/web/versioned_docs/version-0.13.0/auth/entities/_get-username.md
@@ -11,7 +11,7 @@ The `getUsername` helper returns the user's username or `null` if the user doesn
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { getUsername } from 'wasp/auth'
 
     export const createTask = async (args, context) => {
@@ -31,7 +31,7 @@ The `getUsername` helper returns the user's username or `null` if the user doesn
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { getUsername } from 'wasp/auth'
 
     export const createTask: CreateTask<...>  = async (args, context) => {

--- a/web/versioned_docs/version-0.13.0/auth/entities/entities.md
+++ b/web/versioned_docs/version-0.13.0/auth/entities/entities.md
@@ -67,7 +67,7 @@ entity Auth {=psl
   id         String         @id @default(uuid())
   userId     Int?           @unique
   // Wasp injects this relation on the User entity as well
-  user       User?          @relation(fields: [userId], references: [id], onDelete: Cascade) 
+  user       User?          @relation(fields: [userId], references: [id], onDelete: Cascade)
   identities AuthIdentity[]
   sessions   Session[]
 psl=}
@@ -95,7 +95,7 @@ entity AuthIdentity {=psl
   authId         String
   auth           Auth   @relation(fields: [authId], references: [id], onDelete: Cascade)
 
-  @@id([providerName, providerUserId])  
+  @@id([providerName, providerUserId])
 psl=}
 ```
 
@@ -168,7 +168,7 @@ The `getFirstProviderUserId` helper returns the first user ID (e.g. `username` o
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { getFirstProviderUserId } from 'wasp/auth'
 
     export const createTask = async (args, context) => {
@@ -188,7 +188,7 @@ The `getFirstProviderUserId` helper returns the first user ID (e.g. `username` o
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { getFirstProviderUserId } from 'wasp/auth'
 
     export const createTask: CreateTask<...>  = async (args, context) => {
@@ -229,7 +229,7 @@ This can be useful if you want to check if the user has a specific auth identity
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { findUserIdentity } from 'wasp/client/auth'
 
     export const createTask = async (args, context) => {
@@ -261,7 +261,7 @@ This can be useful if you want to check if the user has a specific auth identity
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { findUserIdentity } from 'wasp/client/auth'
 
     export const createTask: CreateTask<...>  = async (args, context) => {

--- a/web/versioned_docs/version-0.13.0/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.13.0/auth/social-auth/github.md
@@ -257,7 +257,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -380,7 +380,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```js title=src/auth/github.js
+    ```js title="src/auth/github.js"
     export const userSignupFields = {
       username: () => "hardcoded-username",
       displayName: (data) => data.profile.name,
@@ -424,7 +424,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```ts title=src/auth/github.ts
+    ```ts title="src/auth/github.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -507,7 +507,7 @@ The `gitHub` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/github.js
+      ```js title="src/auth/github.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -517,7 +517,7 @@ The `gitHub` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/github.ts
+      ```ts title="src/auth/github.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/versioned_docs/version-0.13.0/auth/social-auth/google.md
+++ b/web/versioned_docs/version-0.13.0/auth/social-auth/google.md
@@ -302,7 +302,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -321,7 +321,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -410,7 +410,7 @@ The fields you receive depend on the scopes you request. The default scope is se
     // ...
     ```
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       username: () => "hardcoded-username",
       displayName: (data) => data.profile.name,
@@ -454,7 +454,7 @@ The fields you receive depend on the scopes you request. The default scope is se
     // ...
     ```
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -537,7 +537,7 @@ The `google` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/google.js
+      ```js title="src/auth/google.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -547,7 +547,7 @@ The `google` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/google.ts
+      ```ts title="src/auth/google.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/versioned_docs/version-0.13.0/auth/social-auth/keycloak.md
+++ b/web/versioned_docs/version-0.13.0/auth/social-auth/keycloak.md
@@ -267,7 +267,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -286,7 +286,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -368,7 +368,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/keycloak.js
+    ```js title="src/auth/keycloak.js"
     export const userSignupFields = {
       username: () => "hardcoded-username",
       displayName: (data) => data.profile.name,
@@ -412,7 +412,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/keycloak.ts
+    ```ts title="src/auth/keycloak.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -495,7 +495,7 @@ The `keycloak` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/keycloak.js
+      ```js title="src/auth/keycloak.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -505,7 +505,7 @@ The `keycloak` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/keycloak.ts
+      ```ts title="src/auth/keycloak.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/versioned_docs/version-0.13.0/auth/social-auth/overview.md
+++ b/web/versioned_docs/version-0.13.0/auth/social-auth/overview.md
@@ -32,7 +32,7 @@ Here's what the full setup looks like:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -57,7 +57,7 @@ Here's what the full setup looks like:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -112,7 +112,7 @@ Let's go through both steps in more detail.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     entity User {=psl
         id                        Int           @id @default(autoincrement())
         username                  String?       @unique
@@ -123,7 +123,7 @@ Let's go through both steps in more detail.
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     entity User {=psl
         id                        Int           @id @default(autoincrement())
         username                  String?       @unique
@@ -140,7 +140,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -163,7 +163,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function.
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       isSignupComplete: () => false,
     }
@@ -171,7 +171,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.13.0"
@@ -194,7 +194,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function:
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -218,7 +218,7 @@ For example:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/HomePage.jsx
+    ```jsx title="src/HomePage.jsx"
     import { useAuth } from 'wasp/client/auth'
     import { Redirect } from 'react-router-dom'
 
@@ -235,7 +235,7 @@ For example:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/HomePage.tsx
+    ```tsx title="src/HomePage.tsx"
     import { useAuth } from 'wasp/client/auth'
     import { Redirect } from 'react-router-dom'
 
@@ -276,7 +276,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/LoginPage.jsx
+    ```jsx title="src/LoginPage.jsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,
@@ -299,7 +299,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/LoginPage.tsx
+    ```tsx title="src/LoginPage.tsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,

--- a/web/versioned_docs/version-0.13.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.13.0/data-model/backends.md
@@ -34,7 +34,7 @@ To run your Wasp app in production, you'll need to switch from SQLite to Postgre
 
 1. Set the `app.db.system` field to PostgreSQL.
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 app MyApp {
   title: "My app",
   // ...
@@ -111,7 +111,7 @@ You can define as many **seed functions** as you want in an array under the `app
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -126,7 +126,7 @@ You can define as many **seed functions** as you want in an array under the `app
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -314,7 +314,7 @@ Here's an example that uses the `app.db` field to its full potential:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -332,7 +332,7 @@ Here's an example that uses the `app.db` field to its full potential:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -438,7 +438,7 @@ Use one of the following commands to run the seed functions:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {
@@ -453,7 +453,7 @@ Use one of the following commands to run the seed functions:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {

--- a/web/versioned_docs/version-0.13.0/data-model/crud.md
+++ b/web/versioned_docs/version-0.13.0/data-model/crud.md
@@ -149,7 +149,7 @@ Here's the `src/tasks.{js,ts}` file:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -179,7 +179,7 @@ Here's the `src/tasks.{js,ts}` file:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { type Tasks } from 'wasp/server/crud'
     import { type Task } from 'wasp/entities'
     import { HttpError } from 'wasp/server'

--- a/web/versioned_docs/version-0.13.0/data-model/operations/actions.md
+++ b/web/versioned_docs/version-0.13.0/data-model/operations/actions.md
@@ -236,7 +236,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -270,7 +270,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -315,7 +315,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/actions.js
+    ```js title="src/actions.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -329,7 +329,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/actions.ts
+    ```ts title="src/actions.ts"
     import { type CreateTask } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -583,7 +583,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `createfoo` from the file `src/actions.js`
 
-    ```js title=actions.js
+    ```js title="actions.js"
     export const createFoo = (args, context) => {
       // implementation
     }
@@ -604,7 +604,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `CreateFoo` and specify the Action's inputs and outputs using its type arguments.
 
-    ```ts title=actions.ts
+    ```ts title="actions.ts"
     import { type CreateFoo } from 'wasp/server/operations'
 
     type Foo = // ...
@@ -662,7 +662,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     import {
       useQuery,
@@ -713,7 +713,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     import {
       useQuery,

--- a/web/versioned_docs/version-0.13.0/data-model/operations/queries.md
+++ b/web/versioned_docs/version-0.13.0/data-model/operations/queries.md
@@ -213,7 +213,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/MainPage.jsx
+    ```jsx title="src/MainPage.jsx"
     import React from 'react'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
 
@@ -262,7 +262,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/MainPage.tsx
+    ```tsx title="src/MainPage.tsx"
     import React from 'react'
     import { type Task } from 'wasp/entities'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
@@ -328,7 +328,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/queries.js
+    ```js title="src/queries.js"
     import { HttpError } from 'wasp/server'
 
     export const getAllTasks = async (args, context) => {
@@ -342,7 +342,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/queries.ts
+    ```ts title="src/queries.ts"
     import { type GetAllTasks } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -552,7 +552,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `getFoo` from the file `src/queries.js`
 
-    ```js title=queries.js
+    ```js title="queries.js"
     export const getFoo = (args, context) => {
       // implementation
     }
@@ -573,7 +573,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `GetFoo` and specify the Query's inputs and outputs using its type arguments.
 
-    ```ts title=queries.ts
+    ```ts title="queries.ts"
     import { type GetFoo } from 'wasp/server/operations'
 
     type Foo = // ...

--- a/web/versioned_docs/version-0.13.0/project/testing.md
+++ b/web/versioned_docs/version-0.13.0/project/testing.md
@@ -161,7 +161,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```js title=src/Todo.test.jsx
+    ```js title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -215,7 +215,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -280,7 +280,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```jsx title=src/Todo.test.jsx
+    ```jsx title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -341,7 +341,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 

--- a/web/versioned_docs/version-0.14.0/advanced/middleware-config.md
+++ b/web/versioned_docs/version-0.14.0/advanced/middleware-config.md
@@ -82,7 +82,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -93,7 +93,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.js
+    ```ts title="src/serverSetup.js"
     import cors from 'cors'
     import { config } from 'wasp/server'
 
@@ -106,7 +106,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -117,7 +117,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.ts
+    ```ts title="src/serverSetup.ts"
     import cors from 'cors'
     import { config, type MiddlewareConfigFn } from 'wasp/server'
 
@@ -136,7 +136,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -147,7 +147,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     import express from 'express'
 
     export const webhookCallback = (req, res, _context) => {
@@ -167,7 +167,7 @@ If you would like to modify the middleware for a single API, you can do somethin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -178,7 +178,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type WebhookCallback } from 'wasp/server/api'
     import { type MiddlewareConfigFn } from 'wasp/server'
@@ -215,7 +215,7 @@ If you would like to modify the middleware for all API routes under some common 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -224,7 +224,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     export const fooBarNamespaceMiddlewareFn = (middlewareConfig) => {
       const customMiddleware = (_req, _res, next) => {
         console.log('fooBarNamespaceMiddlewareFn: custom middleware')
@@ -239,7 +239,7 @@ If you would like to modify the middleware for all API routes under some common 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -248,7 +248,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type MiddlewareConfigFn } from 'wasp/server'
 

--- a/web/versioned_docs/version-0.14.0/advanced/web-sockets.md
+++ b/web/versioned_docs/version-0.14.0/advanced/web-sockets.md
@@ -25,7 +25,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -38,7 +38,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -71,7 +71,7 @@ This is how we can define our `webSocketFn` function:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title=src/webSocket.js
+    ```ts title="src/webSocket.js"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
 
@@ -92,7 +92,7 @@ This is how we can define our `webSocketFn` function:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/webSocket.ts
+    ```ts title="src/webSocket.ts"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
     import { type WebSocketDefinition, type WaspSocketData } from 'wasp/server/webSocket'
@@ -164,7 +164,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title=src/ChatPage.jsx
+    ```tsx title="src/ChatPage.jsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -226,7 +226,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
     You can additionally use the `ClientToServerPayload` and `ServerToClientPayload` helper types to get the payload type for a specific event.
 
-    ```tsx title=src/ChatPage.tsx
+    ```tsx title="src/ChatPage.tsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -299,7 +299,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -312,7 +312,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 

--- a/web/versioned_docs/version-0.14.0/auth/entities/entities.md
+++ b/web/versioned_docs/version-0.14.0/auth/entities/entities.md
@@ -142,7 +142,7 @@ This can be useful if you support multiple authentication methods and you need _
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     export const createTask = async (args, context) => {
       const userId = context.user.getFirstProviderUserId()
       // ...
@@ -160,7 +160,7 @@ This can be useful if you support multiple authentication methods and you need _
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     export const createTask: CreateTask<...>  = async (args, context) => {
       const userId = context.user.getFirstProviderUserId()
       // ...

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/discord.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/discord.md
@@ -257,7 +257,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -276,7 +276,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -369,7 +369,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/discord.js
+    ```js title="src/auth/discord.js"
     export const userSignupFields = {
       username: (data) => data.profile.global_name,
       avatarUrl: (data) => data.profile.avatar,
@@ -415,7 +415,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/discord.ts
+    ```ts title="src/auth/discord.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -504,7 +504,7 @@ The `discord` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/discord.js
+      ```js title="src/auth/discord.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -514,7 +514,7 @@ The `discord` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/discord.ts
+      ```ts title="src/auth/discord.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/github.md
@@ -257,7 +257,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -382,7 +382,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```js title=src/auth/github.js
+    ```js title="src/auth/github.js"
     export const userSignupFields = {
       username: () => "hardcoded-username",
       displayName: (data) => data.profile.name,
@@ -428,7 +428,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```ts title=src/auth/github.ts
+    ```ts title="src/auth/github.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -517,7 +517,7 @@ The `gitHub` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/github.js
+      ```js title="src/auth/github.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -527,7 +527,7 @@ The `gitHub` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/github.ts
+      ```ts title="src/auth/github.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/google.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/google.md
@@ -302,7 +302,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -321,7 +321,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -412,7 +412,7 @@ The fields you receive depend on the scopes you request. The default scope is se
     // ...
     ```
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       username: () => "hardcoded-username",
       displayName: (data) => data.profile.name,
@@ -458,7 +458,7 @@ The fields you receive depend on the scopes you request. The default scope is se
     // ...
     ```
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -547,7 +547,7 @@ The `google` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/google.js
+      ```js title="src/auth/google.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -557,7 +557,7 @@ The `google` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/google.ts
+      ```ts title="src/auth/google.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/keycloak.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/keycloak.md
@@ -267,7 +267,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -286,7 +286,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -370,7 +370,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/keycloak.js
+    ```js title="src/auth/keycloak.js"
     export const userSignupFields = {
       username: () => "hardcoded-username",
       displayName: (data) => data.profile.name,
@@ -416,7 +416,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/keycloak.ts
+    ```ts title="src/auth/keycloak.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -505,7 +505,7 @@ The `keycloak` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/keycloak.js
+      ```js title="src/auth/keycloak.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -515,7 +515,7 @@ The `keycloak` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/keycloak.ts
+      ```ts title="src/auth/keycloak.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/versioned_docs/version-0.14.0/auth/social-auth/overview.md
+++ b/web/versioned_docs/version-0.14.0/auth/social-auth/overview.md
@@ -32,7 +32,7 @@ Here's what the full setup looks like:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -58,7 +58,7 @@ Here's what the full setup looks like:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -110,7 +110,7 @@ Let's go through both steps in more detail.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```prisma title=schema.prisma
+    ```prisma title="schema.prisma"
     model User {
       id               Int     @id @default(autoincrement())
       username         String? @unique
@@ -121,7 +121,7 @@ Let's go through both steps in more detail.
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```prisma title=schema.prisma
+    ```prisma title="schema.prisma"
     model User {
       id               Int     @id @default(autoincrement())
       username         String? @unique
@@ -138,7 +138,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -161,7 +161,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function.
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       isSignupComplete: () => false,
     }
@@ -169,7 +169,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.14.0"
@@ -192,7 +192,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function:
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -216,7 +216,7 @@ For example:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/HomePage.jsx
+    ```jsx title="src/HomePage.jsx"
     import { useAuth } from 'wasp/client/auth'
     import { Redirect } from 'react-router-dom'
 
@@ -233,7 +233,7 @@ For example:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/HomePage.tsx
+    ```tsx title="src/HomePage.tsx"
     import { useAuth } from 'wasp/client/auth'
     import { Redirect } from 'react-router-dom'
 
@@ -274,7 +274,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/LoginPage.jsx
+    ```jsx title="src/LoginPage.jsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,
@@ -297,7 +297,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/LoginPage.tsx
+    ```tsx title="src/LoginPage.tsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,

--- a/web/versioned_docs/version-0.14.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.14.0/data-model/backends.md
@@ -157,7 +157,7 @@ You can define as many **seed functions** as you want in an array under the `app
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -171,7 +171,7 @@ You can define as many **seed functions** as you want in an array under the `app
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -314,7 +314,7 @@ You'll often want to call `wasp db seed` right after you run `wasp db reset`, as
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -328,7 +328,7 @@ You'll often want to call `wasp db seed` right after you run `wasp db reset`, as
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -364,7 +364,7 @@ Use one of the following commands to run the seed functions:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {
@@ -378,7 +378,7 @@ Use one of the following commands to run the seed functions:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {

--- a/web/versioned_docs/version-0.14.0/data-model/crud.md
+++ b/web/versioned_docs/version-0.14.0/data-model/crud.md
@@ -157,7 +157,7 @@ Here's the `src/tasks.{js,ts}` file:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -187,7 +187,7 @@ Here's the `src/tasks.{js,ts}` file:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { type Tasks } from 'wasp/server/crud'
     import { type Task } from 'wasp/entities'
     import { HttpError } from 'wasp/server'

--- a/web/versioned_docs/version-0.14.0/data-model/operations/actions.md
+++ b/web/versioned_docs/version-0.14.0/data-model/operations/actions.md
@@ -293,7 +293,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -327,7 +327,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -413,7 +413,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/actions.js
+    ```js title="src/actions.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -427,7 +427,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/actions.ts
+    ```ts title="src/actions.ts"
     import { type CreateTask } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -685,7 +685,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `createfoo` from the file `src/actions.js`
 
-    ```js title=actions.js
+    ```js title="actions.js"
     export const createFoo = (args, context) => {
       // implementation
     }
@@ -706,7 +706,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `CreateFoo` and specify the Action's inputs and outputs using its type arguments.
 
-    ```ts title=actions.ts
+    ```ts title="actions.ts"
     import { type CreateFoo } from 'wasp/server/operations'
 
     type Foo = // ...
@@ -764,7 +764,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     import {
       useQuery,
@@ -815,7 +815,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     import {
       useQuery,

--- a/web/versioned_docs/version-0.14.0/data-model/operations/queries.md
+++ b/web/versioned_docs/version-0.14.0/data-model/operations/queries.md
@@ -311,7 +311,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/MainPage.jsx
+    ```jsx title="src/MainPage.jsx"
     import React from 'react'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
 
@@ -360,7 +360,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/MainPage.tsx
+    ```tsx title="src/MainPage.tsx"
     import React from 'react'
     import { type Task } from 'wasp/entities'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
@@ -426,7 +426,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/queries.js
+    ```js title="src/queries.js"
     import { HttpError } from 'wasp/server'
 
     export const getAllTasks = async (args, context) => {
@@ -440,7 +440,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/queries.ts
+    ```ts title="src/queries.ts"
     import { type GetAllTasks } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -656,7 +656,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `getFoo` from the file `src/queries.js`
 
-    ```js title=queries.js
+    ```js title="queries.js"
     export const getFoo = (args, context) => {
       // implementation
     }
@@ -677,7 +677,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `GetFoo` and specify the Query's inputs and outputs using its type arguments.
 
-    ```ts title=queries.ts
+    ```ts title="queries.ts"
     import { type GetFoo } from 'wasp/server/operations'
 
     type Foo = // ...

--- a/web/versioned_docs/version-0.14.0/general/typescript.md
+++ b/web/versioned_docs/version-0.14.0/general/typescript.md
@@ -43,7 +43,7 @@ model Task {
 
 And your `main.wasp` file defines the `getTaskInfo` query:
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 query getTaskInfo {
   fn: import { getTaskInfo } from "@src/queries",
   entities: [Task]
@@ -97,7 +97,7 @@ To migrate this file to TypeScript, all you have to do is:
   </TabItem>
 
   <TabItem value="after" label="After">
-    ```typescript title=src/queries.ts
+    ```typescript title="src/queries.ts"
     import HttpError from 'wasp/server'
     // highlight-next-line
     import { type Task } from '@wasp/entities'

--- a/web/versioned_docs/version-0.14.0/migrate-from-0-13-to-0-14.md
+++ b/web/versioned_docs/version-0.14.0/migrate-from-0-13-to-0-14.md
@@ -117,7 +117,7 @@ new version of the file and reapplying them.
 
 Here's the new version of the `tsconfig.json` file:
 
-```json title=tsconfig.json
+```json title="tsconfig.json"
 // =============================== IMPORTANT =================================
 //
 // This file is only used for Wasp IDE support. You can change it to configure
@@ -409,7 +409,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getUsername } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -429,7 +429,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const username = context.user.identities.username?.id
            // ...
@@ -455,7 +455,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getEmail } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -475,7 +475,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const email = context.user.identities.email?.id
            // ...
@@ -541,7 +541,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getFirstProviderUserId } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -561,7 +561,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const userId = user.getFirstProviderUserId()
            // ...
@@ -589,7 +589,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { findUserIdentity } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -612,7 +612,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            if (context.user.identities.username) {
                // ...

--- a/web/versioned_docs/version-0.14.0/project/testing.md
+++ b/web/versioned_docs/version-0.14.0/project/testing.md
@@ -161,7 +161,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```js title=src/Todo.test.jsx
+    ```js title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -215,7 +215,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -280,7 +280,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```jsx title=src/Todo.test.jsx
+    ```jsx title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -341,7 +341,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 

--- a/web/versioned_docs/version-0.15.0/advanced/middleware-config.md
+++ b/web/versioned_docs/version-0.15.0/advanced/middleware-config.md
@@ -82,7 +82,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -92,7 +92,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.js
+    ```ts title="src/serverSetup.js"
     import cors from 'cors'
     import { config } from 'wasp/server'
 
@@ -105,7 +105,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -115,7 +115,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.ts
+    ```ts title="src/serverSetup.ts"
     import cors from 'cors'
     import { config, type MiddlewareConfigFn } from 'wasp/server'
 
@@ -134,7 +134,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -145,7 +145,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     import express from 'express'
 
     export const webhookCallback = (req, res, _context) => {
@@ -165,7 +165,7 @@ If you would like to modify the middleware for a single API, you can do somethin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -176,7 +176,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type WebhookCallback } from 'wasp/server/api'
     import { type MiddlewareConfigFn } from 'wasp/server'
@@ -213,7 +213,7 @@ If you would like to modify the middleware for all API routes under some common 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -222,7 +222,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     export const fooBarNamespaceMiddlewareFn = (middlewareConfig) => {
       const customMiddleware = (_req, _res, next) => {
         console.log('fooBarNamespaceMiddlewareFn: custom middleware')
@@ -237,7 +237,7 @@ If you would like to modify the middleware for all API routes under some common 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -246,7 +246,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type MiddlewareConfigFn } from 'wasp/server'
 

--- a/web/versioned_docs/version-0.15.0/advanced/web-sockets.md
+++ b/web/versioned_docs/version-0.15.0/advanced/web-sockets.md
@@ -25,7 +25,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -38,7 +38,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -71,7 +71,7 @@ This is how we can define our `webSocketFn` function:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title=src/webSocket.js
+    ```ts title="src/webSocket.js"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
 
@@ -92,7 +92,7 @@ This is how we can define our `webSocketFn` function:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/webSocket.ts
+    ```ts title="src/webSocket.ts"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
     import { type WebSocketDefinition, type WaspSocketData } from 'wasp/server/webSocket'
@@ -164,7 +164,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title=src/ChatPage.jsx
+    ```tsx title="src/ChatPage.jsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -226,7 +226,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
     You can additionally use the `ClientToServerPayload` and `ServerToClientPayload` helper types to get the payload type for a specific event.
 
-    ```tsx title=src/ChatPage.tsx
+    ```tsx title="src/ChatPage.tsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -299,7 +299,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -312,7 +312,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 

--- a/web/versioned_docs/version-0.15.0/auth/entities/entities.md
+++ b/web/versioned_docs/version-0.15.0/auth/entities/entities.md
@@ -142,7 +142,7 @@ This can be useful if you support multiple authentication methods and you need _
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     export const createTask = async (args, context) => {
       const userId = context.user.getFirstProviderUserId()
       // ...
@@ -160,7 +160,7 @@ This can be useful if you support multiple authentication methods and you need _
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     export const createTask: CreateTask<...>  = async (args, context) => {
       const userId = context.user.getFirstProviderUserId()
       // ...

--- a/web/versioned_docs/version-0.15.0/auth/social-auth/discord.md
+++ b/web/versioned_docs/version-0.15.0/auth/social-auth/discord.md
@@ -257,7 +257,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -276,7 +276,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -369,7 +369,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/discord.js
+    ```js title="src/auth/discord.js"
     export const userSignupFields = {
       username: (data) => data.profile.global_name,
       avatarUrl: (data) => data.profile.avatar,
@@ -415,7 +415,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/discord.ts
+    ```ts title="src/auth/discord.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -504,7 +504,7 @@ The `discord` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/discord.js
+      ```js title="src/auth/discord.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -514,7 +514,7 @@ The `discord` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/discord.ts
+      ```ts title="src/auth/discord.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/versioned_docs/version-0.15.0/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.15.0/auth/social-auth/github.md
@@ -257,7 +257,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -382,7 +382,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```js title=src/auth/github.js
+    ```js title="src/auth/github.js"
     export const userSignupFields = {
       username: () => 'hardcoded-username',
       displayName: (data) => data.profile.name,
@@ -428,7 +428,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```ts title=src/auth/github.ts
+    ```ts title="src/auth/github.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -517,7 +517,7 @@ The `gitHub` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/github.js
+      ```js title="src/auth/github.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -527,7 +527,7 @@ The `gitHub` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/github.ts
+      ```ts title="src/auth/github.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/versioned_docs/version-0.15.0/auth/social-auth/google.md
+++ b/web/versioned_docs/version-0.15.0/auth/social-auth/google.md
@@ -302,7 +302,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -321,7 +321,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -412,7 +412,7 @@ The fields you receive depend on the scopes you request. The default scope is se
     // ...
     ```
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       username: () => 'hardcoded-username',
       displayName: (data) => data.profile.name,
@@ -458,7 +458,7 @@ The fields you receive depend on the scopes you request. The default scope is se
     // ...
     ```
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -547,7 +547,7 @@ The `google` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/google.js
+      ```js title="src/auth/google.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -557,7 +557,7 @@ The `google` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/google.ts
+      ```ts title="src/auth/google.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/versioned_docs/version-0.15.0/auth/social-auth/keycloak.md
+++ b/web/versioned_docs/version-0.15.0/auth/social-auth/keycloak.md
@@ -267,7 +267,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -286,7 +286,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -370,7 +370,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/keycloak.js
+    ```js title="src/auth/keycloak.js"
     export const userSignupFields = {
       username: () => 'hardcoded-username',
       displayName: (data) => data.profile.name,
@@ -416,7 +416,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/keycloak.ts
+    ```ts title="src/auth/keycloak.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -505,7 +505,7 @@ The `keycloak` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/keycloak.js
+      ```js title="src/auth/keycloak.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -515,7 +515,7 @@ The `keycloak` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/keycloak.ts
+      ```ts title="src/auth/keycloak.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/versioned_docs/version-0.15.0/auth/social-auth/overview.md
+++ b/web/versioned_docs/version-0.15.0/auth/social-auth/overview.md
@@ -32,7 +32,7 @@ Here's what the full setup looks like:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -58,7 +58,7 @@ Here's what the full setup looks like:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -110,7 +110,7 @@ Let's go through both steps in more detail.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```prisma title=schema.prisma
+    ```prisma title="schema.prisma"
     model User {
       id               Int     @id @default(autoincrement())
       username         String? @unique
@@ -121,7 +121,7 @@ Let's go through both steps in more detail.
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```prisma title=schema.prisma
+    ```prisma title="schema.prisma"
     model User {
       id               Int     @id @default(autoincrement())
       username         String? @unique
@@ -138,7 +138,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -161,7 +161,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function.
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       isSignupComplete: () => false,
     }
@@ -169,7 +169,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "^0.15.0"
@@ -192,7 +192,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function:
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -216,7 +216,7 @@ For example:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/HomePage.jsx
+    ```jsx title="src/HomePage.jsx"
     import { useAuth } from 'wasp/client/auth'
     import { Navigate } from 'react-router-dom'
 
@@ -233,7 +233,7 @@ For example:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/HomePage.tsx
+    ```tsx title="src/HomePage.tsx"
     import { useAuth } from 'wasp/client/auth'
     import { Navigate } from 'react-router-dom'
 
@@ -274,7 +274,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/LoginPage.jsx
+    ```jsx title="src/LoginPage.jsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,
@@ -297,7 +297,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/LoginPage.tsx
+    ```tsx title="src/LoginPage.tsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,

--- a/web/versioned_docs/version-0.15.0/data-model/backends.md
+++ b/web/versioned_docs/version-0.15.0/data-model/backends.md
@@ -157,7 +157,7 @@ You can define as many **seed functions** as you want in an array under the `app
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -171,7 +171,7 @@ You can define as many **seed functions** as you want in an array under the `app
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -314,7 +314,7 @@ You'll often want to call `wasp db seed` right after you run `wasp db reset`, as
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -328,7 +328,7 @@ You'll often want to call `wasp db seed` right after you run `wasp db reset`, as
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -364,7 +364,7 @@ Use one of the following commands to run the seed functions:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {
@@ -378,7 +378,7 @@ Use one of the following commands to run the seed functions:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {

--- a/web/versioned_docs/version-0.15.0/data-model/crud.md
+++ b/web/versioned_docs/version-0.15.0/data-model/crud.md
@@ -157,7 +157,7 @@ Here's the `src/tasks.{js,ts}` file:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -187,7 +187,7 @@ Here's the `src/tasks.{js,ts}` file:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { type Tasks } from 'wasp/server/crud'
     import { type Task } from 'wasp/entities'
     import { HttpError } from 'wasp/server'

--- a/web/versioned_docs/version-0.15.0/data-model/operations/actions.md
+++ b/web/versioned_docs/version-0.15.0/data-model/operations/actions.md
@@ -293,7 +293,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -327,7 +327,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -413,7 +413,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/actions.js
+    ```js title="src/actions.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -427,7 +427,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/actions.ts
+    ```ts title="src/actions.ts"
     import { type CreateTask } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -685,7 +685,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `createfoo` from the file `src/actions.js`
 
-    ```js title=actions.js
+    ```js title="actions.js"
     export const createFoo = (args, context) => {
       // implementation
     }
@@ -706,7 +706,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `CreateFoo` and specify the Action's inputs and outputs using its type arguments.
 
-    ```ts title=actions.ts
+    ```ts title="actions.ts"
     import { type CreateFoo } from 'wasp/server/operations'
 
     type Foo = // ...
@@ -764,7 +764,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     import {
       useQuery,
@@ -815,7 +815,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     import {
       useQuery,

--- a/web/versioned_docs/version-0.15.0/data-model/operations/queries.md
+++ b/web/versioned_docs/version-0.15.0/data-model/operations/queries.md
@@ -311,7 +311,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/MainPage.jsx
+    ```jsx title="src/MainPage.jsx"
     import React from 'react'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
 
@@ -360,7 +360,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/MainPage.tsx
+    ```tsx title="src/MainPage.tsx"
     import React from 'react'
     import { type Task } from 'wasp/entities'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
@@ -426,7 +426,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/queries.js
+    ```js title="src/queries.js"
     import { HttpError } from 'wasp/server'
 
     export const getAllTasks = async (args, context) => {
@@ -440,7 +440,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/queries.ts
+    ```ts title="src/queries.ts"
     import { type GetAllTasks } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -656,7 +656,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `getFoo` from the file `src/queries.js`
 
-    ```js title=queries.js
+    ```js title="queries.js"
     export const getFoo = (args, context) => {
       // implementation
     }
@@ -677,7 +677,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `GetFoo` and specify the Query's inputs and outputs using its type arguments.
 
-    ```ts title=queries.ts
+    ```ts title="queries.ts"
     import { type GetFoo } from 'wasp/server/operations'
 
     type Foo = // ...

--- a/web/versioned_docs/version-0.15.0/general/typescript.md
+++ b/web/versioned_docs/version-0.15.0/general/typescript.md
@@ -43,7 +43,7 @@ model Task {
 
 And your `main.wasp` file defines the `getTaskInfo` query:
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 query getTaskInfo {
   fn: import { getTaskInfo } from "@src/queries",
   entities: [Task]
@@ -97,7 +97,7 @@ To migrate this file to TypeScript, all you have to do is:
   </TabItem>
 
   <TabItem value="after" label="After">
-    ```typescript title=src/queries.ts
+    ```typescript title="src/queries.ts"
     import HttpError from 'wasp/server'
     // highlight-next-line
     import { type Task } from '@wasp/entities'

--- a/web/versioned_docs/version-0.15.0/migration-guides/migrate-from-0-13-to-0-14.md
+++ b/web/versioned_docs/version-0.15.0/migration-guides/migrate-from-0-13-to-0-14.md
@@ -117,7 +117,7 @@ new version of the file and reapplying them.
 
 Here's the new version of the `tsconfig.json` file:
 
-```json title=tsconfig.json
+```json title="tsconfig.json"
 // =============================== IMPORTANT =================================
 //
 // This file is only used for Wasp IDE support. You can change it to configure
@@ -409,7 +409,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getUsername } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -429,7 +429,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const username = context.user.identities.username?.id
            // ...
@@ -455,7 +455,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getEmail } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -475,7 +475,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const email = context.user.identities.email?.id
            // ...
@@ -541,7 +541,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getFirstProviderUserId } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -561,7 +561,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const userId = user.getFirstProviderUserId()
            // ...
@@ -589,7 +589,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { findUserIdentity } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -612,7 +612,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            if (context.user.identities.username) {
                // ...

--- a/web/versioned_docs/version-0.15.0/project/testing.md
+++ b/web/versioned_docs/version-0.15.0/project/testing.md
@@ -161,7 +161,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```js title=src/Todo.test.jsx
+    ```js title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -215,7 +215,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -280,7 +280,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```jsx title=src/Todo.test.jsx
+    ```jsx title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -341,7 +341,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 

--- a/web/versioned_docs/version-0.16.0/advanced/middleware-config.md
+++ b/web/versioned_docs/version-0.16.0/advanced/middleware-config.md
@@ -82,7 +82,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -92,7 +92,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.js
+    ```ts title="src/serverSetup.js"
     import cors from 'cors'
     import { config } from 'wasp/server'
 
@@ -105,7 +105,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {6} title=main.wasp
+    ```wasp {6} title="main.wasp"
     app todoApp {
       // ...
 
@@ -115,7 +115,7 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
     }
     ```
 
-    ```ts title=src/serverSetup.ts
+    ```ts title="src/serverSetup.ts"
     import cors from 'cors'
     import { config, type MiddlewareConfigFn } from 'wasp/server'
 
@@ -134,7 +134,7 @@ If you would like to modify the middleware for a single API, you can do somethin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -145,7 +145,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     import express from 'express'
 
     export const webhookCallback = (req, res, _context) => {
@@ -165,7 +165,7 @@ If you would like to modify the middleware for a single API, you can do somethin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {5} title=main.wasp
+    ```wasp {5} title="main.wasp"
     // ...
 
     api webhookCallback {
@@ -176,7 +176,7 @@ If you would like to modify the middleware for a single API, you can do somethin
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type WebhookCallback } from 'wasp/server/api'
     import { type MiddlewareConfigFn } from 'wasp/server'
@@ -213,7 +213,7 @@ If you would like to modify the middleware for all API routes under some common 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -222,7 +222,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.js
+    ```ts title="src/apis.js"
     export const fooBarNamespaceMiddlewareFn = (middlewareConfig) => {
       const customMiddleware = (_req, _res, next) => {
         console.log('fooBarNamespaceMiddlewareFn: custom middleware')
@@ -237,7 +237,7 @@ If you would like to modify the middleware for all API routes under some common 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp {4} title=main.wasp
+    ```wasp {4} title="main.wasp"
     // ...
 
     apiNamespace fooBar {
@@ -246,7 +246,7 @@ If you would like to modify the middleware for all API routes under some common 
     }
     ```
 
-    ```ts title=src/apis.ts
+    ```ts title="src/apis.ts"
     import express from 'express'
     import { type MiddlewareConfigFn } from 'wasp/server'
 

--- a/web/versioned_docs/version-0.16.0/advanced/web-sockets.md
+++ b/web/versioned_docs/version-0.16.0/advanced/web-sockets.md
@@ -25,7 +25,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -38,7 +38,7 @@ We specify that we are using WebSockets by adding `webSocket` to our `app` and p
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -71,7 +71,7 @@ This is how we can define our `webSocketFn` function:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title=src/webSocket.js
+    ```ts title="src/webSocket.js"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
 
@@ -92,7 +92,7 @@ This is how we can define our `webSocketFn` function:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/webSocket.ts
+    ```ts title="src/webSocket.ts"
     import { v4 as uuidv4 } from 'uuid'
     import { getFirstProviderUserId } from 'wasp/auth'
     import { type WebSocketDefinition, type WaspSocketData } from 'wasp/server/webSocket'
@@ -164,7 +164,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title=src/ChatPage.jsx
+    ```tsx title="src/ChatPage.jsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -226,7 +226,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
     You can additionally use the `ClientToServerPayload` and `ServerToClientPayload` helper types to get the payload type for a specific event.
 
-    ```tsx title=src/ChatPage.tsx
+    ```tsx title="src/ChatPage.tsx"
     import React, { useState } from 'react'
     import {
       useSocket,
@@ -299,7 +299,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 
@@ -312,7 +312,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=todoApp.wasp
+    ```wasp title="todoApp.wasp"
     app todoApp {
       // ...
 

--- a/web/versioned_docs/version-0.16.0/auth/entities/entities.md
+++ b/web/versioned_docs/version-0.16.0/auth/entities/entities.md
@@ -142,7 +142,7 @@ This can be useful if you support multiple authentication methods and you need _
     }
     ```
 
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     export const createTask = async (args, context) => {
       const userId = context.user.getFirstProviderUserId()
       // ...
@@ -160,7 +160,7 @@ This can be useful if you support multiple authentication methods and you need _
     }
     ```
 
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     export const createTask: CreateTask<...>  = async (args, context) => {
       const userId = context.user.getFirstProviderUserId()
       // ...

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/create-your-own-ui.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/create-your-own-ui.md
@@ -13,7 +13,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/LoginPage.jsx
+    ```jsx title="src/LoginPage.jsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,
@@ -36,7 +36,7 @@ Wasp provides sign-in buttons and URLs for each of the supported social login pr
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/LoginPage.tsx
+    ```tsx title="src/LoginPage.tsx"
     import {
       GoogleSignInButton,
       googleSignInUrl,

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/discord.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/discord.md
@@ -257,7 +257,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -276,7 +276,7 @@ Add `discord: {}` to the `auth.methods` dictionary to use it with default settin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -369,7 +369,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/discord.js
+    ```js title="src/auth/discord.js"
     export const userSignupFields = {
       username: (data) => data.profile.global_name,
       avatarUrl: (data) => data.profile.avatar,
@@ -415,7 +415,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/discord.ts
+    ```ts title="src/auth/discord.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -504,7 +504,7 @@ The `discord` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/discord.js
+      ```js title="src/auth/discord.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -514,7 +514,7 @@ The `discord` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/discord.ts
+      ```ts title="src/auth/discord.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/github.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/github.md
@@ -257,7 +257,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -276,7 +276,7 @@ Add `gitHub: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -382,7 +382,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```js title=src/auth/github.js
+    ```js title="src/auth/github.js"
     export const userSignupFields = {
       username: () => 'hardcoded-username',
       displayName: (data) => data.profile.name,
@@ -428,7 +428,7 @@ The fields you receive will depend on the scopes you requested. By default we do
     // ...
     ```
 
-    ```ts title=src/auth/github.ts
+    ```ts title="src/auth/github.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -517,7 +517,7 @@ The `gitHub` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/github.js
+      ```js title="src/auth/github.js"
       export function getConfig() {
         return {
           scopes: [],
@@ -527,7 +527,7 @@ The `gitHub` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/github.ts
+      ```ts title="src/auth/github.ts"
       export function getConfig() {
         return {
           scopes: [],

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/google.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/google.md
@@ -302,7 +302,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -321,7 +321,7 @@ Add `google: {}` to the `auth.methods` dictionary to use it with default setting
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -412,7 +412,7 @@ The fields you receive depend on the scopes you request. The default scope is se
     // ...
     ```
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       username: () => 'hardcoded-username',
       displayName: (data) => data.profile.name,
@@ -458,7 +458,7 @@ The fields you receive depend on the scopes you request. The default scope is se
     // ...
     ```
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -547,7 +547,7 @@ The `google` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/google.js
+      ```js title="src/auth/google.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -557,7 +557,7 @@ The `google` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/google.ts
+      ```ts title="src/auth/google.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/keycloak.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/keycloak.md
@@ -267,7 +267,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -286,7 +286,7 @@ Add `keycloak: {}` to the `auth.methods` dictionary to use it with default setti
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -370,7 +370,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```js title=src/auth/keycloak.js
+    ```js title="src/auth/keycloak.js"
     export const userSignupFields = {
       username: () => 'hardcoded-username',
       displayName: (data) => data.profile.name,
@@ -416,7 +416,7 @@ The fields you receive will depend on the scopes you requested. The default scop
     // ...
     ```
 
-    ```ts title=src/auth/keycloak.ts
+    ```ts title="src/auth/keycloak.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -505,7 +505,7 @@ The `keycloak` dict has the following properties:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title=src/auth/keycloak.js
+      ```js title="src/auth/keycloak.js"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],
@@ -515,7 +515,7 @@ The `keycloak` dict has the following properties:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title=src/auth/keycloak.ts
+      ```ts title="src/auth/keycloak.ts"
       export function getConfig() {
         return {
           scopes: ['profile', 'email'],

--- a/web/versioned_docs/version-0.16.0/auth/social-auth/overview.md
+++ b/web/versioned_docs/version-0.16.0/auth/social-auth/overview.md
@@ -32,7 +32,7 @@ Here's what the full setup looks like:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -58,7 +58,7 @@ Here's what the full setup looks like:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -110,7 +110,7 @@ Let's go through both steps in more detail.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```prisma title=schema.prisma
+    ```prisma title="schema.prisma"
     model User {
       id               Int     @id @default(autoincrement())
       username         String? @unique
@@ -121,7 +121,7 @@ Let's go through both steps in more detail.
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```prisma title=schema.prisma
+    ```prisma title="schema.prisma"
     model User {
       id               Int     @id @default(autoincrement())
       username         String? @unique
@@ -138,7 +138,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -161,7 +161,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function.
 
-    ```js title=src/auth/google.js
+    ```js title="src/auth/google.js"
     export const userSignupFields = {
       isSignupComplete: () => false,
     }
@@ -169,7 +169,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app myApp {
       wasp: {
         version: "{latestWaspVersion}"
@@ -192,7 +192,7 @@ Declare an import under `app.auth.methods.google.userSignupFields` (the example 
 
     And implement the imported function:
 
-    ```ts title=src/auth/google.ts
+    ```ts title="src/auth/google.ts"
     import { defineUserSignupFields } from 'wasp/server/auth'
 
     export const userSignupFields = defineUserSignupFields({
@@ -218,7 +218,7 @@ For example:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/HomePage.jsx
+    ```jsx title="src/HomePage.jsx"
     import { Navigate } from 'react-router-dom'
 
     export function HomePage({ user }) {
@@ -232,7 +232,7 @@ For example:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/HomePage.tsx
+    ```tsx title="src/HomePage.tsx"
     import { Navigate } from 'react-router-dom'
     import { AuthUser } from 'wasp/auth'
 

--- a/web/versioned_docs/version-0.16.0/data-model/crud.md
+++ b/web/versioned_docs/version-0.16.0/data-model/crud.md
@@ -157,7 +157,7 @@ Here's the `src/tasks.{js,ts}` file:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/tasks.js
+    ```js title="src/tasks.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -187,7 +187,7 @@ Here's the `src/tasks.{js,ts}` file:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/tasks.ts
+    ```ts title="src/tasks.ts"
     import { type Tasks } from 'wasp/server/crud'
     import { type Task } from 'wasp/entities'
     import { HttpError } from 'wasp/server'

--- a/web/versioned_docs/version-0.16.0/data-model/databases.md
+++ b/web/versioned_docs/version-0.16.0/data-model/databases.md
@@ -157,7 +157,7 @@ You can define as many **seed functions** as you want in an array under the `app
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -171,7 +171,7 @@ You can define as many **seed functions** as you want in an array under the `app
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       // ...
       db: {
@@ -314,7 +314,7 @@ You'll often want to call `wasp db seed` right after you run `wasp db reset`, as
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -328,7 +328,7 @@ You'll often want to call `wasp db seed` right after you run `wasp db reset`, as
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```wasp title=main.wasp
+    ```wasp title="main.wasp"
     app MyApp {
       title: "My app",
       // ...
@@ -364,7 +364,7 @@ Use one of the following commands to run the seed functions:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {
@@ -378,7 +378,7 @@ Use one of the following commands to run the seed functions:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```wasp title=main.wasp
+      ```wasp title="main.wasp"
       app MyApp {
         // ...
         db: {

--- a/web/versioned_docs/version-0.16.0/data-model/operations/actions.md
+++ b/web/versioned_docs/version-0.16.0/data-model/operations/actions.md
@@ -293,7 +293,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -327,7 +327,7 @@ When using Actions on the client, you'll most likely want to use them inside a c
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     // highlight-next-line
     import { useQuery, getTask, markTaskAsDone } from 'wasp/client/operations'
@@ -413,7 +413,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/actions.js
+    ```js title="src/actions.js"
     import { HttpError } from 'wasp/server'
 
     export const createTask = async (args, context) => {
@@ -427,7 +427,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/actions.ts
+    ```ts title="src/actions.ts"
     import { type CreateTask } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -685,7 +685,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `createfoo` from the file `src/actions.js`
 
-    ```js title=actions.js
+    ```js title="actions.js"
     export const createFoo = (args, context) => {
       // implementation
     }
@@ -706,7 +706,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `CreateFoo` and specify the Action's inputs and outputs using its type arguments.
 
-    ```ts title=actions.ts
+    ```ts title="actions.ts"
     import { type CreateFoo } from 'wasp/server/operations'
 
     type Foo = // ...
@@ -764,7 +764,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/pages/Task.jsx
+    ```jsx title="src/pages/Task.jsx"
     import React from 'react'
     import {
       useQuery,
@@ -815,7 +815,7 @@ Here's an example showing how to configure the Action `markTaskAsDone` that togg
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/pages/Task.tsx
+    ```tsx title="src/pages/Task.tsx"
     import React from 'react'
     import {
       useQuery,

--- a/web/versioned_docs/version-0.16.0/data-model/operations/queries.md
+++ b/web/versioned_docs/version-0.16.0/data-model/operations/queries.md
@@ -311,7 +311,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```jsx title=src/MainPage.jsx
+    ```jsx title="src/MainPage.jsx"
     import React from 'react'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
 
@@ -360,7 +360,7 @@ Here's an example of calling the Queries using the `useQuery` hook:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```tsx title=src/MainPage.tsx
+    ```tsx title="src/MainPage.tsx"
     import React from 'react'
     import { type Task } from 'wasp/entities'
     import { useQuery, getAllTasks, getFilteredTasks } from 'wasp/client/operations'
@@ -426,7 +426,7 @@ If you do want to pass additional error information to the client, you can const
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title=src/queries.js
+    ```js title="src/queries.js"
     import { HttpError } from 'wasp/server'
 
     export const getAllTasks = async (args, context) => {
@@ -440,7 +440,7 @@ If you do want to pass additional error information to the client, you can const
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title=src/queries.ts
+    ```ts title="src/queries.ts"
     import { type GetAllTasks } from 'wasp/server/operations'
     import { HttpError } from 'wasp/server'
 
@@ -656,7 +656,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     Expects to find a named export `getFoo` from the file `src/queries.js`
 
-    ```js title=queries.js
+    ```js title="queries.js"
     export const getFoo = (args, context) => {
       // implementation
     }
@@ -677,7 +677,7 @@ Since both arguments are positional, you can name the parameters however you wan
 
     You can use the generated type `GetFoo` and specify the Query's inputs and outputs using its type arguments.
 
-    ```ts title=queries.ts
+    ```ts title="queries.ts"
     import { type GetFoo } from 'wasp/server/operations'
 
     type Foo = // ...

--- a/web/versioned_docs/version-0.16.0/general/typescript.md
+++ b/web/versioned_docs/version-0.16.0/general/typescript.md
@@ -43,7 +43,7 @@ model Task {
 
 And your `main.wasp` file defines the `getTaskInfo` query:
 
-```wasp title=main.wasp
+```wasp title="main.wasp"
 query getTaskInfo {
   fn: import { getTaskInfo } from "@src/queries",
   entities: [Task]
@@ -97,7 +97,7 @@ To migrate this file to TypeScript, all you have to do is:
   </TabItem>
 
   <TabItem value="after" label="After">
-    ```typescript title=src/queries.ts
+    ```typescript title="src/queries.ts"
     import HttpError from 'wasp/server'
     // highlight-next-line
     import { type Task } from '@wasp/entities'

--- a/web/versioned_docs/version-0.16.0/migration-guides/migrate-from-0-13-to-0-14.md
+++ b/web/versioned_docs/version-0.16.0/migration-guides/migrate-from-0-13-to-0-14.md
@@ -117,7 +117,7 @@ new version of the file and reapplying them.
 
 Here's the new version of the `tsconfig.json` file:
 
-```json title=tsconfig.json
+```json title="tsconfig.json"
 // =============================== IMPORTANT =================================
 //
 // This file is only used for Wasp IDE support. You can change it to configure
@@ -409,7 +409,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getUsername } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -429,7 +429,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const username = context.user.identities.username?.id
            // ...
@@ -455,7 +455,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getEmail } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -475,7 +475,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const email = context.user.identities.email?.id
            // ...
@@ -541,7 +541,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { getFirstProviderUserId } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -561,7 +561,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            const userId = user.getFirstProviderUserId()
            // ...
@@ -589,7 +589,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        import { findUserIdentity } from 'wasp/auth'
 
        export const createTask: CreateTask<...>  = async (args, context) => {
@@ -612,7 +612,7 @@ Follow the steps below to migrate:
        }
        ```
 
-       ```ts title=src/tasks.ts
+       ```ts title="src/tasks.ts"
        export const createTask: CreateTask<...>  = async (args, context) => {
            if (context.user.identities.username) {
                // ...

--- a/web/versioned_docs/version-0.16.0/project/testing.md
+++ b/web/versioned_docs/version-0.16.0/project/testing.md
@@ -161,7 +161,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```js title=src/Todo.test.jsx
+    ```js title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -215,7 +215,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -280,7 +280,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```jsx title=src/Todo.test.jsx
+    ```jsx title="src/Todo.test.jsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 
@@ -341,7 +341,7 @@ You can see some tests in a Wasp project [here](https://github.com/wasp-lang/was
     };
     ```
 
-    ```tsx title=src/Todo.test.tsx
+    ```tsx title="src/Todo.test.tsx"
     import { test, expect } from "vitest";
     import { screen } from "@testing-library/react";
 


### PR DESCRIPTION
In code blocks, Docusaurus needs the title of the file to be quoted, otherwise it doesn't show up.

I did a find-and-replace.

~~~diff
-```wasp title=main.wasp
+```wasp title="main.wasp"
~~~