### PR TITLE
Fix `FullConfig` propagation in `wasp-config` and other small fixes

### DIFF
--- a/waspc/packages/wasp-config/__tests__/mapUserSpecToAppSpecDecls.unit.test.ts
+++ b/waspc/packages/wasp-config/__tests__/mapUserSpecToAppSpecDecls.unit.test.ts
@@ -223,7 +223,6 @@ describe('mapAuthMethods', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideRoutes: undefined,
       shouldError: false,
     }
   ): void {
@@ -290,7 +289,6 @@ describe('mapEmailAuth', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideRoutes: undefined,
       shouldError: false,
     }
   ): void {
@@ -344,7 +342,6 @@ describe('mapEmailVerification', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideRoutes: undefined,
       shouldError: false,
     }
   ): void {
@@ -393,7 +390,6 @@ describe('mapPasswordReset', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideRoutes: undefined,
       shouldError: false,
     }
   ): void {
@@ -634,7 +630,6 @@ describe('mapOperation', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideEntities: undefined,
       shouldError: false,
     }
   ): void {
@@ -681,7 +676,6 @@ describe('mapCrud', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideEntities: undefined,
       shouldError: false,
     }
   ): void {
@@ -788,7 +782,6 @@ describe('mapApi', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideEntities: undefined,
       shouldError: false,
     }
   ): void {
@@ -853,7 +846,6 @@ describe('mapJob', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideEntities: undefined,
       shouldError: false,
     }
   ): void {

--- a/waspc/packages/wasp-config/__tests__/mapUserSpecToAppSpecDecls.unit.test.ts
+++ b/waspc/packages/wasp-config/__tests__/mapUserSpecToAppSpecDecls.unit.test.ts
@@ -122,7 +122,7 @@ describe('mapAuth', () => {
 
   test('should throw if emailVerification clientRoute ref is not provided when defined', () => {
     const auth = Fixtures.getAuth('full')
-    expect(auth.methods.email?.emailVerification.clientRoute).toBeDefined()
+    expect(auth.methods.email.emailVerification.clientRoute).toBeDefined()
     testMapAuth(auth, {
       overrideRoutes: [Fixtures.getRoute('password-reset').name],
       shouldError: true,
@@ -131,7 +131,7 @@ describe('mapAuth', () => {
 
   test('should throw if passwordReset clientRoute ref is not provided when defined', () => {
     const auth = Fixtures.getAuth('full')
-    expect(auth.methods.email?.passwordReset.clientRoute).toBeDefined()
+    expect(auth.methods.email.passwordReset.clientRoute).toBeDefined()
     testMapAuth(auth, {
       overrideRoutes: [Fixtures.getRoute('email-verification').name],
       shouldError: true,

--- a/waspc/packages/wasp-config/__tests__/mapUserSpecToAppSpecDecls.unit.test.ts
+++ b/waspc/packages/wasp-config/__tests__/mapUserSpecToAppSpecDecls.unit.test.ts
@@ -147,8 +147,6 @@ describe('mapAuth', () => {
           shouldError: boolean | undefined
         }
       | undefined = {
-      overrideEntities: undefined,
-      overrideRoutes: undefined,
       shouldError: false,
     }
   ): void {

--- a/waspc/packages/wasp-config/__tests__/mapUserSpecToAppSpecDecls.unit.test.ts
+++ b/waspc/packages/wasp-config/__tests__/mapUserSpecToAppSpecDecls.unit.test.ts
@@ -124,7 +124,7 @@ describe('mapAuth', () => {
     const auth = Fixtures.getAuth('full')
     expect(auth.methods.email.emailVerification.clientRoute).toBeDefined()
     testMapAuth(auth, {
-      overrideRoutes: [Fixtures.getRoute('password-reset').name],
+      overrideRoutes: [auth.methods.email.passwordReset.clientRoute],
       shouldError: true,
     })
   })
@@ -133,7 +133,7 @@ describe('mapAuth', () => {
     const auth = Fixtures.getAuth('full')
     expect(auth.methods.email.passwordReset.clientRoute).toBeDefined()
     testMapAuth(auth, {
-      overrideRoutes: [Fixtures.getRoute('email-verification').name],
+      overrideRoutes: [auth.methods.email.emailVerification.clientRoute],
       shouldError: true,
     })
   })

--- a/waspc/packages/wasp-config/__tests__/testFixtures.ts
+++ b/waspc/packages/wasp-config/__tests__/testFixtures.ts
@@ -7,15 +7,6 @@ import * as AppSpec from '../src/appSpec.js'
 import * as UserApi from '../src/userApi.js'
 
 /**
- * This type removes all properties from T that are optional.
- *
- * The empty object type - {} - doesn't behave how you expect in TypeScript.
- * It represents any value except null and undefined.
- * To represent empty objects, we use `Record<string, never>` instead.
- * @see https://www.totaltypescript.com/the-empty-object-type-in-typescript
- */
-
-/**
  * Creates a type containing only the required properties from T.
  *
  * This utility:
@@ -41,15 +32,12 @@ type MinimalConfig<T> = keyof T extends never
  *
  * This utility:
  * - Makes all properties required recursively (removes optional flags)
- * - Unwraps branded types to their base types (e.g., `string & {_brand: 'Page'}` → `string`)
- * - Useful for creating comprehensive configuration objects
+ * - Stops from unwrapping branded types fully
  *
  * @template T - The type to make fully required
  */
 type FullConfig<T> = T extends { _brand: string }
-  ? T extends infer BaseType & { _brand: string }
-    ? BaseType
-    : never
+  ? T
   : T extends object
     ? { [K in keyof T]-?: FullConfig<T[K]> }
     : T

--- a/waspc/packages/wasp-config/__tests__/testFixtures.ts
+++ b/waspc/packages/wasp-config/__tests__/testFixtures.ts
@@ -4,6 +4,7 @@
  */
 
 import * as AppSpec from '../src/appSpec.js'
+import { Branded } from '../src/branded.js'
 import * as UserApi from '../src/userApi.js'
 
 /**
@@ -36,11 +37,12 @@ type MinimalConfig<T> = keyof T extends never
  *
  * @template T - The type to make fully required
  */
-type FullConfig<T> = T extends { _brand: string }
-  ? T
-  : T extends object
-    ? { [K in keyof T]-?: FullConfig<T[K]> }
-    : T
+type FullConfig<T> =
+  T extends Branded<infer U, infer B>
+    ? Branded<U, B>
+    : T extends object
+      ? { [K in keyof T]-?: FullConfig<T[K]> }
+      : T
 
 export type Config<T> = MinimalConfig<T> | FullConfig<T>
 
@@ -377,7 +379,7 @@ export function getRoute(routeType: PageType): NamedConfig<UserApi.RouteConfig> 
       name: 'MinimalRoute',
       config: {
         path: '/foo/bar',
-        to: getPage(routeType).name as string & { _brand: 'Page' },
+        to: getPage(routeType).name as Branded<string, 'PageName'>,
       },
     } satisfies MinimalNamedConfig<UserApi.RouteConfig>
   }
@@ -395,7 +397,7 @@ export function getRoute(routeType: PageType): NamedConfig<UserApi.RouteConfig> 
     name,
     config: {
       path: '/foo/bar',
-      to: getPage(routeType).name as string & { _brand: 'Page' },
+      to: getPage(routeType).name as Branded<string, 'PageName'>,
     },
   } satisfies FullNamedConfig<UserApi.RouteConfig>
 }

--- a/waspc/packages/wasp-config/__tests__/testFixtures.ts
+++ b/waspc/packages/wasp-config/__tests__/testFixtures.ts
@@ -379,7 +379,7 @@ export function getRoute(routeType: PageType): NamedConfig<UserApi.RouteConfig> 
       name: 'MinimalRoute',
       config: {
         path: '/foo/bar',
-        to: getPage(routeType).name as Branded<string, 'PageName'>,
+        to: getPage(routeType).name as UserApi.PageName,
       },
     } satisfies MinimalNamedConfig<UserApi.RouteConfig>
   }
@@ -397,7 +397,7 @@ export function getRoute(routeType: PageType): NamedConfig<UserApi.RouteConfig> 
     name,
     config: {
       path: '/foo/bar',
-      to: getPage(routeType).name as Branded<string, 'PageName'>,
+      to: getPage(routeType).name as UserApi.PageName,
     },
   } satisfies FullNamedConfig<UserApi.RouteConfig>
 }

--- a/waspc/packages/wasp-config/__tests__/testFixtures.ts
+++ b/waspc/packages/wasp-config/__tests__/testFixtures.ts
@@ -14,6 +14,18 @@ import * as UserApi from '../src/userApi.js'
  * To represent empty objects, we use `Record<string, never>` instead.
  * @see https://www.totaltypescript.com/the-empty-object-type-in-typescript
  */
+
+/**
+ * Creates a type containing only the required properties from T.
+ *
+ * This utility:
+ * - Filters out optional properties from the type
+ * - Provides a clean type for minimal configuration objects
+ * - Returns `Record<string, never>` (empty object) when no required properties exist
+ *
+ * @template T - The type to extract required properties from
+ * @see https://www.totaltypescript.com/the-empty-object-type-in-typescript
+ */
 type MinimalConfig<T> = keyof T extends never
   ? Record<string, never>
   : {
@@ -23,10 +35,24 @@ type MinimalConfig<T> = keyof T extends never
       ? Record<string, never>
       : R
     : never
+
 /**
- * Required alias for domain consistency sake.
+ * Creates a type with all properties and nested properties required.
+ *
+ * This utility:
+ * - Makes all properties required recursively (removes optional flags)
+ * - Unwraps branded types to their base types (e.g., `string & {_brand: 'Page'}` → `string`)
+ * - Useful for creating comprehensive configuration objects
+ *
+ * @template T - The type to make fully required
  */
-type FullConfig<T> = Required<T>
+type FullConfig<T> = T extends { _brand: string }
+  ? T extends infer BaseType & { _brand: string }
+    ? BaseType
+    : never
+  : T extends object
+    ? { [K in keyof T]-?: FullConfig<T[K]> }
+    : T
 
 export type Config<T> = MinimalConfig<T> | FullConfig<T>
 

--- a/waspc/packages/wasp-config/src/branded.ts
+++ b/waspc/packages/wasp-config/src/branded.ts
@@ -1,0 +1,4 @@
+// Based on https://egghead.io/blog/using-branded-types-in-typescript
+declare const __brand: unique symbol
+type Brand<B> = { [__brand]: B }
+export type Branded<T, B> = T & Brand<B>

--- a/waspc/packages/wasp-config/src/run.ts
+++ b/waspc/packages/wasp-config/src/run.ts
@@ -10,7 +10,7 @@ main(process.argv)
  * Main function that processes command line arguments, analyzes the user app,
  * and writes the output to a file.
  */
-export async function main(args: string[]): Promise<void> {
+async function main(args: string[]): Promise<void> {
   const { waspTsSpecPath, outputFilePath, entityNames } = parseProcessArgsOrThrow(args)
 
   const declsResult = await analyzeUserApp(waspTsSpecPath, entityNames)

--- a/waspc/packages/wasp-config/src/userApi.ts
+++ b/waspc/packages/wasp-config/src/userApi.ts
@@ -264,7 +264,7 @@ export type RouteConfig = {
   to: PageName
 }
 
-type PageName = Branded<string, 'PageName'>
+export type PageName = Branded<string, 'PageName'>
 
 export type ServerConfig = {
   setupFn?: ExtImport

--- a/waspc/packages/wasp-config/src/userApi.ts
+++ b/waspc/packages/wasp-config/src/userApi.ts
@@ -2,6 +2,7 @@
  */
 import { GET_USER_SPEC } from './_private.js'
 import * as AppSpec from './appSpec.js'
+import { Branded } from './branded.js'
 
 export class App {
   #userSpec: UserSpec;
@@ -263,7 +264,7 @@ export type RouteConfig = {
   to: PageName
 }
 
-type PageName = string & { _brand: 'Page' }
+type PageName = Branded<string, 'PageName'>
 
 export type ServerConfig = {
   setupFn?: ExtImport


### PR DESCRIPTION
Fix `FullConfig` to propagate to it's children.
Better configs jsdocs.

Since we fixed the type, remove optional access where unnecessary.

Remove export of `main` in `run.ts`.

Use local vars instead of `Fixtures` where applicable.

Uses new `Branded` type for branded types.

Shortens default values on optional fields.