### PR TITLE
Hotfix: Adapt to new flyctl version

### DIFF
--- a/mage/Dockerfile
+++ b/mage/Dockerfile
@@ -38,7 +38,7 @@ RUN cd .wasp/build/server && npm run bundle
 # TODO: Use pm2?
 # TODO: Use non-root user (node).
 FROM base AS server-production
-RUN curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.16.3
+RUN curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.16.4
 ENV PATH "$PATH:/root/.local/bin"
 ENV NODE_ENV production
 WORKDIR /app

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.4
+
+### 🐞 Bug fixes
+
+- Adds support for the latest version of Fly.io CLI (v0.3.121 or greater) ([#2760](https://github.com/wasp-lang/wasp/pull/2760))
+
 ## 0.16.3
 
 ### 🎉 New Features and improvements

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/main.wasp
@@ -1,6 +1,6 @@
 app waspBuild {
   wasp: {
-    version: "^0.16.3"
+    version: "^0.16.4"
   },
   title: "waspBuild"
 }

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/main.wasp
@@ -1,6 +1,6 @@
 app waspCompile {
   wasp: {
-    version: "^0.16.3"
+    version: "^0.16.4"
   },
   title: "waspCompile"
 }

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/main.wasp
@@ -1,6 +1,6 @@
 app waspComplexTest {
   wasp: {
-    version: "^0.16.3"
+    version: "^0.16.4"
   },
   auth: {
     userEntity: User,

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/main.wasp
@@ -1,6 +1,6 @@
 app waspJob {
   wasp: {
-    version: "^0.16.3"
+    version: "^0.16.4"
   },
   title: "waspJob"
 }

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/main.wasp
@@ -1,6 +1,6 @@
 app waspMigrate {
   wasp: {
-    version: "^0.16.3"
+    version: "^0.16.4"
   },
   title: "waspMigrate"
 }

--- a/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
+++ b/waspc/e2e-test/test-outputs/waspNew-golden/waspNew/main.wasp
@@ -1,6 +1,6 @@
 app waspNew {
   wasp: {
-    version: "^0.16.3"
+    version: "^0.16.4"
   },
   title: "waspNew"
 }

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.16.3
+version:        0.16.4
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues
@@ -407,7 +407,7 @@ library
     Wasp.Psl.Generator.Enum
     Wasp.Psl.Generator.Model
     Wasp.Psl.Generator.Schema
-    Wasp.Psl.Parser.Argument 
+    Wasp.Psl.Parser.Argument
     Wasp.Psl.Parser.Attribute
     Wasp.Psl.Parser.Common
     Wasp.Psl.Parser.ConfigBlock


### PR DESCRIPTION
New `flyctl` version outputs `{ name: string, code: string }` instead of `{ Name: string, Code: string }`. Allow both versions.