### PR TITLE
Stop overriding TSconfig target with old values 

### DIFF
--- a/waspc/data/Generator/templates/server/tsconfig.json
+++ b/waspc/data/Generator/templates/server/tsconfig.json
@@ -17,9 +17,6 @@
     //  - https://github.com/wasp-lang/wasp/pull/1584#discussion_r1404019301
     //  - https://github.com/wasp-lang/wasp/pull/1713/files#diff-58191eecd9cc55f71c73de89420df8b1866dce38ad35f4ef0f6f8874616eda77R32
     "rootDir": ".",
-    // Overriding this because we want to use top-level await
-    "module": "esnext",
-    "target": "es2017",
     // Enable source map for debugging
     "sourceMap": true,
     // The remaining settings should match the extended nodeXY/tsconfig.json, but I kept

--- a/waspc/examples/todoApp/src/rpcTests/operations/fixtures.ts
+++ b/waspc/examples/todoApp/src/rpcTests/operations/fixtures.ts
@@ -10,6 +10,5 @@ export const SERIALIZABLE_OBJECTS_FIXTURE = {
   negInf: -Infinity,
   // we ensure that it'd be too big to be represented as a `number`
   decimal: new Prisma.Decimal(Number.MAX_SAFE_INTEGER).mul(2),
-  // @ts-ignore Server has a tsconfig target of es2017, so BigInt isn't available
   bigint: 2n * BigInt(Number.MAX_SAFE_INTEGER),
 }


### PR DESCRIPTION
Fixes #2735.

There are more improvements to be made here. Covered by: #2776.