### PR TITLE
Fix GHC warnings

### DIFF
--- a/waspc/src/Wasp/Project/Analyze.hs
+++ b/waspc/src/Wasp/Project/Analyze.hs
@@ -16,7 +16,6 @@ import StrongPath
     fromAbsDir,
   )
 import qualified Wasp.AppSpec as AS
-import qualified Wasp.AppSpec.ConfigFile as CF
 import Wasp.AppSpec.Core.Decl.JSON ()
 import qualified Wasp.AppSpec.Valid as ASV
 import Wasp.CompileOptions (CompileOptions)


### PR DESCRIPTION
GHC was complaining:

```
src/Wasp/Project/Analyze.hs:19:1: warning: [-Wunused-imports]
    The qualified import of ‘Wasp.AppSpec.ConfigFile’ is redundant
      except perhaps to import instances from ‘Wasp.AppSpec.ConfigFile’
    To import instances alone, use: import Wasp.AppSpec.ConfigFile()
   |
19 | import qualified Wasp.AppSpec.ConfigFile as CF
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```