### PR TITLE
Remove prettier plugins from auto-js

### DIFF
--- a/web/src/remark/auto-js-code.ts
+++ b/web/src/remark/auto-js-code.ts
@@ -174,16 +174,27 @@ function convertToJs(code: string, { isJsx }: { isJsx: boolean }) {
   return blankSourceFile(sourceFile);
 }
 
-let prettierConfig: prettier.Options | undefined;
+async function getPrettierConfig() {
+  const rawConfig = await prettier.resolveConfig(__dirname, {
+    useCache: true,
+    editorconfig: true,
+  });
 
+  const config = {
+    ...rawConfig,
+    // We don't need any non-default plugins for the case of simple JS/TS examples
+    plugins: [],
+  };
+
+  return config;
+}
+
+let prettierConfig: prettier.Options | undefined;
 async function format(
   code: string,
   { parser }: { parser: prettier.Options["parser"] },
 ) {
-  prettierConfig ??= await prettier.resolveConfig(__dirname, {
-    useCache: true,
-    editorconfig: true,
-  });
+  prettierConfig ??= await getPrettierConfig();
   const formatted = await prettier.format(code, { ...prettierConfig, parser });
   return formatted.trim(); // prettier adds a trailing newline, we remove it
 }


### PR DESCRIPTION
The `auto-js` plugin doesn't really need any plugins added to prettier to work correctly (it's just regular JS/TS code), and it was [tripping up our Cloudflare build](https://dash.cloudflare.com/75c37602a6b75c790961219411cb1b92/pages/view/wasp-docs-on-main/bc567ab6-e706-43a3-a25a-d8a0b022bcf6) (we don't have npm workspaces so the plugins, which are declared at the root level, weren't being installed).