### PR TITLE
Fix `wrun wasp-cli` arguments

### DIFF
--- a/waspc/run
+++ b/waspc/run
@@ -33,7 +33,7 @@ TEST_INSTALL_WASP_APP_RUNNER="cd $PROJECT_ROOT/../wasp-app-runner && npm install
 TEST_HEADLESS_CMD="$TEST_INSTALL_WASP_APP_RUNNER && cd $PROJECT_ROOT/examples/todoApp && npm install && DEBUG=pw:webserver npx playwright test --config headless-tests"
 TEST_CMD="cabal test && echo 'Running headless tests' && $TEST_HEADLESS_CMD && echo 'ALL TESTS PASSED' || { echo 'SOME TESTS FAILED'; exit 1; }"
 
-RUN_CMD="cabal --project-dir=${PROJECT_ROOT} run wasp-cli ${ARGS[@]}"
+RUN_CMD="cabal --project-dir=${PROJECT_ROOT} run wasp-cli -- ${ARGS[@]}"
 GHCID_CMD="ghcid --command=cabal repl"
 
 # ghc version below should be the one from `cabal.project` file, `with-compiler` field.


### PR DESCRIPTION
The `./run wasp-cli` command was not separating cabal arguments from CLI arguments, so flags like `--help` were being passed to cabal.

---

Previously, flag was passed to cabal
```
$ wrun wasp-cli --help
Running: cabal --project-dir=/Users/carlos/Developer/Wasp/wasp/waspc run wasp-cli --help 

Run an executable.

Usage: cabal run [TARGET] [FLAGS] [-- EXECUTABLE_FLAGS]

Runs the specified executable-like component (an executable, a test, or a
benchmark), first ensuring it is up to date.
```

Now, it's passed to wasp-cli
```
$ wrun wasp-cli --help
Running: cabal --project-dir=/Users/carlos/Developer/Wasp/wasp/waspc run wasp-cli -- --help 

Configuration is affected by the following files:
- cabal.project
USAGE
  wasp <command> [command-args]

COMMANDS
```