### PR TITLE
Fixes for CI

### DIFF
--- a/.github/actions/setup-haskell/action.yaml
+++ b/.github/actions/setup-haskell/action.yaml
@@ -23,6 +23,13 @@ inputs:
     required: false
     default: "waspc"
 
+  extra-cache-key:
+    description: |
+      An extra key to use for the cache. Mainly used to keep glibc and musl
+      caches separate, as they are not compatible.
+    required: false
+    default: "default"
+
 runs:
   using: composite
 
@@ -63,6 +70,6 @@ runs:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
         key: |
-          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.ghc-version }}-${{ hashFiles('${{ inputs.cabal-project-dir }}/*.cabal', '${{ inputs.cabal-project-dir }}/*.project', '${{ inputs.cabal-project-dir }}/*.project.freeze') }}
+          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key }-${{ inputs.ghc-version }}-${{ hashFiles(format('{0}/*.cabal', inputs.cabal-project-dir), format('{0}/*.project', inputs.cabal-project-dir), format('{0}/*.project.freeze', inputs.cabal-project-dir)) }}
         restore-keys: |
-          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.ghc-version }}-
+          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key }-${{ inputs.ghc-version }}-

--- a/.github/actions/setup-haskell/action.yaml
+++ b/.github/actions/setup-haskell/action.yaml
@@ -70,6 +70,6 @@ runs:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
         key: |
-          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key }-${{ inputs.ghc-version }}-${{ hashFiles(format('{0}/*.cabal', inputs.cabal-project-dir), format('{0}/*.project', inputs.cabal-project-dir), format('{0}/*.project.freeze', inputs.cabal-project-dir)) }}
+          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key }}-${{ inputs.ghc-version }}-${{ hashFiles(format('{0}/*.cabal', inputs.cabal-project-dir), format('{0}/*.project', inputs.cabal-project-dir), format('{0}/*.project.freeze', inputs.cabal-project-dir)) }}
         restore-keys: |
-          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key }-${{ inputs.ghc-version }}-
+          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key }}-${{ inputs.ghc-version }}-

--- a/.github/actions/setup-haskell/action.yaml
+++ b/.github/actions/setup-haskell/action.yaml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: "waspc"
 
-  extra-cache-key:
+  extra-cache-key-segment:
     description: |
       An extra key to use for the cache. Mainly used to keep glibc and musl
       caches separate, as they are not compatible.
@@ -70,6 +70,6 @@ runs:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
         key: |
-          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key }}-${{ inputs.ghc-version }}-${{ hashFiles(format('{0}/*.cabal', inputs.cabal-project-dir), format('{0}/*.project', inputs.cabal-project-dir), format('{0}/*.project.freeze', inputs.cabal-project-dir)) }}
+          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key-segment }}-${{ inputs.ghc-version }}-${{ hashFiles(format('{0}/*.cabal', inputs.cabal-project-dir), format('{0}/*.project', inputs.cabal-project-dir), format('{0}/*.project.freeze', inputs.cabal-project-dir)) }}
         restore-keys: |
-          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key }}-${{ inputs.ghc-version }}-
+          cabal-${{ inputs.cabal-project-dir }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.extra-cache-key-segment }}-${{ inputs.ghc-version }}-

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -145,7 +145,9 @@ jobs:
         with:
           pattern: wasp-cli-darwin-*
 
-      - run: tree .
+      - run: |
+          brew install tree
+          tree .
 
       - name: Unpack, create universal binary and pack
         run: |

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -161,7 +161,7 @@ jobs:
           # Extract each architecture
           for arch in "${input_arch[@]}"; do
             mkdir "arch-$arch"
-            tar -xzf "wasp-cli-${arch}.tar.gz" -C "arch-$arch"
+            tar -xzf "wasp-cli-${arch}/wasp-${arch}.tar.gz" -C "arch-$arch"
           done
 
           mkdir universal

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -145,10 +145,6 @@ jobs:
         with:
           pattern: wasp-cli-darwin-*
 
-      - run: |
-          brew install tree
-          tree .
-
       - name: Unpack, create universal binary and pack
         run: |
           set -ex # Fail on error and print each command
@@ -172,8 +168,6 @@ jobs:
 
           # Pack back up
           tar -czf wasp-darwin-universal.tar.gz -C universal .
-
-      - run: tree .
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -173,7 +173,7 @@ jobs:
           # Pack back up
           tar -czf wasp-darwin-universal.tar.gz -C universal .
 
-      - run: ls -R .
+      - run: tree .
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -145,6 +145,8 @@ jobs:
         with:
           pattern: wasp-cli-darwin-*
 
+      - run: ls -R .
+
       - name: Unpack, create universal binary and pack
         run: |
           set -ex # Fail on error and print each command

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -145,7 +145,7 @@ jobs:
         with:
           pattern: wasp-cli-darwin-*
 
-      - run: ls -R .
+      - run: tree .
 
       - name: Unpack, create universal binary and pack
         run: |

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -114,7 +114,7 @@ jobs:
       - uses: ./.github/actions/setup-haskell
         with:
           ghc-version: ${{ inputs.ghc-version }}
-          extra-cache-key-segment: ${{ matrix.env.static && 'static' || null }}
+          extra-cache-key-segment: ${{ matrix.env.static && 'static' || 'default' }}
 
       - uses: actions/setup-node@v4
         if: ${{ !matrix.env.skip-node-install }}

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -114,6 +114,7 @@ jobs:
       - uses: ./.github/actions/setup-haskell
         with:
           ghc-version: ${{ inputs.ghc-version }}
+          extra-cache-key: ${{ matrix.env.static && 'static' || null }}
 
       - uses: actions/setup-node@v4
         if: ${{ !matrix.env.skip-node-install }}

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -69,7 +69,7 @@ jobs:
             # https://github.com/actions/setup-node/issues/1293
             # To work around this, we use the alpine variant of the official node
             # image, which already has a working Node.js version installed.
-            container: node:${{ inputs.node-version }}-alpine
+            container: node:${{ inputs.node-version }}-alpine3.21
             skip-node-install: true
             static: true
             install-deps: |

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -157,7 +157,7 @@ jobs:
           # Extract each architecture
           for arch in "${input_arch[@]}"; do
             mkdir "arch-$arch"
-            tar -xzf "wasp-${arch}.tar.gz" -C "arch-$arch"
+            tar -xzf "wasp-cli-${arch}.tar.gz" -C "arch-$arch"
           done
 
           mkdir universal
@@ -168,6 +168,8 @@ jobs:
 
           # Pack back up
           tar -czf wasp-darwin-universal.tar.gz -C universal .
+
+      - run: ls -R .
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -114,7 +114,7 @@ jobs:
       - uses: ./.github/actions/setup-haskell
         with:
           ghc-version: ${{ inputs.ghc-version }}
-          extra-cache-key: ${{ matrix.env.static && 'static' || null }}
+          extra-cache-key-segment: ${{ matrix.env.static && 'static' || null }}
 
       - uses: actions/setup-node@v4
         if: ${{ !matrix.env.skip-node-install }}

--- a/.github/workflows/waspc-release.yaml
+++ b/.github/workflows/waspc-release.yaml
@@ -1,9 +1,7 @@
 name: Build and upload Wasp CLI binaries to release
 
 on:
-  create:
-    tags:
-      - v*
+  create: { tags: [v*] }
 
 jobs:
   ci:

--- a/.github/workflows/waspc-release.yaml
+++ b/.github/workflows/waspc-release.yaml
@@ -1,7 +1,9 @@
 name: Build and upload Wasp CLI binaries to release
 
 on:
-  create: { tags: [v*] }
+  create:
+    tags:
+      - v*
 
 jobs:
   ci:


### PR DESCRIPTION
Three changes that were not caught earlier:
- Add extra caching key to not use glibc builds in musl. Haskell tries to execute some binaries and it fails.
- Correctly format the caching key. In GH Actions, nested `${{ ${{ }} }}` are not permitted (but it doesn't warn if you do it 🤦‍♂️) so you need to use the `${{ format() }}` function
- The `darwin-universal` build had not had the names of the artifacts changed. Now it does.

Check a full complete run here: https://github.com/wasp-lang/wasp/actions/runs/15342687609