### PR TITLE
Skip irrelevant dirs when running Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,5 @@ web/.docusaurus
 web/build/
 web/**/*.md
 web/**/*.mdx
+web/static/img/
+waspc/packages/studio/public/assets/


### PR DESCRIPTION
I've noticed that Prettier got stuck in the web `img` dir and the built `assets` dir of the Wasp Studio. So I ignored them, but I didn't expect to see a 50% reduction :D 

Before:
```
run prettier:format  22.47s user 1.89s system 158% cpu 15.406 total
```

After:
```
run prettier:format  11.48s user 1.13s system 177% cpu 7.115 total
```