### PR TITLE
Improve the DBConnectionEstablished Command Requirement

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command.hs
+++ b/waspc/cli/src/Wasp/Cli/Command.hs
@@ -11,6 +11,7 @@ module Wasp.Cli.Command
     -- See "Wasp.Cli.Command.Requires" for documentation.
     require,
     Requirable (checkRequirement),
+    InDirRequirable (checkRequirementInDir),
   )
 where
 
@@ -20,8 +21,10 @@ import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.State.Strict (StateT, evalStateT, gets, modify)
 import Data.Data (Typeable, cast)
 import Data.Maybe (mapMaybe)
+import qualified StrongPath as SP
 import System.Exit (exitFailure)
 import Wasp.Cli.Message (cliSendMessage)
+import Wasp.Generator (ProjectRootDir)
 import qualified Wasp.Message as Msg
 
 newtype Command a = Command {_runCommand :: StateT [Requirement] (ExceptT CommandError IO) a}
@@ -68,3 +71,6 @@ require =
       req <- checkRequirement
       Command $ modify (Requirement req :)
       return req
+
+class InDirRequirable a where
+  checkRequirementInDir :: SP.Path' SP.Abs (SP.Dir ProjectRootDir) -> Command a

--- a/waspc/cli/src/Wasp/Cli/Command/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Db.hs
@@ -5,7 +5,7 @@ where
 
 import Wasp.Cli.Command (Command, runCommand)
 import Wasp.Cli.Command.Compile (compileWithOptions, defaultCompileOptions)
-import Wasp.Cli.Command.Require (DbConnectionEstablished (DbConnectionEstablished), InWaspProject (InWaspProject), require)
+import Wasp.Cli.Command.Require (DbConnectionEstablished (DbConnectionEstablished), InOutDir (InOutDir), InWaspProject (InWaspProject), require)
 import Wasp.CompileOptions (CompileOptions (generatorWarningsFilter))
 import Wasp.Generator.Monad (GeneratorWarning (GeneratorNeedsMigrationWarning))
 
@@ -21,7 +21,7 @@ makeDbCommand cmd = do
   -- Ensure code is generated and npm dependencies are installed.
   InWaspProject waspProjectDir <- require
   _ <- compileWithOptions $ compileOptions waspProjectDir
-  DbConnectionEstablished <- require
+  InOutDir DbConnectionEstablished <- require
   cmd
   where
     compileOptions waspProjectDir =

--- a/waspc/cli/src/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start.hs
@@ -12,7 +12,7 @@ import StrongPath ((</>))
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Compile (compile, printWarningsAndErrorsIfAny)
 import Wasp.Cli.Command.Message (cliSendMessageC)
-import Wasp.Cli.Command.Require (DbConnectionEstablished (DbConnectionEstablished), InWaspProject (InWaspProject), require)
+import Wasp.Cli.Command.Require (DbConnectionEstablished (DbConnectionEstablished), InOutDir (InOutDir), InWaspProject (InWaspProject), require)
 import Wasp.Cli.Command.Watch (watch)
 import qualified Wasp.Generator
 import qualified Wasp.Message as Msg
@@ -30,7 +30,7 @@ start = do
 
   warnings <- compile
 
-  DbConnectionEstablished <- require
+  InOutDir DbConnectionEstablished <- require
 
   cliSendMessageC $ Msg.Start "Listening for file changes..."
   cliSendMessageC $ Msg.Start "Starting up generated project..."

--- a/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
@@ -176,10 +176,10 @@ testDbConnection genProjectDir = do
 prismaErrorContainsDbNotCreatedError :: T.Text -> Bool
 prismaErrorContainsDbNotCreatedError text = text TR.=~ ("\\bP1003\\b" :: String)
 
-isDbConnectionPossible :: DbConnectionTestResult -> Bool
-isDbConnectionPossible DbConnectionSuccess = True
-isDbConnectionPossible DbNotCreated = True
-isDbConnectionPossible _ = False
+isDbConnectionPossible :: DbConnectionTestResult -> Either (Chan J.JobMessage) ()
+isDbConnectionPossible DbConnectionSuccess = Right ()
+isDbConnectionPossible DbNotCreated = Right ()
+isDbConnectionPossible (DbConnectionFailure chan) = Left chan
 
 generatePrismaClient :: Path' Abs (Dir ProjectRootDir) -> IO (Either String ())
 generatePrismaClient projectRootDir = do

--- a/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Operations.hs
@@ -12,7 +12,7 @@ module Wasp.Generator.DbGenerator.Operations
   )
 where
 
-import Control.Concurrent (newChan)
+import Control.Concurrent (Chan, dupChan, newChan)
 import Control.Concurrent.Async (concurrently)
 import Control.Monad.Catch (catch)
 import Control.Monad.Extra (whenM)
@@ -37,6 +37,7 @@ import Wasp.Generator.DbGenerator.Common
 import qualified Wasp.Generator.DbGenerator.Jobs as DbJobs
 import Wasp.Generator.FileDraft.WriteableMonad (WriteableMonad (copyDirectoryRecursive, doesDirectoryExist))
 import qualified Wasp.Generator.WriteFileDrafts as Generator.WriteFileDrafts
+import qualified Wasp.Job as J
 import Wasp.Job.IO
   ( collectJobTextOutputUntilExitReceived,
     printJobMsgsUntilExitReceived,
@@ -50,7 +51,7 @@ import qualified Wasp.Util.IO as IOUtil
 data DbConnectionTestResult
   = DbConnectionSuccess
   | DbNotCreated
-  | DbConnectionFailure
+  | DbConnectionFailure (Chan J.JobMessage)
   deriving (Eq)
 
 -- | Migrates in the generated project context and then copies the migrations dir back
@@ -155,19 +156,21 @@ testDbConnection ::
   Path' Abs (Dir ProjectRootDir) ->
   IO DbConnectionTestResult
 testDbConnection genProjectDir = do
-  chan <- newChan
-  exitCode <- DbJobs.dbExecuteTest genProjectDir chan
+  chanForInspecting <- newChan
+  chanForPrinting <- dupChan chanForInspecting
+
+  exitCode <- DbJobs.dbExecuteTest genProjectDir chanForInspecting
 
   case exitCode of
     ExitSuccess -> return DbConnectionSuccess
     ExitFailure _ -> do
-      outputLines <- collectJobTextOutputUntilExitReceived chan
+      outputLines <- collectJobTextOutputUntilExitReceived chanForInspecting
       let databaseNotCreated = any prismaErrorContainsDbNotCreatedError outputLines
 
       return $
         if databaseNotCreated
           then DbNotCreated
-          else DbConnectionFailure
+          else DbConnectionFailure chanForPrinting
 
 -- Prisma error code for "Database not created" is P1003.
 prismaErrorContainsDbNotCreatedError :: T.Text -> Bool


### PR DESCRIPTION
Part of #2796

- Prisma commands now run as `npm exec prisma` instead of `node_modules/.bin/prisma`, so we don't need to hardcode binary paths

- Added an option to call a prisma command with the `.env.server` environment, even when the user hasn't run `wasp start` (e.g. a CI that is only running `wasp build`)

- The `DBConnectionEstablished` requirement now prints the Prisma command output if it received an unknown error, helping the user pinpoint the error
  - Specifically, in #2796 I was getting errors for not having `DATABASE_URL` env set, but I couldn't see the prisma output that says so. We can't scan the output for it specifically because it is reported as a `P1012 Invalid schema file`, which could be conflated with actual errors we would like to show to our users.

![image](https://github.com/user-attachments/assets/49994048-166d-403c-b3a4-cc8918477530)

- The `DBConnectionEstablished` is not a requirement anymore, by itself. Instead, we need to wrap it in a `InBuildDir` or `InOutDir` type that will run this requirement in the correct context.