### PR TITLE
Remove workaround for interactive Prisma

### DIFF
--- a/waspc/src/Wasp/Generator/DbGenerator/Jobs.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator/Jobs.hs
@@ -16,57 +16,35 @@ where
 import StrongPath (Abs, Dir, File', Path', (</>))
 import qualified StrongPath as SP
 import StrongPath.TH (relfile)
-import qualified System.Info
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.DbGenerator.Common (MigrateArgs (..), dbSchemaFileInProjectRootDir)
 import Wasp.Generator.ServerGenerator.Common (serverRootDirInProjectRootDir)
 import Wasp.Generator.ServerGenerator.Db.Seed (dbSeedNameEnvVarName)
 import qualified Wasp.Job as J
-import Wasp.Job.Process (runNodeCommandAsJob, runNodeCommandAsJobWithExtraEnv)
+import Wasp.Job.Process (runNodeCommandAsJobWithExtraEnv)
 import Wasp.Project.Common (WaspProjectDir, waspProjectDirFromProjectRootDir)
 
 migrateDev :: Path' Abs (Dir ProjectRootDir) -> MigrateArgs -> J.Job
 migrateDev projectRootDir migrateArgs =
   -- NOTE(matija): We are running this command from server's root dir since that is where
   -- Prisma packages (cli and client) are currently installed.
-  -- NOTE(martin): `prisma migrate dev` refuses to execute when interactivity is needed if stdout is being piped,
-  --   because it assumes it is used in non-interactive environment. In our case we are piping both stdin and stdout
-  --   so we do have interactivity, but Prisma doesn't know that.
-  --   I opened an issue with Prisma https://github.com/prisma/prisma/issues/7113, but in the meantime
-  --   we are using `script` to trick Prisma into thinking it is running in TTY (interactively).
-  runNodeCommandAsJob serverDir "script" scriptArgs J.Db
+  runPrismaCommandAsJobFromWaspServerDir
+    projectRootDir
+    prismaArgs
   where
-    serverDir = projectRootDir </> serverRootDirInProjectRootDir
     schemaFile = projectRootDir </> dbSchemaFileInProjectRootDir
 
-    scriptArgs =
-      if System.Info.os == "darwin"
-        then -- NOTE(martin): On MacOS, command that `script` should execute is treated as multiple arguments.
-          ["-Fq", "/dev/null"] ++ buildPrismaMigrateCmd id
-        else -- NOTE(martin): On Linux, command that `script` should execute is treated as one argument.
-          ["-feqc", unwords $ buildPrismaMigrateCmd quoteArg, "/dev/null"]
-
-    -- NOTE(miho): Since we are running the Prisma command using `script` and we are doing it
-    --  in two different ways (MacOS and Linux), we have to take care of quoting the paths
-    --  differently.
-    --  * MacOS - we are passing the command as multiple arguments, so we MUST NOT quote the paths.
-    --  * Linux - we are passing the command as one argument, so we MUST quote the paths.
-    buildPrismaMigrateCmd :: (String -> String) -> [String]
-    buildPrismaMigrateCmd argQuoter =
-      [ argQuoter $ absPrismaExecutableFp (projectRootDir </> waspProjectDirFromProjectRootDir),
-        "migrate",
+    prismaArgs =
+      [ "migrate",
         "dev",
         "--schema",
-        argQuoter $ SP.fromAbsFile schemaFile,
+        SP.fromAbsFile schemaFile,
         "--skip-generate",
         -- NOTE(martin): We do "--skip-seed" here because I just think seeding happening automatically
         --   in some situations is too aggressive / confusing.
         "--skip-seed"
       ]
         ++ asPrismaCliArgs migrateArgs
-
-    quoteArg :: String -> String
-    quoteArg arg = "\"" ++ arg ++ "\""
 
 asPrismaCliArgs :: MigrateArgs -> [String]
 asPrismaCliArgs migrateArgs = do

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -37,7 +37,6 @@ import qualified Wasp.Generator.DbGenerator.Auth as DbAuth
 import Wasp.Generator.DepVersions (prismaVersion, superjsonVersion)
 import Wasp.Generator.FileDraft (FileDraft)
 import qualified Wasp.Generator.FileDraft as FD
-import qualified Wasp.Generator.JsImport as GJI
 import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.NpmDependencies as N
 import Wasp.Generator.SdkGenerator.AuthG (genAuth)


### PR DESCRIPTION
- Part of #2820

Prisma needs shell interactivity for the `prisma migrate dev` command, so it will check if the terminal is a TTY and die if it's not.

Prisma used to check if _stdout_ is interactive, instead of _stdin_. We had a workaround for this, by calling the Prisma executable through the `script` utility.

This has been fixed since Prisma v4.3.0 (https://github.com/prisma/prisma/pull/14649), they now check for a TTY on stdin, which we have always bequeathed to it.

We can remove our workaround code, and close our issue (https://github.com/prisma/prisma/issues/7113).