### PR TITLE
Move all example apps to CDG region

### DIFF
--- a/examples/waspleau/fly-client.toml
+++ b/examples/waspleau/fly-client.toml
@@ -4,7 +4,7 @@
 #
 
 app = "waspleau-app-client"
-primary_region = "mad"
+primary_region = "cdg"
 
 [build]
 

--- a/examples/waspleau/fly-server.toml
+++ b/examples/waspleau/fly-server.toml
@@ -4,7 +4,7 @@
 #
 
 app = "waspleau-app-server"
-primary_region = "mad"
+primary_region = "cdg"
 
 [build]
 

--- a/examples/websockets-realtime-voting/fly-client.toml
+++ b/examples/websockets-realtime-voting/fly-client.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'websockets-voting-client'
-primary_region = 'mia'
+primary_region = 'cdg'
 
 [build]
 

--- a/examples/websockets-realtime-voting/fly-server.toml
+++ b/examples/websockets-realtime-voting/fly-server.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'websockets-voting-server'
-primary_region = 'mia'
+primary_region = 'cdg'
 
 [build]
 

--- a/mage/fly-client.toml
+++ b/mage/fly-client.toml
@@ -4,7 +4,7 @@
 #
 
 app = "wasp-ai-client"
-primary_region = "mad"
+primary_region = "cdg"
 
 [http_service]
   internal_port = 8043

--- a/mage/fly-server.toml
+++ b/mage/fly-server.toml
@@ -4,7 +4,7 @@
 #
 
 app = "wasp-ai-server"
-primary_region = "mad"
+primary_region = "cdg"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
- Part of #2831
- Part of #2844

--- 

Move all of our example apps to CDG (Paris)

- Some were on MAD (Madrid), which is getting deprecated as per #2844.
- Some were on MIA (Miami), but it makes sense to move them to CDG as well for consistency, and because all the team is in Europe.

The CDG region was chosen base on recommendation by Fly themselves (see the email at #2844) 

**Please note**:
- This PR is being done against `release`.
- The new manifest have not been deployed yet, will do it once we merge.
- Thoughts app has been removed in `main` (and taken offline) but is still in the `release` branch. I did not modify it.