### PR TITLE
Fixes Typescript compiler declaration generation

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/pgBossJob.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/pgBossJob.ts
@@ -102,7 +102,7 @@ export function registerJob<
  * It is not yet submitted until the caller invokes `submit()` on an instance.
  * The caller can make as many calls to `submit()` as they wish.
  */
-class PgBossJob<
+export class PgBossJob<
   Input extends JSONObject,
   Output extends JSONValue | void,
   Entities extends Partial<PrismaDelegate>


### PR DESCRIPTION
We have a type issue with Wasp jobs that users hit when they define their job output as `void`.

### Example error

If you define a job with a return type of `void`:
```ts
export const uppercaseText: UppercaseTextJob<
  { requestId: string },
  void // <----- return type of void
> = // ...
```


Compiler generates this `.wasp/out/server` code with **registerJob** which uses `uppercaseText`:
```ts
registerJob({
  job: _waspJobDefinition,
  jobFn: uppercaseText,
})
```


The compiler tries to build the app... running `tsc --build` on the `.wasp/out/server` files and it gets an error!
<details>
<summary>Full error</summary>

```
src/jobs/uppercaseTextJob.ts:7:3 - error TS2322: Type 'UppercaseTextJob<{ requestId: string; }, void>' is not assignable to type 'JobFn<JSONObject, JSONArray | JSONObject | { value: string; } | { value: number; } | { value: false; } | { value: true; }, { UppercaseTextRequest: DynamicModelExtensionThis<TypeMap<InternalArgs<...> & { ...; }, PrismaClientOptions>, "UppercaseTextRequest", { ...; }, {}>; }>'.
  Type 'Promise<void>' is not assignable to type 'Promise<JSONArray | JSONObject | { value: string; } | { value: number; } | { value: false; } | { value: true; }>'.
    Type 'void' is not assignable to type 'JSONArray | JSONObject | { value: string; } | { value: number; } | { value: false; } | { value: true; }'.

7   jobFn: uppercaseText,
    ~~~~~
```
</details>

The error boils down to `UppercaseTextJob<{ requestId: string; }, void>` (with type of `Output` of `void`) is not assignable to `JobFn`. This is weird because `JobFn` does in fact accept `void` as type of `Output` type param!

### Investigation

#### Setup

Few things to know:
1. **registerJob** expects `jobFn` to be `JobFn<Input, Output, Entities>`
2. `UppercaseTextJob` is defined like:
 	```ts
	export type UppercaseTextJob<Input extends JSONObject, Output extends JSONValue | void> = JobFn<Input, Output, typeof entities>
	```
3. `JobFn` accepts `Ouput` if it extends `JSONValue | void`

This all means that the `uppercaseText` function type is okay and the `Output` of `void` is okay. 

#### Going deeper

Digging a bit further, it seems that **registerJob** function is a generic function with the `Input` and `Output` type params:
```ts
declare function registerJob<
  Input extends JSONObject,
  Output extends JSONValue | void,
  // ...
>({ job, jobFn }: {
  job: PgBossJob<Input, Output, Entities>,
  jobFn: JobFn<Input, Output, Entities>,
})
```

We think that compiler tries to make sure that the `Output` in the `PgBossJob` and `JobFn` are both okay (type unification, if I recall correctly what @sodic said). To see if this makes sense, we expected the `PgBossJob` not to mention `void` or something like that - which could explain the error. Let's look at `PgBossJob`

#### Declaration files for `UppercaseTextJob`

When we looked at `uppercaseTextJob.d.ts` we noticed one curious thing - the `UppercaseTextJob` is defined differently depending if the `PgBossClass` is exported! 

**Not exported**

```ts
export declare const uppercaseTextJob: {
    readonly defaultJobOptions: Parameters<import("pg-boss")["send"]>[2];
    readonly startAfter: number | string | Date | undefined;
    readonly entities: {
        UppercaseTextRequest: import("@prisma/client/runtime/library.js").DynamicModelExtensionThis<import(".prisma/client").Prisma.TypeMap<import("@prisma/client/runtime/library.js").InternalArgs & {
            result: {};
            model: {};
            query: {};
            client: {};
        }, import(".prisma/client").Prisma.PrismaClientOptions>, "UppercaseTextRequest", {
            result: {};
            model: {};
            query: {};
            client: {};
        }, {}>;
    };
    readonly jobSchedule: {
        cron: Parameters<import("pg-boss")["schedule"]>[1];
        options: Parameters<import("pg-boss")["schedule"]>[3];
        args?: NonNullable<Parameters<import("pg-boss")["schedule"]>[2]>;
    } | null;
   }
...
}
```

**Exported**

```ts
export declare const uppercaseTextJob: import("./core/pgBoss/pgBossJob").PgBossJob<JSONObject, void | JSONValue, {
  ...
}>
```

It looks like this non-generic type was giving Typescript trouble when it tried to unify it with `JobFn` and the `Output` type parameter.

### How can we fix it

Exporting the class seems to do the trick. This fixes our type issues, but maybe there is a better way to fix it? Or maybe this is just a quirk of the compiler and we have to accept that we have to export the class. 

@sodic said we should export that class anyways (since users can extract it with Typescript type helpers anyways).