### PR TITLE
Prettier's printWidth to 100

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -8,5 +8,6 @@
   "semi": true,
   "singleQuote": false,
   "jsxSingleQuote": false,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "printWidth": 100
 }


### PR DESCRIPTION
I was revieiwng Miho's Railway PR and I found it is too aggressive at the moment, look at this image I attached (first image is hat I would like it to be, second is how prettier formats it now), it is ridicoulos -> I can easily fit this line on my screen on my laptop while I have two files open at the same time, with extra space, and yet it brakes it into 4 lines, making this code just harder to read.

![image](https://github.com/user-attachments/assets/24194940-17ce-4f59-84f3-df3d310a800c)

It seems to break them at 80 chars right now -> I thought we said that that doesn't mean 80 chars stristly, but just some way it makes decisions and it can easily end up being up to 100 in reality. But doesn't seem to be happening. So I would say let's bump this thing to 100? If not, then at least 90, although I thinkn 100 could be just fine.

Because I see tehre are quite a few functions in this PR that fall under 80-95 range that really don't benefit from being broken into multiple lines.

Discussion on Discord: https://discord.com/channels/686873244791210014/1351908377533354025/1390096824261542111 .

Btw Prettier's default is 80, and they recommend to stick with it.
But since I can see right now that I don't like this, I would rather give it a try, go for more, and then revert if we learn that is not good, than stay forever at 80 that seems silly just because it is default.