### PR TITLE
Fix Release CI

### DIFF
--- a/.github/workflows/waspc-release.yaml
+++ b/.github/workflows/waspc-release.yaml
@@ -29,6 +29,6 @@ jobs:
         with:
           draft: true
           allowUpdates: true
-          artifacts: "./wasp-*"
+          artifacts: "./wasp-cli-*/*"
           artifactErrorsFailBuild: true
           replacesArtifacts: true

--- a/.github/workflows/waspc-release.yaml
+++ b/.github/workflows/waspc-release.yaml
@@ -24,6 +24,11 @@ jobs:
         with:
           pattern: wasp-cli-*
 
+      # `download-artifact` will download each artifact into its own separate
+      # directory. We need to account for this in the glob pattern for the
+      # release artifacts. The glob should only include the files inside the
+      # folders, not the folders themselves.
+
       - name: Create Github release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
Fixes the glob in the create release function, because the `download-artifact` action downloads each in its own folder:

```
Run ls -R .
.:
wasp-cli-darwin-aarch64
wasp-cli-darwin-universal
wasp-cli-darwin-x86_64
wasp-cli-linux-x86_64
wasp-cli-linux-x86_64-static

./wasp-cli-darwin-aarch64:
wasp-darwin-aarch64.tar.gz

./wasp-cli-darwin-universal:
wasp-darwin-universal.tar.gz

./wasp-cli-darwin-x86_64:
wasp-darwin-x86_64.tar.gz

./wasp-cli-linux-x86_64:
wasp-linux-x86_64.tar.gz

./wasp-cli-linux-x86_64-static:
wasp-linux-x86_64-static.tar.gz
```