### PR TITLE
Fix wasp-config package

### DIFF
--- a/waspc/packages/wasp-config/package-lock.json
+++ b/waspc/packages/wasp-config/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "bin": {
-        "wasp-config": "dist/run.js"
+        "wasp-config": "dist/src/run.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",

--- a/waspc/packages/wasp-config/package.json
+++ b/waspc/packages/wasp-config/package.json
@@ -5,10 +5,12 @@
   "description": "Wasp TS SDK",
   "author": "wasp",
   "license": "MIT",
-  "bin": "./dist/run.js",
-  "main": "dist/run.js",
+  "bin": "./dist/src/run.js",
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
There's a bug in Wasp v0.17.0-rc1:

In `wasp-config`, the built TypeScript files are output to `dist/src` instead of just `dist`. This is because we added the one more folder to the TypeScript config [(commit)](https://github.com/wasp-lang/wasp/commit/11909a902999c7d93e12e1f63478e65c8066efae#diff-60eb05a951ff79c3caaf55a3bc4667489fb3635cfdea6f0909ab637428774ee9L23), so TypeScript decides to sub-folder each of them.

My solution is to move the tests inside of `src`, so it will still end up being just one single folder in the TS project.

I tried to have two TS subprojects (`tsconfig.app.json` and `tsconfig.test.json`), but TS was not liking that the test files import app files.

I also explicitly added the types to the exports in the package.json, and removed the `main` reference to the executable file (which should only be `bin`).