### PR TITLE
Removes leftover option from deploy CLI

### DIFF
--- a/waspc/packages/deploy/src/providers/fly/index.ts
+++ b/waspc/packages/deploy/src/providers/fly/index.ts
@@ -171,7 +171,6 @@ function makeFlySetupCommand(): Command {
 function makeFlyDeployCommand(): Command {
   return new FlyCommand("deploy")
     .description("(Re-)Deploy existing app to Fly.io")
-    .option("--skip-build", "do not run `wasp build` before deploying")
     .option("--skip-client", "do not deploy the web client")
     .option("--skip-server", "do not deploy the server")
     .addLocalBuildOption()

--- a/waspc/packages/deploy/src/providers/railway/index.ts
+++ b/waspc/packages/deploy/src/providers/railway/index.ts
@@ -79,7 +79,6 @@ export function createRailwayCommand(): Command {
           .hideHelp()
           .default("railway"),
       )
-      .option("--skip-build", "do not run `wasp build` before the command")
       .hook("preAction", async (cmd) => {
         const { waspProjectDir, waspExe, railwayExe } = cmd.opts<{
           waspProjectDir: WaspProjectDir;


### PR DESCRIPTION
We removed usage of `skipBuild` value (which gets generated from the CLI option) but didn't remove the actual CLI `--skip-build` option. 