### PR TITLE
Avoid TypeScript confusion with Decimal type

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/core/serialization/prisma.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/core/serialization/prisma.ts
@@ -26,8 +26,9 @@ import "./custom-register"
   property, and give it the `Decimal` type that we take from option (b). Importantly, we only
   do a type import from (b) so we don't trigger the runtime error when importing from the client.
 */
-type Decimal = import("@prisma/client/runtime/library").Decimal;
-const Decimal = (Prisma as { Decimal?: typeof Decimal }).Decimal;
+type DecimalClass = typeof import("@prisma/client/runtime/library").Decimal;
+type DecimalInstance = InstanceType<DecimalClass>;
+const Decimal = (Prisma as { Decimal?: DecimalClass }).Decimal;
 
 /*
   And finally, if we have the `Decimal` type because the Prisma schema is using it,
@@ -35,9 +36,9 @@ const Decimal = (Prisma as { Decimal?: typeof Decimal }).Decimal;
   Based on https://github.com/flightcontrolhq/superjson/blob/v2.2.2/README.md#decimaljs--prismadecimal
 */
 if (Decimal) {
-  registerCustom<Decimal, string>(
+  registerCustom<DecimalInstance, string>(
     {
-      isApplicable: (v): v is Decimal => Decimal.isDecimal(v),
+      isApplicable: (v): v is DecimalInstance => Decimal.isDecimal(v),
       serialize: (v) => v.toJSON(),
       deserialize: (v) => new Decimal(v),
     },
@@ -48,6 +49,6 @@ if (Decimal) {
 // We add the `Decimal` to this interface so that it is registered as a custom serialization type
 declare module "superjson" {
   interface WaspInternal_CustomSerializableJSONValue_Register {
-    Decimal: Decimal;
+    Decimal: DecimalInstance;
   }
 }


### PR DESCRIPTION
@infomiho got this error while building `ask-the-documents`:

```
core/serialization/prisma.ts:30:47 - error TS2448: Block-scoped variable 'Decimal' used before its declaration.

30 const Decimal = (Prisma as { Decimal?: typeof Decimal }).Decimal;
                                                 ~~~~~~~

  core/serialization/prisma.ts:30:7
    30 const Decimal = (Prisma as { Decimal?: typeof Decimal }).Decimal;
             ~~~~~~~
    'Decimal' is declared here.


Found 1 error in core/serialization/prisma.ts:30
```

It seems TS is getting confused with the `Decimal` type being the same name of the `Decimal` variable. We'll just rename everything so it doesn't get confused.