### PR TITLE
Always build Wasp project before deployment

### DIFF
--- a/waspc/packages/deploy/src/common/waspBuild.ts
+++ b/waspc/packages/deploy/src/common/waspBuild.ts
@@ -1,0 +1,31 @@
+import { WaspCliExe, WaspProjectDir } from "./brandedTypes.js";
+import { waspSays } from "./terminal.js";
+import { createCommandWithCwd } from "./zx.js";
+
+export const ensureWaspProjectIsBuilt = createEnsureWaspProjectIsBuilt();
+
+function createEnsureWaspProjectIsBuilt() {
+  // We want to build the Wasp project only once per CLI invocation.
+  // Sometimes `ensureWaspProjectIsBuilt` is called multiple times
+  // (e.g. in `setup` command, we call it and then again when deploying).
+  let isWaspBuildExecuted = false;
+
+  async function ensureWaspProjectIsBuilt({
+    waspProjectDir,
+    waspExe,
+  }: {
+    waspProjectDir: WaspProjectDir;
+    waspExe: WaspCliExe;
+  }): Promise<void> {
+    if (isWaspBuildExecuted) {
+      return;
+    }
+
+    waspSays("Building your Wasp app...");
+    const waspCli = createCommandWithCwd(waspExe, waspProjectDir);
+    await waspCli(["build"]);
+    isWaspBuildExecuted = true;
+  }
+
+  return ensureWaspProjectIsBuilt;
+}

--- a/waspc/packages/deploy/src/common/waspProject.ts
+++ b/waspc/packages/deploy/src/common/waspProject.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 
 import { cd } from "zx";
 import { WaspCliExe, WaspProjectDir } from "./brandedTypes.js";
-import { waspSays } from "./terminal.js";
 import { assertDirExists, assertDirPathIsAbsolute } from "./validation.js";
 import { createCommandWithCwd } from "./zx.js";
 
@@ -32,24 +31,6 @@ export function assertWaspProjectDirIsAbsoluteAndPresent(
   const dirNameInError = "Wasp project directory";
   assertDirPathIsAbsolute(waspProjectDir, dirNameInError);
   assertDirExists(waspProjectDir, dirNameInError);
-}
-
-export async function ensureWaspProjectIsBuilt({
-  waspProjectDir,
-  waspExe,
-}: {
-  waspProjectDir: WaspProjectDir;
-  waspExe: WaspCliExe;
-}): Promise<void> {
-  // NOTE: we assume that existance of the build directory means
-  // that the project has been built.
-  if (buildDirExists(waspProjectDir)) {
-    return;
-  }
-
-  waspSays("Building your Wasp app...");
-  const waspCli = createCommandWithCwd(waspExe, waspProjectDir);
-  await waspCli(["build"]);
 }
 
 export function buildDirExists(waspProjectDir: WaspProjectDir): boolean {

--- a/waspc/packages/deploy/src/providers/fly/commands/cmd/cmd.ts
+++ b/waspc/packages/deploy/src/providers/fly/commands/cmd/cmd.ts
@@ -1,7 +1,7 @@
 import { $ } from "zx";
 
 import { waspSays } from "../../../../common/terminal.js";
-import { ensureWaspProjectIsBuilt } from "../../../../common/waspProject.js";
+import { ensureWaspProjectIsBuilt } from "../../../../common/waspBuild.js";
 import { CommonOps, getCommonOps } from "../../CommonOps.js";
 import {
   deleteLocalToml,

--- a/waspc/packages/deploy/src/providers/fly/commands/deploy/deploy.ts
+++ b/waspc/packages/deploy/src/providers/fly/commands/deploy/deploy.ts
@@ -6,10 +6,10 @@ import {
   displayWaspRocketImage,
   waspSays,
 } from "../../../../common/terminal.js";
+import { ensureWaspProjectIsBuilt } from "../../../../common/waspBuild.js";
 import {
   cdToClientBuildDir,
   cdToServerBuildDir,
-  ensureWaspProjectIsBuilt,
 } from "../../../../common/waspProject.js";
 import {
   createDeploymentInstructions,

--- a/waspc/packages/deploy/src/providers/fly/commands/setup/setup.ts
+++ b/waspc/packages/deploy/src/providers/fly/commands/setup/setup.ts
@@ -3,10 +3,10 @@ import { $, chalk, question } from "zx";
 import { getFullCommandName } from "../../../../common/commander.js";
 import { generateRandomHexString } from "../../../../common/random.js";
 import { waspSays } from "../../../../common/terminal.js";
+import { ensureWaspProjectIsBuilt } from "../../../../common/waspBuild.js";
 import {
   cdToClientBuildDir,
   cdToServerBuildDir,
-  ensureWaspProjectIsBuilt,
 } from "../../../../common/waspProject.js";
 import {
   createDeploymentInstructions,

--- a/waspc/packages/deploy/src/providers/railway/commands/deploy/index.ts
+++ b/waspc/packages/deploy/src/providers/railway/commands/deploy/index.ts
@@ -1,7 +1,7 @@
 import { WaspProjectDir } from "../../../../common/brandedTypes.js";
 import { getFullCommandName } from "../../../../common/commander.js";
 import { waspSays } from "../../../../common/terminal.js";
-import { ensureWaspProjectIsBuilt } from "../../../../common/waspProject.js";
+import { ensureWaspProjectIsBuilt } from "../../../../common/waspBuild.js";
 import {
   RailwayCliExe,
   RailwayProjectId,

--- a/waspc/packages/deploy/src/providers/railway/commands/setup/setup.ts
+++ b/waspc/packages/deploy/src/providers/railway/commands/setup/setup.ts
@@ -3,8 +3,8 @@ import { $ } from "zx";
 import { WaspProjectDir } from "../../../../common/brandedTypes.js";
 import { generateRandomHexString } from "../../../../common/random.js";
 import { waspSays } from "../../../../common/terminal.js";
+import { ensureWaspProjectIsBuilt } from "../../../../common/waspBuild.js";
 import {
-  ensureWaspProjectIsBuilt,
   getClientBuildDir,
   getServerBuildDir,
 } from "../../../../common/waspProject.js";


### PR DESCRIPTION
Our current logic assumed that if the `.wasp/build` directory exists - there is no need to run `wasp build`. This is not a really good assumption because the user might have changed the source code and they didn't rerun the `wasp build` command manually. This means that the deployment process will take the old build artefacts and deployment them!

I've added a change to always rebuild the Wasp project before deployment + made sure we only run `wasp build` once. 