### PR TITLE
Change Wasp CLI cmd for websockets example headless tests

### DIFF
--- a/examples/websockets-realtime-voting/headless-tests/playwright.config.ts
+++ b/examples/websockets-realtime-voting/headless-tests/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: `run-wasp-app ${HEADLESS_TEST_MODE} --path-to-app=../ --wasp-cli-cmd=wasp-cli`,
+    command: `run-wasp-app ${HEADLESS_TEST_MODE} --path-to-app=../`,
 
     // Wait for the backend to start
     url: "http://localhost:3001",


### PR DESCRIPTION
In all of our other example apps we don't provide this options but use the default `wasp` command.

I'll merge it when the CI passes.