### PR TITLE
Pin Rollup version that Vite uses in web-app

### DIFF
--- a/waspc/data/Generator/templates/react-app/package.json
+++ b/waspc/data/Generator/templates/react-app/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   {=& depsChunk =},
   {=& devDepsChunk =},
+  {=& overridesChunk =},
   "scripts": {
     "start": "vite",
     "build": "tsc --build && vite build"

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -578,7 +578,7 @@
             "file",
             "web-app/package.json"
         ],
-        "b279e7da4f62c7b9e70b02aff58572e5d23cfe16f128b75a9fc18ec41f961a27"
+        "a4013f0a45e86a308859279ba4e5881818f90a2a7b09f3c06cb2a0c2b266bc39"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/package.json
@@ -25,6 +25,9 @@
     "node": ">=20.0.0"
   },
   "name": "waspBuild",
+  "overrides": {
+    "rollup": "4.44.0"
+  },
   "private": true,
   "scripts": {
     "build": "tsc --build && vite build",

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -592,7 +592,7 @@
             "file",
             "web-app/package.json"
         ],
-        "5ba5fc44476e06348837dfd34d5f4293a2540e06c1535423c3352751b5ff307c"
+        "f276211a2e31df7afcefc31b7e9e439c95e11b8d02c32fcb031dae1e921841fb"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/package.json
@@ -25,6 +25,9 @@
     "node": ">=20.0.0"
   },
   "name": "waspCompile",
+  "overrides": {
+    "rollup": "4.44.0"
+  },
   "private": true,
   "scripts": {
     "build": "tsc --build && vite build",

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -1229,7 +1229,7 @@
             "file",
             "web-app/package.json"
         ],
-        "8a934fd3c835123e71d4b92f5f25839f96b063de740e28e5eaba3d30f2c69d2e"
+        "16d5d7a468e045233ff065edf6660f856009df2dab17485f39ee0c7b7c881df0"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/package.json
@@ -25,6 +25,9 @@
     "node": ">=20.0.0"
   },
   "name": "waspComplexTest",
+  "overrides": {
+    "rollup": "4.44.0"
+  },
   "private": true,
   "scripts": {
     "build": "tsc --build && vite build",

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -690,7 +690,7 @@
             "file",
             "web-app/package.json"
         ],
-        "9c87ad694e90989357cbaafc2cbb04a0df5e48653aeab396aaadc237cf644435"
+        "5f82c47c99523900b638bde2706d1ce09fb9351ae9269f50761a753c1f43a31f"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/package.json
@@ -25,6 +25,9 @@
     "node": ">=20.0.0"
   },
   "name": "waspJob",
+  "overrides": {
+    "rollup": "4.44.0"
+  },
   "private": true,
   "scripts": {
     "build": "tsc --build && vite build",

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -599,7 +599,7 @@
             "file",
             "web-app/package.json"
         ],
-        "864289f9248c94fb6dcd6b4456c0037abc5fcd91d14c77a9b5cc6681457f17cb"
+        "9d0609be5a87344c50c95d5e2f9b49b13285e281042734f071a498896486f549"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/package.json
@@ -25,6 +25,9 @@
     "node": ">=20.0.0"
   },
   "name": "waspMigrate",
+  "overrides": {
+    "rollup": "4.44.0"
+  },
   "private": true,
   "scripts": {
     "build": "tsc --build && vite build",

--- a/waspc/src/Wasp/Generator/NpmDependencies.hs
+++ b/waspc/src/Wasp/Generator/NpmDependencies.hs
@@ -14,6 +14,7 @@ module Wasp.Generator.NpmDependencies
     NpmDepsForWasp (..),
     NpmDepsForUser (..),
     buildWaspFrameworkNpmDeps,
+    getDependencyOverridesPackageJsonEntry,
   )
 where
 
@@ -198,6 +199,9 @@ getDependenciesPackageJsonEntry = dependenciesToPackageJsonEntryWithKey "depende
 -- | Construct devDependencies entry in package.json
 getDevDependenciesPackageJsonEntry :: NpmDepsForPackage -> String
 getDevDependenciesPackageJsonEntry = dependenciesToPackageJsonEntryWithKey "devDependencies" . devDependencies
+
+getDependencyOverridesPackageJsonEntry :: [D.Dependency] -> String
+getDependencyOverridesPackageJsonEntry = dependenciesToPackageJsonEntryWithKey "overrides"
 
 dependenciesToPackageJsonEntryWithKey :: String -> [D.Dependency] -> String
 dependenciesToPackageJsonEntryWithKey key deps =

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -112,9 +112,16 @@ genPackageJson spec waspDependencies = do
             [ "appName" .= (fst (getApp spec) :: String),
               "depsChunk" .= N.getDependenciesPackageJsonEntry combinedDependencies,
               "devDepsChunk" .= N.getDevDependenciesPackageJsonEntry combinedDependencies,
+              "overridesChunk" .= N.getDependencyOverridesPackageJsonEntry dependencyOverrides,
               "nodeVersionRange" .= (">=" <> show NodeVersion.oldestWaspSupportedNodeVersion)
             ]
       )
+  where
+    dependencyOverrides =
+      Npm.Dependency.fromList
+        [ -- TODO: remove this once Rollup fixes their lastest version https://github.com/rollup/rollup/issues/6012
+          ("rollup", "4.44.0")
+        ]
 
 genNpmrc :: Generator FileDraft
 genNpmrc =


### PR DESCRIPTION
`vite build` fails for https://github.com/wasp-lang/ask-the-documents with the latest RC

Connected to: https://github.com/rollup/rollup/issues/6012

We are overriding the `rolldown` version Vite uses to the latest version that works and it's recommended by some commentators in the linked issue.

Ideally, we'd remove this override ASAP since we assume that Rollup will be functional for us in a few days.