### PR TITLE
Make Prisma schema valid

### DIFF
--- a/waspc/examples/todoApp/schema.prisma
+++ b/waspc/examples/todoApp/schema.prisma
@@ -19,7 +19,7 @@ model User {
   tasks                Task[]
   address              String?
   votes                TaskVote[]
-  UppercaseTextRequest UppercaseTextRequest[]
+  uppercaseTextRequest UppercaseTextRequest[]
 }
 
 enum TaskVisibility {

--- a/waspc/examples/todoApp/schema.prisma
+++ b/waspc/examples/todoApp/schema.prisma
@@ -19,7 +19,7 @@ model User {
   tasks                Task[]
   address              String?
   votes                TaskVote[]
-  uppercaseTextRequest UppercaseTextRequest[]
+  uppercaseTextRequests UppercaseTextRequest[]
 }
 
 enum TaskVisibility {

--- a/waspc/examples/todoApp/schema.prisma
+++ b/waspc/examples/todoApp/schema.prisma
@@ -16,9 +16,10 @@ model User {
   isOnAfterLoginHookCalled         Boolean @default(false)
   isOnAfterEmailVerifiedHookCalled Boolean @default(false)
 
-  tasks   Task[]
-  address String?
-  votes   TaskVote[]
+  tasks                Task[]
+  address              String?
+  votes                TaskVote[]
+  UppercaseTextRequest UppercaseTextRequest[]
 }
 
 enum TaskVisibility {


### PR DESCRIPTION
I'm running some Prima parsing experiments and their parser complains that the `UppercaseTextTask -> User` relation needs the define the reverse relation `User -> UppercaseTextTask[]` relation as well.

I ran `prisma format` to get it right