### PR TITLE
Restructure pgboss docs and add data retention section

### DIFF
--- a/web/docs/advanced/jobs.md
+++ b/web/docs/advanced/jobs.md
@@ -181,7 +181,7 @@ Currently, Wasp only has support for one job executor, `PgBoss`.
 
 ### `PgBoss` {#pgboss}
 
-[`PgBoss`](https://github.com/timgit/pg-boss/tree/8.4.2) is a lightweight job queue built on top of PostgreSQL. It is suitable for low-volume production use cases and does not require any additional infrastructure or complex management. By using PostgreSQL (and [SKIP LOCKED](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/)) as its storage and synchronization mechanism, you get many benefits of a traditional job queues on top of your existing Postgres database.
+[`PgBoss`](https://github.com/timgit/pg-boss/tree/8.4.2) is a lightweight job queue built on top of PostgreSQL. It is suitable for low-volume production use cases and does not require any additional infrastructure or complex management. By using PostgreSQL (and [SKIP LOCKED](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/)) as its storage and synchronization mechanism, you get many benefits of a traditional job queue, on top of your existing Postgres database.
 
 #### Requirements
 
@@ -218,7 +218,7 @@ The job name/identifier in your `.wasp` file is the same name that will be used 
 
 #### Job data retention and cleanup
 
-By default, `PgJobs` keeps job data for 12 hours after completion or failure. After that, it moves the data to an archive table, where it is kept for 7 days before being deleted. If you want to change this behavior, you can configure the `PG_BOSS_NEW_OPTIONS` environment variable to set custom values for job archival ([`archivedCompletedAfterSeconds`/`archiveFailedAfterSeconds`](https://github.com/timgit/pg-boss/tree/8.4.2/docs#newoptions:~:text=v1%22%20or%20%22v4%22-,archiveCompletedAfterSeconds,-Specifies%20how%20long)) and removal ([`deleteAfterSeconds`/`deleteAfterMinutes`/etc](https://github.com/timgit/pg-boss/tree/8.4.2/docs#newoptions:~:text=the%20skew%20warnings.-,Archive%20options,-When%20jobs%20in)).
+By default, `PgBoss` keeps job data for 12 hours after completion or failure. After that, it moves the data to an archive table, where it is kept for 7 days before being deleted. If you want to change this behavior, you can configure the `PG_BOSS_NEW_OPTIONS` environment variable to set custom values for job archival ([`archivedCompletedAfterSeconds`/`archiveFailedAfterSeconds`](https://github.com/timgit/pg-boss/tree/8.4.2/docs#newoptions:~:text=v1%22%20or%20%22v4%22-,archiveCompletedAfterSeconds,-Specifies%20how%20long)) and removal ([`deleteAfterSeconds`/`deleteAfterMinutes`/etc](https://github.com/timgit/pg-boss/tree/8.4.2/docs#newoptions:~:text=the%20skew%20warnings.-,Archive%20options,-When%20jobs%20in)).
 
 ```bash
 PG_BOSS_NEW_OPTIONS={"connectionString":"...your postgress connection url...","archiveCompletedAfterSeconds":86400,"deleteAfterDays":30,"maintenanceIntervalMinutes":5}

--- a/web/docs/advanced/jobs.md
+++ b/web/docs/advanced/jobs.md
@@ -221,7 +221,21 @@ When using `PgBoss`, the database setup is automatically taken care of by the Wa
 
 All job data will be stored in a separate database schema called `pgboss`. It has some internal tracking tables, such as `job`, `archive`, and `schedule`. `PgBoss` tables have a `name` column in most tables that will correspond to your Job identifier. Additionally, these tables maintain arguments, states, return values, retry information, start and expiration times, and other metadata required by `PgBoss`.
 
-The job name/identifier in your `.wasp` file is the same name that will be used in the `name` column of `pgboss` tables. If you change a name that had a `schedule` associated with it, pg-boss will continue scheduling those jobs but they will have no handlers associated, and will thus become stale and expire. To resolve this, you can remove the applicable row from the `pgboss.schedule` table.
+#### Known issues
+
+- **Renaming scheduled jobs**
+
+    The job name/identifier in your `.wasp` file is the same name that will be used in the `name` column of `pgboss` tables. If you change a name that had a `schedule` associated with it, pg-boss will continue scheduling those jobs but they will have no handlers associated, and will thus become stale and expire. To resolve this, you can remove the applicable row from the `pgboss.schedule` table.
+
+    For example, if you renamed a job from `emailReminder` to `sendEmailReminder`, you would need to remove the old scheduled job with the following SQL query:
+
+    ```sql
+    BEGIN;
+    DELETE FROM pgboss.schedule WHERE name = 'emailReminder';
+    COMMIT;
+    ```
+
+    **Important:** Only modify the database directly if you're comfortable with SQL operations. If you're unsure, consider keeping the old job name or restarting with a fresh database in development.
 
 #### Job data retention and cleanup
 

--- a/web/docs/advanced/jobs.md
+++ b/web/docs/advanced/jobs.md
@@ -200,9 +200,16 @@ If you need to customize the creation of the `PgBoss` instance, you can set an e
 Please note that setting `PG_BOSS_NEW_OPTIONS` environment variable overwrites all Wasp defaults, so you must include the `connectionString` parameter inside it as well.
 
 For example, to set the connection string and change the job archival and deletion settings, you can set the environment variable like this:
+
 ```bash
+# In an .env file
 PG_BOSS_NEW_OPTIONS={"connectionString":"postgresql://user:password@server:5432/database","archiveCompletedAfterSeconds":86400,"deleteAfterDays":30,"maintenanceIntervalMinutes":5}
+
+# In the shell
+PG_BOSS_NEW_OPTIONS='{"connectionString":"postgresql://user:password@server:5432/database","archiveCompletedAfterSeconds":86400,"deleteAfterDays":30,"maintenanceIntervalMinutes":5}'
 ```
+
+You can read more about escaping JSON in environment variables in the [JSON Env Vars documentation](../project/env-vars.md#json-env-vars).
 
 #### Database setup
 

--- a/web/docs/advanced/jobs.md
+++ b/web/docs/advanced/jobs.md
@@ -193,7 +193,7 @@ Currently, Wasp only has support for one job executor, `PgBoss`.
 
 The `PgBoss` executor in Wasp does not (yet) support independent, horizontal scaling of pg-boss-only applications, nor starting them as separate workers/processes/threads. This means that your server must be running whenever you want to process jobs. If you need to scale your job processing, you will need to run multiple instances of your web server, each with its own `PgBoss` instance.
 
-#### Customization {#PG_BOSS_NEW_OPTIONS}
+#### Customization {#pg_boss_new_options}
 
 If you need to customize the creation of the `PgBoss` instance, you can set an environment variable called `PG_BOSS_NEW_OPTIONS` to a stringified JSON object containing the initialization parameters. See the [pg-boss documentation](https://github.com/timgit/pg-boss/tree/8.4.2/docs#newoptions).
 

--- a/web/docs/advanced/jobs.md
+++ b/web/docs/advanced/jobs.md
@@ -181,7 +181,7 @@ Currently, Wasp only has support for one job executor, `PgBoss`.
 
 ### `PgBoss` {#pgboss}
 
-[`PgBoss`](https://github.com/timgit/pg-boss/tree/8.4.2) is a lightweight job queue built on top of PostgreSQL. It is suitable for low-volume production use cases and does not require any additional infrastructure or complex management. By using PostgreSQL (and [SKIP LOCKED](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/)) as its storage and synchronization mechanism, it allows us to provide many job queue pros with the infrastructure we already put in place for your project.
+[`PgBoss`](https://github.com/timgit/pg-boss/tree/8.4.2) is a lightweight job queue built on top of PostgreSQL. It is suitable for low-volume production use cases and does not require any additional infrastructure or complex management. By using PostgreSQL (and [SKIP LOCKED](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/)) as its storage and synchronization mechanism, you get many benefits of a traditional job queues on top of your existing Postgres database.
 
 #### Requirements
 
@@ -199,6 +199,11 @@ If you need to customize the creation of the `PgBoss` instance, you can set an e
 
 Please note that setting `PG_BOSS_NEW_OPTIONS` environment variable overwrites all Wasp defaults, so you must include the `connectionString` parameter inside it as well.
 
+For example, to set the connection string and change the job archival and deletion settings, you can set the environment variable like this:
+```bash
+PG_BOSS_NEW_OPTIONS={"connectionString":"postgresql://user:password@server:5432/database","archiveCompletedAfterSeconds":86400,"deleteAfterDays":30,"maintenanceIntervalMinutes":5}
+```
+
 #### Database setup
 
 :::tip You don't need to set up the database manually
@@ -207,7 +212,7 @@ When using `PgBoss`, the database setup is automatically taken care of by the Wa
 
 :::
 
-All job data will be stored in a separate database schema called `pgboss`. It has some internal tracking tables, such `job`, `archive`, and `schedule`. `PgBoss` tables have a `name` column in most tables that will correspond to your Job identifier. Additionally, these tables maintain arguments, states, return values, retry information, start and expiration times, and other metadata required by `PgBoss`.
+All job data will be stored in a separate database schema called `pgboss`. It has some internal tracking tables, such as `job`, `archive`, and `schedule`. `PgBoss` tables have a `name` column in most tables that will correspond to your Job identifier. Additionally, these tables maintain arguments, states, return values, retry information, start and expiration times, and other metadata required by `PgBoss`.
 
 The job name/identifier in your `.wasp` file is the same name that will be used in the `name` column of `pgboss` tables. If you change a name that had a `schedule` associated with it, pg-boss will continue scheduling those jobs but they will have no handlers associated, and will thus become stale and expire. To resolve this, you can remove the applicable row from the `pgboss.schedule` table.
 
@@ -216,7 +221,7 @@ The job name/identifier in your `.wasp` file is the same name that will be used 
 By default, `PgJobs` keeps job data for 12 hours after completion or failure. After that, it moves the data to an archive table, where it is kept for 7 days before being deleted. If you want to change this behavior, you can configure the `PG_BOSS_NEW_OPTIONS` environment variable to set custom values for job archival ([`archivedCompletedAfterSeconds`/`archiveFailedAfterSeconds`](https://github.com/timgit/pg-boss/tree/8.4.2/docs#newoptions:~:text=v1%22%20or%20%22v4%22-,archiveCompletedAfterSeconds,-Specifies%20how%20long)) and removal ([`deleteAfterSeconds`/`deleteAfterMinutes`/etc](https://github.com/timgit/pg-boss/tree/8.4.2/docs#newoptions:~:text=the%20skew%20warnings.-,Archive%20options,-When%20jobs%20in)).
 
 ```bash
-PG_BOSS_NEW_OPTIONS='{"connectionString":"...your postgress connection url...","archiveCompletedAfterSeconds":86400,"deleteAfterDays":30,"maintenanceIntervalMinutes":5}'
+PG_BOSS_NEW_OPTIONS={"connectionString":"...your postgress connection url...","archiveCompletedAfterSeconds":86400,"deleteAfterDays":30,"maintenanceIntervalMinutes":5}
 ```
 
 ## API Reference

--- a/web/docs/deployment/deployment-methods/paas.md
+++ b/web/docs/deployment/deployment-methods/paas.md
@@ -462,7 +462,7 @@ heroku logs --tail --app <app-name>
 
 :::note Using `pg-boss` with Heroku
 
-If you wish to deploy an app leveraging [Jobs](../../advanced/jobs) that use `pg-boss` as the executor to Heroku, you need to set an additional environment variable called [`PG_BOSS_NEW_OPTIONS`](../../advanced/jobs.md#PG_BOSS_NEW_OPTIONS) to `{"connectionString":"<REGULAR_HEROKU_DATABASE_URL>","ssl":{"rejectUnauthorized":false}}`. This is because pg-boss uses the `pg` extension, which does not seem to connect to Heroku over SSL by default, which Heroku requires. Additionally, Heroku uses a self-signed cert, so we must handle that as well.
+If you wish to deploy an app leveraging [Jobs](../../advanced/jobs) that use `pg-boss` as the executor to Heroku, you need to set an additional environment variable called [`PG_BOSS_NEW_OPTIONS`](../../advanced/jobs.md#pg_boss_new_options) to `{"connectionString":"<REGULAR_HEROKU_DATABASE_URL>","ssl":{"rejectUnauthorized":false}}`. This is because pg-boss uses the `pg` extension, which does not seem to connect to Heroku over SSL by default, which Heroku requires. Additionally, Heroku uses a self-signed cert, so we must handle that as well.
 
 Read more: https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js
 :::

--- a/web/docs/deployment/deployment-methods/paas.md
+++ b/web/docs/deployment/deployment-methods/paas.md
@@ -322,7 +322,7 @@ You'll deploy the server first:
     ```
 
 <!-- TOPIC: client deployment -->
-    
+
 4. Next, deploy the client build to Railway:
 
     ```shell
@@ -330,7 +330,7 @@ You'll deploy the server first:
     ```
 
     Select `client` when prompted to select a service.
-    
+
     Railway will detect the `index.html` file and deploy the client as a static site using [Railpack](https://railpack.com/languages/staticfile#root-directory-resolution).
 
 
@@ -462,7 +462,7 @@ heroku logs --tail --app <app-name>
 
 :::note Using `pg-boss` with Heroku
 
-If you wish to deploy an app leveraging [Jobs](../../advanced/jobs) that use `pg-boss` as the executor to Heroku, you need to set an additional environment variable called `PG_BOSS_NEW_OPTIONS` to `{"connectionString":"<REGULAR_HEROKU_DATABASE_URL>","ssl":{"rejectUnauthorized":false}}`. This is because pg-boss uses the `pg` extension, which does not seem to connect to Heroku over SSL by default, which Heroku requires. Additionally, Heroku uses a self-signed cert, so we must handle that as well.
+If you wish to deploy an app leveraging [Jobs](../../advanced/jobs) that use `pg-boss` as the executor to Heroku, you need to set an additional environment variable called [`PG_BOSS_NEW_OPTIONS`](../../advanced/jobs.md#PG_BOSS_NEW_OPTIONS) to `{"connectionString":"<REGULAR_HEROKU_DATABASE_URL>","ssl":{"rejectUnauthorized":false}}`. This is because pg-boss uses the `pg` extension, which does not seem to connect to Heroku over SSL by default, which Heroku requires. Additionally, Heroku uses a self-signed cert, so we must handle that as well.
 
 Read more: https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js
 :::

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -159,7 +159,7 @@ If you are using [Keycloak](../auth/social-auth/keycloak.md), you'll need to pro
 
 <EnvVarsTable
   envVars={[
-{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs#pg_boss_new_options">custom config</a> for PgBoss.</span> }
+{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>A <a href="#json-env-vars">JSON env var</a>. Enables you to provide <a href="../advanced/jobs#pg_boss_new_options">custom config</a> for PgBoss.</span> }
 ]}
 />
 
@@ -227,6 +227,34 @@ Defining environment variables in this way can be cumbersome even for a single p
 Defining env variables in production will depend on where you are deploying your Wasp project. In general, you will define them via mechanisms that your hosting provider provides.
 
 We talk about how to define env vars for each deployment option in the [deployment section](../deployment/env-vars.md).
+
+## JSON Env Vars {#json-env-vars}
+
+Some of the environment variables you pass to Wasp are parsed as JSON values. This is useful for features needing more in-depth configuration, but it comes with the caveat of ensuring that the JSON syntax is valid.
+
+The main issue comes in the form of escaping quotes, and the different ways to do it depending on where you are defining the env var.
+
+#### In `.env` files
+
+In `.env` files, you don't need to quote the full value, so you don't need to escape the quotes. For example, you can define a JSON object like this:
+
+```shell
+PG_BOSS_NEW_OPTIONS={"connectionString":"...db url...","jobExpirationInSeconds":60,"maxRetries":3}
+```
+
+#### In the shell
+
+In the shell, you need to quote the full value and escape the quotes inside the JSON object. For example, you can define a JSON object like this:
+
+```shell
+PG_BOSS_NEW_OPTIONS="{\"connectionString\":\"...db url...\",\"jobExpirationInSeconds\":60,\"maxRetries\":3}"
+```
+
+As an alternative, you can use single quotes to avoid escaping the quotes inside the JSON object:
+
+```shell
+PG_BOSS_NEW_OPTIONS='{"connectionString":"...db url...","jobExpirationInSeconds":60,"maxRetries":3}'
+```
 
 ## Custom Env Var Validations
 

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -238,7 +238,7 @@ The main issue comes in the form of escaping quotes, and the different ways to d
 
 In `.env` files, you don't need to quote the full value, so you don't need to escape the quotes. For example, you can define a JSON object like this:
 
-```shell
+```shell title=".env.server"
 PG_BOSS_NEW_OPTIONS={"connectionString":"...db url...","jobExpirationInSeconds":60,"maxRetries":3}
 ```
 

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -159,7 +159,7 @@ If you are using [Keycloak](../auth/social-auth/keycloak.md), you'll need to pro
 
 <EnvVarsTable
   envVars={[
-{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs.md#pg_boss_new_options">custom config</a> for PgBoss.</span> }
+{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs#pg_boss_new_options">custom config</a> for PgBoss.</span> }
 ]}
 />
 

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -159,7 +159,7 @@ If you are using [Keycloak](../auth/social-auth/keycloak.md), you'll need to pro
 
 <EnvVarsTable
   envVars={[
-{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs.md#PG_BOSS_NEW_OPTIONS">custom config</a> for PgBoss.</span> }
+{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs.md#pg_boss_new_options">custom config</a> for PgBoss.</span> }
 ]}
 />
 

--- a/web/docs/project/env-vars.md
+++ b/web/docs/project/env-vars.md
@@ -159,7 +159,7 @@ If you are using [Keycloak](../auth/social-auth/keycloak.md), you'll need to pro
 
 <EnvVarsTable
   envVars={[
-{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs#declaring-jobs">custom config</a> for PgBoss.</span> }
+{ name: "PG_BOSS_NEW_OPTIONS", type: "String", isRequired: false, note: <span>It's parsed as JSON. Enables you to provide <a href="../advanced/jobs.md#PG_BOSS_NEW_OPTIONS">custom config</a> for PgBoss.</span> }
 ]}
 />
 


### PR DESCRIPTION
Resolves #2313 

- Moves all the PgBoss-specific information from a `<details>` inside a `:::note` into its own section, with well-organized subsections.
- Adds a subsection with the information from #2313 on job data archival and removal.