### PR TITLE
fix - Improves UX for auth signin failing due to account already existing

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
@@ -172,7 +172,7 @@ export const LoginSignupForm = ({
     onError: onErrorHandler,
     showEmailVerificationPending() {
       hookForm.reset()
-      setSuccessMessage(`You've signed up successfully! Check your email for the confirmation link.`)
+      setSuccessMessage('If you have an account, you’ll receive an email with further instructions.')
     },
     onLoginSuccess() {
       navigate('{= onAuthSucceededRedirectTo =}')

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
@@ -23,8 +23,10 @@ import {
   isEmailResendAllowed,
   sendEmailVerificationEmail,
 } from 'wasp/server/auth/email/utils'
-import { EmailFromField } from 'wasp/server/email/core/types'
+import { EmailFromField } from 'wasp/server/email'
 import { onAfterSignupHook, onBeforeSignupHook } from '../../hooks.js'
+import { Email } from 'wasp/server/email'
+import { emailSender } from 'wasp/server/email'
 
 export function getSignupRoute({
   userSignupFields,
@@ -82,6 +84,19 @@ export function getSignupRoute({
       // it would take to send the email. Atm, the fake work takes obviously longer than sending
       // the email!
       if (providerData.isEmailVerified) {
+        // Send a generic 'account already exists' email to the user.
+        try {
+          await sendAccountAlreadyExistsEmail(fields.email, {
+            from: fromField,
+            to: fields.email,
+            subject: 'Account Already Exists',
+            text: 'It looks like you (or someone else) tried to sign up with this email. If you already have an account, you can log in or reset your password. If this wasn’t you, you can ignore this email.',
+            html: '<p>It looks like you (or someone else) tried to sign up with this email. If you already have an account, you can <a href="/login">log in</a> or <a href="/reset-password">reset your password</a>. If this wasn’t you, you can ignore this email.</p>'
+          })
+        } catch (e: unknown) {
+          console.error('Failed to send account already exists email:', e)
+          // Do not throw, to avoid leaking info
+        }
         await doFakeWork()
         res.json({ success: true })
         return
@@ -162,4 +177,12 @@ function ensureValidArgs(args: object): void {
   ensureValidEmail(args)
   ensurePasswordIsPresent(args)
   ensureValidPassword(args)
+}
+
+async function sendAccountAlreadyExistsEmail(email: string, content: Email): Promise<void> {
+  // Use the same email sending utility as verification emails, but do not update verification metadata.
+  // This avoids leaking info about verification status.
+  emailSender.send(content).catch((e) => {
+    console.error('Failed to send account already exists email', e);
+  });
 }


### PR DESCRIPTION
### Description

Fixes #3002 - Improves UX for auth signin failing due to account already existing.

When users try to sign up with an email that already exists, Wasp now sends a helpful email to guide them instead of just pretending the signup succeeded. The frontend message is also updated to be more generic and user-friendly.

**Changes:**
- Backend: Send "account already exists" email when signup attempted with verified email
- Frontend: Update signup success message to "If you have an account, you'll receive an email with further instructions"

### Select what type of change this PR introduces:

1. [ ] **Just code/docs improvement** (no functional change).
2. [x] **Bug fix** (non-breaking change which fixes an issue).
3. [ ] **New feature** (non-breaking change which adds functionality).
4. [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

### Update Waspc ChangeLog and version if needed

1. [x] I updated [`ChangeLog.md`](https://github.com/wasp-lang/wasp/blob/main/waspc/ChangeLog.md) with description of the change this PR introduces.
2. [x] I bumped `waspc` version in [`waspc.cabal`](https://github.com/wasp-lang/wasp/blob/main/waspc/waspc.cabal) to reflect changes I introduced, with regards to the version of the latest wasp release, if the bump was needed.