### PR TITLE
Remove old header

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -1931,5 +1931,3 @@ For exact details about new syntax, check https://wasp.sh/docs/language/syntax .
 - Added delay on recompilation to avoid redundant recompiling.
 - Added `onAuthSucceededRedirectTo` field in `app`.
 - and more!
-
-## Unreleased changes


### PR DESCRIPTION
We don't want to get contributors or ourselves confused when adding changes, we're adding them on top