### PR TITLE
Bumps Cabal in CI to 3.10.2.0

### DIFF
--- a/.github/workflows/examples-headless-tests.yaml
+++ b/.github/workflows/examples-headless-tests.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: ./.github/actions/setup-haskell
         with:
           ghc-version: "8.10.7"
-          cabal-version: "3.6.2.0"
+          cabal-version: "3.10.2.0"
           cabal-project-dir: waspc
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -50,7 +50,7 @@ jobs:
         ghc:
           - "8.10.7"
         cabal:
-          - "3.6.2.0"
+          - "3.10.2.0"
         # In addition to the default matrix, we also want to run the build job for
         # additional Node.js versions, to make sure that Wasp works with them.
         # To reduce the number of jobs, we only test the Node.js versions on
@@ -59,11 +59,11 @@ jobs:
           - os: ubuntu-22.04
             node-version: 20
             ghc: "8.10.7"
-            cabal: "3.6.2.0"
+            cabal: "3.10.2.0"
           - os: ubuntu-22.04
             node-version: 22
             ghc: "8.10.7"
-            cabal: "3.6.2.0"
+            cabal: "3.10.2.0"
 
     steps:
       - name: Configure git


### PR DESCRIPTION
CI started failing with our current `3.6.2.0` version. The https://github.com/haskell-actions/setup action has `3.10.2.0` listed as the oldest supported version so I went with that.

Verified that it works here: https://github.com/wasp-lang/wasp/actions/runs/16592588946?pr=3013 but I created this new PR because I didn't branch from `main` in the other PR.