### PR TITLE
Draft: Allow trailing triple-slash comments in Prisma

### DIFF
--- a/waspc/src/Wasp/Psl/Parser/Argument.hs
+++ b/waspc/src/Wasp/Psl/Parser/Argument.hs
@@ -9,9 +9,9 @@ where
 import Text.Megaparsec (choice, optional, try)
 import qualified Text.Megaparsec.Char as C
 import qualified Wasp.Psl.Ast.Argument as Psl.Argument
-import Wasp.Psl.Parser.Common
-  ( Parser,
-    brackets,
+import Wasp.Psl.Parser.Common (Parser)
+import Wasp.Psl.Parser.Tokens
+  ( brackets,
     colon,
     commaSep,
     float,

--- a/waspc/src/Wasp/Psl/Parser/Common.hs
+++ b/waspc/src/Wasp/Psl/Parser/Common.hs
@@ -1,111 +1,14 @@
 module Wasp.Psl.Parser.Common
-  ( whiteSpace,
-    reserved,
-    identifier,
-    braces,
-    symbol,
-    parens,
-    stringLiteral,
-    brackets,
-    commaSep1,
-    commaSep,
-    colon,
-    float,
-    integer,
-    lexeme,
-    SourceCode,
+  ( SourceCode,
     Parser,
   )
 where
 
-import Control.Applicative (liftA2)
-import Data.Functor (void)
 import Data.Void (Void)
 import Text.Megaparsec
   ( Parsec,
-    between,
-    empty,
-    many,
-    manyTill,
-    notFollowedBy,
-    sepBy,
-    sepBy1,
-    takeWhileP,
-    try,
-    (<?>),
-    (<|>),
   )
-import qualified Text.Megaparsec.Char as C
-import qualified Text.Megaparsec.Char.Lexer as L
 
 type Parser = Parsec Void SourceCode
 
 type SourceCode = String
-
-reserved :: String -> Parser ()
-reserved name =
-  lexeme $ try $ C.string name >> (notFollowedBy identLetter <?> ("end of " ++ show name))
-
-identifier :: Parser String
-identifier =
-  lexeme $ try (ident <?> "identifier")
-  where
-    ident = liftA2 (:) identHead identTail
-    identHead = C.letterChar
-    identTail = many identLetter
-
-identLetter :: Parser Char
-identLetter = C.alphaNumChar <|> C.char '_'
-
-braces :: Parser a -> Parser a
-braces = between (symbol "{") (symbol "}")
-
-parens :: Parser a -> Parser a
-parens = between (symbol "(") (symbol ")")
-
-stringLiteral :: Parser String
-stringLiteral = lexeme $ quote >> manyTill L.charLiteral quote
-  where
-    quote = C.char '"'
-
-brackets :: Parser a -> Parser a
-brackets = between (symbol "[") (symbol "]")
-
-commaSep1 :: Parser a -> Parser [a]
-commaSep1 = flip sepBy1 comma
-
-commaSep :: Parser a -> Parser [a]
-commaSep = flip sepBy comma
-
-comma :: Parser String
-comma = symbol ","
-
-colon :: Parser String
-colon = symbol ":"
-
-symbol :: String -> Parser String
-symbol = L.symbol whiteSpace
-
-float :: Parser Double
-float = L.signed whiteSpace unsignedFloat
-  where
-    unsignedFloat = lexeme L.float
-
-integer :: Parser Integer
-integer = L.signed whiteSpace unsignedInteger
-  where
-    unsignedInteger = lexeme L.decimal
-
-lexeme :: Parser a -> Parser a
-lexeme = L.lexeme whiteSpace
-
-whiteSpace :: Parser ()
-whiteSpace =
-  L.space (void C.spaceChar) (void lineComment) empty
-
-lineComment :: Parser String
-lineComment =
-  try doubleSlashSymbol
-    >> takeWhileP (Just "character") (/= '\n')
-  where
-    doubleSlashSymbol = C.string "//" >> notFollowedBy (C.char '/')

--- a/waspc/src/Wasp/Psl/Parser/ConfigBlock.hs
+++ b/waspc/src/Wasp/Psl/Parser/ConfigBlock.hs
@@ -6,12 +6,13 @@ module Wasp.Psl.Parser.ConfigBlock
   )
 where
 
-import Text.Megaparsec (choice, many, try)
+import Text.Megaparsec (choice, sepEndBy, try)
 import qualified Wasp.Psl.Ast.ConfigBlock as Psl.ConfigBlock
 import Wasp.Psl.Parser.Argument (expression)
-import Wasp.Psl.Parser.Common
-  ( Parser,
-    braces,
+import Wasp.Psl.Parser.Common (Parser)
+import Wasp.Psl.Parser.Lexer (compulsoryNewline)
+import Wasp.Psl.Parser.Tokens
+  ( braces,
     identifier,
     reserved,
     symbol,
@@ -35,7 +36,7 @@ configBlock = do
   Psl.ConfigBlock.ConfigBlock configBlockType name <$> configBlockBody
 
 configBlockBody :: Parser [Psl.ConfigBlock.KeyValuePair]
-configBlockBody = braces (many keyValuePair)
+configBlockBody = braces $ keyValuePair `sepEndBy` compulsoryNewline
 
 -- | Parses a key-value pair.
 -- Example of PSL key-value pair:

--- a/waspc/src/Wasp/Psl/Parser/Enum.hs
+++ b/waspc/src/Wasp/Psl/Parser/Enum.hs
@@ -3,12 +3,13 @@ module Wasp.Psl.Parser.Enum
   )
 where
 
-import Text.Megaparsec (choice, many, some, try)
+import Text.Megaparsec (choice, many, sepEndBy1, try)
 import qualified Wasp.Psl.Ast.Enum as Psl.Enum
 import Wasp.Psl.Parser.Attribute (attribute, blockAttribute)
-import Wasp.Psl.Parser.Common
-  ( Parser,
-    braces,
+import Wasp.Psl.Parser.Common (Parser)
+import Wasp.Psl.Parser.Lexer (compulsoryNewline)
+import Wasp.Psl.Parser.Tokens
+  ( braces,
     identifier,
     reserved,
   )
@@ -25,7 +26,7 @@ enum :: Parser Psl.Enum.Enum
 enum = do
   reserved "enum"
   enumName <- identifier
-  Psl.Enum.Enum enumName <$> braces (some $ withCtx enumField)
+  Psl.Enum.Enum enumName <$> braces (withCtx enumField `sepEndBy1` compulsoryNewline)
 
 enumField :: Parser Psl.Enum.Element
 enumField =

--- a/waspc/src/Wasp/Psl/Parser/Lexer.hs
+++ b/waspc/src/Wasp/Psl/Parser/Lexer.hs
@@ -1,0 +1,63 @@
+module Wasp.Psl.Parser.Lexer
+  ( compulsoryNewline,
+    lexeme,
+    spaceConsumer,
+    spaceConsumerNL,
+  )
+where
+
+import qualified Data.Char as Char
+import Data.Functor (void)
+import Text.Megaparsec
+  ( MonadParsec (label),
+    empty,
+    notFollowedBy,
+    satisfy,
+    takeWhileP,
+    try,
+    (<?>),
+    (<|>),
+  )
+import qualified Text.Megaparsec.Char as C
+import qualified Text.Megaparsec.Char.Lexer as L
+import Wasp.Psl.Parser.Common (Parser)
+
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme spaceConsumer
+
+compulsoryNewline :: Parser ()
+compulsoryNewline = newline >> spaceConsumerNL
+
+spaceConsumerNL :: Parser ()
+spaceConsumerNL =
+  L.space
+    whiteSpaceNL
+    (void lineComment)
+    empty
+
+spaceConsumer :: Parser ()
+spaceConsumer =
+  L.space
+    whiteSpace
+    lineComment
+    empty
+
+lineComment :: Parser ()
+lineComment =
+  void $
+    label "line comment" $
+      try commentSymbol
+        >> takeWhileP (Just "character") (/= '\n')
+  where
+    commentSymbol = C.string "//" >> notFollowedBy newline
+
+whiteSpaceNL :: Parser ()
+whiteSpaceNL = whiteSpace <|> newline
+
+newline :: Parser ()
+newline = void C.newline <|> void C.crlf
+
+whiteSpace :: Parser ()
+whiteSpace = void (satisfy isNonNewlineSpace <?> "white space")
+  where
+    isNonNewlineSpace c = Char.Space == Char.generalCategory c

--- a/waspc/src/Wasp/Psl/Parser/Schema.hs
+++ b/waspc/src/Wasp/Psl/Parser/Schema.hs
@@ -6,12 +6,13 @@ module Wasp.Psl.Parser.Schema
 where
 
 import Control.Arrow (left)
-import Text.Megaparsec (choice, eof, errorBundlePretty, many)
+import Text.Megaparsec (choice, eof, errorBundlePretty, sepEndBy)
 import qualified Text.Megaparsec as Megaparsec
 import qualified Wasp.Psl.Ast.Schema as Psl.Schema
-import Wasp.Psl.Parser.Common (Parser, SourceCode, whiteSpace)
+import Wasp.Psl.Parser.Common (Parser, SourceCode)
 import Wasp.Psl.Parser.ConfigBlock (configBlock)
 import Wasp.Psl.Parser.Enum (enum)
+import Wasp.Psl.Parser.Lexer (compulsoryNewline, spaceConsumerNL)
 import Wasp.Psl.Parser.Model (model)
 import Wasp.Psl.Parser.Type (typeBlock)
 import Wasp.Psl.Parser.View (view)
@@ -26,8 +27,8 @@ schema = do
   -- Megaparsec's lexeme parsers in the sub-parsers (model, enum, configBlock)
   -- which consume the (trailing) whitespace themselves. It's a bit of an
   -- implict behaviour that we need to be aware of.
-  whiteSpace
-  elements <- many $ withCtx block
+  spaceConsumerNL
+  elements <- withCtx block `sepEndBy` compulsoryNewline
   -- We want to throw and if there is any source code left after parsing the schema.
   -- If we don't do this, the parser sometimes returns an empty schema when there
   -- are some syntax errors in the schema.

--- a/waspc/src/Wasp/Psl/Parser/Tokens.hs
+++ b/waspc/src/Wasp/Psl/Parser/Tokens.hs
@@ -1,0 +1,93 @@
+module Wasp.Psl.Parser.Tokens
+  ( reserved,
+    identifier,
+    braces,
+    symbol,
+    parens,
+    stringLiteral,
+    brackets,
+    commaSep1,
+    commaSep,
+    colon,
+    float,
+    integer,
+  )
+where
+
+import Control.Applicative (liftA2)
+import Text.Megaparsec
+  ( between,
+    eof,
+    many,
+    manyTill,
+    notFollowedBy,
+    sepBy,
+    sepBy1,
+    try,
+    (<?>),
+    (<|>),
+  )
+import qualified Text.Megaparsec.Char as C
+import qualified Text.Megaparsec.Char.Lexer as L
+import Wasp.Psl.Parser.Common (Parser)
+import Wasp.Psl.Parser.Lexer (compulsoryNewline, lexeme, spaceConsumer)
+
+reserved :: String -> Parser ()
+reserved name =
+  lexeme $
+    try $
+      C.string name
+        >> (notFollowedBy identLetter <?> ("end of " ++ show name))
+
+identifier :: Parser String
+identifier =
+  lexeme $ try (ident <?> "identifier")
+  where
+    ident = liftA2 (:) identHead identTail
+    identHead = C.letterChar
+    identTail = many identLetter
+
+identLetter :: Parser Char
+identLetter = C.alphaNumChar <|> C.char '_'
+
+braces :: Parser a -> Parser a
+braces =
+  between
+    (symbol "{" >> compulsoryNewline)
+    (symbol "}" >> (compulsoryNewline <|> eof))
+
+parens :: Parser a -> Parser a
+parens = between (symbol "(") (symbol ")")
+
+stringLiteral :: Parser String
+stringLiteral = lexeme $ quote >> manyTill L.charLiteral quote
+  where
+    quote = C.char '"'
+
+brackets :: Parser a -> Parser a
+brackets = between (symbol "[") (symbol "]")
+
+commaSep1 :: Parser a -> Parser [a]
+commaSep1 = flip sepBy1 comma
+
+commaSep :: Parser a -> Parser [a]
+commaSep = flip sepBy comma
+
+comma :: Parser String
+comma = symbol ","
+
+colon :: Parser String
+colon = symbol ":"
+
+symbol :: String -> Parser String
+symbol str = L.symbol spaceConsumer str
+
+float :: Parser Double
+float = L.signed spaceConsumer unsignedFloat
+  where
+    unsignedFloat = lexeme L.float
+
+integer :: Parser Integer
+integer = L.signed spaceConsumer unsignedInteger
+  where
+    unsignedInteger = lexeme L.decimal

--- a/waspc/src/Wasp/Psl/Parser/Type.hs
+++ b/waspc/src/Wasp/Psl/Parser/Type.hs
@@ -6,11 +6,13 @@ where
 import qualified Wasp.Psl.Ast.Type as Psl.Type
 import Wasp.Psl.Parser.Common
   ( Parser,
-    braces,
+  )
+import Wasp.Psl.Parser.Model (body)
+import Wasp.Psl.Parser.Tokens
+  ( braces,
     identifier,
     reserved,
   )
-import Wasp.Psl.Parser.Model (body)
 
 -- | Parses PSL (Prisma Schema Language) type.
 -- Example of PSL type:

--- a/waspc/src/Wasp/Psl/Parser/View.hs
+++ b/waspc/src/Wasp/Psl/Parser/View.hs
@@ -6,11 +6,13 @@ where
 import qualified Wasp.Psl.Ast.View as Psl.View
 import Wasp.Psl.Parser.Common
   ( Parser,
-    braces,
+  )
+import Wasp.Psl.Parser.Model (body)
+import Wasp.Psl.Parser.Tokens
+  ( braces,
     identifier,
     reserved,
   )
-import Wasp.Psl.Parser.Model (body)
 
 -- | Parses PSL (Prisma Schema Language) view.
 -- Example of PSL view:

--- a/waspc/src/Wasp/Psl/Parser/WithCtx.hs
+++ b/waspc/src/Wasp/Psl/Parser/WithCtx.hs
@@ -4,8 +4,11 @@ module Wasp.Psl.Parser.WithCtx
   )
 where
 
+import Data.Maybe (maybeToList)
 import Text.Megaparsec
-  ( many,
+  ( label,
+    many,
+    optional,
     takeWhileP,
   )
 import qualified Text.Megaparsec.Char as C
@@ -14,21 +17,22 @@ import Wasp.Psl.Ast.WithCtx
     WithCtx (WithCtx),
   )
 import Wasp.Psl.Comments (DocumentationComment, documentationCommentSymbol)
-import Wasp.Psl.Parser.Common (Parser, lexeme)
+import Wasp.Psl.Parser.Common (Parser)
+import Wasp.Psl.Parser.Lexer (compulsoryNewline)
 
 withCtx :: Parser node -> Parser (WithCtx node)
 withCtx nodeParser = do
-  leadingComments <- many documentationComment
+  leadingComments <- many (documentationComment <* compulsoryNewline)
   node <- nodeParser
-  -- TODO: Handle trailing comments properly, right now we fail on them. (#3041)
+  -- IMPORTANT: We do not consume the trailing newline here! Trailing comments
+  -- are only attached to the node if they are on the same line as it.
+  trailingComment <- optional documentationComment
 
-  return $ WithCtx node (NodeContext {documentationComments = leadingComments})
+  let allComments = leadingComments ++ maybeToList trailingComment
+  return $ WithCtx node (NodeContext {documentationComments = allComments})
 
 documentationComment :: Parser DocumentationComment
 documentationComment =
-  -- Given we're manually parsing on the character level here, we need to wrap
-  -- this in a `lexeme`, so that Parsec identifies it as a token and can
-  -- correctly handle whitespace around the comment.
-  lexeme $
+  label "documentation comment" $
     C.string documentationCommentSymbol
       >> takeWhileP (Just "character") (/= '\n')

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -424,9 +424,11 @@ library
     Wasp.Psl.Parser.Common
     Wasp.Psl.Parser.ConfigBlock
     Wasp.Psl.Parser.Enum
+    Wasp.Psl.Parser.Lexer
     Wasp.Psl.Parser.Model
     Wasp.Psl.Parser.Schema
     Wasp.Psl.Parser.Type
+    Wasp.Psl.Parser.Tokens
     Wasp.Psl.Parser.View
     Wasp.Psl.Parser.WithCtx
     Wasp.Psl.Util


### PR DESCRIPTION
This is a **currently-not-working** PR for allowing trailing documentation comments in a node when parsing PSL:

```prisma
model Post {
  title String /// <- this trailing comment should get attached to the `title` node
}
```

Right now (as of #2949) we only support leading comments.

---

**Problem**

https://github.com/wasp-lang/wasp/pull/2949#discussion_r2237409344

**Solution**

I asked at [Haskell's Matrix Room](https://matrix.to/#/#haskell:matrix.org/$r5LIFH878ytxAArXgRG3Wozr0f5b2h5pMiH1uSbq_HE), and got the suggestion that PSL is a newline-significant language, so it is common to split the `lexeme` parser into one that consumes whitespace and another that consumes whitespace+newlines.

In the end I made two `spaceConsumer` parsers, and use the non-newline version everywhere, and the yes-newline version whenever it makes sense (in between top-level structures in the Prisma file, and inside lines in `{` braces `}`).

I kept debugging and tweaking but at some point I had to stop working on it as it is way eating into the time budget for this task.