### PR TITLE
Prevent the release workflow triggering on branches

### DIFF
--- a/.github/workflows/waspc-release.yaml
+++ b/.github/workflows/waspc-release.yaml
@@ -1,7 +1,7 @@
 name: Build and upload Wasp CLI binaries to release
 
 on:
-  create:
+  push:
     tags:
       - v*
 


### PR DESCRIPTION
I noticed our release workflow is running (and failing) all the time: https://github.com/wasp-lang/wasp/actions/workflows/waspc-release.yaml

I believe this happens because
-  The create event triggers whenever we create a branch or a tag ([docs](https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#createevent)).
- We only apply the `v*` filter to tags.
- The workflow ends up being triggered whenever we create a new branch, since all branches pass the tag-exclusive filter.

My new AI friend and a quick Google search tell me that the correct solution is using a `push` event.