### PR TITLE
Fix Waspello CI

### DIFF
--- a/.github/workflows/examples-headless-tests.yaml
+++ b/.github/workflows/examples-headless-tests.yaml
@@ -28,6 +28,10 @@ jobs:
           - waspello
           - waspleau
           - websockets-realtime-voting
+        include:
+          - example: waspello
+            wasp-ts: true
+
     steps:
       - uses: "actions/checkout@v4"
 
@@ -55,6 +59,11 @@ jobs:
           if [ -f ".env.server.headless" ]; then
             cp .env.server.headless .env.server
           fi
+
+      - name: Setup Wasp TS support
+        run: wasp-cli ts-setup
+        working-directory: examples/${{ matrix.example }}
+        if: matrix.wasp-ts == true
 
       - name: Extract Database Provider
         id: extract-db-provider


### PR DESCRIPTION
The test example app CI step is failing on Waspello due to not running `wasp ts-setup`. This PR fixes that.


Before: https://github.com/wasp-lang/wasp/actions/runs/16745347836/job/47402470404?pr=2914#step:7:9
After: https://github.com/wasp-lang/wasp/actions/runs/16746190236/job/47405193264?pr=2914#step:8:1