### PR TITLE
Create automatic PR labelling workflow

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -38,7 +38,7 @@ jobs:
           )" >> "$GITHUB_OUTPUT"
         env:
           sender_login: ${{ github.event.sender.login }}
-          github_org: ${{ github.repository.owner }}
+          github_org: ${{ github.repository_owner }}
           team_name: ${{ env.internal_team_name }}
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -5,8 +5,6 @@ on:
     types:
       - opened
       - reopened
-      # TODO: Remove before merging, using it for testing
-      - synchronize
 
 env:
   internal_team_name: "eng"

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -5,6 +5,8 @@ on:
     types:
       - opened
       - reopened
+      # TODO: Remove before merging, using it for testing
+      - synchronize
 
 env:
   internal_team_name: "eng"

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -31,14 +31,14 @@ jobs:
         run: |
           pr_is_internal=$(
             gh api "/orgs/$GITHUB_ORG/teams/$TEAM_NAME/members" |
-              jq --arg author "$SENDER_LOGIN" 'map(.login) | contains([$author])'
+              jq --arg author "$AUTHOR_LOGIN" 'map(.login) | contains([$author])'
           )
 
           # Output is a JSON boolean
           echo "pr_is_internal=$pr_is_internal" >>"$GITHUB_OUTPUT"
 
         env:
-          SENDER_LOGIN: ${{ github.event.sender.login }}
+          AUTHOR_LOGIN: ${{ github.event.sender.login }}
           GITHUB_ORG: ${{ github.repository_owner }}
           TEAM_NAME: ${{ env.internal_team_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN_READ_MEMBERS }}

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,44 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+env:
+  internal_team_name: "eng"
+  external_label_name: "external"
+
+jobs:
+  label-external-pr:
+    name: Label external PRs
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      # We're dealing with untrusted input, so we pass inputs as environment
+      # variables instead of interpolation, following GitHub's advice:
+      # https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
+
+      - name: Check if PR is internal
+        id: check_pr
+        run: |
+          echo "pr_is_internal=$(
+            gh api "/orgs/$github_org/teams/$team_name/members" |
+              jq "map(select(.login == \"$sender_login\")) | length > 0"
+          )" >> "$GITHUB_OUTPUT"
+        env:
+          sender_login: ${{ github.event.sender.login }}
+          github_org: ${{ github.repository.owner }}
+          team_name: ${{ env.internal_team_name }}
+
+      - name: Label external PR
+        if: steps.check_pr.outputs.pr_is_internal == 'false'
+        run: gh pr edit "$pr_number" --add-label "$label_name"
+        env:
+          pr_number: ${{ github.event.pull_request.number }}
+          label_name: ${{ env.external_label_name }}

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -29,20 +29,29 @@ jobs:
       - name: Check if PR is internal
         id: check_pr
         run: |
-          echo "pr_is_internal=$(
-            gh api "/orgs/$github_org/teams/$team_name/members" |
-              jq "map(select(.login == \"$sender_login\")) | length > 0"
-          )" >> "$GITHUB_OUTPUT"
+          pr_is_internal=$(
+            # Get usernames of team members
+            gh api "/orgs/$GITHUB_ORG/teams/$TEAM_NAME/members" |
+              jq \
+                `# Pass the author's username as a string with the name $author` \
+                --arg author "$SENDER_LOGIN" \
+                `# Check if the PR author is in the team members list` \
+                'map(.login) | contains([$author])'
+          )
+
+          # Output is a JSON boolean
+          echo "pr_is_internal=$pr_is_internal" >>"$GITHUB_OUTPUT"
+
         env:
-          sender_login: ${{ github.event.sender.login }}
-          github_org: ${{ github.repository_owner }}
-          team_name: ${{ env.internal_team_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN_READ_ORG }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          GITHUB_ORG: ${{ github.repository_owner }}
+          TEAM_NAME: ${{ env.internal_team_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN_READ_MEMBERS }}
 
       - name: Label external PR
         if: steps.check_pr.outputs.pr_is_internal == 'false'
-        run: gh pr edit "$pr_number" --add-label "$label_name"
+        run: gh pr edit "$PR_NUMBER" --add-label "$LABEL_NAME"
         env:
-          pr_number: ${{ github.event.pull_request.number }}
-          label_name: ${{ env.external_label_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABEL_NAME: ${{ env.external_label_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -9,6 +9,7 @@ on:
       - synchronize
 
 env:
+  internal_team_name: "eng"
   external_label_name: "external"
 
 jobs:
@@ -31,16 +32,17 @@ jobs:
           # Bash "strict mode" http://redsymbol.net/articles/unofficial-bash-strict-mode/
           set -euxo pipefail
 
-          gh api "/orgs/$github_org/members" | jq 'map(.login)'
+          gh api "/orgs/$github_org/teams/$team_name/members" | jq 'map(.login)'
 
           echo "pr_is_internal=$(
-            gh api "/orgs/$github_org/members" |
+            gh api "/orgs/$github_org/teams/$team_name/members" |
               jq "map(select(.login == \"$sender_login\")) | length > 0"
           )" >> "$GITHUB_OUTPUT"
         env:
           sender_login: ${{ github.event.sender.login }}
           github_org: ${{ github.repository_owner }}
-          GH_TOKEN: ${{ github.token }}
+          team_name: ${{ env.internal_team_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN_READ_ORG }}
 
       - name: Label external PR
         if: steps.check_pr.outputs.pr_is_internal == 'false'

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Check if PR is internal
         id: check_pr
         run: |
+          # Bash "strict mode" http://redsymbol.net/articles/unofficial-bash-strict-mode/
+          set -euxo pipefail
+
           echo "pr_is_internal=$(
             gh api "/orgs/$github_org/teams/$team_name/members" |
               jq "map(select(.login == \"$sender_login\")) | length > 0"

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -9,7 +9,6 @@ on:
       - synchronize
 
 env:
-  internal_team_name: "eng"
   external_label_name: "external"
 
 jobs:
@@ -32,14 +31,15 @@ jobs:
           # Bash "strict mode" http://redsymbol.net/articles/unofficial-bash-strict-mode/
           set -euxo pipefail
 
+          gh api "/orgs/$github_org/members" | jq 'map(.login)'
+
           echo "pr_is_internal=$(
-            gh api "/orgs/$github_org/teams/$team_name/members" |
+            gh api "/orgs/$github_org/members" |
               jq "map(select(.login == \"$sender_login\")) | length > 0"
           )" >> "$GITHUB_OUTPUT"
         env:
           sender_login: ${{ github.event.sender.login }}
           github_org: ${{ github.repository_owner }}
-          team_name: ${{ env.internal_team_name }}
           GH_TOKEN: ${{ github.token }}
 
       - name: Label external PR

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -41,7 +41,7 @@ jobs:
           AUTHOR_LOGIN: ${{ github.event.sender.login }}
           GITHUB_ORG: ${{ github.repository_owner }}
           TEAM_NAME: ${{ env.internal_team_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN_READ_MEMBERS }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN_READ_WASP_LANG_MEMBERS }}
 
       - name: Label external PR
         if: steps.check_pr.outputs.pr_is_internal == 'false'

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -35,6 +35,7 @@ jobs:
           sender_login: ${{ github.event.sender.login }}
           github_org: ${{ github.repository.owner }}
           team_name: ${{ env.internal_team_name }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Label external PR
         if: steps.check_pr.outputs.pr_is_internal == 'false'
@@ -42,3 +43,4 @@ jobs:
         env:
           pr_number: ${{ github.event.pull_request.number }}
           label_name: ${{ env.external_label_name }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -30,13 +30,8 @@ jobs:
         id: check_pr
         run: |
           pr_is_internal=$(
-            # Get usernames of team members
             gh api "/orgs/$GITHUB_ORG/teams/$TEAM_NAME/members" |
-              jq \
-                `# Pass the author's username as a string with the name $author` \
-                --arg author "$SENDER_LOGIN" \
-                `# Check if the PR author is in the team members list` \
-                'map(.login) | contains([$author])'
+              jq --arg author "$SENDER_LOGIN" 'map(.login) | contains([$author])'
           )
 
           # Output is a JSON boolean

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -29,11 +29,6 @@ jobs:
       - name: Check if PR is internal
         id: check_pr
         run: |
-          # Bash "strict mode" http://redsymbol.net/articles/unofficial-bash-strict-mode/
-          set -euxo pipefail
-
-          gh api "/orgs/$github_org/teams/$team_name/members" | jq 'map(.login)'
-
           echo "pr_is_internal=$(
             gh api "/orgs/$github_org/teams/$team_name/members" |
               jq "map(select(.login == \"$sender_login\")) | length > 0"


### PR DESCRIPTION
Adds a GitHub workflow that gets triggered on PR create or reopen, checks if the author of the PR is in the @wasp-lang/eng team, and labels it "external" if not