### PR TITLE
Experiment of converting patch files to code blocks

### DIFF
--- a/web/docs/tutorial/03-pages.md
+++ b/web/docs/tutorial/03-pages.md
@@ -97,7 +97,7 @@ Now that you've seen how Wasp deals with Routes and Pages, it's finally time to 
 
 Start by cleaning up the starter project and removing unnecessary code and files.
 
-<TutorialAction id="prepare-project" action="apply-patch" />
+<TutorialAction id="prepare-project" action="apply-patch" lang="tsx" title="src/MainPage.tsx" />
 
 First, remove most of the code from the `MainPage` component:
 

--- a/web/docs/tutorial/04-entities.md
+++ b/web/docs/tutorial/04-entities.md
@@ -11,7 +11,7 @@ Wasp uses Prisma to talk to the database, and you define Entities by defining Pr
 
 Since our Todo app is all about tasks, we'll define a Task entity by adding a Task model in the `schema.prisma` file:
 
-<TutorialAction id="prisma-task" action="apply-patch" />
+<TutorialAction id="prisma-task" action="apply-patch" lang="prisma" title="schema.prisma" />
 
 ```prisma title="schema.prisma"
 // ...

--- a/web/docs/tutorial/05-queries.md
+++ b/web/docs/tutorial/05-queries.md
@@ -44,7 +44,7 @@ We need to add a **query** declaration to `main.wasp` so that Wasp knows it exis
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-  <TutorialAction id="query-get-tasks" action="apply-patch" />
+  <TutorialAction id="query-get-tasks" action="apply-patch" lang="wasp" title="main.wasp" />
     ```wasp title="main.wasp"
     // ...
 
@@ -76,7 +76,7 @@ We need to add a **query** declaration to `main.wasp` so that Wasp knows it exis
   Next, create a new file called `src/queries.ts` and define the TypeScript function we've just imported in our `query` declaration:
 </ShowForTs>
 
-<TutorialAction id="query-get-tasks-impl" action="apply-patch" />
+<TutorialAction id="query-get-tasks-impl" action="apply-patch" lang="ts" title="src/queries.ts" />
 
 ```ts title="src/queries.ts" auto-js
 import type { Task } from "wasp/entities";
@@ -122,7 +122,7 @@ While we implement Queries on the server, Wasp generates client-side functions t
 
 This makes it easy for us to use the `getTasks` Query we just created in our React component:
 
-<TutorialAction id="main-page-tasks" action="apply-patch" />
+<TutorialAction id="main-page-tasks" action="apply-patch" lang="tsx" title="src/MainPage.tsx" />
 
 ```tsx title="src/MainPage.tsx" auto-js
 import type { Task } from "wasp/entities";

--- a/web/docs/tutorial/06-actions.md
+++ b/web/docs/tutorial/06-actions.md
@@ -23,7 +23,7 @@ Creating an Action is very similar to creating a Query.
 
 We must first declare the Action in `main.wasp`:
 
-<TutorialAction id="action-create-task" action="apply-patch" />
+<TutorialAction id="action-create-task" action="apply-patch" lang="wasp" title="main.wasp" />
 
 ```wasp title="main.wasp"
 // ...
@@ -38,7 +38,7 @@ action createTask {
 
 Let's now define a <ShowForJs>JavaScript</ShowForJs><ShowForTs>TypeScript</ShowForTs> function for our `createTask` Action:
 
-<TutorialAction id="action-create-task-impl" action="apply-patch" />
+<TutorialAction id="action-create-task-impl" action="apply-patch" lang="ts" title="src/actions.ts" />
 
 ```ts title="src/actions.ts" auto-js
 import type { Task } from "wasp/entities";
@@ -68,7 +68,7 @@ We put the function in a new file `src/actions.{js,ts}`, but we could have put i
 
 Start by defining a form for creating new tasks.
 
-<TutorialAction id="main-page-create-task-impl-form" action="apply-patch" />
+<TutorialAction id="main-page-create-task-impl-form" action="apply-patch" lang="tsx" title="src/MainPage.tsx" />
 
 ```tsx title="src/MainPage.tsx" auto-js
 import type { FormEvent } from "react";
@@ -114,7 +114,7 @@ Unlike Queries, you can call Actions directly (without wrapping them in a hook) 
 
 All that's left now is adding this form to the page component:
 
-<TutorialAction id="main-page-create-task-use-form" action="apply-patch" />
+<TutorialAction id="main-page-create-task-use-form" action="apply-patch" lang="tsx" title="src/MainPage.tsx" />
 
 ```tsx title="src/MainPage.tsx" auto-js
 import type { FormEvent } from "react";
@@ -171,7 +171,7 @@ Since we've already created one task together, try to create this one yourself. 
 <Collapse title="Solution">
   Declaring the Action in `main.wasp`:
 
-  <TutorialAction id="action-update-task" action="apply-patch" />
+  <TutorialAction id="action-update-task" action="apply-patch" lang="wasp" title="main.wasp" />
 
 ```wasp title="main.wasp"
 // ...
@@ -182,7 +182,7 @@ action updateTask {
 }
 ```
 
-  <TutorialAction id="action-update-task-impl" action="apply-patch" />
+  <TutorialAction id="action-update-task-impl" action="apply-patch" lang="ts" title="src/actions.ts" />
 
 Implementing the Action on the server:
 
@@ -210,7 +210,7 @@ export const updateTask: UpdateTask<UpdateTaskPayload, Task> = async (
 
 You can now call `updateTask` from the React component:
 
-<TutorialAction id="main-page-update-task" action="apply-patch" />
+<TutorialAction id="main-page-update-task" action="apply-patch" lang="tsx" title="src/MainPage.tsx" />
 
 ```tsx title="src/MainPage.tsx" auto-js
 import type { FormEvent, ChangeEvent } from "react";

--- a/web/docs/tutorial/07-auth.md
+++ b/web/docs/tutorial/07-auth.md
@@ -24,7 +24,7 @@ Since Wasp manages authentication, it will create [the auth related entities](..
 
 You must only add the `User` Entity to keep track of who owns which tasks:
 
-<TutorialAction id="prisma-user" action="apply-patch" />
+<TutorialAction id="prisma-user" action="apply-patch" lang="prisma" title="schema.prisma" />
 
 ```prisma title="schema.prisma"
 // ...
@@ -38,7 +38,7 @@ model User {
 
 Next, tell Wasp to use full-stack [authentication](../auth/overview):
 
-<TutorialAction id="wasp-file-auth" action="apply-patch" />
+<TutorialAction id="wasp-file-auth" action="apply-patch" lang="wasp" title="main.wasp" />
 
 ```wasp title="main.wasp"
 app TodoApp {
@@ -89,7 +89,7 @@ Wasp also supports authentication using [Google](../auth/social-auth/google), [G
 
 Wasp creates the login and signup forms for us, but we still need to define the pages to display those forms on. We'll start by declaring the pages in the Wasp file:
 
-<TutorialAction id="wasp-file-auth-routes" action="apply-patch" />
+<TutorialAction id="wasp-file-auth-routes" action="apply-patch" lang="wasp" title="main.wasp" />
 
 ```wasp title="main.wasp"
 // ...
@@ -109,7 +109,7 @@ Great, Wasp now knows these pages exist!
 
 Here's the React code for the pages you've just imported:
 
-<TutorialAction id="login-page-initial" action="apply-patch" />
+<TutorialAction id="login-page-initial" action="apply-patch" lang="tsx" title="src/LoginPage.tsx" />
 
 ```tsx title="src/LoginPage.tsx" auto-js
 import { Link } from "react-router-dom";
@@ -130,7 +130,7 @@ export const LoginPage = () => {
 
 The signup page is very similar to the login page:
 
-<TutorialAction id="signup-page-initial" action="apply-patch" />
+<TutorialAction id="signup-page-initial" action="apply-patch" lang="tsx" title="src/SignupPage.tsx" />
 
 ```tsx title="src/SignupPage.tsx" auto-js
 import { Link } from "react-router-dom";
@@ -159,7 +159,7 @@ export const SignupPage = () => {
 
 We don't want users who are not logged in to access the main page, because they won't be able to create any tasks. So let's make the page private by requiring the user to be logged in:
 
-<TutorialAction id="wasp-file-auth-required" action="apply-patch" />
+<TutorialAction id="wasp-file-auth-required" action="apply-patch" lang="wasp" title="main.wasp" />
 
 ```wasp title="main.wasp"
 // ...
@@ -175,7 +175,7 @@ Now that auth is required for this page, unauthenticated users will be redirecte
 
 Additionally, when `authRequired` is `true`, the page's React component will be provided a `user` object as prop.
 
-<TutorialAction id="main-page-add-auth" action="apply-patch" />
+<TutorialAction id="main-page-add-auth" action="apply-patch" lang="tsx" title="src/MainPage.tsx" />
 
 ```tsx title="src/MainPage.tsx" auto-js
 import type { AuthUser } from "wasp/auth";
@@ -211,7 +211,7 @@ However, you will notice that if you try logging in as different users and creat
 
 First, let's define a one-to-many relation between users and tasks (check the [Prisma docs on relations](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/relations)):
 
-<TutorialAction id="prisma-connect-task-user" action="apply-patch" />
+<TutorialAction id="prisma-connect-task-user" action="apply-patch" lang="prisma" title="schema.prisma" />
 
 ```prisma title="schema.prisma"
 // ...
@@ -252,7 +252,7 @@ Instead, we would do a data migration to take care of those tasks, even if it me
 
 Next, let's update the queries and actions to forbid access to non-authenticated users and to operate only on the currently logged-in user's tasks:
 
-<TutorialAction id="query-add-auth" action="apply-patch" />
+<TutorialAction id="query-add-auth" action="apply-patch" lang="ts" title="src/queries.ts" />
 
 ```ts title="src/queries.ts" auto-js
 import type { Task } from "wasp/entities";
@@ -274,7 +274,7 @@ export const getTasks: GetTasks<void, Task[]> = async (args, context) => {
 };
 ```
 
-<TutorialAction id="action-add-auth" action="apply-patch" />
+<TutorialAction id="action-add-auth" action="apply-patch" lang="ts" title="src/actions.ts" />
 
 ```ts title="src/actions.ts" auto-js
 import type { Task } from "wasp/entities";
@@ -340,7 +340,7 @@ You will see that each user has their tasks, just as we specified in our code!
 
 Last, but not least, let's add the logout functionality:
 
-<TutorialAction id="main-page-add-logout" action="apply-patch" />
+<TutorialAction id="main-page-add-logout" action="apply-patch" lang="tsx" title="src/MainPage.tsx" />
 
 ```tsx title="src/MainPage.tsx" auto-js with-hole
 // ...

--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -6,6 +6,7 @@ import autoJSCode from "./src/remark/auto-js-code";
 import codeWithHole from "./src/remark/code-with-hole";
 import fileExtSwitcher from "./src/remark/file-ext-switcher";
 import searchAndReplace from "./src/remark/search-and-replace";
+import { tutorialActionToCodeblock } from "./src/remark/tutorial-action-to-codeblock";
 
 const lightCodeTheme = themes.github;
 
@@ -162,6 +163,7 @@ const config: Config = {
           editUrl: "https://github.com/wasp-lang/wasp/edit/release/web",
           remarkPlugins: [
             autoJSCode,
+            tutorialActionToCodeblock,
             autoImportTabs,
             fileExtSwitcher,
             searchAndReplace,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
         "clsx": "^1.2.1",
         "front-matter": "^4.0.2",
         "glob": "^11.0.2",
+        "parse-git-diff": "^0.0.19",
         "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
         "postcss": "^8.4.19",
         "prism-react-renderer": "^2.4.1",
@@ -30,7 +31,8 @@
         "react-tooltip": "^4.5.1",
         "react-transition-group": "^4.4.5",
         "tailwindcss": "^3.2.4",
-        "ts-blank-space": "^0.6.1"
+        "ts-blank-space": "^0.6.1",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.7.0",
@@ -16316,6 +16318,12 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-git-diff": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/parse-git-diff/-/parse-git-diff-0.0.19.tgz",
+      "integrity": "sha512-oh3giwKzsPlOhekiDDyd/pfFKn04IZoTjEThquhfKigwiUHymiP/Tp6AN5nGIwXQdWuBTQvz9AaRdN5TBsJ8MA==",
       "license": "MIT"
     },
     "node_modules/parse-glob": {

--- a/web/package.json
+++ b/web/package.json
@@ -31,6 +31,7 @@
     "clsx": "^1.2.1",
     "front-matter": "^4.0.2",
     "glob": "^11.0.2",
+    "parse-git-diff": "^0.0.19",
     "plugin-image-zoom": "github:flexanalytics/plugin-image-zoom",
     "postcss": "^8.4.19",
     "prism-react-renderer": "^2.4.1",
@@ -43,7 +44,8 @@
     "react-tooltip": "^4.5.1",
     "react-transition-group": "^4.4.5",
     "tailwindcss": "^3.2.4",
-    "ts-blank-space": "^0.6.1"
+    "ts-blank-space": "^0.6.1",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.7.0",

--- a/web/scripts/test-patch-transform.ts
+++ b/web/scripts/test-patch-transform.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env tsx
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { transformPatch, transformPatchFile, findPatchFile } from '../src/utils/patch-transformer';
+
+function main() {
+  const args = process.argv.slice(2);
+  
+  if (args.length < 1) {
+    console.error('Usage: tsx test-patch-transform.ts <patch-id> [lang]');
+    console.error('       tsx test-patch-transform.ts <patch-file-path> [lang]');
+    console.error('');
+    console.error('Examples:');
+    console.error('  tsx test-patch-transform.ts prepare-project tsx');
+    console.error('  tsx test-patch-transform.ts query-get-tasks wasp');
+    console.error('  tsx test-patch-transform.ts ./patches/05-queries__query-get-tasks.patch wasp');
+    process.exit(1);
+  }
+
+  const inputArg = args[0];
+  const lang = args[1] || 'ts';
+  
+  let patchPath: string;
+  
+  if (inputArg.includes('/') || inputArg.endsWith('.patch')) {
+    // Direct file path
+    patchPath = inputArg;
+  } else {
+    // Patch ID - find the file
+    const patchesDir = join(__dirname, '../docs/tutorial/patches');
+    const foundPath = findPatchFile(patchesDir, inputArg);
+    
+    if (!foundPath) {
+      console.error(`Patch file not found for id: ${inputArg}`);
+      process.exit(1);
+    }
+    
+    patchPath = foundPath;
+  }
+
+  try {
+    console.log(`\n=== Transforming patch: ${patchPath} ===`);
+    console.log(`Language: ${lang}`);
+    console.log(`\n--- Original patch content ---`);
+    
+    const patchContent = readFileSync(patchPath, 'utf-8');
+    console.log(patchContent);
+    
+    console.log(`\n--- Transformed output ---`);
+    const transformed = transformPatchFile(patchPath, lang);
+    console.log(transformed);
+    
+    console.log(`\n=== Done ===`);
+  } catch (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/web/src/remark/tutorial-action-to-codeblock.ts
+++ b/web/src/remark/tutorial-action-to-codeblock.ts
@@ -1,0 +1,72 @@
+import { visit } from 'unist-util-visit';
+import { join } from 'path';
+import type { Root } from 'mdast';
+import type { MdxJsxFlowElement } from 'mdast-util-mdx';
+import { findPatchFile, transformPatchFile } from '../utils/patch-transformer';
+
+interface TutorialActionProps {
+  id: string;
+  action: string;
+  lang?: string;
+  title?: string;
+}
+
+function extractTutorialActionProps(node: MdxJsxFlowElement): TutorialActionProps | null {
+  const props: TutorialActionProps = {
+    id: '',
+    action: 'apply-patch',
+  };
+
+  if (!node.attributes) return null;
+
+  for (const attr of node.attributes) {
+    if (attr.type === 'mdxJsxAttribute' && attr.name) {
+      const value = attr.value;
+      if (typeof value === 'string') {
+        props[attr.name as keyof TutorialActionProps] = value;
+      } else if (value && typeof value === 'object' && 'value' in value) {
+        props[attr.name as keyof TutorialActionProps] = value.value as string;
+      }
+    }
+  }
+
+  return props.id ? props : null;
+}
+
+export function tutorialActionToCodeblock() {
+  return (tree: Root, file: any) => {
+    const basePath = file.dirname || process.cwd();
+    const patchesDir = join(basePath, 'patches');
+
+    visit(tree, 'mdxJsxFlowElement', (node: MdxJsxFlowElement, index, parent) => {
+      if (node.name !== 'TutorialAction') return;
+
+      const props = extractTutorialActionProps(node);
+      if (!props || props.action !== 'apply-patch') return;
+
+      const patchPath = findPatchFile(patchesDir, props.id);
+      if (!patchPath) {
+        console.error(`Patch file not found for id: ${props.id}`);
+        return;
+      }
+
+      const transformedCode = transformPatchFile(patchPath, props.lang || 'ts');
+
+      // Create a code block node
+      const metaValues = [
+        props.title && `title="${props.title}"`,
+        "auto-js",
+      ];
+      const codeBlock = {
+        type: 'code',
+        lang: props.lang || 'tsx',
+        meta: metaValues.filter(Boolean).join(' '),
+        value: transformedCode,
+      };
+
+      if (parent && typeof index === 'number') {
+        parent.children[index] = codeBlock as any;
+      }
+    });
+  };
+}

--- a/web/src/utils/patch-transformer.ts
+++ b/web/src/utils/patch-transformer.ts
@@ -1,0 +1,149 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import parseGitDiff from 'parse-git-diff';
+
+const LANGUAGE_COMMENTS = {
+  javascript: '// ...',
+  js: '// ...',
+  typescript: '// ...',
+  ts: '// ...',
+  tsx: '// ...',
+  jsx: '// ...',
+  wasp: '// ...',
+  css: '/* ... */',
+  html: '<!-- ... -->',
+  xml: '<!-- ... -->',
+  json: '// ...',
+  yaml: '# ...',
+  yml: '# ...',
+  python: '# ...',
+  py: '# ...',
+  shell: '# ...',
+  bash: '# ...',
+  prisma: '// ...',
+} as const;
+
+function getLanguageComment(lang: string): string {
+  return LANGUAGE_COMMENTS[lang as keyof typeof LANGUAGE_COMMENTS] || '// ...';
+}
+
+export function transformPatch(patchContent: string, lang: string = 'ts'): string {
+  try {
+    const parsed = parseGitDiff(patchContent);
+    
+    if (!parsed.files.length) {
+      throw new Error('No files found in patch');
+    }
+
+    // Focus on the main file (usually the first one with additions after deletions)
+    const mainFile = parsed.files.find(file => 
+      file.chunks.some(chunk => 
+        'changes' in chunk && chunk.changes.some(change => change.type === 'AddedLine')
+      )
+    ) || parsed.files[0];
+
+    const lines: string[] = [];
+    const comment = getLanguageComment(lang);
+
+    // Group additions by their logical sections
+    const additionGroups: Array<{ changes: any[], startLine: number, endLine: number }> = [];
+    
+    for (const chunk of mainFile.chunks) {
+      if (!('changes' in chunk)) continue;
+      
+      const additions = chunk.changes.filter(change => change.type === 'AddedLine');
+      if (additions.length === 0) continue;
+      
+      // Group consecutive additions together
+      let currentGroup = [];
+      let lastLineNumber = -1;
+      
+      for (const change of chunk.changes) {
+        if (change.type === 'AddedLine') {
+          // If this addition is not consecutive to the last, start a new group
+          if (lastLineNumber !== -1 && change.lineAfter > lastLineNumber + 5) {
+            if (currentGroup.length > 0) {
+              additionGroups.push({
+                changes: currentGroup,
+                startLine: currentGroup[0].lineAfter,
+                endLine: currentGroup[currentGroup.length - 1].lineAfter
+              });
+              currentGroup = [];
+            }
+          }
+          currentGroup.push(change);
+          lastLineNumber = change.lineAfter;
+        }
+      }
+      
+      if (currentGroup.length > 0) {
+        additionGroups.push({
+          changes: currentGroup,
+          startLine: currentGroup[0].lineAfter,
+          endLine: currentGroup[currentGroup.length - 1].lineAfter
+        });
+      }
+    }
+
+    // Output each group
+    for (let i = 0; i < additionGroups.length; i++) {
+      const group = additionGroups[i];
+      
+      // Add context comment before if not the first group
+      if (i > 0) {
+        lines.push(comment);
+      }
+      
+      // Add highlight around this group
+      lines.push('// highlight-start');
+      for (const change of group.changes) {
+        lines.push(change.content);
+      }
+      lines.push('// highlight-end');
+    }
+
+    return lines.join('\n');
+  } catch (error) {
+    console.error(`Error parsing patch:`, error);
+    return `// Error loading patch: ${error.message}`;
+  }
+}
+
+export function findPatchFile(patchesDir: string, id: string): string | null {
+  try {
+    const patchFiles = readdirSync(patchesDir);
+    
+    // Look for a patch file that ends with __{id}.patch
+    const matchingFile = patchFiles.find(file => {
+      return file.endsWith(`__${id}.patch`);
+    });
+
+    if (matchingFile) {
+      return join(patchesDir, matchingFile);
+    }
+
+    // If no match found, try direct id.patch as fallback
+    const directPath = join(patchesDir, `${id}.patch`);
+    try {
+      readFileSync(directPath);
+      return directPath;
+    } catch {
+      // File doesn't exist
+    }
+
+    return null;
+  } catch (error) {
+    console.error(`Error reading patches directory ${patchesDir}:`, error);
+    return null;
+  }
+}
+
+export function transformPatchFile(patchPath: string, lang: string = 'ts'): string {
+  try {
+    const patchContent = readFileSync(patchPath, 'utf-8');
+    return transformPatch(patchContent, lang);
+  } catch (error) {
+    console.error(`Error reading patch file ${patchPath}:`, error);
+    return `// Error loading patch: ${error.message}`;
+  }
+}


### PR DESCRIPTION
## Idea

- #2732

In the PR linked above, we built a tool that enables us to execute tutorial steps automatically and generate the tutorial app. The steps are written down in Markdown (human readable) and then again as patch files (machine readable). This means we are storing the same information _twice_. What if we could do it only _once_?

If we took the patch files and translated them somehow to human friendly instructions for the users in the docs, we might be able to only maintain the patches and not the manually written code blocks.

I've fired up Claude Code and tried to validate it quickly. The results are mixed bag based on the current examples. 

**Preliminary conclusion:** works great for basic cases, it falls apart in more complex cases - maybe better heuristics or better algorithm can help us to get it looking just right. I'm on the fence if this is something we want to do. 

## Examples

### Basic cases

Hand crafted | Automatic translation
-- | --
<img width="804" height="233" alt="image" src="https://github.com/user-attachments/assets/06f44508-9e70-4079-aca9-1d0d6e90f364" /> | <img width="803" height="175" alt="image" src="https://github.com/user-attachments/assets/7d9ed33a-4466-484c-824a-cd36ff8677bb" />

**Score:** 10/10

<details>
<summary>Based on diff</summary>

```diff
diff --git a/src/MainPage.tsx b/src/MainPage.tsx
index bdb62b3..144163a 100644
--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -1,37 +1,3 @@
-import Logo from "./assets/logo.svg";
-import "./Main.css";
-
-export function MainPage() {
-  return (
-    <main className="container">
-      <img className="logo" src={Logo} alt="wasp" />
-
-      <h2 className="title">Welcome to Wasp!</h2>
-
-      <p className="content">
-        This is page <code>MainPage</code> located at route <code>/</code>.
-        <br />
-        Open <code>src/MainPage.tsx</code> to edit it.
-      </p>
-
-      <div className="buttons">
-        <a
-          className="button button-filled"
-          href="https://wasp.sh/docs/tutorial/create"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Take the Tutorial
-        </a>
-        <a
-          className="button button-outlined"
-          href="https://discord.com/invite/rzdnErX"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Chat on Discord
-        </a>
-      </div>
-    </main>
-  );
-}
+export const MainPage = () => {
+  return <div>Hello world!</div>;
+};
```
</details>

Hand crafted | Automatic translation
-- | --
<img width="814" height="234" alt="SCR-20250811-kvpy" src="https://github.com/user-attachments/assets/442c78d9-bf7f-4bbb-ae5e-e9a817443307" /> | <img width="820" height="215" alt="SCR-20250811-kvpc" src="https://github.com/user-attachments/assets/bcad12c2-63ca-4105-a25d-c7bcb4898456" />

**Score:** 9/10
We can add the `// ...` comment easily

<details>
<summary>Based on diff</summary>

```diff
diff --git a/schema.prisma b/schema.prisma
index 190e2a8..65d7d30 100644
--- a/schema.prisma
+++ b/schema.prisma
@@ -8,3 +8,9 @@ datasource db {
 generator client {
   provider = "prisma-client-js"
 }
+
+model Task {
+  id          Int     @id @default(autoincrement())
+  description String
+  isDone      Boolean @default(false)
+}
```
</details>

### Complex cases

Hand crafted | Automatic translation
-- | --
<img width="801" height="681" alt="SCR-20250811-kvzf" src="https://github.com/user-attachments/assets/1bfb46a0-9a77-4e00-9bd3-02fd7d312f91" /> | <img width="802" height="517" alt="SCR-20250811-kvyh" src="https://github.com/user-attachments/assets/d9caa510-6b67-4dcb-a324-e53bd4cd681c" />

**Score:** 7/10

I'm missing the extra comments that explain the context of the other parts of the file

<details>
<summary>Based on diff</summary>

```diff
diff --git a/src/MainPage.tsx b/src/MainPage.tsx
index addc7ba..3f1732f 100644
--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -1,4 +1,5 @@
-import { getTasks, useQuery } from "wasp/client/operations";
+import type { FormEvent } from "react";
+import { createTask, getTasks, useQuery } from "wasp/client/operations";
 import type { Task } from "wasp/entities";
 
 export const MainPage = () => {
@@ -34,3 +35,24 @@ const TasksList = ({ tasks }: { tasks: Task[] }) => {
     </div>
   );
 };
+
+const NewTaskForm = () => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const target = event.target as HTMLFormElement;
+      const description = target.description.value;
+      target.reset();
+      await createTask({ description });
+    } catch (err: any) {
+      window.alert("Error: " + err.message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input name="description" type="text" defaultValue="" />
+      <input type="submit" value="Create task" />
+    </form>
+  );
+};
```
</details>

Hand crafted | Automatic translation
-- | --
<img width="812" height="490" alt="SCR-20250811-kwba" src="https://github.com/user-attachments/assets/dc36872f-d568-40de-9756-e09587adaa95" /> |  <img width="814" height="144" alt="SCR-20250811-kwak" src="https://github.com/user-attachments/assets/8e87b293-5bc9-420f-b25e-c9589f3166f6" />

**Score:** 3/10
It's completely missing the context where the user should add the component. I think the algorithm should be adjusted to keep the surrounding code.


<details>
<summary>Based on diff</summary>

```diff
diff --git a/src/MainPage.tsx b/src/MainPage.tsx
index eb804b9..cd11965 100644
--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -8,6 +8,7 @@ export const MainPage = () => {
 
   return (
     <div>
+      <NewTaskForm />
       {tasks && <TasksList tasks={tasks} />}
 
       {isLoading && "Loading..."}
```
</details>

Hand crafted | Automatic translation
-- | --
<img width="808" height="467" alt="SCR-20250811-kwfy" src="https://github.com/user-attachments/assets/926dc22a-4b6e-4ec0-b112-2f10cfaf6cd4" /> |  <img width="812" height="303" alt="SCR-20250811-kwff" src="https://github.com/user-attachments/assets/fb8f7897-7529-4695-8080-14f4a6bbf86c" />

**Score:** 1/10
Not only it's missing the surrounding context code, the syntax is broken and it's look off


<details>
<summary>Based on diff</summary>

```diff
diff --git a/main.wasp b/main.wasp
index f761afe..d4798a4 100644
--- a/main.wasp
+++ b/main.wasp
@@ -5,7 +5,17 @@ app TodoApp {
   title: "TodoApp",
   head: [
     "<link rel='icon' href='/favicon.ico' />",
-  ]
+  ],
+  auth: {
+    // Tells Wasp which entity to use for storing users.
+    userEntity: User,
+    methods: {
+      // Enable username and password auth.
+      usernameAndPassword: {}
+    },
+    // We'll see how this is used in a bit.
+    onAuthFailedRedirectTo: "/login"
+  }
 }
 
 route RootRoute { path: "/", to: MainPage }
```
</details>


