### PR TITLE
Update SuperJSON note

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/core/serialization/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/core/serialization/index.ts
@@ -12,10 +12,10 @@ export type Payload = void | SuperJSONValue;
 // https://github.com/blitz-js/superjson/blob/ae7dbcefe5d3ece5b04be0c6afe6b40f3a44a22a/src/types.ts
 //
 // We couldn't use SuperJSON's types directly because:
-//   1. They aren't exported publicly.
-//   2. They have a weird quirk that turns `SuperJSONValue` into `any`.
+//   1. They have a weird quirk that turns `SuperJSONValue` into `any`.
 //      See why here:
 //      https://github.com/blitz-js/superjson/pull/36#issuecomment-669239876
+//   2. We need to add our own custom types to the serialization process.
 //
 // We changed the code as little as possible to make future comparisons easier.
 export type JSONValue = PrimitiveJSONValue | JSONArray | JSONObject;

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -172,7 +172,7 @@
             "file",
             "../out/sdk/wasp/core/serialization/index.ts"
         ],
-        "76793a820deb474b105bccdeb69b5395d7522c53a790b0ed430533fa5158461c"
+        "cb3b769a74f5cadab1582df4e6e36cdeeebfe9f926faa2c9f40e2ddf46ddf75b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/build/sdk/wasp/core/serialization/index.ts
@@ -8,10 +8,10 @@ export type Payload = void | SuperJSONValue;
 // https://github.com/blitz-js/superjson/blob/ae7dbcefe5d3ece5b04be0c6afe6b40f3a44a22a/src/types.ts
 //
 // We couldn't use SuperJSON's types directly because:
-//   1. They aren't exported publicly.
-//   2. They have a weird quirk that turns `SuperJSONValue` into `any`.
+//   1. They have a weird quirk that turns `SuperJSONValue` into `any`.
 //      See why here:
 //      https://github.com/blitz-js/superjson/pull/36#issuecomment-669239876
+//   2. We need to add our own custom types to the serialization process.
 //
 // We changed the code as little as possible to make future comparisons easier.
 export type JSONValue = PrimitiveJSONValue | JSONArray | JSONObject;

--- a/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-test/test-outputs/waspBuild-golden/waspBuild/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -8,10 +8,10 @@ export type Payload = void | SuperJSONValue;
 // https://github.com/blitz-js/superjson/blob/ae7dbcefe5d3ece5b04be0c6afe6b40f3a44a22a/src/types.ts
 //
 // We couldn't use SuperJSON's types directly because:
-//   1. They aren't exported publicly.
-//   2. They have a weird quirk that turns `SuperJSONValue` into `any`.
+//   1. They have a weird quirk that turns `SuperJSONValue` into `any`.
 //      See why here:
 //      https://github.com/blitz-js/superjson/pull/36#issuecomment-669239876
+//   2. We need to add our own custom types to the serialization process.
 //
 // We changed the code as little as possible to make future comparisons easier.
 export type JSONValue = PrimitiveJSONValue | JSONArray | JSONObject;

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -172,7 +172,7 @@
             "file",
             "../out/sdk/wasp/core/serialization/index.ts"
         ],
-        "76793a820deb474b105bccdeb69b5395d7522c53a790b0ed430533fa5158461c"
+        "cb3b769a74f5cadab1582df4e6e36cdeeebfe9f926faa2c9f40e2ddf46ddf75b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-test/test-outputs/waspCompile-golden/waspCompile/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -8,10 +8,10 @@ export type Payload = void | SuperJSONValue;
 // https://github.com/blitz-js/superjson/blob/ae7dbcefe5d3ece5b04be0c6afe6b40f3a44a22a/src/types.ts
 //
 // We couldn't use SuperJSON's types directly because:
-//   1. They aren't exported publicly.
-//   2. They have a weird quirk that turns `SuperJSONValue` into `any`.
+//   1. They have a weird quirk that turns `SuperJSONValue` into `any`.
 //      See why here:
 //      https://github.com/blitz-js/superjson/pull/36#issuecomment-669239876
+//   2. We need to add our own custom types to the serialization process.
 //
 // We changed the code as little as possible to make future comparisons easier.
 export type JSONValue = PrimitiveJSONValue | JSONArray | JSONObject;

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -389,7 +389,7 @@
             "file",
             "../out/sdk/wasp/core/serialization/index.ts"
         ],
-        "f36812afeb3afac66bca99dd8764a45f8def73374f696ed502280223f6677161"
+        "daaf6d88944b11969bcf278b84409b3ca81dc2f3cc97037df3ebc7f293381a74"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-test/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -9,10 +9,10 @@ export type Payload = void | SuperJSONValue;
 // https://github.com/blitz-js/superjson/blob/ae7dbcefe5d3ece5b04be0c6afe6b40f3a44a22a/src/types.ts
 //
 // We couldn't use SuperJSON's types directly because:
-//   1. They aren't exported publicly.
-//   2. They have a weird quirk that turns `SuperJSONValue` into `any`.
+//   1. They have a weird quirk that turns `SuperJSONValue` into `any`.
 //      See why here:
 //      https://github.com/blitz-js/superjson/pull/36#issuecomment-669239876
+//   2. We need to add our own custom types to the serialization process.
 //
 // We changed the code as little as possible to make future comparisons easier.
 export type JSONValue = PrimitiveJSONValue | JSONArray | JSONObject;

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -172,7 +172,7 @@
             "file",
             "../out/sdk/wasp/core/serialization/index.ts"
         ],
-        "76793a820deb474b105bccdeb69b5395d7522c53a790b0ed430533fa5158461c"
+        "cb3b769a74f5cadab1582df4e6e36cdeeebfe9f926faa2c9f40e2ddf46ddf75b"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-test/test-outputs/waspJob-golden/waspJob/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -8,10 +8,10 @@ export type Payload = void | SuperJSONValue;
 // https://github.com/blitz-js/superjson/blob/ae7dbcefe5d3ece5b04be0c6afe6b40f3a44a22a/src/types.ts
 //
 // We couldn't use SuperJSON's types directly because:
-//   1. They aren't exported publicly.
-//   2. They have a weird quirk that turns `SuperJSONValue` into `any`.
+//   1. They have a weird quirk that turns `SuperJSONValue` into `any`.
 //      See why here:
 //      https://github.com/blitz-js/superjson/pull/36#issuecomment-669239876
+//   2. We need to add our own custom types to the serialization process.
 //
 // We changed the code as little as possible to make future comparisons easier.
 export type JSONValue = PrimitiveJSONValue | JSONArray | JSONObject;

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -172,7 +172,7 @@
             "file",
             "../out/sdk/wasp/core/serialization/index.ts"
         ],
-        "f36812afeb3afac66bca99dd8764a45f8def73374f696ed502280223f6677161"
+        "daaf6d88944b11969bcf278b84409b3ca81dc2f3cc97037df3ebc7f293381a74"
     ],
     [
         [

--- a/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-test/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -9,10 +9,10 @@ export type Payload = void | SuperJSONValue;
 // https://github.com/blitz-js/superjson/blob/ae7dbcefe5d3ece5b04be0c6afe6b40f3a44a22a/src/types.ts
 //
 // We couldn't use SuperJSON's types directly because:
-//   1. They aren't exported publicly.
-//   2. They have a weird quirk that turns `SuperJSONValue` into `any`.
+//   1. They have a weird quirk that turns `SuperJSONValue` into `any`.
 //      See why here:
 //      https://github.com/blitz-js/superjson/pull/36#issuecomment-669239876
+//   2. We need to add our own custom types to the serialization process.
 //
 // We changed the code as little as possible to make future comparisons easier.
 export type JSONValue = PrimitiveJSONValue | JSONArray | JSONObject;


### PR DESCRIPTION
SuperJSON now exports the `SuperJSONValue` type https://github.com/flightcontrolhq/superjson/pull/322 (but we still can't use it).
This PR updates the note.