### PR TITLE
Treat package-lock.json as generated in the PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 *.hs linguist-detectable=false
 
 /examples/* linguist-documentation
+
+**/package-lock.json linguist-generated=true


### PR DESCRIPTION
Added by @infomiho 

Read more about how `linguist-generated` works: https://medium.com/@clarkbw/managing-generated-files-in-github-1f1989c09dfd