### PR TITLE
Remove path from on push workflow in examples e2e tests

### DIFF
--- a/.github/workflows/examples-headless-tests.yaml
+++ b/.github/workflows/examples-headless-tests.yaml
@@ -3,8 +3,6 @@ name: Run headless tests on root example apps
 on:
   workflow_call:
   push:
-    paths:
-      - "examples/**"
     branches:
       - main
       - release


### PR DESCRIPTION
This ensure we run the tests on every merge to `main`.
Why?
Because we can break example apps through `waspc` changes without touching the `examples` folder.