### PR TITLE
Fix script for deploying examples

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -8,7 +8,7 @@ on:
         type: string
         description: "Wasp version to use for deployment (e.g., 0.18.0), defaults to latest"
         required: false
-        default: "0.18.0-rc1" # We are relying on the install script treating the empty string as the latest version
+        default: "" # We are relying on the install script treating the empty string as the latest version
     secrets:
       FLY_GITHUB_PRODUCTION_TOKEN:
         description: "Fly API token for deploying apps"
@@ -20,12 +20,7 @@ on:
       version:
         description: "Wasp version to use for deployment (e.g., 0.18.0), defaults to latest"
         required: false
-        default: "0.18.0-rc1" # We are relying on the install script treating the empty string as the latest version
-
-  # TODO: REMOVE THIS BEFORE MERGING, JUST FOR TESTING
-  push:
-    branches:
-      - filip-fix-deploy-examples 
+        default: "" # We are relying on the install script treating the empty string as the latest version
 
 concurrency:
   group: "deploy-examples"


### PR DESCRIPTION
- Set proper Node version
- Leave an example of how a version string is supposed to look like (`v0.18.0` vs `0.18.0`). Discussed here: https://github.com/wasp-lang/wasp/pull/2857#discussion_r2182872515
- Fixed the missing default input value when calling the workflow