### PR TITLE
Clarified context passing for queries when used from server

### DIFF
--- a/web/docs/data-model/operations/queries.md
+++ b/web/docs/data-model/operations/queries.md
@@ -271,7 +271,8 @@ Calling a Query on the server is similar to calling it on the client.
 Here's what you have to do differently:
 
 - Import Queries from `wasp/server/operations` instead of `wasp/client/operations`.
-- Make sure you pass in a context object with the user to authenticated Queries.
+- Make sure you pass in a `context` object with the `user` field to authenticated Queries.
+  - Note that you don't have to pass other parts of the `context` object, like Entities, those will get injected automatically.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">

--- a/web/versioned_docs/version-0.17.0/data-model/operations/queries.md
+++ b/web/versioned_docs/version-0.17.0/data-model/operations/queries.md
@@ -271,8 +271,7 @@ Calling a Query on the server is similar to calling it on the client.
 Here's what you have to do differently:
 
 - Import Queries from `wasp/server/operations` instead of `wasp/client/operations`.
-- Make sure you pass in a `context` object with the `user` to authenticated Queries.
-  - Note that you don't have to pass other parts of the `context` object, like Entities, those will get injected automatically.
+- Make sure you pass in a context object with the user to authenticated Queries.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">

--- a/web/versioned_docs/version-0.17.0/data-model/operations/queries.md
+++ b/web/versioned_docs/version-0.17.0/data-model/operations/queries.md
@@ -271,7 +271,8 @@ Calling a Query on the server is similar to calling it on the client.
 Here's what you have to do differently:
 
 - Import Queries from `wasp/server/operations` instead of `wasp/client/operations`.
-- Make sure you pass in a context object with the user to authenticated Queries.
+- Make sure you pass in a `context` object with the `user` to authenticated Queries.
+  - Note that you don't have to pass other parts of the `context` object, like Entities, those will get injected automatically.
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">


### PR DESCRIPTION
When calling Operations from the server (instead of the client), you need to pass the information about the authenticated user, if Operations expects it. On client that happens automatically, on server you have to specify it.

You can do that by passing `context` object, and specifying `user` field in it. That is what we say in the docs.

However, what was not clear to me (when I was answering a user and reading our docs to figure it out), was what happens with the rest of the `context` object. If we pass our own `context`, what about `context.entities` if Operation needs that -> will that be automatically set for us, so "merged" into the `context` that we provide, or are we then expected to provide that also, since we provided our own `context` and therefore took over the "control" of it in our hands?

Turns out, the `context` we pass will be merged with the "wasp prepared" `context`, so it is enough to just specify the `user` and not `entities` or anything else.

So what I did was add a single sentence to the docs that explains that the rest of the `context` will be provided automatically.