### PR TITLE
Loosen linting-focused Typescript config options

### DIFF
--- a/waspc/data/Generator/templates/react-app/tsconfig.app.json
+++ b/waspc/data/Generator/templates/react-app/tsconfig.app.json
@@ -5,11 +5,19 @@
     // Temporary loosen the type checking until we can address all the errors.
     "jsx": "preserve",
     "allowJs": true,
-    "strict": false,
     "skipLibCheck": true,
     // Allow importing pages with the .tsx extension.
     "allowImportingTsExtensions": true,
     "noEmit": true,
+    // Overriding Vite 7 linting-focused options to be less strict since we
+    // don't want to block web-app builds on linting errors.
+    // We'll tackle it when we do: https://github.com/wasp-lang/wasp/issues/2777
+    "strict": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "erasableSyntaxOnly": false,
+    "noFallthroughCasesInSwitch": false,
+    "noUncheckedSideEffectImports": false
   },
   "include": [
     "src"

--- a/waspc/e2e-tests/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/waspBuild-golden/waspBuild/.wasp/build/.waspchecksums
@@ -690,7 +690,7 @@
             "file",
             "web-app/tsconfig.app.json"
         ],
-        "3569d142426c6c6aa5992f71dab7f4f1099483fbe2a552ea4c1beeed3df3c317"
+        "1c4711b7c2c3a02a3575190ba02bd3f16323bf53c4cde15b3951e144ae520c79"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/tsconfig.app.json
+++ b/waspc/e2e-tests/test-outputs/waspBuild-golden/waspBuild/.wasp/build/web-app/tsconfig.app.json
@@ -4,11 +4,19 @@
     // Temporary loosen the type checking until we can address all the errors.
     "jsx": "preserve",
     "allowJs": true,
-    "strict": false,
     "skipLibCheck": true,
     // Allow importing pages with the .tsx extension.
     "allowImportingTsExtensions": true,
     "noEmit": true,
+    // Overriding Vite 7 linting-focused options to be less strict since we
+    // don't want to block web-app builds on linting errors.
+    // We'll tackle it when we do: https://github.com/wasp-lang/wasp/issues/2777
+    "strict": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "erasableSyntaxOnly": false,
+    "noFallthroughCasesInSwitch": false,
+    "noUncheckedSideEffectImports": false
   },
   "include": [
     "src"

--- a/waspc/e2e-tests/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/waspCompile-golden/waspCompile/.wasp/out/.waspchecksums
@@ -704,7 +704,7 @@
             "file",
             "web-app/tsconfig.app.json"
         ],
-        "3569d142426c6c6aa5992f71dab7f4f1099483fbe2a552ea4c1beeed3df3c317"
+        "1c4711b7c2c3a02a3575190ba02bd3f16323bf53c4cde15b3951e144ae520c79"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/tsconfig.app.json
+++ b/waspc/e2e-tests/test-outputs/waspCompile-golden/waspCompile/.wasp/out/web-app/tsconfig.app.json
@@ -4,11 +4,19 @@
     // Temporary loosen the type checking until we can address all the errors.
     "jsx": "preserve",
     "allowJs": true,
-    "strict": false,
     "skipLibCheck": true,
     // Allow importing pages with the .tsx extension.
     "allowImportingTsExtensions": true,
     "noEmit": true,
+    // Overriding Vite 7 linting-focused options to be less strict since we
+    // don't want to block web-app builds on linting errors.
+    // We'll tackle it when we do: https://github.com/wasp-lang/wasp/issues/2777
+    "strict": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "erasableSyntaxOnly": false,
+    "noFallthroughCasesInSwitch": false,
+    "noUncheckedSideEffectImports": false
   },
   "include": [
     "src"

--- a/waspc/e2e-tests/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/.waspchecksums
@@ -1404,7 +1404,7 @@
             "file",
             "web-app/tsconfig.app.json"
         ],
-        "3569d142426c6c6aa5992f71dab7f4f1099483fbe2a552ea4c1beeed3df3c317"
+        "1c4711b7c2c3a02a3575190ba02bd3f16323bf53c4cde15b3951e144ae520c79"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/tsconfig.app.json
+++ b/waspc/e2e-tests/test-outputs/waspComplexTest-golden/waspComplexTest/.wasp/out/web-app/tsconfig.app.json
@@ -4,11 +4,19 @@
     // Temporary loosen the type checking until we can address all the errors.
     "jsx": "preserve",
     "allowJs": true,
-    "strict": false,
     "skipLibCheck": true,
     // Allow importing pages with the .tsx extension.
     "allowImportingTsExtensions": true,
     "noEmit": true,
+    // Overriding Vite 7 linting-focused options to be less strict since we
+    // don't want to block web-app builds on linting errors.
+    // We'll tackle it when we do: https://github.com/wasp-lang/wasp/issues/2777
+    "strict": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "erasableSyntaxOnly": false,
+    "noFallthroughCasesInSwitch": false,
+    "noUncheckedSideEffectImports": false
   },
   "include": [
     "src"

--- a/waspc/e2e-tests/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/waspJob-golden/waspJob/.wasp/out/.waspchecksums
@@ -802,7 +802,7 @@
             "file",
             "web-app/tsconfig.app.json"
         ],
-        "3569d142426c6c6aa5992f71dab7f4f1099483fbe2a552ea4c1beeed3df3c317"
+        "1c4711b7c2c3a02a3575190ba02bd3f16323bf53c4cde15b3951e144ae520c79"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/tsconfig.app.json
+++ b/waspc/e2e-tests/test-outputs/waspJob-golden/waspJob/.wasp/out/web-app/tsconfig.app.json
@@ -4,11 +4,19 @@
     // Temporary loosen the type checking until we can address all the errors.
     "jsx": "preserve",
     "allowJs": true,
-    "strict": false,
     "skipLibCheck": true,
     // Allow importing pages with the .tsx extension.
     "allowImportingTsExtensions": true,
     "noEmit": true,
+    // Overriding Vite 7 linting-focused options to be less strict since we
+    // don't want to block web-app builds on linting errors.
+    // We'll tackle it when we do: https://github.com/wasp-lang/wasp/issues/2777
+    "strict": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "erasableSyntaxOnly": false,
+    "noFallthroughCasesInSwitch": false,
+    "noUncheckedSideEffectImports": false
   },
   "include": [
     "src"

--- a/waspc/e2e-tests/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/.waspchecksums
@@ -711,7 +711,7 @@
             "file",
             "web-app/tsconfig.app.json"
         ],
-        "3569d142426c6c6aa5992f71dab7f4f1099483fbe2a552ea4c1beeed3df3c317"
+        "1c4711b7c2c3a02a3575190ba02bd3f16323bf53c4cde15b3951e144ae520c79"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/tsconfig.app.json
+++ b/waspc/e2e-tests/test-outputs/waspMigrate-golden/waspMigrate/.wasp/out/web-app/tsconfig.app.json
@@ -4,11 +4,19 @@
     // Temporary loosen the type checking until we can address all the errors.
     "jsx": "preserve",
     "allowJs": true,
-    "strict": false,
     "skipLibCheck": true,
     // Allow importing pages with the .tsx extension.
     "allowImportingTsExtensions": true,
     "noEmit": true,
+    // Overriding Vite 7 linting-focused options to be less strict since we
+    // don't want to block web-app builds on linting errors.
+    // We'll tackle it when we do: https://github.com/wasp-lang/wasp/issues/2777
+    "strict": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "erasableSyntaxOnly": false,
+    "noFallthroughCasesInSwitch": false,
+    "noUncheckedSideEffectImports": false
   },
   "include": [
     "src"


### PR DESCRIPTION
### Error preventing us from deploying an app

After we updated to Vite 7 and our `tsconfig.json` extends their config `@tsconfig/vite-react/tsconfig.json`, we run into some `tsc` errors when we build the `web-app`. 

We got this when building the `ask-the-documents` app:
```ts
src/router.tsx:5:1 - error TS6133: 'createAuthRequiredPage' is declared but its value is never read.

5 import createAuthRequiredPage from "./auth/pages/createAuthRequiredPage"
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

### We want to ignore those errors

Sometimes there will be some unused imports or params in the generated code (it's easier to write the Mustache templates like that sometimes) - so we want to keep the Typescript rules loose.

Discussed with @sodic on a call and agreed to go with this solution for now. In the future, most of the templated code will in the libs which will be strict, so this should be a okay fix for now.