### PR TITLE
Correctly set dir to serve in wasp-app-runner

### DIFF
--- a/wasp-app-runner/package-lock.json
+++ b/wasp-app-runner/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "wasp-app-runner",
+  "name": "@wasp.sh/wasp-app-runner",
   "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wasp-app-runner",
+      "name": "@wasp.sh/wasp-app-runner",
       "version": "0.0.7",
+      "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.1.0",
         "chalk": "^5.4.1",

--- a/wasp-app-runner/src/build/client.ts
+++ b/wasp-app-runner/src/build/client.ts
@@ -64,11 +64,13 @@ async function startClientApp({
 }): Promise<{
   exitCode: number | null;
 }> {
+  const servePath = path.resolve(pathToApp, clientAppBuildOutputDir);
+
   return spawnWithLog({
     name: "client-start-app",
     cmd: "npx",
-    args: ["serve", "--single", "-p", "3000"],
-    cwd: path.join(pathToApp, clientAppBuildOutputDir),
+    args: ["serve", "--single", "-p", "3000", servePath],
+    cwd: servePath,
   });
 }
 


### PR DESCRIPTION
Made as part of
- #3159

---

There is a strange interaction when running `npx` with a custom `cwd`, pointing to a folder inside of a npm workspace. It's a mouthful.

But basically, doing `npx serve .` with `cwd=.wasp/build/web-app/build`, actually searches for the parent package and turns the cwd into it (so `cwd=.wasp/build/web-app`), and thus `serve` doesn't serve the correct directory.

To workaround this npm bug, we explicitly tell `npx serve` the location of the folder we want it to run.

---

I send this PR ahead of time because the `wasp-app-runner` used for E2E examples is taken from `npm`, so we should do this change first and then publish so that #3159 can pass the tests.