### PR TITLE
Remove GHC repetitions from Github actions

### DIFF
--- a/.github/actions/setup-haskell/action.yaml
+++ b/.github/actions/setup-haskell/action.yaml
@@ -15,7 +15,7 @@ inputs:
     description: |
       The version of Cabal to install.
     required: false
-    default: "latest"
+    default: "3.10.2.0"
 
   cabal-project-dir:
     description: |

--- a/.github/workflows/examples-e2e-tests.yaml
+++ b/.github/workflows/examples-e2e-tests.yaml
@@ -32,8 +32,6 @@ jobs:
 
       - uses: ./.github/actions/setup-haskell
         with:
-          ghc-version: "9.0.2"
-          cabal-version: "3.10.2.0"
           cabal-project-dir: waspc
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/starters-e2e-tests.yaml
+++ b/.github/workflows/starters-e2e-tests.yaml
@@ -22,8 +22,6 @@ jobs:
 
       - uses: ./.github/actions/setup-haskell
         with:
-          ghc-version: "9.0.2"
-          cabal-version: "3.10.2.0"
           cabal-project-dir: waspc
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/waspc-build.yaml
+++ b/.github/workflows/waspc-build.yaml
@@ -5,21 +5,12 @@ name: Build wasp-cli binaries for multiple platforms
 on:
   workflow_dispatch:
     inputs:
-      ghc-version:
-        description: "GHC version to use"
-        default: "9.0.2"
-        required: false
       node-version:
         description: "Node.js version to use"
         default: "22"
         required: false
   workflow_call:
     inputs:
-      ghc-version:
-        description: "GHC version to use"
-        default: "9.0.2"
-        type: string
-        required: false
       node-version:
         description: "Node.js version to use"
         default: "22"
@@ -130,7 +121,6 @@ jobs:
 
       - uses: ./.github/actions/setup-haskell
         with:
-          ghc-version: ${{ inputs.ghc-version }}
           extra-cache-key-segment: ${{ matrix.env.static && 'static' || 'default' }}
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/waspc-ci.yaml
+++ b/.github/workflows/waspc-ci.yaml
@@ -47,10 +47,6 @@ jobs:
           - windows-latest
         node-version:
           - "latest"
-        ghc:
-          - "9.0.2"
-        cabal:
-          - "3.10.2.0"
         # In addition to the default matrix, we also want to run the build job for
         # additional Node.js versions, to make sure that Wasp works with them.
         # To reduce the number of jobs, we only test the Node.js versions on
@@ -58,12 +54,8 @@ jobs:
         include:
           - os: ubuntu-22.04
             node-version: 22
-            ghc: "9.0.2"
-            cabal: "3.10.2.0"
           - os: ubuntu-22.04
             node-version: 24
-            ghc: "9.0.2"
-            cabal: "3.10.2.0"
 
     steps:
       - name: Configure git
@@ -91,8 +83,6 @@ jobs:
       - name: Set up Haskell
         uses: ./.github/actions/setup-haskell
         with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
           cabal-project-dir: waspc
 
       - name: Set up Node


### PR DESCRIPTION
This PR reduces the number of places where we explicitly list our GHC/Cabal version by relying on the defualt versions in the `setup-haskell` action.