### PR TITLE
Fix wrong names in "merge release to main" automation

### DIFF
--- a/.github/workflows/automation-merge-release-to-main.yaml
+++ b/.github/workflows/automation-merge-release-to-main.yaml
@@ -10,7 +10,7 @@ env:
   SOURCE_BRANCH: release
   TARGET_BRANCH: main
 
-  GITHUB_ACTOR: ${{ github.actor }}
+  USERNAME: ${{ github.actor }}
 
   PR_TITLE: "Merge `release` into `main`"
   PR_BODY: |
@@ -36,15 +36,15 @@ jobs:
 
           if [ -n "$existing_pr_number" ]; then
             gh pr comment "$existing_pr_number" \
-              --body "Ping @${GITHUB_ACTOR}"
+              --body "Ping @${USERNAME}"
 
             gh pr edit "$existing_pr_number" \
-              --add-assignee "$GITHUB_ACTOR" \
-              --add-reviewer "$GITHUB_ACTOR"
+              --add-assignee "$USERNAME" \
+              --add-reviewer "$USERNAME"
           else
             gh pr create \
-              --assignee "$GITHUB_ACTOR" \
-              --reviewer "$GITHUB_ACTOR" \
+              --assignee "$USERNAME" \
+              --reviewer "$USERNAME" \
               --head "$SOURCE_BRANCH" \
               --base "$TARGET_BRANCH" \
               --title "$PR_TITLE" \


### PR DESCRIPTION
Fixes some names:

- Envs for CLI  `GITHUB_REPOSITORY` -> `GH_REPO` (same with `GH_TOKEN`), those are the correct ones for the `gh` cli
- File was named `.yml` instead of `.yaml` for consistency
- Renamed the `GITHUB_ACTOR` -> `USERNAME` env so it doesn't get confused with the `gh` CLI environment variables