### PR TITLE
Remove assigning and adding reviewer to merge-back PR

### DIFF
--- a/.github/workflows/automation-merge-release-to-main.yaml
+++ b/.github/workflows/automation-merge-release-to-main.yaml
@@ -37,10 +37,6 @@ jobs:
           if [ -n "$existing_pr_number" ]; then
             gh pr comment "$existing_pr_number" \
               --body "Ping @${USERNAME}"
-
-            gh pr edit "$existing_pr_number" \
-              --add-assignee "$USERNAME" \
-              --add-reviewer "$USERNAME"
           else
             gh pr create \
               --assignee "$USERNAME" \


### PR DESCRIPTION
When pushing to `release`, in the merge-back automation, we check if a PR already exists. If so, the person who pushed is
1. pinged in this PR; _and_
2. added as reviewer and assignee.

This PR removes action (2). This is because the `gh pr edit` command needs access to `organization.read`, and GitHub actions can't request access to this scope [(failed run log)](https://github.com/wasp-lang/wasp/actions/runs/18459155651/job/52586383855?pr=3246).

---

_Note:_ it is weird that the CLI requests this scope, as the underlying APIs do not need it (only `pull_request.write` -- [1](https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request), [2](https://docs.github.com/en/rest/issues/assignees?apiVersion=2022-11-28#add-assignees-to-an-issue)). My guess is that the CLI is first checking if the string we pass it is a team name or a user name to do some intelligent handling around that, and that's why it needs the `org.read` scope for.