### PR TITLE
`ask-the-documents`: Add CI testing

### DIFF
--- a/.github/workflows/ci-examples-test.yaml
+++ b/.github/workflows/ci-examples-test.yaml
@@ -19,6 +19,7 @@ jobs:
           - waspello
           - waspleau
           - websockets-realtime-voting
+          - ask-the-documents
 
     steps:
       - uses: "actions/checkout@v5"

--- a/examples/ask-the-documents/e2e-tests/playwright.config.ts
+++ b/examples/ask-the-documents/e2e-tests/playwright.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const WASP_RUN_MODE = process.env.WASP_RUN_MODE ?? "dev";
+const WASP_CLI_CMD = process.env.WASP_CLI_CMD ?? "wasp-cli";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI ? "dot" : "list",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:3000",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    /* Test against mobile viewports. */
+    {
+      name: "Mobile Chrome",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: `run-wasp-app ${WASP_RUN_MODE} --path-to-app=../ --wasp-cli-cmd=${WASP_CLI_CMD} --db-image pgvector/pgvector:pg17`,
+
+    // Wait for the backend to start
+    url: "http://localhost:3001",
+    reuseExistingServer: !process.env.CI,
+    timeout: 180 * 1000,
+    gracefulShutdown: { signal: "SIGTERM", timeout: 500 },
+  },
+});

--- a/examples/ask-the-documents/e2e-tests/tests/simple.spec.ts
+++ b/examples/ask-the-documents/e2e-tests/tests/simple.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("loads successfully", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test("shows the search bar", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector("input[type='search']");
+    await expect(page.locator("input[type='search']")).toBeVisible();
+  });
+});

--- a/examples/ask-the-documents/env.server.example
+++ b/examples/ask-the-documents/env.server.example
@@ -1,6 +1,0 @@
-OPENAI_API_KEY=
-# If you ran run_db.sh, this it okay:
-DATABASE_URL=postgresql://postgres:devpass@localhost:5432/postgres
-
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=

--- a/examples/ask-the-documents/package-lock.json
+++ b/examples/ask-the-documents/package-lock.json
@@ -22,7 +22,9 @@
         "wasp": "file:.wasp/out/sdk/wasp"
       },
       "devDependencies": {
+        "@playwright/test": "1.51.1",
         "@types/react": "^18.0.37",
+        "@wasp.sh/wasp-app-runner": "^0.0.9",
         "prisma": "5.19.1",
         "typescript": "5.8.2",
         "vite": "^7.0.6"
@@ -3014,6 +3016,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.51.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -5914,6 +5932,55 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@wasp.sh/wasp-app-runner": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@wasp.sh/wasp-app-runner/-/wasp-app-runner-0.0.9.tgz",
+      "integrity": "sha512-FkT8l4eDaRBO7mAeHBmlsYVinp9Ftf4FEThiAQ9w6joociRgPj7XoekFu9jt9OVest4qAu4g4xPPqYkuwDqG+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commander-js/extra-typings": "^13.1.0",
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "dotenv": "^16.5.0"
+      },
+      "bin": {
+        "run-wasp-app": "bin/index.js"
+      }
+    },
+    "node_modules/@wasp.sh/wasp-app-runner/node_modules/@commander-js/extra-typings": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-13.1.0.tgz",
+      "integrity": "sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "commander": "~13.1.0"
+      }
+    },
+    "node_modules/@wasp.sh/wasp-app-runner/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@wasp.sh/wasp-app-runner/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -7620,6 +7687,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -11126,6 +11206,53 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.51.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/examples/ask-the-documents/package.json
+++ b/examples/ask-the-documents/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "env:pull": "npx dotenv-vault@latest pull development .env.server",
-    "env:push": "npx dotenv-vault@latest push development .env.server"
+    "env:push": "npx dotenv-vault@latest push development .env.server",
+    "test": "DEBUG=pw:webserver playwright test --config e2e-tests/"
   },
   "dependencies": {
     "@heroui/react": "2.7.5",
@@ -22,7 +23,9 @@
     "wasp": "file:.wasp/out/sdk/wasp"
   },
   "devDependencies": {
+    "@playwright/test": "1.51.1",
     "@types/react": "^18.0.37",
+    "@wasp.sh/wasp-app-runner": "^0.0.9",
     "prisma": "5.19.1",
     "typescript": "5.8.2",
     "vite": "^7.0.6"

--- a/waspc/run
+++ b/waspc/run
@@ -49,6 +49,7 @@ function run_examples_e2e_tests() {
     "examples/waspello"
     "examples/waspleau"
     "examples/websockets-realtime-voting"
+    "examples/ask-the-documents"
   )
 
   for path in "${paths[@]}"; do


### PR DESCRIPTION
- Part of #3141

Adds a simple E2E test. Due to it using Google login and OpenAI as core app functionality, right now I'm only testing that it loads and shows the searchbox.

We don't need to use the custom DB commands as `wasp-app-runner` has support for the `--db-image` argument.

---

PR hierarchy:
- #3174 just imports the repo and runs prettier on it
  - #3252 adds dotenv files with the config that was on railway
    - #3251 adds deployment to Fly in CI
    - #3250 (👈 this one) adds simple e2e testing to CI