### PR TITLE
`ask-the-documents`: Add dotenv files

### DIFF
--- a/examples/ask-the-documents/.env.server.example
+++ b/examples/ask-the-documents/.env.server.example
@@ -1,0 +1,4 @@
+OPENAI_API_KEY="sk-dummy-openai-api-key"
+
+GOOGLE_CLIENT_ID="dummy-g-client-id.apps.googleusercontent.com"
+GOOGLE_CLIENT_SECRET="dummy-g-client-secret"

--- a/examples/ask-the-documents/.env.vault
+++ b/examples/ask-the-documents/.env.vault
@@ -1,0 +1,25 @@
+#/-------------------.env.vault---------------------/
+#/         cloud-agnostic vaulting standard         /
+#/   [how it works](https://dotenv.org/env-vault)   /
+#/--------------------------------------------------/
+
+# development
+DOTENV_VAULT_DEVELOPMENT="BrOwnPksG01dGaKOUBvEDKGGHBmI+hxEWI9RYvybdUzjUL1NVWesyJDU96zscJQ5uIUhxFie5lkgEKX5w6w/gVK3T8uCSy0KyPap7wy7aBePG+jnLw2WIbMliwa4SocJrSAd6D3NQRt8touph6YQLx9QPE7JTTsIaKYxVrPq+lqVOf/b+6P9sohodkMYuo3CaDPpoOAVq1mz5Yx78DhSPXbYqP1+i7QAfsqiFNa8Gtp3b90wPW4QBES+6kbGXViXvnYRae8ArUA145mm8t4xRLZ6Y2go7gHUnJz+o2eyAi/Ujh6U51/wStGnExiUA758Og=="
+DOTENV_VAULT_DEVELOPMENT_VERSION=2
+
+# ci
+DOTENV_VAULT_CI="lWih3a4rNoQcb4m8i9uP2zaTWBIcYKaKjKFu4yA/WHuUY279GYBurrzWm/iNxwtpe11Jtq8gzrlPbc5X21H4S9E2X+tWZ8o6Nq7G4A6e89Q4tzr3LVWwcja8FaF7zGXgL5o="
+DOTENV_VAULT_CI_VERSION=2
+
+# staging
+DOTENV_VAULT_STAGING="ipTAF2j+JQM5LkmMIixdv+NMKJtrGI9bWtxlVaB6s8Rs8JBvEBovPUrgWI+h3FMWq9NBPq5BWaM7XqhiZncqly1VJ0ijuwG6yyUwj8T1v8v5ac+EM0UG2vNvaymVK2f/JFk="
+DOTENV_VAULT_STAGING_VERSION=2
+
+# production
+DOTENV_VAULT_PRODUCTION="M5rt2ChgmWvLy9HFoEO49aiDmTMpwVNnWi1VbHx94A3hpSPFzQnWbdqo5esUZprUfICSMW71Qq+xo8MOkmtQ/B2GgW5ILbF4FZ+cTXMSKeraGvqpK6gU7ULH/eZKEtZTjQ8="
+DOTENV_VAULT_PRODUCTION_VERSION=2
+
+#/----------------settings/metadata-----------------/
+DOTENV_VAULT="vlt_96ba1157e11f2122a3bd0a7ef7fc6858d6e7354a4e5a8a3f1a0b128142b97340"
+DOTENV_API_URL="https://vault.dotenv.org"
+DOTENV_CLI="npx dotenv-vault@latest"

--- a/examples/ask-the-documents/.gitignore
+++ b/examples/ask-the-documents/.gitignore
@@ -9,6 +9,10 @@ node_modules/
 # To be extra safe, we by default ignore any files with `.env` extension in them.
 # If this is too agressive for you, consider allowing specific files with `!` operator,
 # or modify/delete these two lines.
-*.env
-*.env.*
 /.wasp/
+
+.env*
+.flaskenv*
+!.env.project
+!.env.vault
+!.env.server.example

--- a/examples/ask-the-documents/package.json
+++ b/examples/ask-the-documents/package.json
@@ -1,6 +1,10 @@
 {
   "name": "askTheDocuments",
   "type": "module",
+  "scripts": {
+    "env:pull": "npx dotenv-vault@latest pull development .env.server",
+    "env:push": "npx dotenv-vault@latest push development .env.server"
+  },
   "dependencies": {
     "@heroui/react": "2.7.5",
     "axios": "^1.4.0",


### PR DESCRIPTION
- Part of #3141

Uses dotenv in the same way as other apps to store the env variables that were set on the deployed version on Railway.

---

PR hierarchy:
- #3174 just imports the repo and runs prettier on it
  - #3252 (👈 this one) adds dotenv files with the config that was on railway
    - #3251 adds deployment to Fly in CI
    - #3250 adds simple e2e testing to CI