### PR TITLE
Fix dev-tools.project versions

### DIFF
--- a/waspc/dev-tool.project
+++ b/waspc/dev-tool.project
@@ -6,7 +6,7 @@ packages: .
 jobs: $ncpus
 
 constraints:
-  ormolu ==0.5.3.0,
+  ormolu ==0.4.0.0,
   stan ==0.2.1.0,
   hlint ==3.5.0,
   prune-juice ==0.7


### PR DESCRIPTION
Updating `ormolu` version made it so that our project is no longer formatted correctly:
https://github.com/wasp-lang/wasp/actions/runs/18526820452/job/52799513371?pr=3261

So I reverted the `ormolu` version update for now.
I suppose we will do that once we finish updating GHC fully.