### PR TITLE
Update Fly region in CI deployment workflow from 'mia' to 'dfw'

### DIFF
--- a/.github/workflows/ci-deploy-test.yaml
+++ b/.github/workflows/ci-deploy-test.yaml
@@ -13,7 +13,7 @@ env:
 
   APP_PREFIX: ci-${{ github.sha }}
   FLY_API_TOKEN: ${{ secrets.FLY_GITHUB_TESTING_TOKEN }}
-  FLY_REGION: mia
+  FLY_REGION: dfw
   APP_TO_DEPLOY: waspc/examples/todoApp
 
 jobs:


### PR DESCRIPTION
Our CI fails since `mia` got consolidated into `dfw`: https://fly.io/blog/the-region-consolidation-project/