### PR TITLE
Fix Waspleau types

### DIFF
--- a/examples/waspleau/package-lock.json
+++ b/examples/waspleau/package-lock.json
@@ -1188,9 +1188,9 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
-      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.4.tgz",
+      "integrity": "sha512-g64dbryHk7loCIrsa0R3shBnEu5p6LPJ09bu9NG58+jz+cRUjFrc3Bz0kNQ7j9bXeCsrRDvNET1G54P/GJkAyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1200,9 +1200,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
As reported by @infomiho on [Discord](https://discord.com/channels/686873244791210014/1432294650957398026):

> Waspleau fails with an Express-related type error: https://github.com/wasp-lang/wasp/actions/runs/18834197686/job/53731401384?pr=3275

A simple `npm up @types/express-serve-static-core @types/express` solved the issue.

**Explanation**

The user's `package-lock.json` stores the dependency resolution for SDK, and that had the old version. The `.wasp/out/server/package-lock.json` was getting recreated on `wasp start` and using a newer version. 

Code in SDK was using the old Application type, and code in Server was using the new Application type. Types are incompatible in some way, so it was giving us an error.

> Will be solved by #3130 