### PR TITLE
Update linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 
 *.hs linguist-detectable=false
 
-/web/* linguist-documentation
-/examples/* linguist-documentation
+/web/** linguist-documentation
+/examples/** linguist-documentation
 
 **/package-lock.json linguist-generated=true


### PR DESCRIPTION
The syntax for linguist was wrong and the language breakdown wasn't updated. I fixed it and ran GitHub's language detector locally to check:

Results:
```
75.98%  623055     TypeScript
17.22%  141230     JavaScript
2.07%   16942      TeX
1.79%   14689      CSS
1.64%   13419      Shell
0.72%   5898       Dockerfile
0.47%   3861       Lex
0.10%   855        HTML
0.01%   79         PowerShell
```
Note that MDX doesn't appear anymore as they are now correctly marked as documentation