### PR TITLE
Revert "Remove assigning and adding reviewer to merge-back PR"

### DIFF
--- a/.github/workflows/automation-merge-release-to-main.yaml
+++ b/.github/workflows/automation-merge-release-to-main.yaml
@@ -37,6 +37,10 @@ jobs:
           if [ -n "$existing_pr_number" ]; then
             gh pr comment "$existing_pr_number" \
               --body "Ping @${USERNAME}"
+
+            gh pr edit "$existing_pr_number" \
+              --add-assignee "$USERNAME" \
+              --add-reviewer "$USERNAME"
           else
             gh pr create \
               --assignee "$USERNAME" \


### PR DESCRIPTION
- Reverts wasp-lang/wasp#3249

The fix (https://github.com/cli/cli/issues/11920) was merged at the GitHub CLI and is now available in the CI runners. (Released on [`gh` v2.82.0](https://github.com/cli/cli/releases/tag/v2.82.0), and available in runners since [Nov 3rd](https://github.com/actions/runner-images/commit/aab6e2778741c10551dca5dba356433b7fa1a6df#diff-cc12e5c5d005932feaacf280af949d83e2cb6020dff8203d9ead2e00c30e8b7fR110))

We can now assign people to the PR when they push to `release` and there is an already-existing PR for merging back to `main`.