### PR TITLE
CI: Update runner to macOS 15

### DIFF
--- a/.github/workflows/ci-waspc-build.yaml
+++ b/.github/workflows/ci-waspc-build.yaml
@@ -76,7 +76,7 @@ jobs:
               apk add zlib-dev zlib-static
 
           - name: macos-x86_64
-            runner: macos-13 # Latest image still based on Intel architecture that can be used for free
+            runner: macos-15-intel # Latest image still based on Intel architecture that can be used for free
 
             # macOS's syscalls are private and change between versions, so we
             # can't statically link the binary. However, on macOS programs link

--- a/.github/workflows/ci-waspc-test.yaml
+++ b/.github/workflows/ci-waspc-test.yaml
@@ -30,7 +30,7 @@ jobs:
           # and link the binaries statically:
           # https://github.com/wasp-lang/wasp/issues/650#issuecomment-1180488040
           - ubuntu-22.04
-          - macos-13
+          - macos-15-intel
           - windows-latest
         node-version:
           - "latest"
@@ -74,14 +74,14 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: packages/ts-inspect - Run tests
-        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-13'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-15-intel'
         run: |
           cd packages/ts-inspect
           npm ci
           npm test
 
       - name: Compile TS packages and move it into the Cabal data dir
-        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-13'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-15-intel'
         run: ./tools/install_packages_to_data_dir.sh
 
       - name: Build external dependencies


### PR DESCRIPTION
### Description

Replaces the `macos-13` image with `macos-15-intel`. macOS 13 is deprecated in GitHub Runners and will be intentionally disabled on Tuesdays until Dec 8th when it will be disabled for good. This will make our CI fail.

The only other supported macOS Intel version is macOS 15, so we migrate to that.
No foreseeable complications, and build runs correctly. The binary now declares its minimum version to be macOS 15, so this raises our minimum requirement.
