### PR TITLE
Remove ghcup workaround

### DIFF
--- a/.github/workflows/ci-waspc-test.yaml
+++ b/.github/workflows/ci-waspc-test.yaml
@@ -56,13 +56,6 @@ jobs:
 
       - uses: "actions/checkout@v5"
 
-      # TODO: This is a temporary workaround for the failing GHCup installation on Ubuntu 20.04.
-      # The fix will be propagated in a few days, so we can remove this workaround then.
-      # https://github.com/actions/runner-images/issues/7061
-      - name: Workaround runner image issue
-        if: matrix.os == 'ubuntu-22.04'
-        run: sudo chown -R $USER /usr/local/.ghcup
-
       - name: Set up Haskell
         uses: ./.github/actions/setup-haskell
         with:


### PR DESCRIPTION
We had a workaround to avoid an issue with an old GitHub runner image version: we did a `chown` of the ghcup folder.
- https://github.com/actions/runner-images/issues/7061

This issue was fixed upstream and the workaroud is no longer needed.
CI runs correctly: https://github.com/wasp-lang/wasp/actions/runs/19065146636/job/54453848914?pr=3295