### PR TITLE
CI: Pin macOS version for Apple Silicon

### DIFF
--- a/.github/workflows/ci-waspc-build.yaml
+++ b/.github/workflows/ci-waspc-build.yaml
@@ -76,16 +76,13 @@ jobs:
               apk add zlib-dev zlib-static
 
           - name: macos-x86_64
-            runner: macos-15-intel # Latest image still based on Intel architecture that can be used for free
-
+            runner: macos-15-intel
             # macOS's syscalls are private and change between versions, so we
-            # can't statically link the binary. However, on macOS programs link
-            # to `libSystem`, which is quite stable between releases, so we're
-            # fine depending on it.
+            # can't statically link the binary.
             static: false
 
           - name: macos-aarch64
-            runner: macos-latest # Latest macOS images are already Apple Silicon-based
+            runner: macos-15 # By default an Apple Silicon-based runner.
             static: false # Check the comment above for why we can't statically link on macOS
             install-deps: |
               # We need to install llvm@13 for building on Apple Silicon (prebuilt libraries
@@ -152,7 +149,7 @@ jobs:
 
   build-universal:
     needs: build
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Download macOS binaries
         uses: actions/download-artifact@v5


### PR DESCRIPTION
In my previous research I declared that libc was compatible between versions in macOS so that it was not needed to pin macOS to an older version.

While researching for #3293, I researched a bit more and learned that macOS binaries do declare a minimum compatible version, and they might be using new features aside from libc.

Therefore, we do need to avoid automatically updating our macOS version if possible. `macos-latest` currently points to `macos-15`, so I updated the reference to that. It also has the benefit of being the same version as for Intel-based macOS (since #3293), so it doesn't differ based on architecture.