### PR TITLE
CI: Test Wasp on Apple Silicon

### DIFF
--- a/.github/workflows/ci-waspc-test.yaml
+++ b/.github/workflows/ci-waspc-test.yaml
@@ -30,6 +30,7 @@ jobs:
           # and link the binaries statically:
           # https://github.com/wasp-lang/wasp/issues/650#issuecomment-1180488040
           - ubuntu-22.04
+          - macos-15
           - macos-15-intel
           - windows-latest
         node-version:
@@ -67,14 +68,14 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: packages/ts-inspect - Run tests
-        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-15-intel'
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
           cd packages/ts-inspect
           npm ci
           npm test
 
       - name: Compile TS packages and move it into the Cabal data dir
-        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-15-intel'
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: ./tools/install_packages_to_data_dir.sh
 
       - name: Build external dependencies


### PR DESCRIPTION
- Depends on #1446 

If we're to, in the future, publish the macOS Apple Silicon version, we should be testing it, as we do for Intel macOS.