### PR TITLE
Add Playwright test-results dir to ask-the-documents .gitignore

### DIFF
--- a/examples/ask-the-documents/.gitignore
+++ b/examples/ask-the-documents/.gitignore
@@ -16,3 +16,6 @@ node_modules/
 !.env.project
 !.env.vault
 !.env.server.example
+
+# Playwright
+test-results/


### PR DESCRIPTION
When running e2e tests locally the `test-results/` dir get created.