### PR TITLE
Trigger CI on all PRs, not just those to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,6 @@ on:
       - main
       - release
   pull_request:
-    branches:
-      - main
-      - release
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
We want to trigger the CI on all PRs, not just when merging to `main`.

This is useful when we're developing a feature in multiple steps, as was the case with #3305.