### PR TITLE
Bumps the version to 0.18.3 after hotfix

### DIFF
--- a/examples/kitchen-sink/main.wasp
+++ b/examples/kitchen-sink/main.wasp
@@ -1,6 +1,6 @@
 app KitchenSink {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
   title: "Wasp Kitchen Sink",
   // head: [],

--- a/examples/tutorials/TodoApp/main.wasp
+++ b/examples/tutorials/TodoApp/main.wasp
@@ -1,6 +1,6 @@
 app TodoApp {
   wasp: {
-    version: "^0.18.2" // Pins the version of Wasp to use.
+    version: "^0.18.3" // Pins the version of Wasp to use.
   },
   title: "TodoApp", // Used as the browser tab title. Note that all strings in Wasp are double quoted!
   head: [

--- a/examples/tutorials/TodoAppTs/main.wasp
+++ b/examples/tutorials/TodoAppTs/main.wasp
@@ -1,6 +1,6 @@
 app TodoApp {
   wasp: {
-    version: "^0.18.2" // Pins the version of Wasp to use.
+    version: "^0.18.3" // Pins the version of Wasp to use.
   },
   title: "TodoApp", // Used as the browser tab title. Note that all strings in Wasp are double quoted!
   head: [

--- a/examples/waspello/main.wasp.ts
+++ b/examples/waspello/main.wasp.ts
@@ -2,7 +2,7 @@ import { ActionConfig, App, ExtImport } from "wasp-config";
 
 const app = new App("waspello", {
   title: "Waspello",
-  wasp: { version: "^0.18.2" },
+  wasp: { version: "^0.18.3" },
 });
 
 app.auth({

--- a/examples/waspleau/main.wasp
+++ b/examples/waspleau/main.wasp
@@ -1,6 +1,6 @@
 app waspleau {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
 
   title: "Waspleau",

--- a/examples/websockets-realtime-voting/main.wasp
+++ b/examples/websockets-realtime-voting/main.wasp
@@ -1,6 +1,6 @@
 app whereDoWeEat {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
   title: "where-do-we-eat",
   client: {

--- a/mage/Dockerfile
+++ b/mage/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /app/.wasp/build/server/node_modules
 # TODO: Use pm2?
 # TODO: Use non-root user (node).
 FROM base AS server-production
-RUN curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.18.2
+RUN curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v 0.18.3
 ENV PATH "$PATH:/root/.local/bin"
 ENV NODE_ENV production
 WORKDIR /app

--- a/mage/main.wasp
+++ b/mage/main.wasp
@@ -1,6 +1,6 @@
 app waspAi {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
   title: "MAGE - GPT Web App Generator ✨",
   head: [

--- a/waspc/e2e-tests/snapshots/kitchen-sink-golden/wasp-app/main.wasp
+++ b/waspc/e2e-tests/snapshots/kitchen-sink-golden/wasp-app/main.wasp
@@ -1,6 +1,6 @@
 app KitchenSink {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
   title: "Wasp Kitchen Sink",
   // head: [],

--- a/waspc/e2e-tests/snapshots/wasp-build-golden/wasp-app/main.wasp
+++ b/waspc/e2e-tests/snapshots/wasp-build-golden/wasp-app/main.wasp
@@ -1,6 +1,6 @@
 app waspApp {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
   title: "wasp-app",
   head: [

--- a/waspc/e2e-tests/snapshots/wasp-compile-golden/wasp-app/main.wasp
+++ b/waspc/e2e-tests/snapshots/wasp-compile-golden/wasp-app/main.wasp
@@ -1,6 +1,6 @@
 app waspApp {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
   title: "wasp-app",
   head: [

--- a/waspc/e2e-tests/snapshots/wasp-migrate-golden/wasp-app/main.wasp
+++ b/waspc/e2e-tests/snapshots/wasp-migrate-golden/wasp-app/main.wasp
@@ -1,6 +1,6 @@
 app waspApp {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
   title: "wasp-app",
   head: [

--- a/waspc/e2e-tests/snapshots/wasp-new-golden/wasp-app/main.wasp
+++ b/waspc/e2e-tests/snapshots/wasp-new-golden/wasp-app/main.wasp
@@ -1,6 +1,6 @@
 app waspApp {
   wasp: {
-    version: "^0.18.2"
+    version: "^0.18.3"
   },
   title: "wasp-app",
   head: [

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -6,7 +6,7 @@ cabal-version: 2.4
 --    Consider using hpack, or maybe even hpack-dhall.
 
 name:           waspc
-version:        0.18.2
+version:        0.18.3
 description:    Please see the README on GitHub at <https://github.com/wasp-lang/wasp/waspc#readme>
 homepage:       https://github.com/wasp-lang/wasp/waspc#readme
 bug-reports:    https://github.com/wasp-lang/wasp/issues


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Bumps the version to `0.18.3` since we did a hotfix with `0.18.2` (previous version on `main`).

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests:

  - [ ] ~~I added **unit tests** for my change. <!-- If not, explain why. -->~~
  - [ ] ~~_(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->~~
  - [ ] ~~_(if you added/updated a feature)_ I added/updated **e2e tests** at `examples/kitchen-sink/e2e-tests`.~~
  - [ ] ~~_(if you added/updated a feature)_ I updated the **starter templates** at `waspc/data/Cli/templates`, as needed.~~

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** at `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
