### PR TITLE
Make PR automation simpler and more secure

### DIFF
--- a/.github/workflows/automation-pr-label-external.yaml
+++ b/.github/workflows/automation-pr-label-external.yaml
@@ -1,12 +1,12 @@
 name: "Automation - Label external PRs"
 
-#####################################################
-# CAUTION: Do not checkout the PR in this workflow! #
-#####################################################
+############################################################
+# CAUTION: This workflow should not check out the PR code! #
+############################################################
 # The `pull_request_target` event is only intended for simple automations on the
-# PRs themselves (e.g., labeling, commenting). If you checkout the PR code here,
-# you are running untrusted code and giving it access to our repository secrets,
-# which is a major security risk.
+# PRs themselves (e.g., labeling, commenting). If we checked out the PR code here,
+# we would be running untrusted code and giving it access to our repository
+# secrets, which is a major security risk.
 #
 # More info at:
 # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Our automation for tagging external PRs with the "external" tag was not running correctly (`pull_request` event doesn't run in our repo but in the PR author's fork). We need to use `pull_request_target`, as intended by GitHub: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/#:~:text=The%20reason%20to%20introduce%20the%20pull_request_target%20trigger.

However, this event is dangerous _when paired with a code checkout_ (explained in the link above), so I explicitly add a CAUTION message.

I also simplified the Action so it's simpler and doesn't need the extra secret, so it can be even safer.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

### None of the checklist applies here

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** at `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** at `waspc/data/Cli/templates`, as needed.

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** at `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
