### PR TITLE
Add error to action

### DIFF
--- a/.github/actions/fetch-nightly-cli/action.yaml
+++ b/.github/actions/fetch-nightly-cli/action.yaml
@@ -34,6 +34,8 @@ runs:
         )
 
         if [ -z "$run_id" ]; then
+          # Using the ::error:: prefix lets GitHub handle it as a special string, and shows up as a red error in the logs.
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message
           echo "::error::No successful workflow runs found for branch '$BRANCH'."
           exit 1
         fi


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

The action was not erroring out in the case of it not finding the a successful workflow run. The empty string was then passed to `gh run download` which then just picks up the first run it finds instead of erroring out (this seems to be the intended behaviour).

Now we explicitly check and error out.

<img width="778" height="179" alt="image" src="https://github.com/user-attachments/assets/81d2592b-0d5b-47bd-ba0d-79661ed26d8c" />

Example run: https://github.com/wasp-lang/open-saas/actions/runs/19230001646/job/54966078262?pr=540#step:6:36


## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

### Not applicable

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** at `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** at `waspc/data/Cli/templates`, as needed.

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** at `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
