### PR TITLE
Extract file path argument parser

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/BuildStart/ArgumentsParser.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BuildStart/ArgumentsParser.hs
@@ -5,14 +5,15 @@ module Wasp.Cli.Command.BuildStart.ArgumentsParser
 where
 
 import qualified Options.Applicative as Opt
-import Wasp.Cli.Util.EnvVarArgument (EnvVarFileArgument, envVarFileReader, envVarReader)
+import Wasp.Cli.Util.EnvVarArgument (envVarReader)
+import Wasp.Cli.Util.PathArgument (FilePathArgument, filePathReader)
 import Wasp.Env (EnvVar)
 
 data BuildStartArgs = BuildStartArgs
   { clientEnvironmentVariables :: [EnvVar],
-    clientEnvironmentFiles :: [EnvVarFileArgument],
+    clientEnvironmentFiles :: [FilePathArgument],
     serverEnvironmentVariables :: [EnvVar],
-    serverEnvironmentFiles :: [EnvVarFileArgument]
+    serverEnvironmentFiles :: [FilePathArgument]
   }
 
 buildStartArgsParser :: Opt.Parser BuildStartArgs
@@ -41,9 +42,9 @@ buildStartArgsParser =
           <> Opt.metavar "NAME=VALUE"
           <> Opt.help ("Set an environment variable for the " <> targetName <> " (can be used multiple times)")
 
-    makeEnvironmentFileParser :: String -> String -> Opt.Parser EnvVarFileArgument
+    makeEnvironmentFileParser :: String -> String -> Opt.Parser FilePathArgument
     makeEnvironmentFileParser targetName longOptionName =
-      Opt.option envVarFileReader $
+      Opt.option filePathReader $
         Opt.long longOptionName
           <> Opt.metavar "FILE_PATH"
           <> Opt.help ("Load environment variables for the " <> targetName <> " from a file (can be used multiple times)")

--- a/waspc/cli/src/Wasp/Cli/Command/BuildStart/Config.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BuildStart/Config.hs
@@ -23,8 +23,9 @@ import qualified Wasp.AppSpec.Valid as ASV
 import Wasp.Cli.Command (Command, CommandError (CommandError))
 import Wasp.Cli.Command.BuildStart.ArgumentsParser (BuildStartArgs)
 import qualified Wasp.Cli.Command.BuildStart.ArgumentsParser as Args
-import Wasp.Cli.Util.EnvVarArgument (EnvVarFileArgument, readEnvVarFile)
-import Wasp.Env (EnvVar, nubEnvVars, overrideEnvVars)
+import Wasp.Cli.Util.PathArgument (FilePathArgument)
+import qualified Wasp.Cli.Util.PathArgument as PathArgument
+import Wasp.Env (EnvVar, nubEnvVars, overrideEnvVars, parseDotEnvFile)
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.ServerGenerator.Common (defaultDevServerUrl)
 import qualified Wasp.Generator.ServerGenerator.Common as Server
@@ -108,8 +109,11 @@ overrideEnvVarsCommand forced existing =
             intercalate ", " duplicateNames
     Right combined -> return combined
 
-combineEnvVarsWithEnvFiles :: [EnvVar] -> [EnvVarFileArgument] -> IO [EnvVar]
+combineEnvVarsWithEnvFiles :: [EnvVar] -> [FilePathArgument] -> IO [EnvVar]
 combineEnvVarsWithEnvFiles pairs files = do
-  pairsFromFiles <- mapM readEnvVarFile files
+  pairsFromFiles <- mapM readEnvVarsFromFile files
   let allEnvVars = pairs <> concat pairsFromFiles
   return $ nubEnvVars allEnvVars
+
+readEnvVarsFromFile :: FilePathArgument -> IO [EnvVar]
+readEnvVarsFromFile pathArg = PathArgument.getFilePath pathArg >>= parseDotEnvFile

--- a/waspc/cli/src/Wasp/Cli/Util/EnvVarArgument.hs
+++ b/waspc/cli/src/Wasp/Cli/Util/EnvVarArgument.hs
@@ -1,19 +1,11 @@
 module Wasp.Cli.Util.EnvVarArgument
   ( envVarReader,
     envVarFromString,
-    EnvVarFileArgument,
-    getEnvVarFilePath,
-    envVarFileReader,
-    readEnvVarFile,
   )
 where
 
-import Control.Monad ((>=>))
-import Options.Applicative (ReadM, eitherReader, str)
-import StrongPath (Abs, File, Path')
-import StrongPath.FilePath (parseAbsFile)
-import System.Directory (makeAbsolute)
-import Wasp.Env (EnvVar, parseDotEnvFile)
+import Options.Applicative (ReadM, eitherReader)
+import Wasp.Env (EnvVar)
 
 envVarReader :: ReadM EnvVar
 envVarReader = eitherReader envVarFromString
@@ -28,20 +20,3 @@ envVarFromString var =
     _ -> failure
   where
     failure = Left $ "Environment variable must be in the format NAME=VALUE: " ++ var
-
-envVarFileReader :: ReadM EnvVarFileArgument
-envVarFileReader = EnvVarFileArgument <$> str
-
--- Paths passed as arguments to a CLI are conventionally either absolute paths,
--- or paths relative to the current working directory. We need IO to resolve
--- which kind of path it is, but we also don't want any unsafe transformations
--- in the meantime; so we make this type opaque until we have access to the IO
--- monad.
-newtype EnvVarFileArgument = EnvVarFileArgument FilePath
-  deriving (Show, Eq)
-
-getEnvVarFilePath :: EnvVarFileArgument -> IO (Path' Abs (File ()))
-getEnvVarFilePath (EnvVarFileArgument filePath) = makeAbsolute filePath >>= parseAbsFile
-
-readEnvVarFile :: EnvVarFileArgument -> IO [EnvVar]
-readEnvVarFile = getEnvVarFilePath >=> parseDotEnvFile

--- a/waspc/cli/src/Wasp/Cli/Util/PathArgument.hs
+++ b/waspc/cli/src/Wasp/Cli/Util/PathArgument.hs
@@ -1,0 +1,26 @@
+module Wasp.Cli.Util.PathArgument
+  ( FilePathArgument,
+    getFilePath,
+    filePathReader,
+  )
+where
+
+import Options.Applicative (ReadM, str)
+import StrongPath (Abs, File', Path')
+import StrongPath.FilePath (parseAbsFile)
+import System.Directory (makeAbsolute)
+
+-- Paths passed as arguments to a CLI are conventionally either absolute paths,
+-- or paths relative to the current working directory. We need IO to resolve
+-- which kind of path it is, but we also don't want any unsafe transformations
+-- in the meantime; so we make these types opaque until we have access to the IO
+-- monad.
+
+newtype FilePathArgument = FilePathArgument FilePath
+  deriving (Show, Eq)
+
+filePathReader :: ReadM FilePathArgument
+filePathReader = FilePathArgument <$> str
+
+getFilePath :: FilePathArgument -> IO (Path' Abs File')
+getFilePath (FilePathArgument filePath) = makeAbsolute filePath >>= parseAbsFile

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -619,6 +619,7 @@ library cli-lib
     Wasp.Cli.Interactive
     Wasp.Cli.GithubRepo
     Wasp.Cli.Util.EnvVarArgument
+    Wasp.Cli.Util.PathArgument
     Wasp.Cli.Util.Parser
 
 executable wasp-cli


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

As part of https://github.com/wasp-lang/wasp/pull/3338, I need to add a dir path argument parser (https://github.com/wasp-lang/wasp/pull/3343).
When doing that, it makes sense to extract the file path argument parser from `EnvVarArgument` into its own file.

## Connections

- Working towards https://github.com/wasp-lang/wasp/issues/3073
- Part of https://github.com/wasp-lang/wasp/pull/3338 -- I split the refactors into their own PRs for ease of review:
	- https://github.com/wasp-lang/wasp/pull/3340
	- https://github.com/wasp-lang/wasp/pull/3341
	- https://github.com/wasp-lang/wasp/pull/3342
	- https://github.com/wasp-lang/wasp/pull/3343
	- https://github.com/wasp-lang/wasp/pull/3344
	- https://github.com/wasp-lang/wasp/pull/3345
	- https://github.com/wasp-lang/wasp/pull/3346

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests:
  - [ ] ~~I added **unit tests** for my change.~~ <!-- If not, explain why. -->
  - [ ] ~~_(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->~~
  - [ ] ~~_(if you added/updated a feature)_ I added/updated **e2e tests** at `examples/kitchen-sink/e2e-tests`.~~
  - [ ] ~~_(if you added/updated a feature)_ I updated the **starter templates** at `waspc/data/Cli/templates`, as needed.~~
  - Just moving stuff

- 📜 Documentation:
  - [ ] ~~_(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.~~

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] ~~I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.~~
  - [ ] ~~_(if you did a breaking change)_ I added a step to the current **migration guide** at `web/docs/migration-guides/`.~~
  - [ ] ~~I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.~~

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
