### PR TITLE
Add Renovate configuration for .github/ updates only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "includePaths": [".github/**"]
+}


### PR DESCRIPTION
## Summary
Adds a Renovate configuration file that restricts dependency updates to files in the `.github/` directory only. This prevents Renovate from modifying dependency files in the rest of the repository while still allowing it to manage GitHub Actions workflows and related dependencies.

Resolves https://github.com/wasp-lang/wasp/issues/3358

## Configuration Details
- Uses `includePaths` to limit scanning to `.github/**`
- Extends Renovate's recommended configuration for sensible defaults
- Includes JSON schema for IDE support

🤖 Generated with Claude Code