### PR TITLE
Update PhraseTutor links to point to the correct domain

### DIFF
--- a/web/blog/2023-03-02-wasp-beta-update-feb.mdx
+++ b/web/blog/2023-03-02-wasp-beta-update-feb.mdx
@@ -85,7 +85,7 @@ If you want to stay in the loop (and I guess you do since you're reading this :D
 
 ## 🕹 Community highlights
 
-- [PhraseTutor: Learn Italian in a week](https://phrasetutor.com/)! There is a new app built from scratch with Wasp, by Mihovil - one of our early community members who recently joined the team as an engineer! It's smooth both on the front end and back end and will teach you Italian before you can say (or eat) "quattro formaggi"!
+- [PhraseTutor: Learn Italian in a week](https://phrasetutor.miho.dev/)! There is a new app built from scratch with Wasp, by Mihovil - one of our early community members who recently joined the team as an engineer! It's smooth both on the front end and back end and will teach you Italian before you can say (or eat) "quattro formaggi"!
   <ImgWithCaption alt="Phrase Tutor" source="img/update-feb-23/phrase-tutor.png" />
 
 ## Developer life 💻⌨️💽

--- a/web/blog/2023-03-08-building-a-full-stack-app-supabase-vs-wasp.mdx
+++ b/web/blog/2023-03-08-building-a-full-stack-app-supabase-vs-wasp.mdx
@@ -15,7 +15,7 @@ import { ImgWithCaption } from './components/ImgWithCaption';
 
 ### What to expect
 
-In this blog post, I will explain how I created the [Phrase Tutor](https://phrasetutor.com/) app for learning Italian phrases using two different technologies. I will share some code snippets to show what was required to build the app with both Wasp and Supabase.
+In this blog post, I will explain how I created the [Phrase Tutor](https://phrasetutor.miho.dev/) app for learning Italian phrases using two different technologies. I will share some code snippets to show what was required to build the app with both Wasp and Supabase.
 
 <ImgWithCaption alt="Phrase Tutor’s front-end" source="img/building-a-full-stack-app-supabase-vs-wasp/phrase_tutor.gif" caption="Phrase Tutor’s front-end" />
 
@@ -293,7 +293,7 @@ Writing a full-stack React and Express.js with Wasp felt like a guided experienc
 Instead, I could focus on the logic needed for Phrase Tutor to work and just run `wasp start` most of the time. I did need to write some extra code to get everything running, but I'm free to customize this code however I want.
 
 :::info
-Check out the deployed project built with Wasp: [https://phrasetutor.com](https://phrasetutor.com/)
+Check out the deployed project built with Wasp: [https://phrasetutor.miho.dev](https://phrasetutor.miho.dev/)
 :::
 
 :::info
@@ -314,7 +314,7 @@ I want to compare the features of Supabase and Wasp. It's good to think about di
 
 With Supabase, I liked how familiar the SDK felt and their UI made it easy to configure parts of my backend. I didn’t need to think about deploying Supabase since I used their hosted version, but it did get paused after 1 week of inactivity on the free tier.
 
-On the other hand, Wasp felt like the glue for my React + Express.js + Prisma app and I needed to write more code to get things done. It felt more explicit because I wrote code closer to what I would normally write. I deployed it to [fly.io](https://fly.io) with the Wasp command `wasp deploy fly launch` and it’s now live on [https://phrasetutor.com](https://phrasetutor.com/)
+On the other hand, Wasp felt like the glue for my React + Express.js + Prisma app and I needed to write more code to get things done. It felt more explicit because I wrote code closer to what I would normally write. I deployed it to [fly.io](https://fly.io) with the Wasp command `wasp deploy fly launch` and it’s now live on [https://phrasetutor.miho.dev](https://phrasetutor.miho.dev/)
 
 ## Conclusion
 


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Stopped paying for the domain, switch Phrase Tutor to subdomain.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
