### PR TITLE
Fix typo in domain existence check message

### DIFF
--- a/waspc/packages/deploy/src/providers/railway/railwayService/url.ts
+++ b/waspc/packages/deploy/src/providers/railway/railwayService/url.ts
@@ -36,7 +36,7 @@ export async function generateServiceUrl(
     throw new Error(`There was a problem getting a domain for ${serviceName}.`);
   }
 
-  if (result.stdout.includes("Domains already exists on the service:")) {
+  if (result.stdout.includes("Domains already exist on the service:")) {
     return extractServiceUrlFromString(result.stdout);
   } else {
     return RailwayCliDomainSchema.parse(result.json()).domain;


### PR DESCRIPTION
Fixes #3427

## Description

Railway CLI recently fixed a grammar typo in their error message - they changed "Domains already exists" to "Domains already exist". Since we check for this exact string to detect domain errors, our detection was going to break with newer versions of Railway CLI.

This PR updates the string we're checking for to match the corrected message.

## Type of change

- [x] Bug fix

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.