### PR TITLE
Add `./run get-version`

### DIFF
--- a/waspc/run
+++ b/waspc/run
@@ -75,7 +75,7 @@ TEST_CMD="cabal test && \
 RUN_CMD="cabal --project-dir=${PROJECT_ROOT} run wasp-cli -- ${ARGS[@]}"
 
 # Utility
-GET_VERSION_CMD="cabal repl waspc -v0 <<<'putStrLn $ Data.Version.showVersion Paths_waspc.version'"
+GET_WASPC_VERSION_CMD="cabal repl waspc -v0 <<< 'putStrLn $ Data.Version.showVersion Paths_waspc.version'"
 GHCID_CMD="ghcid --command=cabal repl"
 # HLS version below should be one that works with the GHC version from the
 # `with-compiler` field in `cabal.project`
@@ -177,7 +177,7 @@ print_usage() {
   echo ""
   print_usage_cmd "ghcup-set" \
     "Sets the correct version of GHC and Cabal for this project (via GHCup)."
-  print_usage_cmd "get-version" \
+  print_usage_cmd "get-waspc-version" \
     "Gets the current version of waspc from the Haskell project."
 }
 
@@ -305,8 +305,8 @@ case $COMMAND in
   ghcup-set)
     echo_and_eval "$GHCUP_SET"
     ;;
-  get-version)
-    echo_and_eval "$GET_VERSION_CMD"
+  get-waspc-version)
+    echo_and_eval "$GET_WASPC_VERSION_CMD"
     ;;
   *)
     print_usage


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

For https://github.com/wasp-lang/wasp/issues/3127, I'll need to query the current waspc.cabal version from the CI, so I added a `./run` command to do so.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
