### PR TITLE
CI: Split npm build workflow

### DIFF
--- a/.github/workflows/ci-npm-package-build.yaml
+++ b/.github/workflows/ci-npm-package-build.yaml
@@ -1,0 +1,74 @@
+name: "Build - Wasp npm packages"
+
+on:
+  workflow_call:
+    inputs:
+      build-outputs:
+        description: "The returned outputs from the build workflow, as a JSON string"
+        required: true
+        type: string
+
+env:
+  WASP_TELEMETRY_DISABLE: 1
+
+jobs:
+  make-npm-packages:
+    runs-on: ubuntu-latest
+
+    name: Make npm packages
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute artifact names for download
+        uses: ./.github/actions/compute-artifact-names
+        id: compute-download-artifact-names
+        with:
+          build-name: all
+
+      - uses: actions/download-artifact@v6
+        with:
+          path: "./download/"
+          pattern: ${{ steps.compute-download-artifact-names.outputs.artifact-name }}
+
+      - name: Copy artifacts to input folder
+        run: |
+          mkdir -p ./input/
+          cp ./download/${{ steps.compute-download-artifact-names.outputs.artifact-name }}/* ./input/
+
+      - name: Create build metadata file
+        env:
+          INPUT_DATA: ${{ inputs.build-outputs}}
+          JQ_PROGRAM:
+            # The schema for this file is at `scripts/make-npm-packages/src/schema/input-data.ts`.
+            # We'll wrangle the data from the build jobs into that schema here.
+            |
+            {
+              version: .waspc_version,
+              tarballs:
+                with_entries(select(.key | startswith("output_")))
+                | map(
+                    fromjson
+                    | {
+                        fileName: .["tarball-name"],
+                        target: (.["npm-target"] | fromjson)
+                      }
+                  )
+            }
+        run: echo "$INPUT_DATA" | jq "$JQ_PROGRAM" > ./input/data.json
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies for script
+        working-directory: ./scripts/make-npm-packages
+        run: npm ci
+
+      - name: Run packager script
+        run: node ./scripts/make-npm-packages/src/index.ts --input-dir ./input/ --output-dir ./output/
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: wasp-npm-packages
+          path: ./output/

--- a/.github/workflows/ci-waspc-build.yaml
+++ b/.github/workflows/ci-waspc-build.yaml
@@ -16,6 +16,22 @@ on:
         default: "22"
         type: string
         required: false
+    outputs:
+      waspc_version:
+        value: ${{ jobs.build.outputs.waspc_version }}
+        description: "The Wasp version built in this workflow."
+      output_linux-x86_64:
+        value: ${{ jobs.build.outputs.output_linux-x86_64 }}
+        description: "The build output metadata for linux-x86_64."
+      output_linux-x86_64-static:
+        value: ${{ jobs.build.outputs.output_linux-x86_64-static }}
+        description: "The build output metadata for linux-x86_64-static."
+      output_macos-x86_64:
+        value: ${{ jobs.build.outputs.output_macos-x86_64 }}
+        description: "The build output metadata for macos-x86_64."
+      output_macos-aarch64:
+        value: ${{ jobs.build.outputs.output_macos-aarch64 }}
+        description: "The build output metadata for macos-aarch64."
 
 env:
   WASP_TELEMETRY_DISABLE: 1
@@ -200,66 +216,3 @@ jobs:
         with:
           name: ${{ steps.compute-artifact-names.outputs.artifact-name }}
           path: ./${{ steps.compute-artifact-names.outputs.tarball-name }}
-
-  make-npm-packages:
-    needs: build
-
-    runs-on: ubuntu-latest
-
-    name: Make npm packages
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Compute artifact names for download
-        uses: ./.github/actions/compute-artifact-names
-        id: compute-download-artifact-names
-        with:
-          build-name: all
-
-      - uses: actions/download-artifact@v6
-        with:
-          path: "./download/"
-          pattern: ${{ steps.compute-download-artifact-names.outputs.artifact-name }}
-
-      - name: Copy artifacts to input folder
-        run: |
-          mkdir -p ./input/
-          cp ./download/${{ steps.compute-download-artifact-names.outputs.artifact-name }}/* ./input/
-
-      - name: Create build metadata file
-        env:
-          INPUT_DATA: ${{ toJson(needs.build.outputs) }}
-          JQ_PROGRAM:
-            # The schema for this file is at `scripts/make-npm-packages/src/schema/input-data.ts`.
-            # We'll wrangle the data from the build jobs into that schema here.
-            |
-            {
-              version: .waspc_version,
-              tarballs:
-                with_entries(select(.key | startswith("output_")))
-                | map(
-                    fromjson
-                    | {
-                        fileName: .["tarball-name"],
-                        target: (.["npm-target"] | fromjson)
-                      }
-                  )
-            }
-        run: echo "$INPUT_DATA" | jq "$JQ_PROGRAM" > ./input/data.json
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: npm
-
-      - name: Install dependencies for script
-        working-directory: ./scripts/make-npm-packages
-        run: npm ci
-
-      - name: Run packager script
-        run: node ./scripts/make-npm-packages/src/index.ts --input-dir ./input/ --output-dir ./output/
-
-      - uses: actions/upload-artifact@v5
-        with:
-          name: wasp-npm-packages
-          path: ./output/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,13 +38,20 @@ jobs:
     uses: ./.github/workflows/ci-waspc-build.yaml
     secrets: inherit
 
-  npm-package-test:
+  npm-package-build:
     needs: waspc-build
+    uses: ./.github/workflows/ci-npm-package-build.yaml
+    secrets: inherit
+    with:
+      build-outputs: ${{ toJson(needs.waspc-build.outputs) }}
+
+  npm-package-test:
+    needs: npm-package-build
     uses: ./.github/workflows/ci-npm-package-test.yaml
     secrets: inherit
 
   npm-package-publish:
-    needs: waspc-build
+    needs: npm-package-build
     uses: ./.github/workflows/ci-npm-package-publish.yaml
 
   waspc-test:


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

- As part of https://github.com/wasp-lang/wasp/issues/3444
- Preparation for #3525

This PR extracts the npm building job out of `ci-waspc-build.yaml`. This is done in preparation of https://github.com/wasp-lang/wasp/pull/3525, which adds some flexibility to this step, and becomes too overbearing to keep all in the same workflow.


<details>
<summary>Checklist not applicable (click here to show anyway)</summary>



## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
--> 

</details>