### PR TITLE
Refactor `<script>`s in our website

### DIFF
--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -239,21 +239,28 @@ const config: Config = {
 };
 
 function getScripts() {
-  const scripts: DocusaurusConfig["scripts"] = [
-    "/scripts/posthog.js",
+  const sharedScripts: DocusaurusConfig["scripts"] = [
     "/js/fix-multiple-trailing-slashes.js",
   ];
 
-  if (isProduction) {
+  const devOnlyScripts: DocusaurusConfig["scripts"] = [];
+
+  const prodOnlyScripts: DocusaurusConfig["scripts"] = [
+    { src: "/scripts/posthog.js", defer: true },
     // Using Cloudflare Workers to proxy the analytics script
-    scripts.push({
+    {
       src: "/waspara/wasp/script.js",
       defer: true,
       "data-domain": "wasp.sh",
       "data-api": "/waspara/wasp/event",
-    });
+    },
+  ];
+
+  if (isProduction) {
+    return [...sharedScripts, ...prodOnlyScripts];
+  } else {
+    return [...sharedScripts, ...devOnlyScripts];
   }
-  return scripts;
 }
 
 export default config;


### PR DESCRIPTION
Three refactors in one, concerning adding `<script>`s to our Docusaurus website. Done as part of #3532 

- The config had an array of scripts and then did an `Array.push` if it was a production script. I separated the scripts array into `shared`, `devOnly`, and `prodOnly`, for ease of understanding and maintenance.

- Moved the Posthog script into the `prodOnly` array since we don't need it/want it when developing.

- The Posthog initialization script was being loaded as a **blocking** script. I added the [`defer` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#defer) to the script so that it becomes non-blocking.
  - **Blocking** means that it makes the browser stop the HTML parsing, spin up the JS, evaluate the script, and then continue. It can greatly impact website performance
  - **Non-blocking** means that it allows the browser to continue the HTML job while the JS runs in the background.
  - With `defer` it will still wait until both HTML and JS parsing is done before declaring the page ready. [(docs)](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#defer)
  - It doesn't negatively affect Posthog since our script is one that creates _another_ script tag to actually import Posthog, and it's marked `async` which means it's non-blocking anyway.