### PR TITLE
Refactor to BuildType

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build.hs
@@ -24,6 +24,7 @@ import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Generator.Monad (GeneratorWarning (GeneratorNeedsMigrationWarning))
 import Wasp.Generator.SdkGenerator.Common (sdkRootDirInGeneratedCodeDir, sdkRootDirInProjectRootDir)
 import qualified Wasp.Message as Msg
+import qualified Wasp.Project.BuildType as BuildType
 import Wasp.Project.Common
   ( CompileError,
     CompileWarning,
@@ -170,7 +171,7 @@ buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir bu
     options =
       CompileOptions
         { waspProjectDirPath = waspProjectDir,
-          isBuild = True,
+          buildType = BuildType.Production,
           sendMessage = cliSendMessage,
           -- Ignore "DB needs migration warnings" during build, as that is not a required step.
           generatorWarningsFilter =

--- a/waspc/cli/src/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Compile.hs
@@ -26,6 +26,7 @@ import qualified Wasp.Generator
 import qualified Wasp.Message as Msg
 import Wasp.Project (CompileError, CompileWarning, WaspProjectDir)
 import qualified Wasp.Project
+import qualified Wasp.Project.BuildType as BuildType
 import Wasp.Project.Common (dotWaspDirInWaspProjectDir, generatedCodeDirInDotWaspDir)
 
 -- | Same like 'compileWithOptions', but with default compile options.
@@ -117,7 +118,7 @@ defaultCompileOptions :: Path' Abs (Dir WaspProjectDir) -> CompileOptions
 defaultCompileOptions waspProjectDir =
   CompileOptions
     { waspProjectDirPath = waspProjectDir,
-      isBuild = False,
+      buildType = BuildType.Development,
       sendMessage = cliSendMessage,
       generatorWarningsFilter = id
     }

--- a/waspc/src/Wasp/AppSpec.hs
+++ b/waspc/src/Wasp/AppSpec.hs
@@ -21,6 +21,8 @@ module Wasp.AppSpec
     getApiNamespaces,
     getCruds,
     userNodeVersionRange,
+    isProduction,
+    isDevelopment,
   )
 where
 
@@ -49,6 +51,7 @@ import Wasp.Env (EnvVar)
 import Wasp.ExternalConfig.Npm.PackageJson (PackageJson)
 import Wasp.ExternalConfig.TsConfig (TsConfig)
 import Wasp.Node.Version (oldestWaspSupportedNodeVersion)
+import qualified Wasp.Project.BuildType as BuildType
 import Wasp.Project.Common (SrcTsConfigFile, WaspProjectDir)
 import Wasp.Project.Db.Migrations (DbMigrationsDir)
 import qualified Wasp.Psl.Ast.Schema as Psl.Schema
@@ -79,9 +82,7 @@ data AppSpec = AppSpec
     devEnvVarsServer :: [EnvVar],
     -- | Env variables to be provided to the client only during the development.
     devEnvVarsClient :: [EnvVar],
-    -- | If true, it means project is being compiled for production/deployment -> it is being "built".
-    -- If false, it means project is being compiled for development purposes (e.g. "wasp start").
-    isBuild :: Bool,
+    buildType :: BuildType.BuildType,
     -- | The contents of the optional user Dockerfile found in the root of the wasp project source.
     userDockerfileContents :: Maybe Text,
     -- | A list of paths to Tailwind specific config files and where to copy them.
@@ -160,3 +161,9 @@ asAbsWaspProjectDirFile spec file = waspProjectDir spec </> file
 --   In the meantime, we determine it based on the oldest node version that Wasp supports.
 userNodeVersionRange :: AppSpec -> SV.Range
 userNodeVersionRange _ = SV.Range [SV.backwardsCompatibleWith oldestWaspSupportedNodeVersion]
+
+isProduction :: AppSpec -> Bool
+isProduction spec = buildType spec == BuildType.Production
+
+isDevelopment :: AppSpec -> Bool
+isDevelopment spec = buildType spec == BuildType.Development

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -183,7 +183,7 @@ validateEmailSenderIsDefinedIfEmailAuthIsUsed spec = case App.auth app of
 
 validateDummyEmailSenderIsNotUsedInProduction :: AppSpec -> [ValidationError]
 validateDummyEmailSenderIsNotUsedInProduction spec =
-  if AS.isBuild spec && isDummyEmailSenderUsed
+  if AS.isProduction spec && isDummyEmailSenderUsed
     then [GenericValidationError "app.emailSender must not be set to Dummy when building for production."]
     else []
   where

--- a/waspc/src/Wasp/CompileOptions.hs
+++ b/waspc/src/Wasp/CompileOptions.hs
@@ -6,6 +6,7 @@ where
 import StrongPath (Abs, Dir, Path')
 import Wasp.Generator.Monad (GeneratorWarning)
 import Wasp.Message (SendMessage)
+import qualified Wasp.Project.BuildType as BuildType
 import Wasp.Project.Common (WaspProjectDir)
 
 -- TODO(martin): Should these be merged with Wasp data? Is it really a separate thing or not?
@@ -13,7 +14,7 @@ import Wasp.Project.Common (WaspProjectDir)
 --   Maybe it is, even more than this!
 data CompileOptions = CompileOptions
   { waspProjectDirPath :: !(Path' Abs (Dir WaspProjectDir)),
-    isBuild :: !Bool,
+    buildType :: !BuildType.BuildType,
     -- We give the compiler the ability to send messages. The code that
     -- invokes the compiler (such as the CLI) can then implement a way
     -- to display these messages.

--- a/waspc/src/Wasp/Generator/DbGenerator.hs
+++ b/waspc/src/Wasp/Generator/DbGenerator.hs
@@ -69,7 +69,7 @@ genPrismaSchema spec = do
   (datasourceProvider :: String) <- case dbSystem of
     AS.Db.PostgreSQL -> return Pls.Db.dbProviderPostgresqlStringLiteral
     AS.Db.SQLite ->
-      if AS.isBuild spec
+      if AS.isProduction spec
         then logAndThrowGeneratorError $ GenericGeneratorError "SQLite (a default database) is not supported in production. To build your Wasp app for production, switch to a different database. Switching to PostgreSQL: https://wasp.sh/docs/data-model/databases#migrating-from-sqlite-to-postgresql ."
         else return Pls.Db.dbProviderSqliteStringLiteral
 
@@ -144,7 +144,7 @@ postWriteDbGeneratorActions spec dstDir = do
     -- example if we are in development (`wasp start`).
     -- However if we are in build (`wasp build`), then there is no database to check against right
     -- now.
-    if not (AS.isBuild spec)
+    if not (AS.isProduction spec)
       then maybeToList <$> warnIfDbNeedsMigration spec dstDir
       else pure []
   dbGeneratorErrors <- maybeToList <$> generatePrismaClient spec dstDir

--- a/waspc/src/Wasp/Generator/NpmWorkspaces.hs
+++ b/waspc/src/Wasp/Generator/NpmWorkspaces.hs
@@ -10,7 +10,7 @@ import Data.Set (Set, fromList)
 import StrongPath (Dir, Path', Rel, (</>))
 import qualified StrongPath as SP
 import qualified System.FilePath.Posix as FP
-import Wasp.AppSpec (AppSpec, isBuild)
+import qualified Wasp.AppSpec as AS
 import Wasp.Generator.Common (ProjectRootDir)
 import Wasp.Project.Common
   ( WaspProjectDir,
@@ -44,15 +44,15 @@ requiredWorkspaceGlobs =
           ++ show inputDir
           ++ ")"
 
-serverPackageName :: AppSpec -> String
+serverPackageName :: AS.AppSpec -> String
 serverPackageName = workspacePackageName "server"
 
-webAppPackageName :: AppSpec -> String
+webAppPackageName :: AS.AppSpec -> String
 webAppPackageName = workspacePackageName "webapp"
 
-workspacePackageName :: String -> AppSpec -> String
+workspacePackageName :: String -> AS.AppSpec -> String
 workspacePackageName baseName spec = "@wasp.sh/generated-" ++ baseName ++ "-" ++ modeName
   where
     modeName
-      | isBuild spec = "build"
+      | AS.isProduction spec = "build"
       | otherwise = "dev"

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -92,7 +92,7 @@ genServer spec =
 genDotEnv :: AppSpec -> Generator [FileDraft]
 -- Don't generate .env if we are building for production, since .env is to be used only for
 -- development.
-genDotEnv spec | AS.isBuild spec = return []
+genDotEnv spec | AS.isProduction spec = return []
 genDotEnv spec =
   return
     [ createTextFileDraft
@@ -198,7 +198,7 @@ genNpmrc spec
   --
   -- We do expect users to manually go into the generated directories when bundling the built ouput.
   -- So we do add the `.npmrc` there to help them avoid using an incompatible Node.js version.
-  | AS.isBuild spec =
+  | AS.isProduction spec =
       return
         [ C.mkTmplFdWithDstAndData
             (C.asTmplFile [relfile|npmrc|])
@@ -284,7 +284,7 @@ genRoutesIndex spec =
           "isAuthEnabled" .= (isAuthEnabled spec :: Bool),
           "areThereAnyCustomApiRoutes" .= (not . null $ AS.getApis spec),
           "areThereAnyCrudRoutes" .= (not . null $ AS.getCruds spec),
-          "isDevelopment" .= (not $ AS.isBuild spec :: Bool),
+          "isDevelopment" .= (AS.isDevelopment spec :: Bool),
           "appName" .= (fst $ getApp spec :: String)
         ]
 
@@ -293,7 +293,7 @@ operationsRouteInRootRouter = "operations"
 
 genViewsDir :: AppSpec -> Generator [FileDraft]
 genViewsDir spec
-  | AS.isBuild spec = return []
+  | AS.isProduction spec = return []
   | otherwise =
       sequence
         [ genFileCopy [relfile|views/wrong-port.ts|]

--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/EmailAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/EmailAuthG.hs
@@ -71,7 +71,7 @@ genEmailAuthConfig spec emailAuthConfig = return $ C.mkTmplFdWithDstAndData tmpl
     maybeName = AS.EmailSender.name fromField
     email = AS.EmailSender.email fromField
 
-    isDevelopment = not $ AS.isBuild spec
+    isDevelopment = AS.isDevelopment spec
 
     emailVerificationClientRoute = getRoutePathFromRef spec $ AS.Auth.EmailVerification.clientRoute emailVerification
     passwordResetClientRoute = getRoutePathFromRef spec $ AS.Auth.PasswordReset.clientRoute passwordReset

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -93,7 +93,7 @@ genAppTsConfigJson spec = do
 genDotEnv :: AppSpec -> Generator [FileDraft]
 -- Don't generate .env if we are building for production, since .env is to be used only for
 -- development.
-genDotEnv spec | AS.isBuild spec = return []
+genDotEnv spec | AS.isProduction spec = return []
 genDotEnv spec =
   return
     [ createTextFileDraft
@@ -136,7 +136,7 @@ genNpmrc spec
   --
   -- We do expect users to manually go into the generated directories when bundling the built ouput.
   -- So we do add the `.npmrc` there to help them avoid using an incompatible Node.js version.
-  | AS.isBuild spec =
+  | AS.isProduction spec =
       return
         [ C.mkTmplFdWithDstAndData
             (C.asTmplFile [relfile|npmrc|])

--- a/waspc/src/Wasp/Project/Analyze.hs
+++ b/waspc/src/Wasp/Project/Analyze.hs
@@ -108,7 +108,7 @@ constructAppSpec waspDir compileOptions externalConfigs parsedPrismaSchema decls
             AS.migrationsDir = maybeMigrationsDir,
             AS.devEnvVarsServer = serverEnvVars,
             AS.devEnvVarsClient = clientEnvVars,
-            AS.isBuild = CompileOptions.isBuild compileOptions,
+            AS.buildType = CompileOptions.buildType compileOptions,
             AS.userDockerfileContents = maybeUserDockerfileContents,
             AS.devDatabaseUrl = devDbUrl,
             AS.customViteConfigPath = customViteConfigPath,

--- a/waspc/src/Wasp/Project/BuildType.hs
+++ b/waspc/src/Wasp/Project/BuildType.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Wasp.Project.BuildType where
+
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generic)
+
+data BuildType
+  = -- | Project is being compiled for development purposes (e.g. "wasp start").
+    Development
+  | -- | Project is being compiled for production/deployment (e.g. "wasp build").
+    Production
+  deriving (Eq, Show, Generic)
+
+instance FromJSON BuildType
+
+instance ToJSON BuildType

--- a/waspc/tests/AppSpec/ValidTest.hs
+++ b/waspc/tests/AppSpec/ValidTest.hs
@@ -35,6 +35,7 @@ import qualified Wasp.AppSpec.Valid as ASV
 import qualified Wasp.ExternalConfig.Npm.PackageJson as Npm.PackageJson
 import qualified Wasp.ExternalConfig.TsConfig as T
 import qualified Wasp.Generator.NpmWorkspaces as NW
+import qualified Wasp.Project.BuildType as BuildType
 import qualified Wasp.Psl.Ast.Argument as Psl.Argument
 import qualified Wasp.Psl.Ast.Attribute as Psl.Attribute
 import qualified Wasp.Psl.Ast.Model as Psl.Model
@@ -336,9 +337,9 @@ spec_AppSpecValid = do
                       }
                 }
 
-        let makeSpec emailSender isBuild =
+        let makeSpec emailSender isProduction =
               basicAppSpec
-                { AS.isBuild = isBuild,
+                { AS.buildType = if isProduction then BuildType.Production else BuildType.Development,
                   AS.decls =
                     [ AS.Decl.makeDecl "TestApp" $
                         basicApp
@@ -510,7 +511,7 @@ spec_AppSpecValid = do
                 Npm.PackageJson.devDependencies = M.empty,
                 Npm.PackageJson.workspaces = Just $ S.toList NW.requiredWorkspaceGlobs
               },
-          AS.isBuild = False,
+          AS.buildType = BuildType.Development,
           AS.migrationsDir = Nothing,
           AS.devEnvVarsClient = [],
           AS.devEnvVarsServer = [],

--- a/waspc/tests/Generator/WebAppGeneratorTest.hs
+++ b/waspc/tests/Generator/WebAppGeneratorTest.hs
@@ -24,6 +24,7 @@ import Wasp.Generator.Monad (runGenerator)
 import qualified Wasp.Generator.NpmWorkspaces as NW
 import Wasp.Generator.WebAppGenerator
 import qualified Wasp.Generator.WebAppGenerator.Common as Common
+import qualified Wasp.Project.BuildType as BuildType
 import qualified Wasp.Psl.Ast.Schema as Psl.Schema
 import qualified Wasp.Version as WV
 
@@ -63,7 +64,7 @@ spec_WebAppGenerator = do
                   Npm.PackageJson.devDependencies = M.empty,
                   Npm.PackageJson.workspaces = Just $ S.toList NW.requiredWorkspaceGlobs
                 },
-            AS.isBuild = False,
+            AS.buildType = BuildType.Development,
             AS.migrationsDir = Nothing,
             AS.devEnvVarsServer = [],
             AS.devEnvVarsClient = [],

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -388,6 +388,7 @@ library
     Wasp.NodePackageFFI
     Wasp.Project
     Wasp.Project.Analyze
+    Wasp.Project.BuildType
     Wasp.Project.Common
     Wasp.Project.Db
     Wasp.Project.Db.Dev.Postgres


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

- Part of #3540

Creates a new `data BuildType = Development | Production`, replacing the `AppSpec.isBuild :: Bool` property, with a more explicit name that reflects its usage.

I created shorthand functions `isDevelopment`/`isProduction` and used them around the codebase.

### Motivation

The `AppSpec.isBuild` property has a very overloaded name. We meant it as a "is production" property, but it would be easy to confuse with the general process of _building_ (what we call _compiling_ in our codebase).

Moreover, passing the value to functions lacks a lot of context. e.g. if we had to do `makeWaspInfo True`, the `True` could mean a bunch of different things.

## All the PRs

- #3541
- #3540
- #3539
- #3538

<details>
<summary>Checklist not applicable, click here to show anyway</summary>




## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
--> 

</details>