### PR TITLE
docs: Update SendGrid docs to reflect free plan retirement

### DIFF
--- a/web/docs/advanced/email/email.md
+++ b/web/docs/advanced/email/email.md
@@ -146,6 +146,10 @@ MAILGUN_API_URL=https://api.eu.mailgun.net
 
 ### Using the SendGrid Provider {#sendgrid}
 
+:::caution SendGrid Free Plan Retired
+As of May 27, 2025, SendGrid has [retired its free plans](https://www.twilio.com/en-us/changelog/sendgrid-free-plan). A paid SendGrid plan is now required to send emails. Consider using [Mailgun](#mailgun) or [SMTP](#smtp) with another provider if you need a free tier option.
+:::
+
 Set the provider field to `SendGrid` in your `main.wasp` file.
 
 ```wasp title="main.wasp"
@@ -161,7 +165,7 @@ Then, get the SendGrid API key and add it to your `.env.server` file.
 
 #### Getting the API Key
 
-1. Go to [SendGrid](https://sendgrid.com/) and create an account.
+1. Go to [SendGrid](https://sendgrid.com/) and create an account (paid plan required).
 2. Go to [API Keys](https://app.sendgrid.com/settings/api_keys) and create a new API key.
 3. Copy the API key and add it to your `.env.server` file.
 


### PR DESCRIPTION
## Description

- Resolves https://github.com/wasp-lang/wasp/issues/3279

SendGrid [retired its free plans](https://www.twilio.com/en-us/changelog/sendgrid-free-plan) as of May 27, 2025. This PR updates the Wasp docs to reflect this change by:

- Adding a caution admonition in the SendGrid provider section warning users that the free plan is no longer available
- Updating the account creation step to note that a paid plan is required
- Suggesting alternative providers (Mailgun or SMTP) for users needing free tier options

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- N/A - docs only change -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- N/A -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- N/A -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- N/A -->
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- N/A -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa). <!-- N/A -->

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- N/A - docs only -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`. <!-- N/A -->
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- N/A - docs only -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)