### PR TITLE
Add versioned docs map to llms.txt and refactor generation script

### DIFF
--- a/web/scripts/generate-llm-files.ts
+++ b/web/scripts/generate-llm-files.ts
@@ -135,7 +135,7 @@ async function generateFiles() {
 
 function buildDocsMapsByVersionSection(versions: string[]): string {
   const latestVersion = versions[0];
-  let section = `## Documentation Maps by Version\n*IMPORTANT: First run \`wasp version\` to get the installed Wasp version before following the relevant link.*`;
+  let section = `## Documentation Maps by Version\n*IMPORTANT:* You should run \`wasp version\` to get the installed Wasp CLI version before choosing the correct link.\n`;
   for (const version of versions) {
     const label = version === latestVersion ? `${version} (latest)` : version;
     section += `- [${label}](${WASP_BASE_URL}llms-${version}.txt)\n`;


### PR DESCRIPTION
## Summary

- Adds a "Documentation Maps by Version" section to all `llms.txt` files, allowing LLMs to easily access docs for specific Wasp versions

- Replaced `processDocumentationFiles()` (which did 3 things) with:
- `gatherDocumentation()` - collects and structures doc data
- `buildDocumentationMap()` - pure function for llms.txt TOC
- `buildFullDocumentation()` - pure function for llms-full.txt content