### PR TITLE
Output `wasp info` error in databse provider script

### DIFF
--- a/scripts/get-wasp-database-provider.sh
+++ b/scripts/get-wasp-database-provider.sh
@@ -22,11 +22,17 @@ if [ "$WASP_COMMAND" != "wasp" ] && [ "$WASP_COMMAND" != "wasp-cli" ]; then
   exit 1
 fi
 
+WASP_INFO_OUTPUT=$($WASP_COMMAND info 2>&1) || {
+  echo "ERROR: '$WASP_COMMAND info' failed with exit code $?:" >&2
+  echo $WASP_INFO_OUTPUT >&2
+  exit 1
+}
+
 # Take the database line
 # Take everything after the colon
 # Remove ANSI color codes
 # Convert to lowercase
-DATABASE_PROVIDER=$($WASP_COMMAND info \
+DATABASE_PROVIDER=$(echo "$WASP_INFO_OUTPUT" \
   | grep "Database system" \
   | sed 's/.*: //' \
   | sed -e 's/\x1b\[[0-9;]*m//g' \


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

I had an issue with Waspello app in the CI with getting the DB provider, the output was only:
```
ERROR: Could not determine database system from wasp-cli info
Error: Process completed with exit code 1.
```

The error output will be now:
```
ERROR: 'wasp-cli info' failed with exit code 1:
Error: [  Wasp  ] main.wasp.ts(1,46): error TS2307: Cannot find module 'wasp-config' or its corresponding type declarations.

Error: Error] Analyzing wasp project failed: -------------------------------------

1 errors found:
- Got TypeScript compiler errors for /home/runner/work/wasp/wasp/examples/waspello/main.wasp.ts.
Error: Process completed with exit code 1.
```

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
