### PR TITLE
Remove references to codespaces

### DIFF
--- a/examples/tutorials/TodoApp/README.md
+++ b/examples/tutorials/TodoApp/README.md
@@ -4,26 +4,6 @@ This is an example app that complements the [Intro Wasp Tutorial](https://wasp.s
 
 This example app represents the final state of the tutorial. If you'd prefer to follow it step-by-step, you can find [the tutorial here](https://wasp.sh/docs/tutorial/create).
 
-This project also allows you to run the app in GitHub Codespaces, so you can try out Wasp without installing anything on your machine.
-
-## Running the App in GitHub Codespaces
-
-On the [Wasp repo's `release` branch](https://github.com/wasp-lang/wasp/tree/release), click on the green "Code" button and create a new Codespace.
-
-Give the Codespace some time to install Wasp and finish initializing, then in the terminal run:
-
-```bash
-wasp db migrate-dev
-```
-
-Once the migration is done, you can start the app by running:
-
-```bash
-wasp start
-```
-
-This will start the app. The codespace should prompt you with an "Open in Browser" button. If not, click on the "Ports" tab next to the terminal in the bottom of the Codespace and click on the "forwarded address" for port 3000.
-
 ## Running the App Locally
 
 After you've cloned this repository, you can run the app locally by following these steps:

--- a/web/docs/introduction/quick-start.md
+++ b/web/docs/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 :::tip Having trouble running Wasp?
   If you get stuck with a weird error while developing with Wasp, try running `wasp clean` - this is the Wasp equivalent of "turning it off and on again"!
   Do however let us know about the issue on our GitHub repo or Discord server.

--- a/web/versioned_docs/version-0.13.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.13.0/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 ### What next?
 
 - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈

--- a/web/versioned_docs/version-0.14.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.14.0/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 ### What next?
 
 - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈

--- a/web/versioned_docs/version-0.15.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.15.0/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 ### What next?
 
 - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈

--- a/web/versioned_docs/version-0.16.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.16.0/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 ### What next?
 
 - [ ] 👉 **Check out the [Todo App tutorial](../tutorial/01-create.md), which will take you through all the core features of Wasp!** 👈

--- a/web/versioned_docs/version-0.17.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.17.0/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 :::tip Having trouble running Wasp?
   If you get stuck with a weird error while developing with Wasp, try running `wasp clean` - this is the Wasp equivalent of "turning it off and on again"!
   Do however let us know about the issue on our GitHub repo or Discord server.

--- a/web/versioned_docs/version-0.18.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.18.0/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 :::tip Having trouble running Wasp?
   If you get stuck with a weird error while developing with Wasp, try running `wasp clean` - this is the Wasp equivalent of "turning it off and on again"!
   Do however let us know about the issue on our GitHub repo or Discord server.

--- a/web/versioned_docs/version-0.19.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.19.0/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 :::tip Having trouble running Wasp?
   If you get stuck with a weird error while developing with Wasp, try running `wasp clean` - this is the Wasp equivalent of "turning it off and on again"!
   Do however let us know about the issue on our GitHub repo or Discord server.

--- a/web/versioned_docs/version-0.20.0/introduction/quick-start.md
+++ b/web/versioned_docs/version-0.20.0/introduction/quick-start.md
@@ -42,10 +42,6 @@ Check [More Details](#more-details) section below if anything went wrong with th
 Try out [Wasp AI](../wasp-ai/creating-new-app.md) 🤖 to generate a new Wasp app in minutes just from a title and short description!
 :::
 
-:::tip Try Wasp Without Installing 🤔?
-Give Wasp a spin in the browser with GitHub Codespaces by following the intructions in our [Tutorial App README](https://github.com/wasp-lang/wasp/tree/release/examples/tutorials/TodoApp)
-:::
-
 :::tip Having trouble running Wasp?
   If you get stuck with a weird error while developing with Wasp, try running `wasp clean` - this is the Wasp equivalent of "turning it off and on again"!
   Do however let us know about the issue on our GitHub repo or Discord server.


### PR DESCRIPTION
Leftovers from #3629

Remove all documentation regarding codespaces (also in versioned docs since those also do not work anymore)