### PR TITLE
Fix dark mode issue and gitignore Flowbite files

### DIFF
--- a/examples/websockets-realtime-voting/.gitignore
+++ b/examples/websockets-realtime-voting/.gitignore
@@ -12,3 +12,6 @@ node_modules/
 
 # Playwright
 test-results/
+
+# Flowbite React
+.flowbite-react

--- a/examples/websockets-realtime-voting/src/Main.css
+++ b/examples/websockets-realtime-voting/src/Main.css
@@ -1,5 +1,7 @@
 @import "tailwindcss" source(".");
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* Flowbite React */
 @import "flowbite-react/plugin/tailwindcss";
 @source "../node_modules/flowbite-react/**/*.{js,jsx,ts,tsx}";


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Fixes issues with dark mode being activated by user preferences, but we wanted everything in light mode. Also, gitignoring some auto-generated files by Flowbite.

| <img width="1628" height="1068" alt="SCR-20260116-odts" src="https://github.com/user-attachments/assets/af91c7c6-5b25-4cd2-bde3-0bbe3789715f" /> | <img width="1604" height="989" alt="SCR-20260116-oduu" src="https://github.com/user-attachments/assets/bf60b4ab-936a-4313-9c11-2a79df4e6a0d" /> |
| --- | --- |
| Before | After |

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
