### PR TITLE
Skip deployment for external PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,12 @@ concurrency:
 
 jobs:
   deploy-test:
+    # Only run if the PR doesn't come from a fork, since then it wouldn't have
+    # access to secrets:
+    if: >
+      github.event.pull_request.head.repo.full_name
+      == github.event.pull_request.base.repo.full_name
+
     uses: ./.github/workflows/ci-deploy-test.yaml
     secrets: inherit
 


### PR DESCRIPTION
## Description

Skip the `deploy-test` CI job for PRs that come from forks, since they don't have access to repository secrets and would fail anyway.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- N/A - CI workflow change -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.