### PR TITLE
Support Railway CLI v4.18.1+ with schema versioning

### DIFF
--- a/waspc/data/packages/deploy/package-lock.json
+++ b/waspc/data/packages/deploy/package-lock.json
@@ -13,7 +13,7 @@
         "commander": "^13.1.0",
         "semver": "^7.7.2",
         "toml": "^3.0.0",
-        "zod": "^3.24.4",
+        "zod": "^4.3.6",
         "zx": "^8.3.2"
       },
       "bin": {
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -3519,9 +3519,9 @@
       "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA=="
     },
     "zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
     },
     "zx": {
       "version": "8.3.2",

--- a/waspc/data/packages/deploy/package.json
+++ b/waspc/data/packages/deploy/package.json
@@ -16,7 +16,7 @@
     "commander": "^13.1.0",
     "semver": "^7.7.2",
     "toml": "^3.0.0",
-    "zod": "^3.24.4",
+    "zod": "^4.3.6",
     "zx": "^8.3.2"
   },
   "devDependencies": {

--- a/waspc/data/packages/deploy/src/common/schema.ts
+++ b/waspc/data/packages/deploy/src/common/schema.ts
@@ -1,0 +1,32 @@
+import * as z from "zod";
+
+/**
+ * Takes a series of schemas representing different versions of the same output
+ * and combines them into a single schema that can parse any of the versions.
+ *
+ * The first schema provided is considered the canonical version, while the rest
+ * are considered older versions and forced to transform to the same type.
+ *
+ * @remark Alternative schemas will be piped in to the canonical schema to
+ * ensure consistency. As such, it's recommended that the alternative schemas do
+ * as little transformation as possible, and just transform the structure to
+ * match the canonical schema's input.
+ */
+export const canonicalSchema = <
+  CanonicalInput,
+  Canonical extends z.ZodType<unknown, CanonicalInput>,
+  const Alternatives extends readonly z.ZodType<CanonicalInput>[],
+>(
+  canonicalVersionSchema: Canonical,
+  alternativeSchemas: Alternatives,
+) =>
+  z.union([
+    canonicalVersionSchema,
+    ...alternativeSchemas.map((schema) => schema.pipe(canonicalVersionSchema)),
+  ]);
+
+/** Transforms all keys of an object to lowercase */
+export const toLowerCaseKeysSchema = z.looseRecord(
+  z.string().toLowerCase(),
+  z.unknown(),
+);

--- a/waspc/data/packages/deploy/src/providers/fly/flyCli.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/flyCli.ts
@@ -82,8 +82,5 @@ async function regionExists(regionCode: string): Promise<boolean> {
 export async function secretExists(secretName: string): Promise<boolean> {
   const proc = await $`flyctl secrets list -j`;
   const secrets = FlySecretListSchema.parse(proc.json());
-  return secrets.some((s) => {
-    const name = "name" in s ? s.name : s.Name;
-    return name === secretName;
-  });
+  return secrets.some((s) => s.name === secretName);
 }

--- a/waspc/data/packages/deploy/src/providers/railway/jsonOutputSchemas.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/jsonOutputSchemas.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { canonicalSchema } from "../../common/schema";
 
 export type RailwayCliService = z.infer<typeof RailwayCliServiceSchema>;
 
@@ -23,15 +24,15 @@ export const RailwayCliProjectSchema = z.object({
 
 export const RailwayProjectListSchema = z.array(RailwayCliProjectSchema);
 
-export const RailwayCliDomainSchema = z.union([
-  // Railway CLI >=4.18.1
-  z.object({ domains: z.array(z.string()).min(1) }),
+export const RailwayCliDomainSchema = canonicalSchema(
+  z.array(z.string()).nonempty(),
+  [
+    // Railway CLI >=4.18.1
+    z.object({ domains: z.unknown() }).transform(({ domains }) => domains),
 
-  // Railway CLI <4.18.1
-  z
-    .object({ domain: z.string() })
-    // Convert to the newer format
-    .transform(({ domain }) => ({ domains: [domain] })),
-]);
+    // Railway CLI <4.18.1
+    z.object({ domain: z.unknown() }).transform(({ domain }) => [domain]),
+  ],
+);
 
 export type RailwayCliDomain = z.infer<typeof RailwayCliDomainSchema>;

--- a/waspc/data/packages/deploy/src/providers/railway/railwayService/url.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayService/url.ts
@@ -43,7 +43,7 @@ export async function generateServiceUrl(
   if (domainAlreadyExistsPattern.test(result.stdout)) {
     return extractServiceUrlFromString(result.stdout);
   } else {
-    const { domains } = RailwayCliDomainSchema.parse(result.json());
+    const domains = RailwayCliDomainSchema.parse(result.json());
 
     const REACT_APP_API_URL = process.env.REACT_APP_API_URL;
     if (REACT_APP_API_URL) {


### PR DESCRIPTION
## Description

A small refactor that makes it easier to author schemas for different versions of an input. Includes a Zod update.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
--> 