### PR TITLE
Add some details to the release checklist

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -484,8 +484,8 @@ If doing this, steps are the following:
 2. Locally execute the `new-release` script. Append `-rc` to the version number to make it obvious that this release is a pre-release used for testing (e.g., `./new-release 0.19.1-rc1`).
    The script will throw some warnings which you should accept.
 3. Once the draft release is created on Github:
-    - Use their UI to mark it as a pre-release and publish it. This will automatically remove the checkmark from "latest release", which is exactly what we want. **This is the crucial step that differentiates test release from the proper release.**
-    - Push the `rc-<version>` branch to remote.
+   - Use their UI to mark it as a pre-release and publish it. This will automatically remove the checkmark from "latest release", which is exactly what we want. **This is the crucial step that differentiates test release from the proper release.**
+   - Push the `rc-<version>` branch to remote.
 4. Since npm installs the latest release by default, it will skip this pre-release (which is what we wanted). You can install it by pasing an explicit version! That way user's don't get in touch with it, but we can install and use it normally:
 
 ```sh


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Clearning up some fuzzy parts of our release process.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
