### PR TITLE
Fix semantic version module demo 1

### DIFF
--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -105,7 +105,7 @@ validateWaspVersion specWaspVersionStr = eitherUnitToErrorList $ do
             waspVersionRangeStr =~ ("\\`\\^([0-9]+)\\.([0-9]+)\\.([0-9]+)\\'" :: String)
 
       waspSpecVersion <- case mapM readMaybe waspVersionRangeDigits of
-        Just [major, minor, patch] -> Right $ SV.Version major minor patch
+        Just [major, minor, patch] -> Right $ SV.FullVersion major minor patch
         __ -> Left $ GenericValidationError "Wasp version should be in the format ^major.minor.patch"
 
       Right $ SV.Range [SV.backwardsCompatibleWith waspSpecVersion]

--- a/waspc/src/Wasp/Generator/DepVersions.hs
+++ b/waspc/src/Wasp/Generator/DepVersions.hs
@@ -22,17 +22,17 @@ import qualified Wasp.SemanticVersion as SV
 -- `data/Generator/templates/sdk/wasp/prisma-runtime-library.d.ts` is up to
 -- date.
 prismaVersion :: SV.Version
-prismaVersion = SV.Version 5 19 1
+prismaVersion = SV.FullVersion 5 19 1
 
 superjsonVersion :: SV.ComparatorSet
-superjsonVersion = SV.backwardsCompatibleWith $ SV.Version 2 2 1
+superjsonVersion = SV.backwardsCompatibleWith $ SV.FullVersion 2 2 1
 
 typescriptVersion :: SV.Version
-typescriptVersion = SV.Version 5 8 2
+typescriptVersion = SV.FullVersion 5 8 2
 
 -- When updating the React version, also update it in `peerDependencies` in `waspc/libs/auth/package.json`.
 reactVersion :: SV.ComparatorSet
-reactVersion = SV.backwardsCompatibleWith $ SV.Version 19 2 1
+reactVersion = SV.backwardsCompatibleWith $ SV.FullVersion 19 2 1
 
 -- React and ReactDOM versions should always match.
 reactDomVersion :: SV.ComparatorSet
@@ -41,13 +41,13 @@ reactDomVersion = reactVersion
 -- Follows React major version
 -- When updating the React types version, also update it in `devDependencies` in `waspc/libs/auth/package.json`.
 reactTypesVersion :: SV.ComparatorSet
-reactTypesVersion = SV.backwardsCompatibleWith $ SV.Version 19 2 7
+reactTypesVersion = SV.backwardsCompatibleWith $ SV.FullVersion 19 2 7
 
 reactDomTypesVersion :: SV.ComparatorSet
-reactDomTypesVersion = SV.backwardsCompatibleWith $ SV.Version 19 2 3
+reactDomTypesVersion = SV.backwardsCompatibleWith $ SV.FullVersion 19 2 3
 
 reactRouterVersion :: SV.ComparatorSet
-reactRouterVersion = SV.backwardsCompatibleWith $ SV.Version 7 12 0
+reactRouterVersion = SV.backwardsCompatibleWith $ SV.FullVersion 7 12 0
 
 -- TODO: Update react query and express to use Wasp.SemanticVersion when we'll
 -- have support for patch versions https://github.com/wasp-lang/wasp/issues/2941
@@ -59,10 +59,10 @@ expressVersionStr :: String
 expressVersionStr = "~5.1.0"
 
 expressTypesVersion :: SV.ComparatorSet
-expressTypesVersion = SV.backwardsCompatibleWith $ SV.Version 5 0 0
+expressTypesVersion = SV.backwardsCompatibleWith $ SV.FullVersion 5 0 0
 
 axiosVersion :: SV.ComparatorSet
-axiosVersion = SV.backwardsCompatibleWith $ SV.Version 1 4 0
+axiosVersion = SV.backwardsCompatibleWith $ SV.FullVersion 1 4 0
 
 viteVersion :: SV.ComparatorSet
-viteVersion = SV.backwardsCompatibleWith $ SV.Version 7 0 6
+viteVersion = SV.backwardsCompatibleWith $ SV.FullVersion 7 0 6

--- a/waspc/src/Wasp/Generator/SdkGenerator/EmailSender/Providers.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/EmailSender/Providers.hs
@@ -32,7 +32,7 @@ smtp =
     }
   where
     nodeMailerVersionRange :: SV.Range
-    nodeMailerVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.Version 6 9 1)]
+    nodeMailerVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.FullVersion 6 9 1)]
 
     nodeMailerDependency :: Npm.Dependency.Dependency
     nodeMailerDependency = Npm.Dependency.make ("nodemailer", show nodeMailerVersionRange)
@@ -45,7 +45,7 @@ sendGrid =
     }
   where
     sendGridVersionRange :: SV.Range
-    sendGridVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.Version 7 7 0)]
+    sendGridVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.FullVersion 7 7 0)]
 
     sendGridDependency :: Npm.Dependency.Dependency
     sendGridDependency = Npm.Dependency.make ("@sendgrid/mail", show sendGridVersionRange)
@@ -58,7 +58,7 @@ mailgun =
     }
   where
     mailgunVersionRange :: SV.Range
-    mailgunVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.Version 10 2 3)]
+    mailgunVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.FullVersion 10 2 3)]
 
     mailgunDependency :: Npm.Dependency.Dependency
     mailgunDependency = Npm.Dependency.make ("mailgun.js", show mailgunVersionRange)

--- a/waspc/src/Wasp/Generator/SdkGenerator/Server/JobGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Server/JobGenerator.hs
@@ -137,7 +137,7 @@ genJobExecutors spec = case getJobs spec of
 -- NOTE: Our pg-boss related documentation references this version in URLs.
 -- Please update the docs when this changes (until we solve: https://github.com/wasp-lang/wasp/issues/596).
 pgBossVersionRange :: SV.Range
-pgBossVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.Version 8 4 2)]
+pgBossVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.FullVersion 8 4 2)]
 
 pgBossDependency :: Npm.Dependency.Dependency
 pgBossDependency = Npm.Dependency.make ("pg-boss", show pgBossVersionRange)

--- a/waspc/src/Wasp/Generator/WebSocket.hs
+++ b/waspc/src/Wasp/Generator/WebSocket.hs
@@ -16,10 +16,10 @@ areWebSocketsUsed :: AppSpec -> Bool
 areWebSocketsUsed spec = isJust $ AS.App.webSocket $ snd $ getApp spec
 
 socketIoVersionRange :: SV.Range
-socketIoVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.Version 4 6 1)]
+socketIoVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.FullVersion 4 6 1)]
 
 socketIoComponentEmitterVersionRange :: SV.Range
-socketIoComponentEmitterVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.Version 4 0 0)]
+socketIoComponentEmitterVersionRange = SV.Range [SV.backwardsCompatibleWith (SV.FullVersion 4 0 0)]
 
 serverDepsRequiredForWebSockets :: [Npm.Dependency.Dependency]
 serverDepsRequiredForWebSockets =

--- a/waspc/src/Wasp/Node/Version.hs
+++ b/waspc/src/Wasp/Node/Version.hs
@@ -20,10 +20,10 @@ import Wasp.Util (indent)
 -- NOTE: Don't change Wasp's lowest supported Node version without updating it
 -- in all required places. Check /.nvmrc for the full list.
 oldestWaspSupportedNodeVersion :: SV.Version
-oldestWaspSupportedNodeVersion = SV.Version 22 12 0
+oldestWaspSupportedNodeVersion = SV.FullVersion 22 12 0
 
 oldestWaspSupportedNpmVersion :: SV.Version
-oldestWaspSupportedNpmVersion = SV.Version 10 9 0
+oldestWaspSupportedNpmVersion = SV.FullVersion 10 9 0
 
 isRangeInWaspSupportedRange :: SV.Range -> Bool
 isRangeInWaspSupportedRange range =

--- a/waspc/src/Wasp/SemanticVersion.hs
+++ b/waspc/src/Wasp/SemanticVersion.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Wasp.SemanticVersion
   ( Version (..),
+    pattern FullVersion,
     Range (..),
     ComparatorSet,
     isVersionInRange,
@@ -17,7 +20,7 @@ import Control.Monad (guard)
 import Data.List (intercalate, nub)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (isJust)
-import Wasp.SemanticVersion.Version (Version (..), nextBreakingChangeVersion)
+import Wasp.SemanticVersion.Version (Version (..), nextBreakingChangeVersion, pattern FullVersion)
 import Wasp.SemanticVersion.VersionBound
   ( HasVersionBounds (versionBounds),
     VersionBound (Exclusive, Inclusive, Inf),

--- a/waspc/src/Wasp/SemanticVersion/Version.hs
+++ b/waspc/src/Wasp/SemanticVersion/Version.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Wasp.SemanticVersion.Version
   ( Version (..),
+    pattern FullVersion,
     nextBreakingChangeVersion,
     parseVersion,
     versionParser,
@@ -9,25 +11,47 @@ module Wasp.SemanticVersion.Version
   )
 where
 
+import Data.Maybe (fromMaybe)
 import qualified Language.Haskell.TH.Quote as TH
 import qualified Language.Haskell.TH.Syntax as TH
 import Numeric.Natural (Natural)
 import Text.Parsec (ParseError, Parsec, char, parse, sepBy)
 import Text.Parsec.Language (emptyDef)
 import Text.Parsec.Token (makeTokenParser, natural)
-import Text.Printf (printf)
 import Wasp.Util.TH (quasiQuoterFromParser)
 
 data Version = Version
   { major :: !Natural,
-    minor :: !Natural,
-    patch :: !Natural
+    minor :: !(Maybe Natural),
+    patch :: !(Maybe Natural)
   }
-  deriving (Eq, Ord, TH.Lift)
+  deriving (TH.Lift)
+
+-- | Eq instance that treats missing components as 0.
+-- So "1" == "1.0" == "1.0.0".
+instance Eq Version where
+  Version maj1 mnr1 ptc1 == Version maj2 mnr2 ptc2 =
+    maj1 == maj2
+      && fromMaybe 0 mnr1 == fromMaybe 0 mnr2
+      && fromMaybe 0 ptc1 == fromMaybe 0 ptc2
+
+-- | Ord instance that treats missing components as 0.
+-- So "1" == "1.0" == "1.0.0".
+instance Ord Version where
+  compare (Version maj1 mnr1 ptc1) (Version maj2 mnr2 ptc2) =
+    compare maj1 maj2
+      <> compare (fromMaybe 0 mnr1) (fromMaybe 0 mnr2)
+      <> compare (fromMaybe 0 ptc1) (fromMaybe 0 ptc2)
+
+-- | Pattern synonym for the common case where all three version components are present.
+pattern FullVersion :: Natural -> Natural -> Natural -> Version
+pattern FullVersion maj mnr ptc = Version maj (Just mnr) (Just ptc)
 
 -- | We rely on this `show` implementation to produce valid semver representation of version.
 instance Show Version where
-  show (Version mjr mnr ptc) = printf "%d.%d.%d" mjr mnr ptc
+  show (Version mjr mnr ptc) = show mjr ++ showMaybe mnr ++ showMaybe ptc
+    where
+      showMaybe = maybe "" (("." ++) . show)
 
 parseVersion :: String -> Either ParseError Version
 parseVersion = parse versionParser ""
@@ -35,9 +59,9 @@ parseVersion = parse versionParser ""
 versionParser :: Parsec String () Version
 versionParser = do
   naturalP `sepBy` char '.' >>= \case
-    [a] -> return $ Version a 0 0
-    [a, b] -> return $ Version a b 0
-    [a, b, c] -> return $ Version a b c
+    [a] -> return $ Version a Nothing Nothing
+    [a, b] -> return $ Version a (Just b) Nothing
+    [a, b, c] -> return $ Version a (Just b) (Just c)
     _invalidFormat -> fail "Invalid version format"
   where
     naturalP = fromIntegral <$> natural lexer
@@ -46,8 +70,12 @@ versionParser = do
 v :: TH.QuasiQuoter
 v = quasiQuoterFromParser parseVersion
 
+-- | A missing minor and patch values will desugar to zero.
 nextBreakingChangeVersion :: Version -> Version
 nextBreakingChangeVersion = \case
-  (Version 0 0 x) -> Version 0 0 (succ x)
-  (Version 0 x _) -> Version 0 (succ x) 0
-  (Version x _ _) -> Version (succ x) 0 0
+  -- 0.0.x -> 0.0.(x+1)
+  FullVersion 0 0 ptc -> FullVersion 0 0 (succ ptc)
+  -- 0.x.y -> 0.(x+1).0
+  Version 0 (Just mnr) _ -> FullVersion 0 (succ mnr) 0
+  -- x.y.z -> (x+1).0.0
+  Version maj _ _ -> FullVersion (succ maj) 0 0

--- a/waspc/src/Wasp/Version.hs
+++ b/waspc/src/Wasp/Version.hs
@@ -6,5 +6,5 @@ import qualified Wasp.SemanticVersion as SV
 
 waspVersion :: SV.Version
 waspVersion = case Paths_waspc.version of
-  DV.Version [major, minor, patch] _ -> SV.Version (toEnum major) (toEnum minor) (toEnum patch)
+  DV.Version [major, minor, patch] _ -> SV.FullVersion (toEnum major) (toEnum minor) (toEnum patch)
   _ -> error "This should never happen. Wasp binary version must have exactly three digits, but it doesn't."

--- a/waspc/tests/Node/InternalTest.hs
+++ b/waspc/tests/Node/InternalTest.hs
@@ -2,22 +2,22 @@ module Node.InternalTest where
 
 import Test.Hspec
 import Wasp.Node.Internal (parseVersionFromCommandOutput)
-import Wasp.SemanticVersion.Version (Version (..))
+import qualified Wasp.SemanticVersion.Version as SV
 
 spec_NodeInternal :: Spec
 spec_NodeInternal =
   describe "parseVersionFromCommandOutput" $ do
     it "parses a version when the version string is at the end" $ do
       let output = "Some informational output...\nVersion: 20.3.1"
-      parseVersionFromCommandOutput output `shouldBe` Right (Version 20 3 1)
+      parseVersionFromCommandOutput output `shouldBe` Right (SV.FullVersion 20 3 1)
 
     it "parses a version when the version string is in the middle" $ do
       let output = "Starting up v20.3.1 and initializing modules"
-      parseVersionFromCommandOutput output `shouldBe` Right (Version 20 3 1)
+      parseVersionFromCommandOutput output `shouldBe` Right (SV.FullVersion 20 3 1)
 
     it "parses a version when there is only version string" $ do
       let output = "20.3.1"
-      parseVersionFromCommandOutput output `shouldBe` Right (Version 20 3 1)
+      parseVersionFromCommandOutput output `shouldBe` Right (SV.FullVersion 20 3 1)
 
     it "fails when no valid version is found" $ do
       let output = "This output has no semantic version info!"

--- a/waspc/tests/SemanticVersion/VersionBoundTest.hs
+++ b/waspc/tests/SemanticVersion/VersionBoundTest.hs
@@ -7,18 +7,18 @@ import Wasp.SemanticVersion.VersionBound
 spec_SemanticVersionBound :: Spec
 spec_SemanticVersionBound = do
   it "showInterval" $ do
-    showInterval (Inclusive (Version 1 2 3), Exclusive (Version 2 3 4)) `shouldBe` "[1.2.3, 2.3.4)"
-    showInterval (Exclusive (Version 1 2 3), Inclusive (Version 2 3 4)) `shouldBe` "(1.2.3, 2.3.4]"
+    showInterval (Inclusive (FullVersion 1 2 3), Exclusive (FullVersion 2 3 4)) `shouldBe` "[1.2.3, 2.3.4)"
+    showInterval (Exclusive (FullVersion 1 2 3), Inclusive (FullVersion 2 3 4)) `shouldBe` "(1.2.3, 2.3.4]"
     showInterval (Inf, Inf) `shouldBe` "(inf, inf)"
 
   it "parseInterval" $ do
-    parseInterval "[1.2.3, 0.1)" `shouldBe` Right (Inclusive (Version 1 2 3), Exclusive (Version 0 1 0))
-    parseInterval "(1,inf)" `shouldBe` Right (Exclusive (Version 1 0 0), Inf)
-    parseInterval "  ( inf , 1.2.3 ] " `shouldBe` Right (Inf, Inclusive (Version 1 2 3))
+    parseInterval "[1.2.3, 0.1)" `shouldBe` Right (Inclusive (FullVersion 1 2 3), Exclusive (Version 0 (Just 1) Nothing))
+    parseInterval "(1,inf)" `shouldBe` Right (Exclusive (Version 1 Nothing Nothing), Inf)
+    parseInterval "  ( inf , 1.2.3 ] " `shouldBe` Right (Inf, Inclusive (FullVersion 1 2 3))
 
   it "vi quasi quoter" $ do
-    [vi| [1.2.3, 2.3.4) |] `shouldBe` (Inclusive (Version 1 2 3), Exclusive (Version 2 3 4))
-    [vi| (1.2.3, 2.3.4] |] `shouldBe` (Exclusive (Version 1 2 3), Inclusive (Version 2 3 4))
+    [vi| [1.2.3, 2.3.4) |] `shouldBe` (Inclusive (FullVersion 1 2 3), Exclusive (FullVersion 2 3 4))
+    [vi| (1.2.3, 2.3.4] |] `shouldBe` (Exclusive (FullVersion 1 2 3), Inclusive (FullVersion 2 3 4))
     [vi| (inf, inf) |] `shouldBe` (Inf, Inf)
 
   describe "intervalIntersection" $ do

--- a/waspc/tests/SemanticVersion/VersionTest.hs
+++ b/waspc/tests/SemanticVersion/VersionTest.hs
@@ -7,24 +7,35 @@ import Wasp.SemanticVersion.Version
 spec_SemanticVersion_Version :: Spec
 spec_SemanticVersion_Version = do
   it "show produces valid semver representation of version" $ do
-    show (Version 1 2 3) `shouldBe` "1.2.3"
+    show (Version 1 (Just 2) (Just 3)) `shouldBe` "1.2.3"
+    show (Version 1 (Just 2) Nothing) `shouldBe` "1.2"
+    show (Version 1 Nothing Nothing) `shouldBe` "1"
 
   it "parseVersion" $ do
-    parseVersion "1" `shouldBe` Right (Version 1 0 0)
-    parseVersion "1.2" `shouldBe` Right (Version 1 2 0)
-    parseVersion "1.2.3" `shouldBe` Right (Version 1 2 3)
-    parseVersion "103.20.35" `shouldBe` Right (Version 103 20 35)
-    parseVersion "0.1.33" `shouldBe` Right (Version 0 1 33)
-    parseVersion "1.2.3foobar" `shouldBe` Right (Version 1 2 3)
-    parseVersion "1.2.3-alpha" `shouldBe` Right (Version 1 2 3)
-    parseVersion "1.2.3 some other stuff" `shouldBe` Right (Version 1 2 3)
+    parseVersion "1" `shouldBe` Right (Version 1 Nothing Nothing)
+    parseVersion "1.2" `shouldBe` Right (Version 1 (Just 2) Nothing)
+    parseVersion "1.2.3" `shouldBe` Right (Version 1 (Just 2) (Just 3))
+    parseVersion "103.20.35" `shouldBe` Right (Version 103 (Just 20) (Just 35))
+    parseVersion "0.1.33" `shouldBe` Right (Version 0 (Just 1) (Just 33))
+    parseVersion "1.2.3foobar" `shouldBe` Right (Version 1 (Just 2) (Just 3))
+    parseVersion "1.2.3-alpha" `shouldBe` Right (Version 1 (Just 2) (Just 3))
+    parseVersion "1.2.3 some other stuff" `shouldBe` Right (Version 1 (Just 2) (Just 3))
     isLeft (parseVersion "1.2.3.") `shouldBe` True
     isLeft (parseVersion "1.2.3.blabla") `shouldBe` True
     isLeft (parseVersion "v1.2.3") `shouldBe` True
     isLeft (parseVersion ".2.3") `shouldBe` True
     isLeft (parseVersion "foo") `shouldBe` True
 
+  it "nextBreakingChangeVersion" $ do
+    nextBreakingChangeVersion (FullVersion 1 2 3) `shouldBe` FullVersion 2 0 0
+    nextBreakingChangeVersion (FullVersion 0 2 3) `shouldBe` FullVersion 0 3 0
+    nextBreakingChangeVersion (FullVersion 0 0 3) `shouldBe` FullVersion 0 0 4
+    nextBreakingChangeVersion (Version 1 (Just 2) Nothing) `shouldBe` FullVersion 2 0 0
+    nextBreakingChangeVersion (Version 1 Nothing Nothing) `shouldBe` FullVersion 2 0 0
+
   it "v quasi quoter" $ do
-    [v|1.2.3|] `shouldBe` Version 1 2 3
-    [v|1 |] `shouldBe` Version 1 0 0
-    [v|0.2|] `shouldBe` Version 0 2 0
+    [v|1.2.3|] `shouldBe` Version 1 (Just 2) (Just 3)
+    [v|1.2|] `shouldBe` Version 1 (Just 2) Nothing
+    [v|1|] `shouldBe` Version 1 Nothing Nothing
+    [v|0.2|] `shouldBe` Version 0 (Just 2) Nothing
+    [v|0.0.2|] `shouldBe` Version 0 (Just 0) (Just 2)

--- a/waspc/tests/SemanticVersionTest.hs
+++ b/waspc/tests/SemanticVersionTest.hs
@@ -10,21 +10,17 @@ spec_SemanticVersion :: Spec
 spec_SemanticVersion = do
   -- TODO: Add more tests to cover everything.
   describe "`show` produces valid semver strings" $ do
-    it "show Version" $ do
-      show (Version 0 0 0) `shouldBe` "0.0.0"
-      show (Version 0 19 0) `shouldBe` "0.19.0"
-      show (Version 1 2 314) `shouldBe` "1.2.314"
     it "show empty Range" $ do
       show (mempty :: Range) `shouldBe` ""
     it "show complex Range" $ do
       show
-        ( Range [lte (Version 1 3 6) <> backwardsCompatibleWith (Version 1 2 0)]
-            <> Range [eq (Version 1 2 3)]
+        ( Range [lte (FullVersion 1 3 6) <> backwardsCompatibleWith (FullVersion 1 2 0)]
+            <> Range [eq (FullVersion 1 2 3)]
         )
         `shouldBe` "<=1.3.6 ^1.2.0 || 1.2.3"
   it "Concatenating version ranges produces union of their comparator sets" $ do
-    let v1 = Version 1 0 0
-    let v2 = Version 2 0 0
+    let v1 = FullVersion 1 0 0
+    let v2 = FullVersion 2 0 0
     let r1 = Range [gt v1, lt v2]
     let r2 = Range [lt v2]
     r1 <> r2 `shouldBe` r1
@@ -41,7 +37,7 @@ spec_SemanticVersion = do
         ]
     it "Recognizes only version v to be in range '=v'" $
       testRange
-        (Range [eq (Version 1 2 3)])
+        (Range [eq (FullVersion 1 2 3)])
         [ ((0, 5, 5), False),
           ((1, 0, 0), False),
           ((1, 2, 3), True),
@@ -51,7 +47,7 @@ spec_SemanticVersion = do
         ]
     it "Recognizes only versions lesser or equal to v to be in range '<=v'" $
       testRange
-        (Range [lte (Version 1 2 3)])
+        (Range [lte (FullVersion 1 2 3)])
         [ ((0, 5, 5), True),
           ((1, 0, 0), True),
           ((1, 2, 3), True),
@@ -62,7 +58,7 @@ spec_SemanticVersion = do
     describe "Recognizes only versions >=v but smaller than next breaking change to be in range '^v'" $ do
       it "when v is of shape x.y.z where x != 0." $
         testRange
-          (Range [backwardsCompatibleWith (Version 1 2 3)])
+          (Range [backwardsCompatibleWith (FullVersion 1 2 3)])
           [ ((0, 5, 5), False),
             ((1, 0, 0), False),
             ((1, 2, 3), True),
@@ -72,7 +68,7 @@ spec_SemanticVersion = do
           ]
       it "when v is of shape 0.y.z where y != 0." $
         testRange
-          (Range [backwardsCompatibleWith (Version 0 2 3)])
+          (Range [backwardsCompatibleWith (FullVersion 0 2 3)])
           [ ((0, 0, 0), False),
             ((0, 1, 3), False),
             ((0, 2, 0), False),
@@ -84,7 +80,7 @@ spec_SemanticVersion = do
           ]
       it "when v is of shape 0.0.z." $
         testRange
-          (Range [backwardsCompatibleWith (Version 0 0 2)])
+          (Range [backwardsCompatibleWith (FullVersion 0 0 2)])
           [ ((0, 0, 1), False),
             ((0, 0, 2), True),
             ((0, 0, 3), False),
@@ -93,7 +89,7 @@ spec_SemanticVersion = do
           ]
       it "Correctly works for complex version range." $
         testRange
-          (Range [lte (Version 1 2 3) <> backwardsCompatibleWith (Version 1 1 0), eq (Version 0 5 6)])
+          (Range [lte (FullVersion 1 2 3) <> backwardsCompatibleWith (FullVersion 1 1 0), eq (FullVersion 0 5 6)])
           [ ((0, 5, 5), False),
             ((0, 5, 6), True),
             ((0, 5, 7), False),
@@ -133,7 +129,7 @@ spec_SemanticVersion = do
   where
     testRange :: Range -> [((Natural, Natural, Natural), Bool)] -> Expectation
     testRange range versionsWithResults =
-      ( (`isVersionInRange` range) . (\(x, y, z) -> Version x y z)
+      ( (`isVersionInRange` range) . (\(x, y, z) -> FullVersion x y z)
           <$> map fst versionsWithResults
       )
         `shouldBe` map snd versionsWithResults


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Fixes https://github.com/wasp-lang/wasp/issues/3699

TLDR: The issue is that we don't support optional minor and patch version. We can't just assume that missing values are "0", because some operators (~) have special behavior around missing values.

So the `Version` has to support not defining minor/patch values.

Approaches I've thought about:

### Just add `Maybe` approach (also the one I implemented)

```hs
data Version = Version
  { major :: !Natural,
    minor :: !(Maybe Natural),
    patch :: !(Maybe Natural)
  }
  deriving (TH.Lift)
```
Requires overriding default `Eq` and `Ord` implementation:
```hs
-- Also similar for 'Ord'
instance Eq Version where
  Version maj1 mnr1 ptc1 == Version maj2 mnr2 ptc2 =
    maj1 == maj2
      && fromMaybe 0 mnr1 == fromMaybe 0 mnr2
      && fromMaybe 0 ptc1 == fromMaybe 0 ptc2
```
Other than that there are no real changes to the old code, except the new syntax for `Version`, which is also the biggest downside:
```hs
prismaVersion :: SV.Version
prismaVersion = SV.Version 5 (Just 19) (Just 1)
```
To help with that we can use pattern synonyms:
```hs
{-# LANGUAGE PatternSynonyms #-}

-- | Pattern synonym for the common case where all three version components are present.
pattern FullVersion :: Natural -> Natural -> Natural -> Version
pattern FullVersion maj mnr ptc = Version maj (Just mnr) (Just ptc)
```
Which is then used as:
```hs
prismaVersion :: SV.Version
prismaVersion = SV.FullVersion 5 19 1
```
### Three constructors approach

```hs
data Version
  = MajorOnly !Natural
  | MajorMinor !Natural !Natural
  | MajorMinorPatch !Natural !Natural !Natural
  deriving (TH.Lift)
```
Seemed like it would bring too much complexity.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
