### PR TITLE
Implement cache support for SDK assets copying

### DIFF
--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -872,7 +872,7 @@
             "file",
             "sdk/wasp/scripts/copy-assets.js"
         ],
-        "5682402f0e4cc83eaa65364d105524c67190b354a195de98bfebc3c4abf2fb95"
+        "0b7e3d7a0238faae3d97c43c50dfcbcfb088b769632046048ff78f8970e1d55b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -424,7 +424,7 @@
             "file",
             "sdk/wasp/scripts/copy-assets.js"
         ],
-        "5682402f0e4cc83eaa65364d105524c67190b354a195de98bfebc3c4abf2fb95"
+        "0b7e3d7a0238faae3d97c43c50dfcbcfb088b769632046048ff78f8970e1d55b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -424,7 +424,7 @@
             "file",
             "sdk/wasp/scripts/copy-assets.js"
         ],
-        "5682402f0e4cc83eaa65364d105524c67190b354a195de98bfebc3c4abf2fb95"
+        "0b7e3d7a0238faae3d97c43c50dfcbcfb088b769632046048ff78f8970e1d55b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -431,7 +431,7 @@
             "file",
             "sdk/wasp/scripts/copy-assets.js"
         ],
-        "5682402f0e4cc83eaa65364d105524c67190b354a195de98bfebc3c4abf2fb95"
+        "0b7e3d7a0238faae3d97c43c50dfcbcfb088b769632046048ff78f8970e1d55b"
     ],
     [
         [


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Copying of SDK assets (CSS, HTML files) happens on each SDK build which happens on each code change. This causes Vite to do a full-reload because now we are copying the virtual `index.html` in the SDK.

### Solution

If the source file is newer or the destination file doesn't exist - copy the source file.

### Context from Discord

Right now on _each_ user file change:
1. Wasp compiler regenerates files
    - Generator is "smart" by using checksums
2. Runs ⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨`tsc`⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩ to rebuild the SDK
    - smart with ⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨`incremental`⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩ compilation
3. Copies extra files for the SDK ⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨`dist`⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩ dir
    - just copies files each time

**This causes Vite dev server to detect these changes and reload the client app changes. The side-effect is sometimes full page reload which wipes the client state.**

:one: We prevented the ⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨`tsc`⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩ from doing too many changes by implementing ⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨`incremental`⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩ compilation: https://github.com/wasp-lang/wasp/pull/1931

:two: Since we introduced asset copying (for CSS, HTML files which ⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨⁨`tsc`⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩⁩ doesn't handle) in the SDK, this started happening again more aggressively. 

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
