### PR TITLE
Remove redundant libs copy in the server's Dockerfile

### DIFF
--- a/waspc/data/Generator/templates/Dockerfile
+++ b/waspc/data/Generator/templates/Dockerfile
@@ -38,10 +38,6 @@ COPY package-lock.json .
 COPY tsconfig*.json .
 COPY server .wasp/out/server
 COPY sdk .wasp/out/sdk
-# We copy Wasp libs twice, because server needs them in .wasp/build/libs
-# and SDK needs them in .wasp/out/libs becuase the SDK needs to live in the
-# out directory to be accessible to the client code: https://github.com/wasp-lang/wasp/issues/1769
-COPY libs .wasp/build/libs
 COPY libs .wasp/out/libs
 # Install npm packages, resulting in node_modules/.
 RUN npm install && cd .wasp/out/server && npm install

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "676e1ca39b46ceeb296a989dd721ad1d7123483d8be5633f5d34ecf9aa3c0a7e"
+        "ff8141dd75c0841e5eeffa9f2ebe8b247da05da8b6f4ba417e6433d617190361"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/Dockerfile
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/Dockerfile
@@ -35,10 +35,6 @@ COPY package-lock.json .
 COPY tsconfig*.json .
 COPY server .wasp/out/server
 COPY sdk .wasp/out/sdk
-# We copy Wasp libs twice, because server needs them in .wasp/build/libs
-# and SDK needs them in .wasp/out/libs becuase the SDK needs to live in the
-# out directory to be accessible to the client code: https://github.com/wasp-lang/wasp/issues/1769
-COPY libs .wasp/build/libs
 COPY libs .wasp/out/libs
 # Install npm packages, resulting in node_modules/.
 RUN npm install && cd .wasp/out/server && npm install

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "79a40c490e5592b9bbc5a2e91b748ad3d8c7481ad39aef43cf12b2f1c450e6cf"
+        "6e694e2399b3ae10649312530dfdfd57b7bc9e40591da89f58543be1b613fb2a"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/Dockerfile
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/Dockerfile
@@ -35,10 +35,6 @@ COPY package-lock.json .
 COPY tsconfig*.json .
 COPY server .wasp/out/server
 COPY sdk .wasp/out/sdk
-# We copy Wasp libs twice, because server needs them in .wasp/build/libs
-# and SDK needs them in .wasp/out/libs becuase the SDK needs to live in the
-# out directory to be accessible to the client code: https://github.com/wasp-lang/wasp/issues/1769
-COPY libs .wasp/build/libs
 COPY libs .wasp/out/libs
 # Install npm packages, resulting in node_modules/.
 RUN npm install && cd .wasp/out/server && npm install

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "79a40c490e5592b9bbc5a2e91b748ad3d8c7481ad39aef43cf12b2f1c450e6cf"
+        "6e694e2399b3ae10649312530dfdfd57b7bc9e40591da89f58543be1b613fb2a"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/Dockerfile
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/Dockerfile
@@ -35,10 +35,6 @@ COPY package-lock.json .
 COPY tsconfig*.json .
 COPY server .wasp/out/server
 COPY sdk .wasp/out/sdk
-# We copy Wasp libs twice, because server needs them in .wasp/build/libs
-# and SDK needs them in .wasp/out/libs becuase the SDK needs to live in the
-# out directory to be accessible to the client code: https://github.com/wasp-lang/wasp/issues/1769
-COPY libs .wasp/build/libs
 COPY libs .wasp/out/libs
 # Install npm packages, resulting in node_modules/.
 RUN npm install && cd .wasp/out/server && npm install

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -11,7 +11,7 @@
             "file",
             "Dockerfile"
         ],
-        "ab81cd2bb236ac6f214bb8ecf617de9dcc6f2cbd68d4cc5ed641f42a18bb8ece"
+        "cc2d4052df4876668c7e37527c7566d5454bb88c361b7fc5e99f7853ca234552"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/Dockerfile
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/Dockerfile
@@ -35,10 +35,6 @@ COPY package-lock.json .
 COPY tsconfig*.json .
 COPY server .wasp/out/server
 COPY sdk .wasp/out/sdk
-# We copy Wasp libs twice, because server needs them in .wasp/build/libs
-# and SDK needs them in .wasp/out/libs becuase the SDK needs to live in the
-# out directory to be accessible to the client code: https://github.com/wasp-lang/wasp/issues/1769
-COPY libs .wasp/build/libs
 COPY libs .wasp/out/libs
 # Install npm packages, resulting in node_modules/.
 RUN npm install && cd .wasp/out/server && npm install


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Left over from a bad merge, my bad! Since we removed the `.wasp/build` dir, we no longer need to copy the libs twice.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
