### PR TITLE
Fix e2e snapshot tests parallelization interruptions

### DIFF
--- a/waspc/e2e-tests/SnapshotTest.hs
+++ b/waspc/e2e-tests/SnapshotTest.hs
@@ -33,7 +33,7 @@ import System.Directory (doesFileExist)
 import System.Directory.Recursive (getDirFiltered)
 import System.Exit (ExitCode (..))
 import System.FilePath (equalFilePath, isExtensionOf, makeRelative, takeFileName)
-import System.Process (CreateProcess (..), createProcess, interruptProcessGroupOf, shell, waitForProcess)
+import System.Process (CreateProcess (..), callCommand, createProcess, interruptProcessGroupOf, shell, waitForProcess)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden (goldenVsFileDiff)
 
@@ -97,10 +97,10 @@ createSnapshotTestTree snapshotTestData =
 -- 2. Ensuring the current and golden snapshot directories exist.
 setupSnapshotTestEnvironment :: Path' Abs (Dir SnapshotDir) -> Path' Abs (Dir SnapshotDir) -> IO ()
 setupSnapshotTestEnvironment currentSnapshotDir goldenSnapshotDir = do
-  callCommandInProcessGroup $ "rm -rf " ++ SP.fromAbsDir currentSnapshotDir
+  callCommand $ "rm -rf " ++ SP.fromAbsDir currentSnapshotDir
 
-  callCommandInProcessGroup $ "mkdir " ++ SP.fromAbsDir currentSnapshotDir
-  callCommandInProcessGroup $ "mkdir -p " ++ SP.fromAbsDir goldenSnapshotDir
+  callCommand $ "mkdir " ++ SP.fromAbsDir currentSnapshotDir
+  callCommand $ "mkdir -p " ++ SP.fromAbsDir goldenSnapshotDir
 
 executeSnapshotTestCommand :: SnapshotTest -> Path' Abs (Dir SnapshotDir) -> IO ()
 executeSnapshotTestCommand snapshotTest snapshotDir = do


### PR DESCRIPTION
## Problem

Currently, when a snapshot test process errors and exists early, that error propagates and also interrupts the main process (`cabal test e2e-tests`), but other snapshot test shell command processes continue working orphapned.

<img width="817" height="723" alt="image" src="https://github.com/user-attachments/assets/5bb8778e-5450-4553-9064-ef66491202ad" />
<img width="726" height="517" alt="image" src="https://github.com/user-attachments/assets/6c9032f1-eef5-464b-8749-36dce3bc4fd2" />

So the workflow is:

In the failing test:
1. wasp fails → shell exits → `callCommand` throws exception (it internally checks exit code)
2. Exception propagates up to `mapConcurrently`

In sibling tests:
1. `mapConcurrently` throws `AsyncCancelled` to them
2. `callCommand` is blocked in `waitForProcess` internally
3. `waitForProcess` is interrupted by `AsyncCancelled`
4. No cleanup
5. `AsyncCancelled` propagates, threads die
6. Shell + wasp processes are still running (nobody sent them a signal)

Then:
1. `mapConcurrently` propagates the original exception from the failing test
2. It reaches `main`
3. Haskell process exits
4. Shell + wasp processes are now orphans (re-parented to PID 1)
5. They keep running and writing to the terminal

## Solution

So what we want to do is for all processes started by a snapshot test process to die together with it.

My solution is snapshot test process run the commands as separate process groups, that cleanup on interruptions:
```hs
-- | Interruptible version of callCommand that terminates the entire process tree on async exception.
-- Uses process groups so that when a thread is cancelled (e.g., when another concurrent test fails),
-- all child processes are also terminated rather than continuing to run.
callCommandInProcessGroup :: String -> IO ()
callCommandInProcessGroup cmd =
  bracket
    (createProcess (shell cmd) {create_group = True})
    (\(_, _, _, ph) -> interruptProcessGroupOf ph)
    ( \(_, _, _, ph) -> do
        exitCode <- waitForProcess ph
        case exitCode of
          ExitSuccess -> return ()
          ExitFailure code -> fail $ "Command failed with exit code " ++ show code ++ ": " ++ cmd
    )
```


So the workflow is:

In the failing test:
1. wasp fails → shell exits → `waitForProcess` returns `ExitFailure`
2. We throw via `fail` - "Command failed..."
3. `bracket` cleanup runs (but process already exited, so it's a no-op)
4. Exception propagates up to `mapConcurrently`

In sibling tests:
1. `mapConcurrently` throws `AsyncCancelled` to them
2. `waitForProcess` is interrupted
3. `bracket` cleanup runs → `interruptProcessGroupOf` kills the running processes
4. `bracket` re-throws `AsyncCancelled`
5. Threads die

Then:
1. `mapConcurrently` propagates the original exception from the failing test
2. It reaches `main`
3. Haskell process exits

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
