### PR TITLE
Upgrade axios version floor to ^1.7.9 (#2935)

### DIFF
--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -9,7 +9,7 @@
     "@vitest/ui": "^4.0.16",
     "@wasp.sh/lib-auth": "file:../../libs/auth/wasp.sh-lib-auth-0.21.2.tgz",
     "arctic": "^1.2.1",
-    "axios": "^1.4.0",
+    "axios": "^1.7.9",
     "dotenv": "^16.6.1",
     "dotenv-expand": "^12.0.3",
     "express": "~5.1.0",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -6,7 +6,7 @@
     "@testing-library/react": "^16.3.1",
     "@vitest/ui": "^4.0.16",
     "@wasp.sh/lib-auth": "file:../../libs/auth/wasp.sh-lib-auth-0.21.2.tgz",
-    "axios": "^1.4.0",
+    "axios": "^1.7.9",
     "dotenv": "^16.6.1",
     "dotenv-expand": "^12.0.3",
     "express": "~5.1.0",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -6,7 +6,7 @@
     "@testing-library/react": "^16.3.1",
     "@vitest/ui": "^4.0.16",
     "@wasp.sh/lib-auth": "file:../../libs/auth/wasp.sh-lib-auth-0.21.2.tgz",
-    "axios": "^1.4.0",
+    "axios": "^1.7.9",
     "dotenv": "^16.6.1",
     "dotenv-expand": "^12.0.3",
     "express": "~5.1.0",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -6,7 +6,7 @@
     "@testing-library/react": "^16.3.1",
     "@vitest/ui": "^4.0.16",
     "@wasp.sh/lib-auth": "file:../../libs/auth/wasp.sh-lib-auth-0.21.2.tgz",
-    "axios": "^1.4.0",
+    "axios": "^1.7.9",
     "dotenv": "^16.6.1",
     "dotenv-expand": "^12.0.3",
     "express": "~5.1.0",

--- a/waspc/src/Wasp/Generator/DepVersions.hs
+++ b/waspc/src/Wasp/Generator/DepVersions.hs
@@ -63,7 +63,7 @@ expressTypesVersion :: SV.ComparatorSet
 expressTypesVersion = SV.backwardsCompatibleWith $ SV.Version 5 0 0
 
 axiosVersion :: SV.ComparatorSet
-axiosVersion = SV.backwardsCompatibleWith $ SV.Version 1 4 0
+axiosVersion = SV.backwardsCompatibleWith $ SV.Version 1 7 9
 
 viteVersion :: SV.ComparatorSet
 viteVersion = SV.backwardsCompatibleWith $ SV.Version 7 0 6


### PR DESCRIPTION
## Summary

Bumps the minimum axios version floor from `^1.4.0` to `^1.7.9`.

Closes #2935

## Motivation

- Addresses GHSA-wf5p-g6vw-rhxx (SSRF vulnerability fixed in axios 1.7.4)
- The `^1.4.0` floor allowed installing versions with known security issues

## Changes

- **`waspc/src/Wasp/Generator/DepVersions.hs`**: `SV.Version 1 4 0` → `SV.Version 1 7 9`
- **4 e2e golden snapshots**: Updated `"axios": "^1.4.0"` → `"axios": "^1.7.9"`

No template/API changes needed — axios API is stable across 1.x.

## Note

There's discussion in #2935 about potentially migrating from axios to `fetch` or a fetch-based library (also related: #3288 re: streaming support). This PR is a conservative version bump that fixes the security issue. A full axios→fetch migration would be a separate, larger effort.