### PR TITLE
Add missing wasp() plugin to Tailwind migration example

### DIFF
--- a/web/docs/migration-guides/migrate-from-0-20-to-0-21.md
+++ b/web/docs/migration-guides/migrate-from-0-20-to-0-21.md
@@ -309,12 +309,14 @@ Wasp no longer manages Tailwind CSS internally, so there are a few changes regar
 1. Add the `@tailwindcss/vite` plugin to your `vite.config.{js,ts}` file.
 
     ```ts title="vite.config.ts"
+    import { wasp } from 'wasp/client/vite';
     // highlight-next-line
     import tailwindcss from '@tailwindcss/vite';
     import { defineConfig } from 'vite';
 
     export default defineConfig({
       plugins: [
+        wasp(),
         // highlight-next-line
         tailwindcss(),
       ],

--- a/web/versioned_docs/version-0.21/migration-guides/migrate-from-0-20-to-0-21.md
+++ b/web/versioned_docs/version-0.21/migration-guides/migrate-from-0-20-to-0-21.md
@@ -309,12 +309,14 @@ Wasp no longer manages Tailwind CSS internally, so there are a few changes regar
 1. Add the `@tailwindcss/vite` plugin to your `vite.config.{js,ts}` file.
 
     ```ts title="vite.config.ts"
+    import { wasp } from 'wasp/client/vite';
     // highlight-next-line
     import tailwindcss from '@tailwindcss/vite';
     import { defineConfig } from 'vite';
 
     export default defineConfig({
       plugins: [
+        wasp(),
         // highlight-next-line
         tailwindcss(),
       ],


### PR DESCRIPTION
## Description

The vite.config.ts example in the 'Option B: Upgrade to Tailwind CSS v4' section of the migration guide was missing the required `wasp()` plugin import and call. This fix ensures the example is complete and matches the correct configuration shown in the Tailwind CSS guide.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.