### PR TITLE
Fix crossposting canonical URL for non-blog sections

### DIFF
--- a/web/.claude/skills/crossposting/scripts/convert-mdx.ts
+++ b/web/.claude/skills/crossposting/scripts/convert-mdx.ts
@@ -176,7 +176,9 @@ function buildCanonicalUrl(filePath: string): string {
     throw new Error(`Unexpected filename format: ${filename}`);
   }
   const [, year, month, day, slug] = match;
-  return `${WASP_BASE_URL}/blog/${year}/${month}/${day}/${slug}`;
+  // Detect section from parent directory (e.g. "blog", "resources")
+  const section = basename(dirname(resolve(filePath)));
+  return `${WASP_BASE_URL}/${section}/${year}/${month}/${day}/${slug}`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes `buildCanonicalUrl` in the crossposting script to derive the URL section (`blog`, `resources`, etc.) from the file's parent directory instead of hardcoding `/blog/`
- Articles in `resources/` now correctly get `wasp.sh/resources/...` canonical URLs

## Test plan
- [x] Dry run on `resources/2026-02-24-best-frameworks-web-dev-2026.mdx` produces `https://wasp.sh/resources/2026/02/24/best-frameworks-web-dev-2026`