### PR TITLE
Refactor network HTTP logic into a module

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Archive.hs
+++ b/waspc/cli/src/Wasp/Cli/Archive.hs
@@ -6,13 +6,13 @@ import Control.Exception (SomeException, try)
 import qualified Data.ByteString.Lazy as BL
 import Data.Functor ((<&>))
 import Data.Maybe (fromJust)
-import Network.HTTP.Conduit (simpleHttp)
 import Path.IO (copyDirRecur)
 import StrongPath (Abs, Dir, File, Path', Rel, reldir, (</>))
 import qualified StrongPath as SP
 import StrongPath.Path (toPathAbsDir)
 import System.FilePath (takeFileName)
 import Wasp.Cli.FileSystem (withTempDir)
+import qualified Wasp.Util.Network.HTTP as HTTP
 
 fetchArchiveAndCopySubdirToDisk ::
   String ->
@@ -38,7 +38,7 @@ fetchArchiveAndCopySubdirToDisk archiveDownloadUrl targetFolder destinationOnDis
 
     downloadFile :: String -> Path' Abs (File f) -> IO ()
     downloadFile downloadUrl destinationPath =
-      simpleHttp downloadUrl >>= BL.writeFile (SP.fromAbsFile destinationPath)
+      HTTP.httpLBS downloadUrl >>= BL.writeFile (SP.fromAbsFile destinationPath)
 
     unpackArchive :: Path' Abs (File f) -> Path' Abs (Dir d) -> IO ()
     unpackArchive sourceFile destinationDir =

--- a/waspc/cli/src/Wasp/Cli/Command/News/Fetching.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/News/Fetching.hs
@@ -5,19 +5,15 @@ module Wasp.Cli.Command.News.Fetching
 where
 
 import Control.Exception (try)
-import Data.Functor ((<&>))
 import Data.Maybe (fromMaybe)
 import Network.HTTP.Simple (HttpException, parseRequest)
 import System.Environment (lookupEnv)
-import System.Timeout (timeout)
 import Wasp.Cli.Command.News.Core (NewsEntry)
-import Wasp.Util.Network.HTTP (httpJSONThatThrowsIfNot2xx)
+import Wasp.Util.Network.HTTP (httpJSONThatThrowsIfNot2xx, withTimeout)
 
 fetchNewsWithTimeout :: Int -> IO (Either String [NewsEntry])
 fetchNewsWithTimeout timeoutSeconds =
-  timeout timeoutMicroseconds fetchNews <&> fromMaybe (Left "News fetching timed out")
-  where
-    timeoutMicroseconds = timeoutSeconds * 1000000
+  withTimeout timeoutSeconds "News fetching timed out" fetchNews
 
 fetchNews :: IO (Either String [NewsEntry])
 fetchNews = do

--- a/waspc/src/Wasp/AI/OpenAI/ChatGPT.hs
+++ b/waspc/src/Wasp/AI/OpenAI/ChatGPT.hs
@@ -24,10 +24,8 @@ import Data.List (find)
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics (Generic)
-import qualified Network.HTTP.Conduit as HTTP.C
 import qualified Network.HTTP.Simple as HTTP
 import Wasp.AI.OpenAI (OpenAIApiKey)
-import qualified Wasp.Util as Util
 import Wasp.Util.Debug (debugTrace)
 import qualified Wasp.Util.Network.HTTP as Utils.HTTP
 
@@ -43,7 +41,7 @@ queryChatGPT apiKey params requestMessages = do
       request =
         -- 90 seconds should be more than enough for ChatGPT to generate an answer, or reach its own timeout.
         -- If it proves in the future that it might need more time, we can increase this number.
-        HTTP.setRequestResponseTimeout (HTTP.C.responseTimeoutMicro $ Util.secondsToMicroSeconds 300) $
+        Utils.HTTP.setRequestTimeout 300 $
           HTTP.setRequestHeader "Authorization" [BSU.fromString $ "Bearer " <> apiKey] $
             HTTP.setRequestBodyJSON reqBodyJson $
               HTTP.parseRequest_ "POST https://api.openai.com/v1/chat/completions"

--- a/waspc/src/Wasp/Util/Network/HTTP.hs
+++ b/waspc/src/Wasp/Util/Network/HTTP.hs
@@ -3,17 +3,24 @@ module Wasp.Util.Network.HTTP
     getHttpExceptionStatusCode,
     httpJSONThatThrowsIfNot2xx,
     checkUrlExists,
+    withTimeout,
+    setRequestTimeout,
+    httpLBS,
   )
 where
 
 import Control.Arrow ()
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.ByteString.Lazy (ByteString)
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
+import Data.Functor ((<&>))
+import Data.Maybe (fromMaybe)
 import qualified Network.HTTP.Conduit as HTTP.C
 import qualified Network.HTTP.Simple as HTTP
 import Network.HTTP.Types.Status (statusIsSuccessful)
+import qualified System.Timeout as Timeout
 import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception (catch, throwIO)
 
@@ -65,3 +72,28 @@ httpHeadRequest url = do
       <$> HTTP.parseRequest url
 
   HTTP.httpNoBody req
+
+-- | Execute an IO action with a timeout in seconds.
+-- Returns 'Left' with the timeout message if the action times out,
+-- otherwise returns 'Right' with the result.
+withTimeout :: Int -> String -> IO a -> IO (Either String a)
+withTimeout timeoutSeconds timeoutMsg action =
+  Timeout.timeout timeoutMicroseconds action
+    <&> fromMaybe (Left timeoutMsg) . fmap Right
+  where
+    timeoutMicroseconds = timeoutSeconds * 1000000
+
+-- | Set request timeout in seconds for an HTTP request.
+setRequestTimeout :: Int -> HTTP.Request -> HTTP.Request
+setRequestTimeout timeoutSeconds =
+  HTTP.setRequestResponseTimeout (HTTP.C.responseTimeoutMicro timeoutMicroseconds)
+  where
+    timeoutMicroseconds = timeoutSeconds * 1000000
+
+-- | A simpler wrapper around HTTP.httpLBS for making basic HTTP requests.
+-- Fetches the content from a URL and returns it as a lazy ByteString.
+httpLBS :: (MonadIO m) => String -> m ByteString
+httpLBS url = liftIO $ do
+  request <- HTTP.parseRequest url
+  response <- HTTP.httpLBS request
+  return $ HTTP.getResponseBody response


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

This PR refactors network HTTP logic into a centralized `Wasp.Util.Network.HTTP` module as requested in issue #3661. Previously, timeout and HTTP request logic was duplicated across multiple files. This change extracts common patterns into reusable utilities to establish a single source of truth for network operations.

**Key changes:**

- Extended `Wasp.Util.Network.HTTP` module with three new utility functions:

  - `withTimeout` - Generic timeout wrapper that converts IO actions with timeouts to Either results
  - `setRequestTimeout` - Standardized HTTP request timeout setter (takes seconds, handles microseconds internally)
  - `httpLBS` - Simplified wrapper for basic HTTP requests returning lazy ByteString

- Refactored files to use the centralized utilities:
  - `Wasp.Cli.Command.News.Fetching` - Now uses `withTimeout` instead of manual timeout logic
  - `Wasp.Cli.Archive` - Now uses `httpLBS` instead of `Network.HTTP.Conduit.simpleHttp`
  - `Wasp.AI.OpenAI.ChatGPT` - Now uses `setRequestTimeout` instead of manual timeout configuration

**Benefits:**

- Eliminates code duplication
- Provides consistent timeout handling across the codebase
- Makes future network-related changes easier to maintain
- Improves code readability by abstracting low-level details

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- No new tests needed - refactoring only -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- N/A -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- N/A - internal refactoring -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- N/A -->
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- N/A -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa). <!-- N/A -->

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- N/A - internal implementation detail -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- N/A - no user-facing changes -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`. <!-- N/A -->
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- N/A - no user-facing changes -->

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**