### PR TITLE
Add CLAUDE.md for Wasp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,14 @@ Wasp is a full-stack web framework that compiles `.wasp` configuration files int
   - `src/` — Main compiler library (Analyzer, Generator, AppSpec, Psl)
   - `cli/src/` — CLI commands (start, build, new, deploy, etc.)
   - `waspls/` — Language Server Protocol implementation
-  - `data/packages/` — TypeScript packages embedded in the compiler
+  - `data/packages/` — TypeScript packages called by the CLI when compiling projects as FFI
+  - `data/Generator/libs/` — TypeScript libraries embedded into generated project code
   - `data/Generator/templates/` — Mustache templates for code generation
   - `e2e-tests/` — Golden file snapshot tests
   - `run` — **Main development script** (run `./run` with no args to see all commands)
 - `wasp-app-runner/` — Node.js CLI for running Wasp apps in e2e tests
 - `web/` — Documentation website (Docusaurus), deployed to wasp.sh
-- `mage/` — Example Wasp showcase app (Vite + React)
+- `mage/` — Web frontend for `wasp new:ai`, which generates Wasp apps from a description
 - `examples/` — Tutorial and example apps (kitchen-sink, waspello, etc.)
 - `scripts/` — Monorepo-level build/packaging scripts
 
@@ -24,7 +25,7 @@ All waspc development commands run from the `waspc/` directory via the `./run` s
 
 Key things to know:
 
-- Two-phase build: TS packages in `data/packages/` compile first, then Haskell (which embeds them). Use `./run build` for the full build.
+- Two-phase build: TS packages in `data/packages/` and libs in `data/Generator/libs/` compile first, then Haskell (which embeds them). Use `./run build` for the full build.
 - Run the dev CLI with `./run wasp-cli <args>`.
 - Toolchain versions (GHC, HLS) are specified in `waspc/cabal.project` and `waspc/dev-tool.project`. Use `./run ghcup-set` to set the correct versions.
 - Node.js minimum version is in `.nvmrc`.
@@ -47,7 +48,7 @@ Key things to know:
 
 ### Architecture
 
-- **Analyzer** parses `.wasp` files → **AppSpec** (AST) → **Generator** produces React/Node.js code.
+- **Analyzer** parses `.wasp` files → **AppSpec** (IR) → **Generator** produces React/Node.js code.
 - Code generation uses a file draft system and Mustache templates in `data/Generator/templates/`.
 
 ## Important Rules


### PR DESCRIPTION
## Description

Added a comprehensive `CLAUDE.md` file to document the Wasp monorepo structure, development workflow, and collaboration guidelines. This serves as a reference for AI agents and developers working on the project.

Covers:
- Repository structure (waspc compiler, examples, docs, etc.)
- Build & development commands via `./run` script
- Toolchain versions (GHC 9.6.7, Node v22.12.0, Prettier, Ormolu, etc.)
- Code conventions for Haskell and TypeScript
- CI pipeline overview
- Critical notes about E2E snapshots, documentation versioning, and PR templates

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in \`examples/kitchen-sink/e2e-tests\`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in \`waspc/data/Cli/templates\`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in \`examples/\`, as needed.
    - [ ] _(if you updated \`examples/tutorials\`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in \`web/docs/\`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated \`waspc/ChangeLog.md\` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in \`web/docs/migration-guides/\`.
  - [ ] I **bumped the \`version\`** in \`waspc/waspc.cabal\` to reflect the changes I introduced.