### PR TITLE
Remove redundant imports

### DIFF
--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/OperationsGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/OperationsGenerator.hs
@@ -17,7 +17,6 @@ import Wasp.Generator.SdkGenerator.Common
     clientTemplatesDirInSdkTemplatesDir,
     genFileCopy,
     getOperationTypeName,
-    makeSdkImportPath,
     mkTmplFdWithData,
   )
 import Wasp.Generator.SdkGenerator.Server.OperationsGenerator (getServerOperationsImportPath)

--- a/waspc/src/Wasp/Project/ExternalConfig/ViteConfig.hs
+++ b/waspc/src/Wasp/Project/ExternalConfig/ViteConfig.hs
@@ -5,7 +5,6 @@ module Wasp.Project.ExternalConfig.ViteConfig
   )
 where
 
-import Data.List (isInfixOf)
 import qualified Data.Text as T
 import NeatInterpolation (trimming)
 import StrongPath (Abs, Dir, File', Path', relfile, toFilePath, (</>))


### PR DESCRIPTION
## Description

Fixes redundant import warnings from the build:
- Removed unused `Data.List.isInfixOf` from ViteConfig.hs
- Removed unused `makeSdkImportPath` from OperationsGenerator.hs

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.