### PR TITLE
Upgrade ormolu from 0.7.2.0 to 0.8.0.2

### DIFF
--- a/.github/workflows/ci-formatting.yaml
+++ b/.github/workflows/ci-formatting.yaml
@@ -48,8 +48,7 @@ jobs:
         id: get-ormolu-version
         run: echo "ORMOLU_VERSION=$(mise tool ormolu --requested)" >> $GITHUB_OUTPUT
 
-      # `run-ormolu` versions > 15 require ormolu version >= 0.7.5.0
-      - uses: haskell-actions/run-ormolu@v15
+      - uses: haskell-actions/run-ormolu@v17
         with:
           version: ${{ steps.get-ormolu-version.outputs.ORMOLU_VERSION }}
 

--- a/mise.lock
+++ b/mise.lock
@@ -33,33 +33,30 @@ url = "https://github.com/tfausak/cabal-gild/releases/download/1.5.0.1/cabal-gil
 url_api = "https://api.github.com/repos/tfausak/cabal-gild/releases/assets/177007971"
 
 [[tools.ormolu]]
-version = "0.7.2.0"
+version = "0.8.0.2"
 backend = "github:tweag/ormolu"
 
-[tools.ormolu."platforms.linux-arm64"]
-url = "https://github.com/tweag/ormolu/releases/download/0.7.2.0/ormolu-Linux.zip"
-url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/124848989"
-
-[tools.ormolu."platforms.linux-arm64-musl"]
-url = "https://github.com/tweag/ormolu/releases/download/0.7.2.0/ormolu-Linux.zip"
-url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/124848989"
-
 [tools.ormolu."platforms.linux-x64"]
-url = "https://github.com/tweag/ormolu/releases/download/0.7.2.0/ormolu-Linux.zip"
-url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/124848989"
+checksum = "sha256:f737b11835537d020d83a497903a392f19d4943aea03b75f76f1c5719d70f9f8"
+url = "https://github.com/tweag/ormolu/releases/download/0.8.0.2/ormolu-x86_64-linux.zip"
+url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/296728814"
 
 [tools.ormolu."platforms.linux-x64-musl"]
-url = "https://github.com/tweag/ormolu/releases/download/0.7.2.0/ormolu-Linux.zip"
-url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/124848989"
+checksum = "sha256:f737b11835537d020d83a497903a392f19d4943aea03b75f76f1c5719d70f9f8"
+url = "https://github.com/tweag/ormolu/releases/download/0.8.0.2/ormolu-x86_64-linux.zip"
+url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/296728814"
 
 [tools.ormolu."platforms.macos-arm64"]
-url = "https://github.com/tweag/ormolu/releases/download/0.7.2.0/ormolu-macOS.zip"
-url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/124848990"
+checksum = "sha256:942bc1cf11a0589f262a3306062f4eee59b7bcccacb5ade3851bfc3c448115a0"
+url = "https://github.com/tweag/ormolu/releases/download/0.8.0.2/ormolu-aarch64-darwin.zip"
+url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/296731103"
 
 [tools.ormolu."platforms.macos-x64"]
-url = "https://github.com/tweag/ormolu/releases/download/0.7.2.0/ormolu-macOS.zip"
-url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/124848990"
+checksum = "sha256:e94fa4253dcb9b58075c7550f6f43e908a0761b3df6bde7513222705f0c63167"
+url = "https://github.com/tweag/ormolu/releases/download/0.8.0.2/ormolu-x86_64-darwin.zip"
+url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/296735879"
 
 [tools.ormolu."platforms.windows-x64"]
-url = "https://github.com/tweag/ormolu/releases/download/0.7.2.0/ormolu-Windows.zip"
-url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/124853921"
+checksum = "sha256:3e484422d68260083fcb7841433a9fa172ff01131f8610d750c1902fba4f2b7e"
+url = "https://github.com/tweag/ormolu/releases/download/0.8.0.2/ormolu-x86_64-windows.zip"
+url_api = "https://api.github.com/repos/tweag/ormolu/releases/assets/296728843"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 cabal-gild = "1.5.0.1"
-ormolu = "0.7.2.0"
+ormolu = "latest"
 
 [tool_alias]
 cabal-gild = "github:tfausak/cabal-gild"

--- a/waspc/cli/src/Wasp/Cli/Command/Deps.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Deps.hs
@@ -38,13 +38,11 @@ depsMessage appSpec =
     ]
       ++ printDeps
         "Server dependencies:"
-        ( N.dependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
-        )
+        (N.dependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec)
       ++ [""]
       ++ printDeps
         "Server devDependencies:"
-        ( N.devDependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
-        )
+        (N.devDependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec)
 
 printDeps :: String -> [Npm.Dependency.Dependency] -> [String]
 printDeps dependenciesTitle dependencies =

--- a/waspc/cli/src/Wasp/Cli/Command/Studio.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Studio.hs
@@ -175,25 +175,25 @@ studio = do
                      --   Best to use TH here to generate this object from AuthMethods?
                      concat
                        [ [ "usernameAndPassword"
-                           | isJust $ AS.App.Auth.usernameAndPassword methods
+                         | isJust $ AS.App.Auth.usernameAndPassword methods
                          ],
                          [ "slack"
-                           | isJust $ AS.App.Auth.slack methods
+                         | isJust $ AS.App.Auth.slack methods
                          ],
                          [ "discord"
-                           | isJust $ AS.App.Auth.discord methods
+                         | isJust $ AS.App.Auth.discord methods
                          ],
                          [ "google"
-                           | isJust $ AS.App.Auth.google methods
+                         | isJust $ AS.App.Auth.google methods
                          ],
                          [ "keycloak"
-                           | isJust $ AS.App.Auth.keycloak methods
+                         | isJust $ AS.App.Auth.keycloak methods
                          ],
                          [ "gitHub"
-                           | isJust $ AS.App.Auth.gitHub methods
+                         | isJust $ AS.App.Auth.gitHub methods
                          ],
                          [ "email"
-                           | isJust $ AS.App.Auth.email methods
+                         | isJust $ AS.App.Auth.email methods
                          ]
                        ] ::
                        [String]

--- a/waspc/e2e-tests/Tests/ViteBuildTest.hs
+++ b/waspc/e2e-tests/Tests/ViteBuildTest.hs
@@ -29,12 +29,10 @@ viteBuildTest =
     "vite-build-env-vars"
     [ TestCase
         "fail-on-missing-required-env-vars"
-        ( createViteBuildTestCase [expectCommandFailure <$> viteBuild]
-        ),
+        (createViteBuildTestCase [expectCommandFailure <$> viteBuild]),
       TestCase
         "success-with-required-env-vars"
-        ( createViteBuildTestCase [appendInlineEnvVars [apiUrlEnvVar] <$> viteBuild]
-        ),
+        (createViteBuildTestCase [appendInlineEnvVars [apiUrlEnvVar] <$> viteBuild]),
       TestCase
         "fail-missing-inline-env-var"
         ( createViteBuildTestCase

--- a/waspc/src/Wasp/AI/GenerateNewProject/Plan.hs
+++ b/waspc/src/Wasp/AI/GenerateNewProject/Plan.hs
@@ -301,7 +301,7 @@ checkPlanForLogoutAndLoginActions plan = checkForAction "login" ++ checkForActio
   where
     checkForAction name =
       [ "You included the '" <> name <> "' action in the plan, but it's already included in Wasp. Remove it."
-        | name `elem` actionNames
+      | name `elem` actionNames
       ]
     actionNames = map (map toLower . opName) $ actions plan
 

--- a/waspc/src/Wasp/Analyzer/Parser/Valid.hs
+++ b/waspc/src/Wasp/Analyzer/Parser/Valid.hs
@@ -18,8 +18,7 @@ validateNoEntityDeclInWaspFile ast@(P.AST stmts) = case findEntityStmt stmts of
     findEntityStmt :: [P.WithCtx P.Stmt] -> Maybe (P.WithCtx P.Stmt)
     findEntityStmt =
       find
-        ( \(P.WithCtx _ (P.Decl declTypeName _ _)) -> declTypeName == entityDeclTypeName
-        )
+        (\(P.WithCtx _ (P.Decl declTypeName _ _)) -> declTypeName == entityDeclTypeName)
 
     entitiesNoLongerSupportedError :: String
     entitiesNoLongerSupportedError =

--- a/waspc/src/Wasp/Analyzer/Prisma.hs
+++ b/waspc/src/Wasp/Analyzer/Prisma.hs
@@ -38,5 +38,5 @@ makeEntityStmt (name, body) = wrapWithCtx $ Parser.Decl "entity" name $ wrapWith
 generatePrismaModelSources :: Psl.Schema.Schema -> [(ModelName, ModelBody)]
 generatePrismaModelSources schema =
   [ (name, Psl.Model.Generator.generateModelBody body)
-    | (Psl.Model.Model name body) <- Psl.WithCtx.getNode <$> Psl.Schema.getModels schema
+  | (Psl.Model.Model name body) <- Psl.WithCtx.getNode <$> Psl.Schema.getModels schema
   ]

--- a/waspc/src/Wasp/AppSpec/Entity.hs
+++ b/waspc/src/Wasp/AppSpec/Entity.hs
@@ -42,7 +42,7 @@ makeEntity body =
     makeEntityFieldsFromPslBody (Psl.Model.Body pslElements) =
       Field.pslFieldToEntityField
         <$> [ field
-              | (Psl.Model.ElementField field) <- Psl.WithCtx.getNode <$> pslElements
+            | (Psl.Model.ElementField field) <- Psl.WithCtx.getNode <$> pslElements
             ]
 
 getFields :: Entity -> [Field]

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -149,7 +149,7 @@ validateAppAuthIsSetIfAnyPageRequiresAuth :: AppSpec -> [ValidationError]
 validateAppAuthIsSetIfAnyPageRequiresAuth spec =
   [ GenericValidationError
       "Expected app.auth to be defined since there are Pages with authRequired set to true."
-    | anyPageRequiresAuth && not (isAuthEnabled spec)
+  | anyPageRequiresAuth && not (isAuthEnabled spec)
   ]
   where
     anyPageRequiresAuth = any ((== Just True) . Page.authRequired) (snd <$> AS.getPages spec)
@@ -161,7 +161,7 @@ validateOnlyEmailOrUsernameAndPasswordAuthIsUsed spec =
     Just auth ->
       [ GenericValidationError
           "Expected app.auth to use either email or username and password authentication, but not both."
-        | areBothAuthMethodsUsed
+      | areBothAuthMethodsUsed
       ]
       where
         areBothAuthMethodsUsed = Auth.isEmailAuthEnabled auth && Auth.isUsernameAndPasswordAuthEnabled auth
@@ -170,7 +170,7 @@ validateDbIsPostgresIfPgBossUsed :: AppSpec -> [ValidationError]
 validateDbIsPostgresIfPgBossUsed spec =
   [ GenericValidationError
       ("The database provider in the schema.prisma file must be \"" ++ Psl.Db.dbProviderPostgresqlStringLiteral ++ "\" since there are jobs with executor set to PgBoss.")
-    | isPgBossJobExecutorUsed spec && not (isPostgresUsed spec)
+  | isPgBossJobExecutorUsed spec && not (isPostgresUsed spec)
   ]
 
 validateEmailSenderIsDefinedIfEmailAuthIsUsed :: AppSpec -> [ValidationError]

--- a/waspc/src/Wasp/Generator/Valid/PackageJson/Dependencies.hs
+++ b/waspc/src/Wasp/Generator/Valid/PackageJson/Dependencies.hs
@@ -45,10 +45,10 @@ dependenciesValidator spec =
     optionalDepsValidator =
       V.all $
         [ makeOptionalDepValidator depType dep
-          | depType <- [Runtime, Development],
-            -- We check all the Wasp dependencies everywhere in case they are used
-            -- in the user's package.json, to avoid conflicts.
-            dep <- M.toList onlyOptionalWaspDeps
+        | depType <- [Runtime, Development],
+          -- We check all the Wasp dependencies everywhere in case they are used
+          -- in the user's package.json, to avoid conflicts.
+          dep <- M.toList onlyOptionalWaspDeps
         ]
 
     -- We don't check for dependencies as optional that are already going to be
@@ -61,8 +61,8 @@ dependenciesValidator spec =
     forbiddenDepsValidator =
       V.all $
         [ makeForbiddenDepValidator depType pkgName
-          | depType <- [Runtime, Development],
-            pkgName <- forbiddenUserDeps
+        | depType <- [Runtime, Development],
+          pkgName <- forbiddenUserDeps
         ]
 
 -- | Validates that a required dependency is present in the correct dependency

--- a/waspc/tests/Generator/Valid/PackageJsonTest.hs
+++ b/waspc/tests/Generator/Valid/PackageJsonTest.hs
@@ -189,11 +189,11 @@ itEach testName fn =
   sequence_
     [ it (printf "%s (%s dep, %s)" testName (show depType) (pkgJsonName :: String)) $
         fn depType pkgJson
-      | depType <- [Runtime, Development],
-        (pkgJson, pkgJsonName) <-
-          [ (mockPackageJson, "mocked package.json"),
-            (emptyPackageJson, "empty package.json")
-          ]
+    | depType <- [Runtime, Development],
+      (pkgJson, pkgJsonName) <-
+        [ (mockPackageJson, "mocked package.json"),
+          (emptyPackageJson, "empty package.json")
+        ]
     ]
 
 mockPackageJson :: P.PackageJson

--- a/waspc/tests/Psl/Parser/ModelTest.hs
+++ b/waspc/tests/Psl/Parser/ModelTest.hs
@@ -68,11 +68,9 @@ spec_parsePslModel = do
                               ]
                           ),
                         Psl.Model.ElementField
-                          ( Psl.Model.Field "internets" (Psl.Model.UserType "Internet") [Psl.Model.List] []
-                          ),
+                          (Psl.Model.Field "internets" (Psl.Model.UserType "Internet") [Psl.Model.List] []),
                         Psl.Model.ElementField
-                          ( Psl.Model.Field "strings" (Psl.Model.UserType "Strings") [Psl.Model.List] []
-                          )
+                          (Psl.Model.Field "strings" (Psl.Model.UserType "Strings") [Psl.Model.List] [])
                       ]
             )
 

--- a/waspc/tests/Psl/Parser/TypeTest.hs
+++ b/waspc/tests/Psl/Parser/TypeTest.hs
@@ -52,8 +52,7 @@ spec_parsePslType = do
                                 ]
                             ),
                           Psl.Model.ElementField
-                            ( Psl.Model.Field "url" Psl.Model.String [] []
-                            )
+                            (Psl.Model.Field "url" Psl.Model.String [] [])
                         ]
               )
 
@@ -86,8 +85,7 @@ spec_parsePslType = do
                                 ]
                             ),
                           Psl.Model.ElementField
-                            ( Psl.Model.Field "url" Psl.Model.String [] []
-                            )
+                            (Psl.Model.Field "url" Psl.Model.String [] [])
                         ]
               )
 

--- a/waspc/tests/Psl/Parser/ViewTest.hs
+++ b/waspc/tests/Psl/Parser/ViewTest.hs
@@ -32,20 +32,15 @@ spec_parsePslView = do
               ( Psl.Model.Body $
                   Psl.WithCtx.empty
                     <$> [ Psl.Model.ElementField
-                            ( Psl.Model.Field "id" Psl.Model.Int [Psl.Model.Optional] []
-                            ),
+                            (Psl.Model.Field "id" Psl.Model.Int [Psl.Model.Optional] []),
                           Psl.Model.ElementField
-                            ( Psl.Model.Field "email" Psl.Model.String [Psl.Model.Optional] []
-                            ),
+                            (Psl.Model.Field "email" Psl.Model.String [Psl.Model.Optional] []),
                           Psl.Model.ElementField
-                            ( Psl.Model.Field "name" Psl.Model.String [Psl.Model.Optional] []
-                            ),
+                            (Psl.Model.Field "name" Psl.Model.String [Psl.Model.Optional] []),
                           Psl.Model.ElementField
-                            ( Psl.Model.Field "bio" Psl.Model.String [Psl.Model.Optional] []
-                            ),
+                            (Psl.Model.Field "bio" Psl.Model.String [Psl.Model.Optional] []),
                           Psl.Model.ElementBlockAttribute
-                            ( Psl.Attribute.Attribute "ignore" []
-                            )
+                            (Psl.Attribute.Attribute "ignore" [])
                         ]
               )
 
@@ -94,8 +89,7 @@ spec_parsePslView = do
                                 []
                             ),
                           Psl.Model.ElementBlockAttribute
-                            ( Psl.Attribute.Attribute "ignore" []
-                            )
+                            (Psl.Attribute.Attribute "ignore" [])
                         ]
               )
 


### PR DESCRIPTION
## Description

Upgrade ormolu to the latest version (0.8.0.2) via mise. Updates `mise.toml` to track `latest` and regenerates `mise.lock` with the new binary URLs and checksums. Builds on #3930, which introduced mise for tool management.

Then, ran format with the new version.

- Fixes #3926 

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.