### PR TITLE
Auth provider registry + ServerGenerator OAuth migration

### DIFF
--- a/waspc/src/Wasp/Generator/Auth/OAuthGen.hs
+++ b/waspc/src/Wasp/Generator/Auth/OAuthGen.hs
@@ -1,0 +1,29 @@
+module Wasp.Generator.Auth.OAuthGen
+  ( OAuthGenContext (..),
+    genForEachEnabledOAuth,
+  )
+where
+
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import Wasp.Generator.Auth.Provider (OAuthProviderSpec, enabledOAuthProviders)
+import Wasp.Generator.FileDraft (FileDraft)
+import Wasp.Generator.Monad (Generator)
+
+data OAuthGenContext = OAuthGenContext
+  { oAuthSpec :: OAuthProviderSpec,
+    oAuthUserConfig :: AS.Auth.ExternalAuthConfig
+  }
+
+genForEachEnabledOAuth ::
+  AS.Auth.Auth ->
+  (OAuthGenContext -> Generator [FileDraft]) ->
+  Generator [FileDraft]
+genForEachEnabledOAuth auth genProvider =
+  concat <$> mapM genOne (enabledOAuthProviders auth)
+  where
+    genOne (spec, cfg) =
+      genProvider
+        OAuthGenContext
+          { oAuthSpec = spec,
+            oAuthUserConfig = cfg
+          }

--- a/waspc/src/Wasp/Generator/Auth/Provider.hs
+++ b/waspc/src/Wasp/Generator/Auth/Provider.hs
@@ -20,7 +20,6 @@ where
 import Data.Aeson (KeyValue ((.=)), object)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AesonKey
-import Data.Char (toUpper)
 import Data.Maybe (isJust, mapMaybe)
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import Wasp.Generator.Common (makeJsArrayFromHaskellList)
@@ -102,11 +101,7 @@ enabledAuthMethodsJson auth =
   where
     methods = AS.Auth.methods auth
     isProviderEnabled spec = isJust $ extractConfig spec methods
-    providerJsonKey spec = AesonKey.fromString $ "is" ++ capitalize (slug spec) ++ "AuthEnabled"
-
-capitalize :: String -> String
-capitalize [] = []
-capitalize (c : cs) = toUpper c : cs
+    providerJsonKey spec = AesonKey.fromString $ "is" ++ displayName spec ++ "AuthEnabled"
 
 serverOAuthLoginUrl :: OAuthProviderSpec -> String
 serverOAuthLoginUrl spec = "/auth/" ++ slug spec ++ "/login"

--- a/waspc/src/Wasp/Generator/Auth/Provider.hs
+++ b/waspc/src/Wasp/Generator/Auth/Provider.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+
+module Wasp.Generator.Auth.Provider
+  ( OAuthProviderSpec (..),
+    allOAuthProviders,
+    enabledOAuthProviders,
+    enabledAuthMethodsJson,
+    isOAuthEnabled,
+    isEmailEnabled,
+    isUsernameAndPasswordEnabled,
+    serverOAuthLoginUrl,
+    serverOAuthCallbackUrl,
+    clientOAuthCallbackPath,
+    serverExchangeCodeForTokenUrl,
+    oauthProviderScopeStr,
+  )
+where
+
+import Data.Aeson (KeyValue ((.=)), object)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as AesonKey
+import Data.Char (toUpper)
+import Data.Maybe (isJust, mapMaybe)
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import Wasp.Generator.Common (makeJsArrayFromHaskellList)
+
+data OAuthProviderSpec = OAuthProviderSpec
+  { slug :: String,
+    displayName :: String,
+    requiredScopes :: [String],
+    extractConfig :: AS.Auth.AuthMethods -> Maybe AS.Auth.ExternalAuthConfig
+  }
+
+allOAuthProviders :: [OAuthProviderSpec]
+allOAuthProviders =
+  [ OAuthProviderSpec
+      { slug = "google",
+        displayName = "Google",
+        requiredScopes = ["profile"],
+        extractConfig = AS.Auth.google
+      },
+    OAuthProviderSpec
+      { slug = "github",
+        displayName = "GitHub",
+        requiredScopes = [],
+        extractConfig = AS.Auth.gitHub
+      },
+    OAuthProviderSpec
+      { slug = "discord",
+        displayName = "Discord",
+        requiredScopes = ["identify"],
+        extractConfig = AS.Auth.discord
+      },
+    OAuthProviderSpec
+      { slug = "keycloak",
+        displayName = "Keycloak",
+        requiredScopes = ["profile"],
+        extractConfig = AS.Auth.keycloak
+      },
+    OAuthProviderSpec
+      { slug = "slack",
+        displayName = "Slack",
+        requiredScopes = ["openid"],
+        extractConfig = AS.Auth.slack
+      },
+    OAuthProviderSpec
+      { slug = "microsoft",
+        displayName = "Microsoft",
+        requiredScopes = ["openid", "profile", "email"],
+        extractConfig = AS.Auth.microsoft
+      }
+  ]
+
+enabledOAuthProviders :: AS.Auth.Auth -> [(OAuthProviderSpec, AS.Auth.ExternalAuthConfig)]
+enabledOAuthProviders auth =
+  mapMaybe tryEnable allOAuthProviders
+  where
+    methods = AS.Auth.methods auth
+    tryEnable spec = case extractConfig spec methods of
+      Just cfg -> Just (spec, cfg)
+      Nothing -> Nothing
+
+isOAuthEnabled :: AS.Auth.Auth -> Bool
+isOAuthEnabled = not . null . enabledOAuthProviders
+
+isEmailEnabled :: AS.Auth.Auth -> Bool
+isEmailEnabled = isJust . AS.Auth.email . AS.Auth.methods
+
+isUsernameAndPasswordEnabled :: AS.Auth.Auth -> Bool
+isUsernameAndPasswordEnabled = isJust . AS.Auth.usernameAndPassword . AS.Auth.methods
+
+enabledAuthMethodsJson :: AS.Auth.Auth -> Aeson.Value
+enabledAuthMethodsJson auth =
+  object $
+    [ (providerJsonKey spec .= isProviderEnabled spec)
+      | spec <- allOAuthProviders
+    ]
+      ++ [ "isUsernameAndPasswordAuthEnabled" .= isUsernameAndPasswordEnabled auth,
+           "isEmailAuthEnabled" .= isEmailEnabled auth
+         ]
+  where
+    methods = AS.Auth.methods auth
+    isProviderEnabled spec = isJust $ extractConfig spec methods
+    providerJsonKey spec = AesonKey.fromString $ "is" ++ capitalize (slug spec) ++ "AuthEnabled"
+
+capitalize :: String -> String
+capitalize [] = []
+capitalize (c : cs) = toUpper c : cs
+
+serverOAuthLoginUrl :: OAuthProviderSpec -> String
+serverOAuthLoginUrl spec = "/auth/" ++ slug spec ++ "/login"
+
+serverOAuthCallbackUrl :: OAuthProviderSpec -> String
+serverOAuthCallbackUrl spec = "/auth/" ++ slug spec ++ "/callback"
+
+clientOAuthCallbackPath :: String
+clientOAuthCallbackPath = "/oauth/callback"
+
+serverExchangeCodeForTokenUrl :: String
+serverExchangeCodeForTokenUrl = "/auth/exchange-code"
+
+oauthProviderScopeStr :: OAuthProviderSpec -> String
+oauthProviderScopeStr spec = makeJsArrayFromHaskellList (requiredScopes spec)

--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/OAuthAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/OAuthAuthG.hs
@@ -4,7 +4,7 @@ module Wasp.Generator.ServerGenerator.Auth.OAuthAuthG
 where
 
 import Data.Aeson (object, (.=))
-import Data.Maybe (fromJust, isJust)
+import Data.Maybe (fromJust)
 import StrongPath
   ( Dir,
     File',
@@ -20,16 +20,12 @@ import StrongPath
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
-import Wasp.Generator.AuthProviders
-  ( discordAuthProvider,
-    gitHubAuthProvider,
-    googleAuthProvider,
-    keycloakAuthProvider,
-    microsoftAuthProvider,
-    slackAuthProvider,
+import Wasp.Generator.Auth.OAuthGen (OAuthGenContext (..), genForEachEnabledOAuth)
+import Wasp.Generator.Auth.Provider
+  ( OAuthProviderSpec (..),
+    isOAuthEnabled,
+    oauthProviderScopeStr,
   )
-import Wasp.Generator.AuthProviders.OAuth (OAuthAuthProvider)
-import qualified Wasp.Generator.AuthProviders.OAuth as OAuth
 import qualified Wasp.Generator.DbGenerator.Auth as DbAuth
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
@@ -41,15 +37,20 @@ import qualified Wasp.Util as Util
 
 genOAuthAuth :: AS.Auth.Auth -> Generator [FileDraft]
 genOAuthAuth auth
-  | AS.Auth.isExternalAuthEnabled auth =
+  | isOAuthEnabled auth =
       genOAuthHelpers auth
-        <++> genOAuthProvider slackAuthProvider (AS.Auth.slack . AS.Auth.methods $ auth)
-        <++> genOAuthProvider discordAuthProvider (AS.Auth.discord . AS.Auth.methods $ auth)
-        <++> genOAuthProvider googleAuthProvider (AS.Auth.google . AS.Auth.methods $ auth)
-        <++> genOAuthProvider keycloakAuthProvider (AS.Auth.keycloak . AS.Auth.methods $ auth)
-        <++> genOAuthProvider gitHubAuthProvider (AS.Auth.gitHub . AS.Auth.methods $ auth)
-        <++> genOAuthProvider microsoftAuthProvider (AS.Auth.microsoft . AS.Auth.methods $ auth)
+        <++> genForEachEnabledOAuth auth genSingleProvider
   | otherwise = return []
+
+genSingleProvider :: OAuthGenContext -> Generator [FileDraft]
+genSingleProvider ctx =
+  sequence
+    [ genOAuthConfig (oAuthSpec ctx) (oAuthUserConfig ctx) $
+        [reldir|auth/providers/config|] </> providerTsFile
+    ]
+  where
+    providerTsFile :: Path' (Rel ()) File'
+    providerTsFile = fromJust $ SP.parseRelFile $ slug (oAuthSpec ctx) ++ ".ts"
 
 genOAuthHelpers :: AS.Auth.Auth -> Generator [FileDraft]
 genOAuthHelpers auth =
@@ -82,43 +83,22 @@ genTypes auth = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
     tmplData = object ["userEntityName" .= userEntityName]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
 
-genOAuthProvider ::
-  OAuthAuthProvider ->
-  Maybe AS.Auth.ExternalAuthConfig ->
-  Generator [FileDraft]
-genOAuthProvider provider maybeUserConfig
-  | isJust maybeUserConfig =
-      sequence
-        [ genOAuthConfig provider maybeUserConfig $ [reldir|auth/providers/config|] </> providerTsFile
-        ]
-  | otherwise = return []
-  where
-    providerTsFile :: Path' (Rel ()) File'
-    providerTsFile = fromJust $ SP.parseRelFile $ providerId ++ ".ts"
-
-    providerId = OAuth.providerId provider
-
--- Used to generate the specific provider config based on the generic oauth.ts file.
--- The config receives everything: auth info, npm packages, user defined imports and env variables.
--- It's all in one config file.
 genOAuthConfig ::
-  OAuthAuthProvider ->
-  Maybe AS.Auth.ExternalAuthConfig ->
+  OAuthProviderSpec ->
+  AS.Auth.ExternalAuthConfig ->
   Path' (Rel ServerTemplatesSrcDir) File' ->
   Generator FileDraft
-genOAuthConfig provider maybeUserConfig pathToConfigTmpl = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
+genOAuthConfig spec config pathToConfigTmpl = return $ C.mkTmplFdWithData tmplFile (Just tmplData)
   where
     tmplFile = C.srcDirInServerTemplatesDir </> pathToConfigTmpl
     tmplData =
       object
-        [ "providerId" .= OAuth.providerId provider,
-          "displayName" .= OAuth.displayName provider,
-          "requiredScopes" .= OAuth.scopeStr provider,
-          "configFn" .= extImportToImportJson relPathFromAuthConfigToServerSrcDir maybeConfigFn,
-          "userSignupFields" .= extImportToImportJson relPathFromAuthConfigToServerSrcDir maybeUserSignupFields
+        [ "providerId" .= slug spec,
+          "displayName" .= displayName spec,
+          "requiredScopes" .= oauthProviderScopeStr spec,
+          "configFn" .= extImportToImportJson relPathFromAuthConfigToServerSrcDir (AS.Auth.configFn config),
+          "userSignupFields" .= extImportToImportJson relPathFromAuthConfigToServerSrcDir (AS.Auth.userSignupFieldsForExternalAuth config)
         ]
-    maybeConfigFn = AS.Auth.configFn =<< maybeUserConfig
-    maybeUserSignupFields = AS.Auth.userSignupFieldsForExternalAuth =<< maybeUserConfig
 
     relPathFromAuthConfigToServerSrcDir :: Path Posix (Rel importLocation) (Dir C.ServerSrcDir)
     relPathFromAuthConfigToServerSrcDir = [reldirP|../../../|]

--- a/waspc/tests/Generator/Auth/ProviderTest.hs
+++ b/waspc/tests/Generator/Auth/ProviderTest.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Generator.Auth.ProviderTest where
+
+import Data.Aeson (Value (..))
+import qualified Data.Aeson.KeyMap as KM
+import Data.Maybe (isJust)
+import Test.Hspec
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import qualified Wasp.AppSpec.Core.Ref as AS.Core.Ref
+import Wasp.Generator.Auth.Provider
+
+spec_AuthProvider :: Spec
+spec_AuthProvider = do
+  describe "allOAuthProviders" $ do
+    it "covers every ExternalAuthConfig field on AuthMethods" $ do
+      let allFieldsSet =
+            AS.Auth.AuthMethods
+              { AS.Auth.usernameAndPassword = Nothing,
+                AS.Auth.discord = Just dummyExternalConfig,
+                AS.Auth.slack = Just dummyExternalConfig,
+                AS.Auth.google = Just dummyExternalConfig,
+                AS.Auth.gitHub = Just dummyExternalConfig,
+                AS.Auth.keycloak = Just dummyExternalConfig,
+                AS.Auth.microsoft = Just dummyExternalConfig,
+                AS.Auth.email = Nothing
+              }
+      let extractedConfigs = map (\spec -> extractConfig spec allFieldsSet) allOAuthProviders
+      all isJust extractedConfigs `shouldBe` True
+
+    it "contains 6 providers" $ do
+      length allOAuthProviders `shouldBe` 6
+
+    it "has unique slugs" $ do
+      let slugs = map slug allOAuthProviders
+      length slugs `shouldBe` length (unique slugs)
+
+  describe "enabledOAuthProviders" $ do
+    it "returns empty list when no OAuth methods are enabled" $ do
+      let enabled = enabledOAuthProviders (makeAuth emptyMethods)
+      map (slug . fst) enabled `shouldBe` []
+
+    it "returns only enabled providers" $ do
+      let methods =
+            emptyMethods
+              { AS.Auth.google = Just dummyExternalConfig,
+                AS.Auth.slack = Just dummyExternalConfig
+              }
+      let enabled = enabledOAuthProviders (makeAuth methods)
+      length enabled `shouldBe` 2
+      map (slug . fst) enabled `shouldMatchList` ["google", "slack"]
+
+    it "returns all providers when all are enabled" $ do
+      let methods =
+            emptyMethods
+              { AS.Auth.google = Just dummyExternalConfig,
+                AS.Auth.gitHub = Just dummyExternalConfig,
+                AS.Auth.discord = Just dummyExternalConfig,
+                AS.Auth.keycloak = Just dummyExternalConfig,
+                AS.Auth.slack = Just dummyExternalConfig,
+                AS.Auth.microsoft = Just dummyExternalConfig
+              }
+      let enabled = enabledOAuthProviders (makeAuth methods)
+      length enabled `shouldBe` 6
+
+  describe "isOAuthEnabled" $ do
+    it "returns False when no OAuth is enabled" $ do
+      isOAuthEnabled (makeAuth emptyMethods) `shouldBe` False
+
+    it "returns True when any OAuth is enabled" $ do
+      let methods = emptyMethods {AS.Auth.google = Just dummyExternalConfig}
+      isOAuthEnabled (makeAuth methods) `shouldBe` True
+
+  describe "isEmailEnabled" $ do
+    it "returns False when email is not enabled" $ do
+      isEmailEnabled (makeAuth emptyMethods) `shouldBe` False
+
+  describe "isUsernameAndPasswordEnabled" $ do
+    it "returns False when username/password is not enabled" $ do
+      isUsernameAndPasswordEnabled (makeAuth emptyMethods) `shouldBe` False
+
+    it "returns True when username/password is enabled" $ do
+      let methods =
+            emptyMethods
+              { AS.Auth.usernameAndPassword =
+                  Just AS.Auth.UsernameAndPasswordConfig {AS.Auth.userSignupFields = Nothing}
+              }
+      isUsernameAndPasswordEnabled (makeAuth methods) `shouldBe` True
+
+  describe "enabledAuthMethodsJson" $ do
+    it "produces JSON with correct keys for enabled providers" $ do
+      let methods = emptyMethods {AS.Auth.google = Just dummyExternalConfig}
+      let Object jsonObj = enabledAuthMethodsJson (makeAuth methods)
+      KM.lookup "isGoogleAuthEnabled" jsonObj `shouldBe` Just (Bool True)
+      KM.lookup "isSlackAuthEnabled" jsonObj `shouldBe` Just (Bool False)
+      KM.lookup "isUsernameAndPasswordAuthEnabled" jsonObj `shouldBe` Just (Bool False)
+      KM.lookup "isEmailAuthEnabled" jsonObj `shouldBe` Just (Bool False)
+
+  describe "serverOAuthLoginUrl" $ do
+    it "constructs URL from slug" $ do
+      let spec = head allOAuthProviders -- google
+      serverOAuthLoginUrl spec `shouldBe` "/auth/google/login"
+
+-- Helpers
+
+unique :: Eq a => [a] -> [a]
+unique [] = []
+unique (x : xs) = x : unique (filter (/= x) xs)
+
+dummyExternalConfig :: AS.Auth.ExternalAuthConfig
+dummyExternalConfig =
+  AS.Auth.ExternalAuthConfig
+    { AS.Auth.configFn = Nothing,
+      AS.Auth.userSignupFields = Nothing
+    }
+
+emptyMethods :: AS.Auth.AuthMethods
+emptyMethods =
+  AS.Auth.AuthMethods
+    { AS.Auth.usernameAndPassword = Nothing,
+      AS.Auth.discord = Nothing,
+      AS.Auth.slack = Nothing,
+      AS.Auth.google = Nothing,
+      AS.Auth.gitHub = Nothing,
+      AS.Auth.keycloak = Nothing,
+      AS.Auth.microsoft = Nothing,
+      AS.Auth.email = Nothing
+    }
+
+makeAuth :: AS.Auth.AuthMethods -> AS.Auth.Auth
+makeAuth methods =
+  AS.Auth.Auth
+    { AS.Auth.userEntity = AS.Core.Ref.Ref "User",
+      AS.Auth.externalAuthEntity = Nothing,
+      AS.Auth.methods = methods,
+      AS.Auth.onAuthFailedRedirectTo = "/",
+      AS.Auth.onAuthSucceededRedirectTo = Nothing,
+      AS.Auth.onBeforeSignup = Nothing,
+      AS.Auth.onAfterSignup = Nothing,
+      AS.Auth.onAfterEmailVerified = Nothing,
+      AS.Auth.onBeforeOAuthRedirect = Nothing,
+      AS.Auth.onBeforeLogin = Nothing,
+      AS.Auth.onAfterLogin = Nothing
+    }

--- a/waspc/tests/Generator/Auth/ProviderTest.hs
+++ b/waspc/tests/Generator/Auth/ProviderTest.hs
@@ -96,6 +96,11 @@ spec_AuthProvider = do
       KM.lookup "isUsernameAndPasswordAuthEnabled" jsonObj `shouldBe` Just (Bool False)
       KM.lookup "isEmailAuthEnabled" jsonObj `shouldBe` Just (Bool False)
 
+    it "uses displayName for JSON keys (GitHub has capital H)" $ do
+      let methods = emptyMethods {AS.Auth.gitHub = Just dummyExternalConfig}
+      let Object jsonObj = enabledAuthMethodsJson (makeAuth methods)
+      KM.lookup "isGitHubAuthEnabled" jsonObj `shouldBe` Just (Bool True)
+
   describe "serverOAuthLoginUrl" $ do
     it "constructs URL from slug" $ do
       let spec = head allOAuthProviders -- google
@@ -103,7 +108,7 @@ spec_AuthProvider = do
 
 -- Helpers
 
-unique :: Eq a => [a] -> [a]
+unique :: (Eq a) => [a] -> [a]
 unique [] = []
 unique (x : xs) = x : unique (filter (/= x) xs)
 

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -281,6 +281,8 @@ library
     Wasp.ExternalConfig.Npm.Tarball
     Wasp.ExternalConfig.TsConfig
     Wasp.Generator
+    Wasp.Generator.Auth.OAuthGen
+    Wasp.Generator.Auth.Provider
     Wasp.Generator.AuthProviders
     Wasp.Generator.AuthProviders.Common
     Wasp.Generator.AuthProviders.Email


### PR DESCRIPTION
## Description

Visual walkthrough of the full refactor: https://auth-refactor-wasp.static.miho.dev/

This is step 1 of a 4-PR stack that consolidates scattered auth provider definitions into a single registry.

**PR Stack:** #3951 (this) -> #3952 -> #3953 -> #3954

This PR introduces the foundation and proves the pattern on one real generator:

- **`Auth.Provider`**: `OAuthProviderSpec` record type + `allOAuthProviders` registry. Single source of truth for slugs, display names, required scopes, and config extraction. Derives `enabledOAuthProviders`, `enabledAuthMethodsJson`, `isOAuthEnabled`, URL builders, and scope strings.
- **`Auth.OAuthGen`**: `genForEachEnabledOAuth` iteration helper that replaces per-provider enumeration in generators.
- **`ServerGenerator/Auth/OAuthAuthG.hs`**: Migrated from 6 explicit `<++> genOAuthProvider` branches to a single `genForEachEnabledOAuth auth genSingleProvider` call.
- **Unit tests**: Registry completeness check (catches forgotten providers), enabled filtering, JSON key generation (including `isGitHubAuthEnabled` casing regression test).

**5 files changed, +325 -46**

## Type of change

- [x] **🔧 Just code/docs improvement**
- [ ] **🐞 Bug fix**
- [ ] **🚀 New/improved feature**
- [ ] **💥 Breaking change**

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.