### PR TITLE
Migrate remaining ServerGenerator auth files to Auth.Provider

### DIFF
--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/EmailAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/EmailAuthG.hs
@@ -23,8 +23,6 @@ import qualified Wasp.AppSpec.App.Auth.EmailVerification as AS.Auth.EmailVerific
 import qualified Wasp.AppSpec.App.Auth.PasswordReset as AS.Auth.PasswordReset
 import qualified Wasp.AppSpec.App.EmailSender as AS.EmailSender
 import Wasp.AppSpec.Util (getRoutePathFromRef)
-import Wasp.Generator.AuthProviders (emailAuthProvider)
-import qualified Wasp.Generator.AuthProviders.Email as Email
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.ServerGenerator.Common as C
@@ -50,8 +48,8 @@ genEmailAuthConfig spec emailAuthConfig = return $ C.mkTmplFdWithDstAndData tmpl
 
     tmplData =
       object
-        [ "providerId" .= Email.providerId emailAuthProvider,
-          "displayName" .= Email.displayName emailAuthProvider,
+        [ "providerId" .= ("email" :: String),
+          "displayName" .= ("Email and password" :: String),
           "fromField" .= fromFieldJson,
           "emailVerificationClientRoute" .= emailVerificationClientRoute,
           "passwordResetClientRoute" .= passwordResetClientRoute,

--- a/waspc/src/Wasp/Generator/ServerGenerator/Auth/LocalAuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Auth/LocalAuthG.hs
@@ -19,8 +19,6 @@ import StrongPath
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
-import Wasp.Generator.AuthProviders (localAuthProvider)
-import qualified Wasp.Generator.AuthProviders.Local as Local
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.ServerGenerator.Common as C
@@ -47,8 +45,8 @@ genLocalAuthConfig usernameAndPasswordConfig = return $ C.mkTmplFdWithDstAndData
 
     tmplData =
       object
-        [ "providerId" .= Local.providerId localAuthProvider,
-          "displayName" .= Local.displayName localAuthProvider,
+        [ "providerId" .= ("username" :: String),
+          "displayName" .= ("Username and password" :: String),
           "userSignupFields" .= extImportToImportJson relPathToServerSrcDir maybeUserSignupFields
         ]
 

--- a/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
@@ -24,19 +24,13 @@ import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import Wasp.AppSpec.Valid (getApp)
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
-import Wasp.Generator.AuthProviders
-  ( discordAuthProvider,
-    emailAuthProvider,
-    gitHubAuthProvider,
-    googleAuthProvider,
-    keycloakAuthProvider,
-    localAuthProvider,
-    microsoftAuthProvider,
-    slackAuthProvider,
+import Wasp.Generator.Auth.Provider
+  ( OAuthProviderSpec (..),
+    enabledOAuthProviders,
+    isEmailEnabled,
+    isOAuthEnabled,
+    isUsernameAndPasswordEnabled,
   )
-import qualified Wasp.Generator.AuthProviders.Email as EmailProvider
-import qualified Wasp.Generator.AuthProviders.Local as LocalProvider
-import qualified Wasp.Generator.AuthProviders.OAuth as OAuthProvider
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.JsImport (jsImportToImportJson)
 import Wasp.Generator.Monad (Generator)
@@ -72,7 +66,7 @@ genAuthRoutesIndex auth = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Ju
     tmplFile = C.srcDirInServerTemplatesDir </> SP.castRel authIndexFileInSrcDir
     dstFile = C.serverSrcDirInServerRootDir </> authIndexFileInSrcDir
     tmplData =
-      object ["isExternalAuthEnabled" .= AS.Auth.isExternalAuthEnabled auth]
+      object ["isExternalAuthEnabled" .= isOAuthEnabled auth]
 
     authIndexFileInSrcDir :: Path' (Rel C.ServerSrcDir) File'
     authIndexFileInSrcDir = [relfile|routes/auth/index.js|]
@@ -83,20 +77,15 @@ genProvidersIndex auth = return $ C.mkTmplFdWithData [relfile|src/auth/providers
     tmplData =
       object
         [ "providers" .= providers,
-          "isExternalAuthEnabled" .= AS.Auth.isExternalAuthEnabled auth
+          "isExternalAuthEnabled" .= isOAuthEnabled auth
         ]
 
     providers =
       makeConfigImportJson
         <$> concat
-          [ [OAuthProvider.providerId slackAuthProvider | AS.Auth.isSlackAuthEnabled auth],
-            [OAuthProvider.providerId discordAuthProvider | AS.Auth.isDiscordAuthEnabled auth],
-            [OAuthProvider.providerId gitHubAuthProvider | AS.Auth.isGitHubAuthEnabled auth],
-            [OAuthProvider.providerId googleAuthProvider | AS.Auth.isGoogleAuthEnabled auth],
-            [OAuthProvider.providerId keycloakAuthProvider | AS.Auth.isKeycloakAuthEnabled auth],
-            [OAuthProvider.providerId microsoftAuthProvider | AS.Auth.isMicrosoftAuthEnabled auth],
-            [LocalProvider.providerId localAuthProvider | AS.Auth.isUsernameAndPasswordAuthEnabled auth],
-            [EmailProvider.providerId emailAuthProvider | AS.Auth.isEmailAuthEnabled auth]
+          [ [slug spec | (spec, _) <- enabledOAuthProviders auth],
+            ["username" | isUsernameAndPasswordEnabled auth],
+            ["email" | isEmailEnabled auth]
           ]
 
     makeConfigImportJson providerId =


### PR DESCRIPTION
## Description

Step 2 of 4. Completes the ServerGenerator migration started in #3951.

**PR Stack:** #3951 -> #3952 (this) -> #3953 -> #3954

- **`ServerGenerator/AuthG.hs`**: Provider index now derived from `enabledOAuthProviders` instead of 6 hardcoded guard clauses + individual provider imports.
- **`ServerGenerator/Auth/EmailAuthG.hs`** and **`LocalAuthG.hs`**: Inlined their trivial provider IDs (`"email"`, `"username"`), removing the dependency on the old `AuthProviders` modules.

After this PR, no ServerGenerator file imports from `AppSpec.App.Auth` predicates or `AuthProviders.*`.

**3 files changed, +15 -30**

## Type of change

- [x] **🔧 Just code/docs improvement**
- [ ] **🐞 Bug fix**
- [ ] **🚀 New/improved feature**
- [ ] **💥 Breaking change**

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.