### PR TITLE
Migrate SdkGenerator auth files to Auth.Provider

### DIFF
--- a/waspc/src/Wasp/Generator/SdkGenerator/Auth/AuthFormsG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Auth/AuthFormsG.hs
@@ -6,16 +6,12 @@ where
 import Data.Aeson (object, (.=))
 import StrongPath (Dir', File', Path', Rel, Rel', reldir, relfile, (</>))
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
-import Wasp.Generator.AuthProviders
-  ( discordAuthProvider,
-    gitHubAuthProvider,
-    googleAuthProvider,
-    keycloakAuthProvider,
-    microsoftAuthProvider,
-    slackAuthProvider,
+import Wasp.Generator.Auth.Provider
+  ( enabledAuthMethodsJson,
+    isEmailEnabled,
+    isOAuthEnabled,
+    isUsernameAndPasswordEnabled,
   )
-import qualified Wasp.Generator.AuthProviders as AuthProviders
-import qualified Wasp.Generator.AuthProviders.OAuth as OAuth
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 -- todo(filip) -- Should I put this under something like Wasp.Generator.Auth (doesn't exist) or Wasp.Generator.Common?
@@ -46,7 +42,7 @@ genAuthComponent auth =
       (authFormsDirInSdkTemplatesDir </> [relfile|Auth.tsx|])
       tmplData
   where
-    tmplData = object ["isEmailAuthEnabled" .= AS.Auth.isEmailAuthEnabled auth]
+    tmplData = object ["isEmailAuthEnabled" .= isEmailEnabled auth]
 
 genTypes :: AS.Auth.Auth -> Generator FileDraft
 genTypes auth =
@@ -55,7 +51,7 @@ genTypes auth =
       (authFormsDirInSdkTemplatesDir </> [relfile|types.ts|])
       tmplData
   where
-    tmplData = object ["isEmailAuthEnabled" .= AS.Auth.isEmailAuthEnabled auth]
+    tmplData = object ["isEmailAuthEnabled" .= isEmailEnabled auth]
 
 genEmailForms :: AS.Auth.Auth -> Generator [FileDraft]
 genEmailForms auth =
@@ -66,7 +62,7 @@ genEmailForms auth =
         genFileCopyInAuthForms [relfile|VerifyEmail.tsx|]
       ]
   where
-    isEmailAuthEnabled = AS.Auth.isEmailAuthEnabled auth
+    isEmailAuthEnabled = isEmailEnabled auth
 
 genInternalAuthComponents :: AS.Auth.Auth -> Generator [FileDraft]
 genInternalAuthComponents auth =
@@ -125,9 +121,9 @@ genInternalAuthComponents auth =
           genFileCopyInAuthFormsInternal [relfile|social/SocialIcons.module.css|]
         ]
 
-    isEmailAuthEnabled = AS.Auth.isEmailAuthEnabled auth
-    isUsernameAndPasswordAuthEnabled = AS.Auth.isUsernameAndPasswordAuthEnabled auth
-    isExternalAuthEnabled = AS.Auth.isExternalAuthEnabled auth
+    isEmailAuthEnabled = isEmailEnabled auth
+    isUsernameAndPasswordAuthEnabled = isUsernameAndPasswordEnabled auth
+    isExternalAuthEnabled = isOAuthEnabled auth
 
 genLoginSignupForm :: AS.Auth.Auth -> Generator [FileDraft]
 genLoginSignupForm auth =
@@ -146,17 +142,18 @@ genLoginSignupForm auth =
         [ "onAuthSucceededRedirectTo" .= getOnAuthSucceededRedirectToOrDefault auth,
           "areBothSocialAndPasswordBasedAuthEnabled" .= areBothSocialAndPasswordBasedAuthEnabled,
           "isAnyPasswordBasedAuthEnabled" .= isAnyPasswordBasedAuthEnabled,
-          "isSocialAuthEnabled" .= AS.Auth.isExternalAuthEnabled auth,
-          "slackSignInPath" .= OAuth.serverLoginUrl slackAuthProvider,
-          "discordSignInPath" .= OAuth.serverLoginUrl discordAuthProvider,
-          "googleSignInPath" .= OAuth.serverLoginUrl googleAuthProvider,
-          "keycloakSignInPath" .= OAuth.serverLoginUrl keycloakAuthProvider,
-          "gitHubSignInPath" .= OAuth.serverLoginUrl gitHubAuthProvider,
-          "microsoftSignInPath" .= OAuth.serverLoginUrl microsoftAuthProvider,
-          "enabledProviders" .= AuthProviders.getEnabledAuthProvidersJson auth
+          "isSocialAuthEnabled" .= isOAuthEnabled auth,
+          "slackSignInPath" .= providerLoginUrlBySlug "slack",
+          "discordSignInPath" .= providerLoginUrlBySlug "discord",
+          "googleSignInPath" .= providerLoginUrlBySlug "google",
+          "keycloakSignInPath" .= providerLoginUrlBySlug "keycloak",
+          "gitHubSignInPath" .= providerLoginUrlBySlug "github",
+          "microsoftSignInPath" .= providerLoginUrlBySlug "microsoft",
+          "enabledProviders" .= enabledAuthMethodsJson auth
         ]
-    areBothSocialAndPasswordBasedAuthEnabled = AS.Auth.isExternalAuthEnabled auth && isAnyPasswordBasedAuthEnabled
-    isAnyPasswordBasedAuthEnabled = AS.Auth.isUsernameAndPasswordAuthEnabled auth || AS.Auth.isEmailAuthEnabled auth
+    areBothSocialAndPasswordBasedAuthEnabled = isOAuthEnabled auth && isAnyPasswordBasedAuthEnabled
+    isAnyPasswordBasedAuthEnabled = isUsernameAndPasswordEnabled auth || isEmailEnabled auth
+    providerLoginUrlBySlug s = "/auth/" ++ s ++ "/login" :: String
 
 genConditionally :: Bool -> Generator [FileDraft] -> Generator [FileDraft]
 genConditionally isEnabled gen = if isEnabled then gen else return []

--- a/waspc/src/Wasp/Generator/SdkGenerator/Auth/AuthFormsG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Auth/AuthFormsG.hs
@@ -4,13 +4,18 @@ module Wasp.Generator.SdkGenerator.Auth.AuthFormsG
 where
 
 import Data.Aeson (object, (.=))
+import qualified Data.Aeson.Key as AesonKey
+import Data.Char (toLower)
 import StrongPath (Dir', File', Path', Rel, Rel', reldir, relfile, (</>))
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import Wasp.Generator.Auth.Provider
-  ( enabledAuthMethodsJson,
+  ( OAuthProviderSpec (..),
+    allOAuthProviders,
+    enabledAuthMethodsJson,
     isEmailEnabled,
     isOAuthEnabled,
     isUsernameAndPasswordEnabled,
+    serverOAuthLoginUrl,
   )
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
@@ -138,22 +143,20 @@ genLoginSignupForm auth =
           (authFormsInternalDirInSdkTemplatesDir </> [relfile|common/LoginSignupForm.tsx|])
           loginSignupFormComponentTmplData
     loginSignupFormComponentTmplData =
-      object
+      object $
         [ "onAuthSucceededRedirectTo" .= getOnAuthSucceededRedirectToOrDefault auth,
           "areBothSocialAndPasswordBasedAuthEnabled" .= areBothSocialAndPasswordBasedAuthEnabled,
           "isAnyPasswordBasedAuthEnabled" .= isAnyPasswordBasedAuthEnabled,
           "isSocialAuthEnabled" .= isOAuthEnabled auth,
-          "slackSignInPath" .= providerLoginUrlBySlug "slack",
-          "discordSignInPath" .= providerLoginUrlBySlug "discord",
-          "googleSignInPath" .= providerLoginUrlBySlug "google",
-          "keycloakSignInPath" .= providerLoginUrlBySlug "keycloak",
-          "gitHubSignInPath" .= providerLoginUrlBySlug "github",
-          "microsoftSignInPath" .= providerLoginUrlBySlug "microsoft",
           "enabledProviders" .= enabledAuthMethodsJson auth
         ]
+          ++ [ AesonKey.fromString (lowerFirst (displayName spec) ++ "SignInPath") .= serverOAuthLoginUrl spec
+               | spec <- allOAuthProviders
+             ]
     areBothSocialAndPasswordBasedAuthEnabled = isOAuthEnabled auth && isAnyPasswordBasedAuthEnabled
     isAnyPasswordBasedAuthEnabled = isUsernameAndPasswordEnabled auth || isEmailEnabled auth
-    providerLoginUrlBySlug s = "/auth/" ++ s ++ "/login" :: String
+    lowerFirst (c : cs) = toLower c : cs
+    lowerFirst [] = []
 
 genConditionally :: Bool -> Generator [FileDraft] -> Generator [FileDraft]
 genConditionally isEnabled gen = if isEnabled then gen else return []

--- a/waspc/src/Wasp/Generator/SdkGenerator/Auth/OAuthAuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Auth/OAuthAuthG.hs
@@ -4,56 +4,41 @@ module Wasp.Generator.SdkGenerator.Auth.OAuthAuthG
 where
 
 import Data.Aeson (object, (.=))
-import StrongPath (File', Path', Rel', reldir, relfile, (</>))
+import StrongPath (reldir, relfile, (</>))
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
-import Wasp.Generator.AuthProviders
-  ( discordAuthProvider,
-    gitHubAuthProvider,
-    googleAuthProvider,
-    keycloakAuthProvider,
-    microsoftAuthProvider,
-    slackAuthProvider,
+import Wasp.Generator.Auth.Provider
+  ( OAuthProviderSpec (..),
+    enabledOAuthProviders,
+    isOAuthEnabled,
+    serverOAuthLoginUrl,
   )
-import Wasp.Generator.AuthProviders.OAuth (OAuthAuthProvider)
-import qualified Wasp.Generator.AuthProviders.OAuth as OAuth
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import Wasp.Generator.SdkGenerator.Common as C
 
 genOAuthAuth :: AS.Auth.Auth -> Generator [FileDraft]
 genOAuthAuth auth
-  | AS.Auth.isExternalAuthEnabled auth =
-      genOAuthHelpers auth
+  | isOAuthEnabled auth = return $ map makeHelperFd (enabledOAuthProviders auth)
   | otherwise = return []
-
-genOAuthHelpers :: AS.Auth.Auth -> Generator [FileDraft]
-genOAuthHelpers auth =
-  return $
-    concat
-      [ [slackHelpersFd | AS.Auth.isSlackAuthEnabled auth],
-        [discordHelpersFd | AS.Auth.isDiscordAuthEnabled auth],
-        [gitHubHelpersFd | AS.Auth.isGitHubAuthEnabled auth],
-        [googleHelpersFd | AS.Auth.isGoogleAuthEnabled auth],
-        [keycloakHelpersFd | AS.Auth.isKeycloakAuthEnabled auth],
-        [microsoftHelpersFd | AS.Auth.isMicrosoftAuthEnabled auth]
-      ]
   where
-    slackHelpersFd = makeOAuthHelpersFd slackAuthProvider [relfile|Slack.tsx|]
-    discordHelpersFd = makeOAuthHelpersFd discordAuthProvider [relfile|Discord.tsx|]
-    gitHubHelpersFd = makeOAuthHelpersFd gitHubAuthProvider [relfile|GitHub.tsx|]
-    googleHelpersFd = makeOAuthHelpersFd googleAuthProvider [relfile|Google.tsx|]
-    keycloakHelpersFd = makeOAuthHelpersFd keycloakAuthProvider [relfile|Keycloak.tsx|]
-    microsoftHelpersFd = makeOAuthHelpersFd microsoftAuthProvider [relfile|Microsoft.tsx|]
-
-    makeOAuthHelpersFd :: OAuthAuthProvider -> Path' Rel' File' -> FileDraft
-    makeOAuthHelpersFd provider helpersFp =
+    makeHelperFd (spec, _config) =
       mkTmplFdWithDstAndData
         [relfile|auth/helpers/_Provider.tsx|]
         ([reldir|auth/helpers|] </> helpersFp)
         (Just tmplData)
       where
+        helpersFp = sdkHelperFile spec
         tmplData =
           object
-            [ "signInPath" .= OAuth.serverLoginUrl provider,
-              "displayName" .= OAuth.displayName provider
+            [ "signInPath" .= serverOAuthLoginUrl spec,
+              "displayName" .= displayName spec
             ]
+
+    sdkHelperFile spec = case slug spec of
+      "google" -> [relfile|Google.tsx|]
+      "github" -> [relfile|GitHub.tsx|]
+      "discord" -> [relfile|Discord.tsx|]
+      "keycloak" -> [relfile|Keycloak.tsx|]
+      "slack" -> [relfile|Slack.tsx|]
+      "microsoft" -> [relfile|Microsoft.tsx|]
+      other -> error $ "Unknown OAuth provider: " ++ other

--- a/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
@@ -10,6 +10,7 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import Wasp.AppSpec.Valid (getApp)
+import Wasp.Generator.Auth.Provider as AP (isEmailEnabled, isUsernameAndPasswordEnabled)
 import Wasp.Generator.Common (makeJsArrayFromHaskellList)
 import qualified Wasp.Generator.DbGenerator.Auth as DbAuth
 import Wasp.Generator.FileDraft (FileDraft)
@@ -146,8 +147,8 @@ genIndexTs auth =
         [ "isEmailAuthEnabled" .= isEmailAuthEnabled,
           "isLocalAuthEnabled" .= isLocalAuthEnabled
         ]
-    isEmailAuthEnabled = AS.Auth.isEmailAuthEnabled auth
-    isLocalAuthEnabled = AS.Auth.isUsernameAndPasswordAuthEnabled auth
+    isEmailAuthEnabled = AP.isEmailEnabled auth
+    isLocalAuthEnabled = AP.isUsernameAndPasswordEnabled auth
 
 genProvdersIndex :: AS.Auth.Auth -> Generator FileDraft
 genProvdersIndex auth =

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/AuthG.hs
@@ -3,12 +3,20 @@ module Wasp.Generator.SdkGenerator.Client.AuthG
   )
 where
 
+import Data.Maybe (fromJust)
 import StrongPath (Dir', File', Path', Rel, Rel', reldir, relfile, (</>))
+import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import Wasp.AppSpec.Valid (getApp)
-import qualified Wasp.Generator.AuthProviders as AuthProviders
+import Wasp.Generator.Auth.Provider
+  ( OAuthProviderSpec (..),
+    enabledAuthMethodsJson,
+    enabledOAuthProviders,
+    isEmailEnabled,
+    isUsernameAndPasswordEnabled,
+  )
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import Wasp.Generator.SdkGenerator.Common
@@ -29,12 +37,7 @@ genNewClientAuth spec =
         ]
         <++> genAuthEmail auth
         <++> genAuthUsername auth
-        <++> genAuthSlack auth
-        <++> genAuthDiscord auth
-        <++> genAuthGoogle auth
-        <++> genAuthKeycloak auth
-        <++> genAuthGitHub auth
-        <++> genAuthMicrosoft auth
+        <++> genOAuthClientFiles auth
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
 
@@ -43,66 +46,33 @@ genAuthIndex auth =
   return $
     mkTmplFdWithData
       (clientAuthDirInSdkTemplatesDir </> [relfile|index.ts|])
-      tmplData
-  where
-    tmplData = AuthProviders.getEnabledAuthProvidersJson auth
+      (enabledAuthMethodsJson auth)
 
 genAuthUi :: AS.Auth.Auth -> Generator FileDraft
 genAuthUi auth =
   return $
     mkTmplFdWithData
       (clientAuthDirInSdkTemplatesDir </> [relfile|ui.ts|])
-      tmplData
-  where
-    tmplData = AuthProviders.getEnabledAuthProvidersJson auth
+      (enabledAuthMethodsJson auth)
 
 genAuthEmail :: AS.Auth.Auth -> Generator [FileDraft]
 genAuthEmail auth =
-  if AS.Auth.isEmailAuthEnabled auth
+  if isEmailEnabled auth
     then sequence [genFileCopyInClientAuth [relfile|email.ts|]]
     else return []
 
 genAuthUsername :: AS.Auth.Auth -> Generator [FileDraft]
 genAuthUsername auth =
-  if AS.Auth.isUsernameAndPasswordAuthEnabled auth
+  if isUsernameAndPasswordEnabled auth
     then sequence [genFileCopyInClientAuth [relfile|username.ts|]]
     else return []
 
-genAuthSlack :: AS.Auth.Auth -> Generator [FileDraft]
-genAuthSlack auth =
-  if AS.Auth.isSlackAuthEnabled auth
-    then sequence [genFileCopyInClientAuth [relfile|slack.ts|]]
-    else return []
-
-genAuthDiscord :: AS.Auth.Auth -> Generator [FileDraft]
-genAuthDiscord auth =
-  if AS.Auth.isDiscordAuthEnabled auth
-    then sequence [genFileCopyInClientAuth [relfile|discord.ts|]]
-    else return []
-
-genAuthGoogle :: AS.Auth.Auth -> Generator [FileDraft]
-genAuthGoogle auth =
-  if AS.Auth.isGoogleAuthEnabled auth
-    then sequence [genFileCopyInClientAuth [relfile|google.ts|]]
-    else return []
-
-genAuthKeycloak :: AS.Auth.Auth -> Generator [FileDraft]
-genAuthKeycloak auth =
-  if AS.Auth.isKeycloakAuthEnabled auth
-    then sequence [genFileCopyInClientAuth [relfile|keycloak.ts|]]
-    else return []
-
-genAuthGitHub :: AS.Auth.Auth -> Generator [FileDraft]
-genAuthGitHub auth =
-  if AS.Auth.isGitHubAuthEnabled auth
-    then sequence [genFileCopyInClientAuth [relfile|github.ts|]]
-    else return []
-
-genAuthMicrosoft :: AS.Auth.Auth -> Generator [FileDraft]
-genAuthMicrosoft auth =
-  if AS.Auth.isMicrosoftAuthEnabled auth
-    then sequence [genFileCopyInClientAuth [relfile|microsoft.ts|]]
-    else return []
+genOAuthClientFiles :: AS.Auth.Auth -> Generator [FileDraft]
+genOAuthClientFiles auth =
+  sequence
+    [ genFileCopyInClientAuth (fromJust $ SP.parseRelFile $ slug spec ++ ".ts")
+      | (spec, _) <- enabledOAuthProviders auth
+    ]
 
 clientAuthDirInSdkTemplatesDir :: Path' (Rel SdkTemplatesDir) Dir'
 clientAuthDirInSdkTemplatesDir = [reldir|client/auth|]

--- a/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
@@ -10,7 +10,7 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import Wasp.AppSpec.Valid (getApp)
-import qualified Wasp.Generator.AuthProviders as AuthProviders
+import Wasp.Generator.Auth.Provider (enabledAuthMethodsJson, isEmailEnabled, isOAuthEnabled, isUsernameAndPasswordEnabled)
 import qualified Wasp.Generator.DbGenerator.Auth as DbAuth
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
@@ -45,10 +45,10 @@ genAuthIndex auth =
   where
     tmplData =
       object
-        [ "enabledProviders" .= AuthProviders.getEnabledAuthProvidersJson auth,
+        [ "enabledProviders" .= enabledAuthMethodsJson auth,
           "isExternalAuthEnabled" .= isExternalAuthEnabled
         ]
-    isExternalAuthEnabled = AS.Auth.isExternalAuthEnabled auth
+    isExternalAuthEnabled = isOAuthEnabled auth
 
 genAuthUser :: AS.Auth.Auth -> Generator FileDraft
 genAuthUser auth =
@@ -64,7 +64,7 @@ genAuthUser auth =
           "authFieldOnUserEntityName" .= DbAuth.authFieldOnUserEntityName,
           "authIdentityEntityName" .= DbAuth.authIdentityEntityName,
           "identitiesFieldOnAuthEntityName" .= DbAuth.identitiesFieldOnAuthEntityName,
-          "enabledProviders" .= AuthProviders.getEnabledAuthProvidersJson auth
+          "enabledProviders" .= enabledAuthMethodsJson auth
         ]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
 
@@ -75,17 +75,17 @@ genHooks auth =
       (serverAuthDirInSdkTemplatesDir </> [relfile|hooks.ts|])
       tmplData
   where
-    tmplData = object ["enabledProviders" .= AuthProviders.getEnabledAuthProvidersJson auth]
+    tmplData = object ["enabledProviders" .= enabledAuthMethodsJson auth]
 
 genAuthEmail :: AS.Auth.Auth -> Generator [FileDraft]
 genAuthEmail auth =
-  if AS.Auth.isEmailAuthEnabled auth
+  if isEmailEnabled auth
     then sequence [genFileCopyInServerAuth [relfile|email/index.ts|]]
     else return []
 
 genAuthUsername :: AS.Auth.Auth -> Generator [FileDraft]
 genAuthUsername auth =
-  if AS.Auth.isUsernameAndPasswordAuthEnabled auth
+  if isUsernameAndPasswordEnabled auth
     then sequence [genFileCopyInServerAuth [relfile|username.ts|]]
     else return []
 

--- a/waspc/src/Wasp/Generator/SdkGenerator/Server/OAuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Server/OAuthG.hs
@@ -5,23 +5,20 @@ module Wasp.Generator.SdkGenerator.Server.OAuthG
 where
 
 import Data.Aeson (KeyValue ((.=)), object)
-import Data.Maybe (fromJust, isJust)
+import Data.Maybe (fromJust)
 import StrongPath (Dir', File', Path', Rel, Rel', parseRelFile, reldir, relfile, (</>))
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
-import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.Valid as AS.Valid
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
-import Wasp.Generator.AuthProviders (discordAuthProvider, getEnabledAuthProvidersJson, gitHubAuthProvider, googleAuthProvider, keycloakAuthProvider, microsoftAuthProvider, slackAuthProvider)
-import Wasp.Generator.AuthProviders.OAuth
-  ( OAuthAuthProvider,
+import Wasp.Generator.Auth.Provider
+  ( OAuthProviderSpec (..),
     clientOAuthCallbackPath,
-    serverExchangeCodeForTokenHandlerPath,
-    serverOAuthCallbackHandlerPath,
-    serverOAuthLoginHandlerPath,
+    enabledAuthMethodsJson,
+    enabledOAuthProviders,
+    isOAuthEnabled,
   )
-import qualified Wasp.Generator.AuthProviders.OAuth as OAuth
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import Wasp.Generator.SdkGenerator.Common
@@ -33,19 +30,14 @@ import Wasp.Util ((<++>))
 
 genOAuth :: AS.Auth.Auth -> Generator [FileDraft]
 genOAuth auth
-  | AS.Auth.isExternalAuthEnabled auth =
+  | isOAuthEnabled auth =
       sequence
         [ genIndexTs auth,
           genRedirectHelper,
           genFileCopyInServerOAuth [relfile|oneTimeCode.ts|],
           genFileCopyInServerOAuth [relfile|provider.ts|]
         ]
-        <++> genOAuthProvider slackAuthProvider (AS.Auth.slack . AS.Auth.methods $ auth)
-        <++> genOAuthProvider discordAuthProvider (AS.Auth.discord . AS.Auth.methods $ auth)
-        <++> genOAuthProvider googleAuthProvider (AS.Auth.google . AS.Auth.methods $ auth)
-        <++> genOAuthProvider keycloakAuthProvider (AS.Auth.keycloak . AS.Auth.methods $ auth)
-        <++> genOAuthProvider gitHubAuthProvider (AS.Auth.gitHub . AS.Auth.methods $ auth)
-        <++> genOAuthProvider microsoftAuthProvider (AS.Auth.microsoft . AS.Auth.methods $ auth)
+        <++> concatMapM genSingleProvider (enabledOAuthProviders auth)
   | otherwise = return []
 
 genIndexTs :: AS.Auth.Auth -> Generator FileDraft
@@ -57,7 +49,7 @@ genIndexTs auth =
   where
     tmplData =
       object
-        [ "enabledProviders" .= getEnabledAuthProvidersJson auth
+        [ "enabledProviders" .= enabledAuthMethodsJson auth
         ]
 
 genRedirectHelper :: Generator FileDraft
@@ -69,24 +61,17 @@ genRedirectHelper =
   where
     tmplData =
       object
-        [ "serverOAuthCallbackHandlerPath" .= serverOAuthCallbackHandlerPath,
+        [ "serverOAuthCallbackHandlerPath" .= ("callback" :: String),
           "clientOAuthCallbackPath" .= clientOAuthCallbackPath,
-          "serverOAuthLoginHandlerPath" .= serverOAuthLoginHandlerPath,
-          "serverExchangeCodeForTokenHandlerPath" .= serverExchangeCodeForTokenHandlerPath
+          "serverOAuthLoginHandlerPath" .= ("login" :: String),
+          "serverExchangeCodeForTokenHandlerPath" .= ("exchange-code" :: String)
         ]
 
-genOAuthProvider ::
-  OAuthAuthProvider ->
-  Maybe AS.Auth.ExternalAuthConfig ->
-  Generator [FileDraft]
-genOAuthProvider provider maybeUserConfig
-  | isJust maybeUserConfig = sequence [genOAuthConfig provider]
-  | otherwise = return []
+genSingleProvider :: (OAuthProviderSpec, AS.Auth.ExternalAuthConfig) -> Generator [FileDraft]
+genSingleProvider (spec, _config) = sequence [genOAuthConfig spec]
 
-genOAuthConfig ::
-  OAuthAuthProvider ->
-  Generator FileDraft
-genOAuthConfig provider =
+genOAuthConfig :: OAuthProviderSpec -> Generator FileDraft
+genOAuthConfig spec =
   return $
     mkTmplFdWithData
       (serverOAuthDirInSdkTemplatesDir </> [reldir|providers|] </> providerTsFile)
@@ -94,15 +79,15 @@ genOAuthConfig provider =
   where
     tmplData =
       object
-        [ "providerId" .= OAuth.providerId provider,
-          "displayName" .= OAuth.displayName provider
+        [ "providerId" .= slug spec,
+          "displayName" .= displayName spec
         ]
 
-    providerTsFile = fromJust $ parseRelFile $ OAuth.providerId provider ++ ".ts"
+    providerTsFile = fromJust $ parseRelFile $ slug spec ++ ".ts"
 
 depsRequiredByOAuth :: AppSpec -> [Npm.Dependency.Dependency]
 depsRequiredByOAuth spec =
-  [Npm.Dependency.make ("arctic", "^1.2.1") | (AS.App.Auth.isExternalAuthEnabled <$> maybeAuth) == Just True]
+  [Npm.Dependency.make ("arctic", "^1.2.1") | (isOAuthEnabled <$> maybeAuth) == Just True]
   where
     maybeAuth = AS.App.auth $ snd $ AS.Valid.getApp spec
 
@@ -111,3 +96,6 @@ serverOAuthDirInSdkTemplatesDir = [reldir|server/auth/oauth|]
 
 genFileCopyInServerOAuth :: Path' Rel' File' -> Generator FileDraft
 genFileCopyInServerOAuth = genFileCopy . (serverOAuthDirInSdkTemplatesDir </>)
+
+concatMapM :: (Monad m) => (a -> m [b]) -> [a] -> m [b]
+concatMapM f xs = concat <$> mapM f xs


### PR DESCRIPTION
## Description

Step 3 of 4. The biggest simplification in the stack: collapses per-provider enumeration across 6 SDK generator files.

**PR Stack:** #3951 -> #3952 -> #3953 (this) -> #3954

- **`SdkGenerator/Auth/OAuthAuthG.hs`**: 6 hardcoded provider branches replaced with `enabledOAuthProviders` iteration.
- **`SdkGenerator/Client/AuthG.hs`**: 6 `genAuthSlack`/`genAuthDiscord`/... functions collapsed into a single `genOAuthClientFiles` loop.
- **`SdkGenerator/Server/OAuthG.hs`**: Per-provider `genOAuthProvider` enumeration replaced with `concatMapM genSingleProvider`.
- **`SdkGenerator/Server/AuthG.hs`**: Switched to `enabledAuthMethodsJson` and registry predicates.
- **`SdkGenerator/Auth/AuthFormsG.hs`**: Sign-in path template data derived from `allOAuthProviders` + `serverOAuthLoginUrl` instead of 6 hardcoded entries.
- **`SdkGenerator/AuthG.hs`**: Predicate imports migrated.

After this PR, no file in the codebase imports from `AppSpec.App.Auth` predicates or `AuthProviders.*`.

**6 files changed, +99 -155 (net -56)**

## Type of change

- [x] **🔧 Just code/docs improvement**
- [ ] **🐞 Bug fix**
- [ ] **🚀 New/improved feature**
- [ ] **💥 Breaking change**

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.