### PR TITLE
Add Render deployment guide

### DIFF
--- a/web/docs/deployment/deployment-methods/paas.md
+++ b/web/docs/deployment/deployment-methods/paas.md
@@ -21,6 +21,8 @@ We have step-by-step guides for deploying your Wasp app to some of the most popu
 
 <GuideLink linkToGuide="../../guides/deployment/railway" title="Deploying Wasp to Railway" description="Uses Railway, Railway CLI" />
 
+<GuideLink linkToGuide="../../guides/deployment/render" title="Deploying Wasp to Render" description="Uses Render, Blueprint (IaC)" />
+
 If your desired provider isn't on the list, no worries, you can still deploy your app  - it just means we don't yet have a step-by-step guide for you to follow.
 Feel free to [open a PR](https://github.com/wasp-lang/wasp/edit/release/web/docs/deployment/deployment-methods/paas.md) if you'd like to write one yourself :)
 

--- a/web/docs/deployment/deployment-methods/paas.md
+++ b/web/docs/deployment/deployment-methods/paas.md
@@ -11,15 +11,15 @@ You can deploy the built Wasp app wherever and however you want, as long as your
 
 We have step-by-step guides for deploying your Wasp app to some of the most popular providers you can follow:
 
-<GuideLink linkToGuide="../../guides/deployment/flyio" title="Deploying Wasp to Fly.io" description="Uses Fly.io, fly CLI, Docker" />
+<GuideLink linkToGuide="../../guides/deployment/cloudflare" title="Deploying Wasp to Cloudflare Workers" description="Uses Cloudflare Workers, Wrangler CLI" />
 
-<GuideLink linkToGuide="../../guides/deployment/railway" title="Deploying Wasp to Railway" description="Uses Railway, Railway CLI" />
+<GuideLink linkToGuide="../../guides/deployment/flyio" title="Deploying Wasp to Fly.io" description="Uses Fly.io, fly CLI, Docker" />
 
 <GuideLink linkToGuide="../../guides/deployment/heroku" title="Deploying Wasp to Heroku" description="Uses Heroku, heroku CLI, Docker" />
 
 <GuideLink linkToGuide="../../guides/deployment/netlify" title="Deploying Wasp to Netlify" description="Uses Netlify, Netlify CLI" />
 
-<GuideLink linkToGuide="../../guides/deployment/cloudflare" title="Deploying Wasp to Cloudflare Workers" description="Uses Cloudflare Workers, Wrangler CLI" />
+<GuideLink linkToGuide="../../guides/deployment/railway" title="Deploying Wasp to Railway" description="Uses Railway, Railway CLI" />
 
 If your desired provider isn't on the list, no worries, you can still deploy your app  - it just means we don't yet have a step-by-step guide for you to follow.
 Feel free to [open a PR](https://github.com/wasp-lang/wasp/edit/release/web/docs/deployment/deployment-methods/paas.md) if you'd like to write one yourself :)

--- a/web/docs/deployment/deployment-methods/self-hosted.md
+++ b/web/docs/deployment/deployment-methods/self-hosted.md
@@ -11,11 +11,11 @@ If you have your server or rent out a server, you can self-host your Wasp apps. 
 
 We have step-by-step guides for deploying your Wasp app on your server with different methods. Check out the guides below:
 
-<GuideLink linkToGuide="../../guides/deployment/vps" title="Deploying Wasp with Docker on your server" description="Uses Ubuntu, Git, Caddy, Docker" />
+<GuideLink linkToGuide="../../guides/deployment/caprover" title="Deploying Wasp with Caprover on your server" description="Uses Caprover, Github Actions, Github Container Registry" />
 
 <GuideLink linkToGuide="../../guides/deployment/coolify" title="Deploying Wasp with Coolify on your server" description="Uses Coolify, Github Actions, Github Container Registry" />
 
-<GuideLink linkToGuide="../../guides/deployment/caprover" title="Deploying Wasp with Caprover on your server" description="Uses Caprover, Github Actions, Github Container Registry" />
+<GuideLink linkToGuide="../../guides/deployment/vps" title="Deploying Wasp with Docker on your server" description="Uses Ubuntu, Git, Caddy, Docker" />
 
 ## Manual deployment
 

--- a/web/docs/guides/deployment/cloud-providers/render.md
+++ b/web/docs/guides/deployment/cloud-providers/render.md
@@ -6,7 +6,6 @@ last_checked_with_versions:
 ---
 
 import AddExternalAuthEnvVarsReminder from './_addExternalAuthEnvVarsReminder.md'
-import { SecretGeneratorBlock } from '../../../project/SecretGeneratorBlock'
 import { Server, Client, Database } from '../DeploymentTag'
 
 # Render
@@ -29,17 +28,17 @@ To get started, follow these steps:
 
 Create a `render.yaml` file in the root of your repository. This defines all three services (database, server, and client):
 
-```yaml
+```yaml title="render.yaml"
 services:
   # Node.js server -- Render installs Wasp and builds from source
   - type: web
     name: <app-name>-server
     runtime: node
-    plan: free
-    region: oregon # pick the region closest to your users
+    plan: <plan>
+    region: <region>
     branch: main
     buildCommand: >-
-      npm install -g @wasp.sh/wasp-cli &&
+      npm install -g @wasp.sh/wasp-cli@<wasp-version> &&
       export PATH="$(npm prefix -g)/bin:$PATH" &&
       wasp build &&
       cd .wasp/out/server &&
@@ -65,7 +64,7 @@ services:
     runtime: static
     branch: main
     buildCommand: >-
-      npm install -g @wasp.sh/wasp-cli &&
+      npm install -g @wasp.sh/wasp-cli@<wasp-version> &&
       export PATH="$(npm prefix -g)/bin:$PATH" &&
       wasp build &&
       npx vite build
@@ -80,10 +79,19 @@ services:
 
 databases:
   - name: <app-name>-db
-    plan: free
-    region: oregon # must match the server region
+    plan: <plan>
+    region: <region>
     postgresMajorVersion: "18"
 ```
+
+You should replace the following values for your app:
+
+| Variable | Value | Example |
+|---|---|---|
+| `<app-name>` | A unique name for your app | `my-wasp-app` |
+| `<wasp-version>` | The Wasp CLI version you're using | `0.23` |
+| `<plan>` | The Render plan for your services | `free` |
+| `<region>` | The Render region closest to your users | `oregon` |
 
 :::caution
 The Render free-tier PostgreSQL database [expires after 30 days](https://render.com/docs/free#30-day-limit). Use the Starter plan or an external provider for production.
@@ -99,28 +107,26 @@ git push origin main
 
 ### Deploy with the Blueprint
 
-1. In the Render Dashboard, click **New > Blueprint**
-2. Connect your Git repository and select the branch with the `render.yaml`
-3. Render will parse the Blueprint and show the resources it will create. Review them and click **Apply**
+1. In the Render Dashboard, click **New > Blueprint**.
+2. Connect your Git repository and select the branch with the `render.yaml`.
+3. Render will parse the Blueprint and show the resources it will create. Do not fill out the environment variables form yet. Click **Apply**.
 
-This creates all three services and the database at once. Once they're provisioned, you need to set a few environment variables that couldn't be determined ahead of time.
+This will try to create all three services. It will fail initially, as some environment variables are missing.
 
 #### Set the Environment Variables
 
-Go to each service in the Render Dashboard and note its URL (e.g., `https://<app-name>-server.onrender.com` and `https://<app-name>-client.onrender.com`).
+Wait until all services are created. Go to each one in the Render Dashboard and note its URL (usually `https://<app-name>-server.onrender.com` and `https://<app-name>-client.onrender.com`).
 
-On the **server** Web Service, go to **Settings > Environment** and set:
+On the **server** Web Service, go to **Settings > Environment** and set the following variables. When you're done, click **Save and rebuild**:
 
 | Variable | Value |
 |---|---|
 | `WASP_SERVER_URL` | `https://<app-name>-server.onrender.com` |
 | `WASP_WEB_CLIENT_URL` | `https://<app-name>-client.onrender.com` |
 
-We can help you generate a `JWT_SECRET` if you didn't use the `generateValue: true` option in the Blueprint:<br/><SecretGeneratorBlock />
-
 <AddExternalAuthEnvVarsReminder />
 
-On the **client** Static Site, go to **Settings > Environment** and set:
+On the **client** Static Site, go to **Settings > Environment** and set the following variables. When you're done, click **Save and rebuild**:
 
 | Variable | Value |
 |---|---|
@@ -129,8 +135,6 @@ On the **client** Static Site, go to **Settings > Environment** and set:
 :::caution
 `REACT_APP_API_URL` must be set **before** the client build runs. Vite embeds it into the compiled JavaScript at build time. If it's missing, all API calls from the client will fail.
 :::
-
-After setting all the variables, trigger a manual redeploy for both services so they pick up the new values.
 
 :::tip Using a Render Environment Group
 Rather than setting variables on each service separately, you can create an [Environment Group](https://docs.render.com/configure-environment-variables#environment-groups) and link it to both services to manage shared variables in one place. This is a best practice on the Render platform.

--- a/web/docs/guides/deployment/cloud-providers/render.md
+++ b/web/docs/guides/deployment/cloud-providers/render.md
@@ -76,13 +76,13 @@ services:
     routes:
       - type: rewrite
         source: /*
-        destination: /index.html
+        destination: /200.html
 
 databases:
   - name: <app-name>-db
     plan: free
     region: oregon # must match the server region
-    postgresMajorVersion: "16"
+    postgresMajorVersion: "18"
 ```
 
 :::caution

--- a/web/docs/guides/deployment/cloud-providers/render.md
+++ b/web/docs/guides/deployment/cloud-providers/render.md
@@ -2,7 +2,7 @@
 comments: true
 last_checked_with_versions:
   Wasp: "0.23"
-  Render: 2026-04-06
+  Render: 2026-04-15
 ---
 
 import AddExternalAuthEnvVarsReminder from './_addExternalAuthEnvVarsReminder.md'

--- a/web/docs/guides/deployment/cloud-providers/render.md
+++ b/web/docs/guides/deployment/cloud-providers/render.md
@@ -22,7 +22,7 @@ Unlike the other providers listed here, Render builds your Wasp app from source 
 To get started, follow these steps:
 
 1. Create a [Render](https://render.com/) account.
-1. Push your Wasp project to a Git repository (GitHub or GitLab).
+1. Push your Wasp project to a Git repository (GitHub, GitLab, or Bitbucket).
 1. Generate your initial database migrations locally by running `wasp db migrate-dev` and commit the `migrations/` directory. Render needs these migration files in the repo to set up your database.
 
 ### Create the render.yaml Blueprint
@@ -86,7 +86,7 @@ databases:
 ```
 
 :::caution
-The Render free-tier PostgreSQL database expires after 90 days. Use the Starter plan or an external provider for production.
+The Render free-tier PostgreSQL database [expires after 30 days](https://render.com/docs/free#30-day-limit). Use the Starter plan or an external provider for production.
 :::
 
 Commit this file and push to your repository:
@@ -133,7 +133,7 @@ On the **client** Static Site, go to **Settings > Environment** and set:
 After setting all the variables, trigger a manual redeploy for both services so they pick up the new values.
 
 :::tip Using a Render Environment Group
-Rather than setting variables on each service separately, you can create an [Environment Group](https://docs.render.com/configure-environment-variables#environment-groups) and link it to both services to manage shared variables in one place.
+Rather than setting variables on each service separately, you can create an [Environment Group](https://docs.render.com/configure-environment-variables#environment-groups) and link it to both services to manage shared variables in one place. This is a best practice on the Render platform.
 :::
 
 ### Redeploying After Changes

--- a/web/docs/guides/deployment/cloud-providers/render.md
+++ b/web/docs/guides/deployment/cloud-providers/render.md
@@ -1,0 +1,167 @@
+<!--
+  NOTE: This is a proposed Render deployment section for inclusion in the Wasp docs.
+
+  It is a rewrite of https://github.com/Ho1yShif/open-saas/blob/main/render_deployment_guide.md
+  adapted to match the style and conventions of:
+  https://github.com/wasp-lang/wasp/blob/main/web/docs/deployment/deployment-methods/paas.md
+
+  The original guide is Open SaaS-specific and includes a render.yaml Blueprint file
+  (https://github.com/Ho1yShif/open-saas/blob/main/render.yaml) that automates the setup.
+  This rewrite is for generic Wasp apps.
+
+  Key technical difference from other providers: Render builds the app from source on its
+  servers. You don't need to run `wasp build` locally at all. Both the server and client
+  services install Wasp and run `wasp build` as part of their build commands, configured
+  via a `render.yaml` Blueprint file.
+
+  This section would be added to paas.md alongside Fly.io, Railway, Heroku, etc.
+  It references components that are imported at the top of paas.md:
+    - <Server />, <Client />, <Database /> - deployment scope tags from ./DeploymentTag
+    - <SecretGeneratorBlock /> - interactive JWT_SECRET generator
+    - <AddExternalAuthEnvVarsReminder /> - reminder for OAuth env vars (./_addExternalAuthEnvVarsReminder.md)
+
+  Render would also need to be added to the provider list at the top of paas.md:
+    - [Render](#render) in the bullet list
+    - Render <Server /> <Client /> <Database /> in the "Different Providers" section
+-->
+
+## Render <Server /> <Client /> <Database /> {#render}
+
+In this section, we'll show how to deploy the server, client, and provision a database on Render.
+
+Unlike the other providers listed here, Render builds your Wasp app from source on its servers, so you don't need to run `wasp build` locally before deploying. You'll define your entire deployment setup in a `render.yaml` file that Render uses as a [Blueprint](https://docs.render.com/infrastructure-as-code) to create and configure all services.
+
+### Prerequisites
+
+To get started, follow these steps:
+
+1. Create a [Render](https://render.com/) account.
+1. Push your Wasp project to a Git repository (GitHub or GitLab).
+1. Generate your initial database migrations locally by running `wasp db migrate-dev` and commit the `migrations/` directory. Render needs these migration files in the repo to set up your database.
+
+### Create the render.yaml Blueprint
+
+Create a `render.yaml` file in the root of your repository. This defines all three services (database, server, and client):
+
+```yaml
+services:
+  # Node.js server -- Render installs Wasp and builds from source
+  - type: web
+    name: <app-name>-server
+    runtime: node
+    plan: free
+    region: oregon # pick the region closest to your users
+    branch: main
+    buildCommand: >-
+      npm install -g @wasp.sh/wasp-cli &&
+      export PATH="$(npm prefix -g)/bin:$PATH" &&
+      wasp build &&
+      cd .wasp/out/server &&
+      npm install &&
+      npx prisma generate --schema=../db/schema.prisma &&
+      npm run bundle
+    startCommand: cd .wasp/out/server && npm run start-production
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: <app-name>-db
+          property: connectionString
+      - key: JWT_SECRET
+        generateValue: true
+      - key: WASP_SERVER_URL
+        sync: false # you'll fill this in after the first deploy
+      - key: WASP_WEB_CLIENT_URL
+        sync: false # you'll fill this in after the first deploy
+
+  # React client -- static site built with Vite
+  - type: web
+    name: <app-name>-client
+    runtime: static
+    branch: main
+    buildCommand: >-
+      npm install -g @wasp.sh/wasp-cli &&
+      export PATH="$(npm prefix -g)/bin:$PATH" &&
+      wasp build &&
+      npx vite build
+    staticPublishPath: .wasp/out/web-app/build
+    envVars:
+      - key: REACT_APP_API_URL
+        sync: false # you'll fill this in after the first deploy
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
+
+databases:
+  - name: <app-name>-db
+    plan: free
+    region: oregon # must match the server region
+    postgresMajorVersion: "16"
+```
+
+:::caution
+The Render free-tier PostgreSQL database expires after 90 days. Use the Starter plan or an external provider for production.
+:::
+
+Commit this file and push to your repository:
+
+```bash
+git add render.yaml
+git commit -m "Add Render Blueprint"
+git push origin main
+```
+
+### Deploy with the Blueprint
+
+1. In the Render Dashboard, click **New > Blueprint**
+2. Connect your Git repository and select the branch with the `render.yaml`
+3. Render will parse the Blueprint and show the resources it will create. Review them and click **Apply**
+
+This creates all three services and the database at once. Once they're provisioned, you need to set a few environment variables that couldn't be determined ahead of time.
+
+<!-- TOPIC: env vars -->
+
+#### Set the Environment Variables
+
+Go to each service in the Render Dashboard and note its URL (e.g., `https://<app-name>-server.onrender.com` and `https://<app-name>-client.onrender.com`).
+
+On the **server** Web Service, go to **Settings > Environment** and set:
+
+| Variable | Value |
+|---|---|
+| `WASP_SERVER_URL` | `https://<app-name>-server.onrender.com` |
+| `WASP_WEB_CLIENT_URL` | `https://<app-name>-client.onrender.com` |
+
+We can help you generate a `JWT_SECRET` if you didn't use the `generateValue: true` option in the Blueprint:<br/><SecretGeneratorBlock />
+
+<AddExternalAuthEnvVarsReminder />
+
+On the **client** Static Site, go to **Settings > Environment** and set:
+
+| Variable | Value |
+|---|---|
+| `REACT_APP_API_URL` | `https://<app-name>-server.onrender.com` |
+
+:::caution
+`REACT_APP_API_URL` must be set **before** the client build runs. Vite embeds it into the compiled JavaScript at build time. If it's missing, all API calls from the client will fail.
+:::
+
+After setting all the variables, trigger a manual redeploy for both services so they pick up the new values.
+
+:::tip Using a Render Environment Group
+Rather than setting variables on each service separately, you can create an [Environment Group](https://docs.render.com/configure-environment-variables#environment-groups) and link it to both services to manage shared variables in one place.
+:::
+
+### Redeploying After Changes
+
+Render auto-deploys when it detects a new commit on the configured branch. Just push your changes:
+
+```bash
+git push origin main
+```
+
+If you have new database model changes, make sure to run `wasp db migrate-dev` locally first and commit the generated migration files along with your code changes. The server runs `prisma migrate deploy` on startup, so new migrations are applied automatically on each deploy.
+
+:::note Build time
+Both services install Wasp and compile the app from source on each deploy. On the free tier, this can take 10-15 minutes. If builds consistently time out, consider upgrading to the Starter plan.
+:::

--- a/web/docs/guides/deployment/cloud-providers/render.md
+++ b/web/docs/guides/deployment/cloud-providers/render.md
@@ -1,33 +1,19 @@
-<!--
-  NOTE: This is a proposed Render deployment section for inclusion in the Wasp docs.
+---
+comments: true
+last_checked_with_versions:
+  Wasp: "0.23"
+  Render: 2026-04-06
+---
 
-  It is a rewrite of https://github.com/Ho1yShif/open-saas/blob/main/render_deployment_guide.md
-  adapted to match the style and conventions of:
-  https://github.com/wasp-lang/wasp/blob/main/web/docs/deployment/deployment-methods/paas.md
+import AddExternalAuthEnvVarsReminder from './_addExternalAuthEnvVarsReminder.md'
+import { SecretGeneratorBlock } from '../../../project/SecretGeneratorBlock'
+import { Server, Client, Database } from '../DeploymentTag'
 
-  The original guide is Open SaaS-specific and includes a render.yaml Blueprint file
-  (https://github.com/Ho1yShif/open-saas/blob/main/render.yaml) that automates the setup.
-  This rewrite is for generic Wasp apps.
+# Render
 
-  Key technical difference from other providers: Render builds the app from source on its
-  servers. You don't need to run `wasp build` locally at all. Both the server and client
-  services install Wasp and run `wasp build` as part of their build commands, configured
-  via a `render.yaml` Blueprint file.
+## Deploy Wasp to Render <Server /> <Client /> <Database />
 
-  This section would be added to paas.md alongside Fly.io, Railway, Heroku, etc.
-  It references components that are imported at the top of paas.md:
-    - <Server />, <Client />, <Database /> - deployment scope tags from ./DeploymentTag
-    - <SecretGeneratorBlock /> - interactive JWT_SECRET generator
-    - <AddExternalAuthEnvVarsReminder /> - reminder for OAuth env vars (./_addExternalAuthEnvVarsReminder.md)
-
-  Render would also need to be added to the provider list at the top of paas.md:
-    - [Render](#render) in the bullet list
-    - Render <Server /> <Client /> <Database /> in the "Different Providers" section
--->
-
-## Render <Server /> <Client /> <Database /> {#render}
-
-In this section, we'll show how to deploy the server, client, and provision a database on Render.
+This guide shows you how to deploy the server, client, and provision a database on Render.
 
 Unlike the other providers listed here, Render builds your Wasp app from source on its servers, so you don't need to run `wasp build` locally before deploying. You'll define your entire deployment setup in a `render.yaml` file that Render uses as a [Blueprint](https://docs.render.com/infrastructure-as-code) to create and configure all services.
 
@@ -118,8 +104,6 @@ git push origin main
 3. Render will parse the Blueprint and show the resources it will create. Review them and click **Apply**
 
 This creates all three services and the database at once. Once they're provisioned, you need to set a few environment variables that couldn't be determined ahead of time.
-
-<!-- TOPIC: env vars -->
 
 #### Set the Environment Variables
 

--- a/web/docs/guides/deployment/cloud-providers/render.md
+++ b/web/docs/guides/deployment/cloud-providers/render.md
@@ -57,6 +57,8 @@ services:
         sync: false # you'll fill this in after the first deploy
       - key: WASP_WEB_CLIENT_URL
         sync: false # you'll fill this in after the first deploy
+      - key: NODE_VERSION
+        value: "24"
 
   # React client -- static site built with Vite
   - type: web
@@ -72,6 +74,8 @@ services:
     envVars:
       - key: REACT_APP_API_URL
         sync: false # you'll fill this in after the first deploy
+      - key: NODE_VERSION
+        value: "24"
     routes:
       - type: rewrite
         source: /*


### PR DESCRIPTION
## Description

Adds a new deployment guide for Render, covering server, client, and database setup using Render's Blueprint (Infrastructure as Code) approach. Also sorts the deployment provider links alphabetically in the PaaS and self-hosted pages.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.