### PR TITLE
build(wasp-cli): fix typescript execution on arm64 build

### DIFF
--- a/waspc/run
+++ b/waspc/run
@@ -23,7 +23,7 @@ DEFAULT_COLOR="\033[39m"
 WASP_PACKAGES_COMPILE="for pkg in ${SCRIPT_DIR}/data/packages/*/package.json; do \
   (cd \$(dirname \$pkg) && npm install && npm run build); \
 done"
-WASP_LIBS_COMPILE="node ${SCRIPT_DIR}/tools/libs/build.ts"
+WASP_LIBS_COMPILE="npx tsx ${SCRIPT_DIR}/tools/libs/build.ts"
 WASP_ALL_DEPS_COMPILE="$WASP_PACKAGES_COMPILE && $WASP_LIBS_COMPILE"
 BUILD_HS_CMD="cabal build all ${BUILD_STATIC:+--enable-executable-static}"
 BUILD_HS_FULL_CMD="cabal build all --enable-tests --enable-benchmarks"
@@ -42,9 +42,9 @@ WASP_CLI_TESTS_CMD="cabal test wasp-cli-tests --test-options='--hide-successes'"
 
 WASPLS_TESTS_CMD="cabal test waspls-tests --test-options='--hide-successes'"
 
-LIBS_TESTS_CMD="node ${SCRIPT_DIR}/tools/libs/test.ts"
+LIBS_TESTS_CMD="npx tsx ${SCRIPT_DIR}/tools/libs/test.ts"
 
-PACKAGES_TESTS_CMD="node ${SCRIPT_DIR}/tools/packages/test.ts"
+PACKAGES_TESTS_CMD="npx tsx ${SCRIPT_DIR}/tools/packages/test.ts"
 
 KITCHEN_SINK_E2E_TESTS_CMD="cd $REPOSITORY_ROOT/examples/kitchen-sink && npm i && npm run test"
 
@@ -366,7 +366,7 @@ case $COMMAND in
     echo_and_eval "$GHCUP_SET"
     ;;
   get-waspc-version)
-    node "$SCRIPT_DIR/tools/get-waspc-version.ts"
+    npx tsx "$SCRIPT_DIR/tools/get-waspc-version.ts"
     ;;
   *)
     print_usage

--- a/waspc/tools/libs/build.ts
+++ b/waspc/tools/libs/build.ts
@@ -51,7 +51,7 @@ function assertLibVersionValid(libName: string, libVersion: string): void {
 }
 
 function getWaspcVersion(): string {
-  return runCmd("node", [join("tools", "get-waspc-version.ts")], {
+  return runCmd("npx", ["tsx", join("tools", "get-waspc-version.ts")], {
     cwd: waspcDirPath,
   }).trim();
 }


### PR DESCRIPTION
## Description

fix `waspc` build script to use `tsx` instead of bare `node` when executing typescript files, enabling successfull build on apple silicon (arm64) without requiring specific node.js version with typescript support.

## Issue

the `waspc` build script (`waspc/run`) and related typescript build tools use `node` to execute `.ts` files:

 e.g. `node ${SCRIPT_DIR}/tools/libs/build.ts`

also, `waspc/tools/libs/build.ts` spawns a child node process using `node`:

`runCmd("node", [join("tools", "get-waspc-version.ts")], { cwd: waspcDirPath })`

This fails on systems where the default `node` cannot handle typescript files without additional loaders, resulting in the following error:

`TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`

## Changes

replace all `node` instances for `.ts` files with `npx tsx`, which properly loads typescript files.

## Why

`tsx` requires no config and is available via npx without preinstall and the project already includes `typescript` as a dev dependency in `package.json`; `npx tsx` works across all nodejs versions and platforms.


## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

Just a change to the build tooling; existing tests work fine.