### PR TITLE
fix(deploy): pass workspace filter to Railway project listing

### DIFF
--- a/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
@@ -90,6 +90,7 @@ async function setupRailwayProjectForDirectory({
     waspProjectDir,
     railwayExe,
     existingProjectId,
+    workspace,
   });
 
   switch (status) {

--- a/waspc/data/packages/deploy/src/providers/railway/railwayProject/cli.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayProject/cli.ts
@@ -106,27 +106,29 @@ export async function getRailwayProjectForDirectory(
 export async function getRailwayProjectById(
   railwayExe: RailwayCliExe,
   id: string,
+  workspace?: string,
 ): Promise<RailwayProject | null> {
-  const projects = await getRailwayProjects(railwayExe);
+  const projects = await getRailwayProjects(railwayExe, workspace);
   return projects.find((project) => project.id === id) ?? null;
 }
 
 export async function getRailwayProjectByName(
   railwayExe: RailwayCliExe,
   name: string,
+  workspace?: string,
 ): Promise<RailwayProject | null> {
-  const projects = await getRailwayProjects(railwayExe);
+  const projects = await getRailwayProjects(railwayExe, workspace);
   return projects.find((project) => project.name === name) ?? null;
 }
 
-// TODO: Figure out how to specify the workspace when listing projects.
-// This command lists all projects in all the workspaces the user has access to.
 async function getRailwayProjects(
   railwayExe: RailwayCliExe,
+  workspace?: string,
 ): Promise<RailwayProject[]> {
+  const workspaceArg = workspace ? ["--workspace", workspace] : [];
   const result = await $({
     verbose: false,
-  })`${railwayExe} list --json`;
+  })`${railwayExe} list --json ${workspaceArg}`;
 
   const projects = RailwayProjectListSchema.parse(JSON.parse(result.stdout));
 

--- a/waspc/data/packages/deploy/src/providers/railway/railwayProject/index.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayProject/index.ts
@@ -22,11 +22,13 @@ export async function getRailwayProjectStatus({
   waspProjectDir,
   railwayExe,
   existingProjectId,
+  workspace,
 }: {
   projectName: RailwayProjectName;
   existingProjectId?: RailwayProjectId;
   waspProjectDir: WaspProjectDir;
   railwayExe: RailwayCliExe;
+  workspace?: string;
 }): Promise<
   | {
       status: ProjectStatus.EXISTING_PROJECT_ALREADY_LINKED;
@@ -62,6 +64,7 @@ export async function getRailwayProjectStatus({
     const existingProject = await getExistingProjectById(
       railwayExe,
       existingProjectId,
+      workspace,
     );
 
     return {
@@ -70,7 +73,7 @@ export async function getRailwayProjectStatus({
     };
   }
 
-  await assertUniqueProjectName(railwayExe, projectName);
+  await assertUniqueProjectName(railwayExe, projectName, workspace);
   return {
     status: ProjectStatus.MISSING_PROJECT,
     project: null,
@@ -80,10 +83,12 @@ export async function getRailwayProjectStatus({
 async function getExistingProjectById(
   railwayExe: RailwayCliExe,
   existingProjectId: RailwayProjectId,
+  workspace?: string,
 ): Promise<RailwayProject> {
   const projectById = await getRailwayProjectById(
     railwayExe,
     existingProjectId,
+    workspace,
   );
   if (projectById === null) {
     throw new Error(`Project with ID "${existingProjectId}" does not exist.`);
@@ -106,8 +111,13 @@ async function assertProvidedProjectNameSameAsExistingProjectName(
 async function assertUniqueProjectName(
   railwayExe: RailwayCliExe,
   projectName: RailwayProjectName,
+  workspace?: string,
 ): Promise<void> {
-  const project = await getRailwayProjectByName(railwayExe, projectName);
+  const project = await getRailwayProjectByName(
+    railwayExe,
+    projectName,
+    workspace,
+  );
   if (project !== null) {
     throw new Error(
       `Project with name "${project.name}" already exists. Add "--existing-project-id ${project.id}" option to this command to link it or use a different name.`,

--- a/waspc/data/packages/deploy/test/providers/railway/cli.test.ts
+++ b/waspc/data/packages/deploy/test/providers/railway/cli.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockTagFn = vi.fn();
+
+vi.mock("zx", () => ({
+  $: vi.fn(() => mockTagFn),
+}));
+
+import { $ } from "zx";
+import {
+  getRailwayProjectById,
+  getRailwayProjectByName,
+} from "../../../src/providers/railway/railwayProject/cli.js";
+
+const mock$ = $ as unknown as ReturnType<typeof vi.fn>;
+
+const mockProjects = [
+  {
+    id: "proj-1",
+    name: "my-project",
+    services: { edges: [] },
+  },
+  {
+    id: "proj-2",
+    name: "other-project",
+    services: { edges: [] },
+  },
+];
+
+function mockRailwayList(projects: object[] = mockProjects) {
+  mockTagFn.mockResolvedValue({
+    stdout: JSON.stringify(projects),
+  });
+}
+
+/** Reconstruct the command string from a tagged template call's arguments. */
+function getCommandFromTaggedTemplateCall(call: unknown[]): string {
+  const strings = call[0] as string[];
+  const values = call.slice(1);
+  let cmd = "";
+  for (let i = 0; i < strings.length; i++) {
+    cmd += strings[i];
+    if (i < values.length) {
+      cmd += String(values[i]);
+    }
+  }
+  return cmd.trim();
+}
+
+describe("getRailwayProjectById", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("finds project by id without workspace", async () => {
+    mockRailwayList();
+    const project = await getRailwayProjectById("railway" as any, "proj-1");
+    expect(project).not.toBeNull();
+    expect(project!.id).toBe("proj-1");
+  });
+
+  test("passes --workspace to railway list when workspace provided", async () => {
+    mockRailwayList();
+    await getRailwayProjectById("railway" as any, "proj-1", "team-xyz");
+
+    expect(mockTagFn).toHaveBeenCalledTimes(1);
+    const cmd = getCommandFromTaggedTemplateCall(mockTagFn.mock.calls[0]);
+    expect(cmd).toContain("--workspace");
+    expect(cmd).toContain("team-xyz");
+  });
+
+  test("does not pass --workspace when workspace is undefined", async () => {
+    mockRailwayList();
+    await getRailwayProjectById("railway" as any, "proj-1", undefined);
+
+    expect(mockTagFn).toHaveBeenCalledTimes(1);
+    const cmd = getCommandFromTaggedTemplateCall(mockTagFn.mock.calls[0]);
+    expect(cmd).not.toContain("--workspace");
+  });
+});
+
+describe("getRailwayProjectByName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("finds project by name without workspace", async () => {
+    mockRailwayList();
+    const project = await getRailwayProjectByName(
+      "railway" as any,
+      "my-project",
+    );
+    expect(project).not.toBeNull();
+    expect(project!.name).toBe("my-project");
+  });
+
+  test("passes --workspace to railway list when workspace provided", async () => {
+    mockRailwayList();
+    await getRailwayProjectByName("railway" as any, "my-project", "team-xyz");
+
+    expect(mockTagFn).toHaveBeenCalledTimes(1);
+    const cmd = getCommandFromTaggedTemplateCall(mockTagFn.mock.calls[0]);
+    expect(cmd).toContain("--workspace");
+    expect(cmd).toContain("team-xyz");
+  });
+});


### PR DESCRIPTION
## Summary

The `wasp deploy railway launch` command accepts a `--workspace` option but never used it when fetching Railway projects via `railway list`. This meant users with projects in specific workspaces couldn't select them during deployment.

Closes #3430

## Changes

- `railwayProject/cli.ts`: Added `workspace?` parameter to `getRailwayProjects()`, `getRailwayProjectById()`, `getRailwayProjectByName()`. Passes `--workspace` flag to `railway list --json`.
- `railwayProject/index.ts`: Forwarded `workspace` parameter through the public API functions.
- `commands/setup/setup.ts`: Passes `workspace` from deployment options to project status lookup.
- Removed the existing TODO comment acknowledging this gap.

## Tests

5 new tests in `cli.test.ts` covering workspace passthrough via mocked `zx.$`.

## Verification

- 62 tests passing (57 existing + 5 new)
- TypeScript compiles cleanly
- Prettier confirms formatting is correct