### PR TITLE
fix: clarify bash completion is Bash-only, not Zsh compatible

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
@@ -56,14 +56,12 @@ printBashCompletionInstruction =
     unlines
       [ "Setting up Bash auto-completion for Wasp:",
         "",
-        "1. Add the following line at the end of your shell configuration file:",
+        "1. Add the following line at the end of your " ++ styleCode "~/.bashrc" ++ " file:",
         styleCode "     complete -o default -o nospace -C 'wasp completion:list' wasp",
-        "",
-        "   Default shell configuration file locations:",
-        "   - Bash: " ++ styleCode "~/.bashrc",
-        "   - Zsh: " ++ styleCode "~/.zshrc",
         "",
         "2. Save the file and restart your terminal.",
         "",
-        "Done! Now you can use the TAB key to auto-complete Wasp commands in your shell."
+        "Note: Bash auto-completion is currently only supported for Bash, not Zsh or other shells.",
+        "",
+        "Done! Now you can use the TAB key to auto-complete Wasp commands."
       ]


### PR DESCRIPTION
## Summary
The `wasp completion` command prints setup instructions that suggest adding the `complete` builtin to `~/.zshrc`, but `complete` is a Bash-specific command that does not exist in Zsh. Users following the instructions for Zsh will get a "command not found: complete" error.

## Changes
- Removed the misleading Zsh config file mention
- Updated instructions to specifically reference `~/.bashrc`
- Added a note that auto-completion is currently only supported for Bash

Related #256

Assisted-by: GLM 5.1