### PR TITLE
Add `action` to the new spec pipeline

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/spec/mapApp.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/mapApp.unit.test.ts
@@ -3,6 +3,7 @@ import * as AppSpec from "../../src/appSpec.js";
 import {
   deriveExtImportName,
   makeRefParser,
+  mapAction,
   mapApp,
   mapExtImport,
   mapPage,
@@ -132,6 +133,28 @@ describe("mapQuery", () => {
       entities: query.entities?.map(entityRefParser),
       auth: query.auth,
     } satisfies AppSpec.Query);
+  }
+});
+
+describe("mapAction", () => {
+  test("should map minimal config correctly", () => {
+    testMapAction(Fixtures.getAction("minimal"));
+  });
+
+  test("should map full config correctly", () => {
+    testMapAction(Fixtures.getAction("full"));
+  });
+
+  function testMapAction(action: TsAppSpec.Action): void {
+    const entityRefParser = makeRefParser("Entity", action.entities ?? []);
+
+    const result = mapAction(action, entityRefParser);
+
+    expect(result).toStrictEqual({
+      fn: mapExtImport(action.fn),
+      entities: action.entities?.map(entityRefParser),
+      auth: action.auth,
+    } satisfies AppSpec.Action);
   }
 });
 

--- a/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
@@ -6,7 +6,7 @@
 
 import * as AppSpec from "../../src/appSpec.js";
 import { Branded } from "../../src/branded.js";
-import { app, page, query } from "../../src/spec/publicApi/index.js";
+import { action, app, page, query } from "../../src/spec/publicApi/index.js";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
 
 const CONFIG_TYPES = ["minimal", "full"] as const;
@@ -44,6 +44,23 @@ export function getQuery(scope: ConfigType): Config<TsAppSpec.Query> {
       return query(getExtImport("minimal", "named"));
     case "full":
       return query(getExtImport("full", "named"), {
+        entities: ["Task"],
+        auth: true,
+      });
+    default:
+      assertUnreachable(scope);
+  }
+}
+
+export function getAction(scope: "minimal"): MinimalConfig<TsAppSpec.Action>;
+export function getAction(scope: "full"): FullConfig<TsAppSpec.Action>;
+export function getAction(scope: ConfigType): Config<TsAppSpec.Action>;
+export function getAction(scope: ConfigType): Config<TsAppSpec.Action> {
+  switch (scope) {
+    case "minimal":
+      return action(getExtImport("minimal", "named"));
+    case "full":
+      return action(getExtImport("full", "named"), {
         entities: ["Task"],
         auth: true,
       });

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -33,6 +33,14 @@ export function mapApp(
     (query) => mapQuery(query, entityRefParser),
   );
 
+  const actions = extractParts("action", parts);
+  const actionDecls = mapToDecls(
+    actions,
+    "Action",
+    (action) => deriveExtImportName(action.fn),
+    (action) => mapAction(action, entityRefParser),
+  );
+
   const appDecl = {
     declType: "App" as const,
     declName: name,
@@ -54,9 +62,9 @@ export function mapApp(
     App: [appDecl],
     Page: pageDecls,
     Query: queryDecls,
+    Action: actionDecls,
     // TODO: add these guys
     Route: [],
-    Action: [],
     Job: [],
     Api: [],
     ApiNamespace: [],
@@ -77,6 +85,18 @@ export function mapQuery(
   entityRefParser: RefParser<"Entity">,
 ): AppSpec.Query {
   const { fn, entities, auth } = query;
+  return {
+    fn: mapExtImport(fn),
+    entities: entities?.map(entityRefParser),
+    auth,
+  };
+}
+
+export function mapAction(
+  action: TsAppSpec.Action,
+  entityRefParser: RefParser<"Entity">,
+): AppSpec.Action {
+  const { fn, entities, auth } = action;
   return {
     fn: mapExtImport(fn),
     entities: entities?.map(entityRefParser),

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/constructors.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/constructors.ts
@@ -1,4 +1,4 @@
-import type { App, Page, Query } from "./tsAppSpec.js";
+import type { Action, App, Page, Query } from "./tsAppSpec.js";
 
 export function app(input: Omit<App, "kind">): App {
   return input;
@@ -16,4 +16,11 @@ export function query(
   config?: Pick<Query, "entities" | "auth">,
 ): Query {
   return { kind: "query", fn, ...config };
+}
+
+export function action(
+  fn: Action["fn"],
+  config?: Pick<Action, "entities" | "auth">,
+): Action {
+  return { kind: "action", fn, ...config };
 }

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/index.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/index.ts
@@ -1,2 +1,2 @@
-export { app, page, query } from "./constructors.js";
-export type { App, ExtImport, Page, Part, Query } from "./tsAppSpec.js";
+export { action, app, page, query } from "./constructors.js";
+export type { Action, App, ExtImport, Page, Part, Query } from "./tsAppSpec.js";

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -6,7 +6,7 @@ export type App = {
   parts: Part[];
 };
 
-export type Part = Page | Query;
+export type Part = Page | Query | Action;
 
 export type Page = MakePart<
   "page",
@@ -18,6 +18,15 @@ export type Page = MakePart<
 
 export type Query = MakePart<
   "query",
+  {
+    fn: ExtImport;
+    entities?: string[];
+    auth?: boolean;
+  }
+>;
+
+export type Action = MakePart<
+  "action",
   {
     fn: ExtImport;
     entities?: string[];


### PR DESCRIPTION
## Description

Adds the \`action\` part on top of the spec skeleton in #4076. 

Stacks on #4076 - review that one first.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in \`examples/kitchen-sink/e2e-tests\`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in \`waspc/data/Cli/templates\`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in \`examples/\`, as needed.
    - [ ] _(if you updated \`examples/tutorials\`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in \`web/docs/\`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated \`waspc/ChangeLog.md\` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in \`web/docs/migration-guides/\`.
  - [ ] I **bumped the \`version\`** in \`waspc/waspc.cabal\` to reflect the changes I introduced.