### PR TITLE
Properly set the `NODE_ENV` env var depending on the command used to run Wasp

### DIFF
--- a/examples/waspello/tsconfig.wasp.json
+++ b/examples/waspello/tsconfig.wasp.json
@@ -12,6 +12,7 @@
     "module": "NodeNext",
     "noEmit": true,
 
+    "types": ["node"],
     "lib": ["ES2023"]
   },
   "include": ["main.wasp.ts"]

--- a/examples/waspello/tsconfig.wasp.json
+++ b/examples/waspello/tsconfig.wasp.json
@@ -12,7 +12,6 @@
     "module": "NodeNext",
     "noEmit": true,
 
-    "types": ["node"],
     "lib": ["ES2023"]
   },
   "include": ["main.wasp.ts"]

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -9,6 +9,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 ### 🎉 New Features
 
 - The `api` export from `wasp/client/api` is now a [Ky](https://github.com/sindresorhus/ky) instance instead of Axios for improved performance and smaller final size. ([#3998](https://github.com/wasp-lang/wasp/pull/3998))
+- Wasp TS spec now properly sets the `NODE_ENV` environment variable depending on which command you use to run Wasp. ([#4087](https://github.com/wasp-lang/wasp/pull/4087))
 
 ## 0.23.0
 

--- a/waspc/cli/src/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Wasp.Cli.Command.Build
   ( build,
   )
@@ -159,7 +161,7 @@ buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir bu
   where
     options =
       CompileOptions
-        { waspProjectDirPath = waspProjectDir,
+        { waspProjectDir,
           buildType = BuildType.Production,
           sendMessage = cliSendMessage,
           -- Ignore "DB needs migration warnings" during build, as that is not a required step.

--- a/waspc/cli/src/Wasp/Cli/Command/Compile.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Compile.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Wasp.Cli.Command.Compile
   ( compileIO,
     compile,
@@ -132,7 +134,7 @@ compileIOWithOptions options waspProjectDir outDir =
 defaultCompileOptions :: Path' Abs (Dir WaspProjectDir) -> CompileOptions
 defaultCompileOptions waspProjectDir =
   CompileOptions
-    { waspProjectDirPath = waspProjectDir,
+    { waspProjectDir,
       buildType = BuildType.Development,
       sendMessage = cliSendMessage,
       generatorWarningsFilter = id

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/AvailableTemplates.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/AvailableTemplates.hs
@@ -3,6 +3,10 @@
 module Wasp.Cli.Command.CreateNewProject.AvailableTemplates
   ( availableStarterTemplates,
     defaultStarterTemplate,
+    basicStarterTemplate,
+    minimalStarterTemplate,
+    tsMinimalStarterTemplate,
+    openSaasStarterTemplate,
   )
 where
 

--- a/waspc/data/Cli/starters/ts-minimal/tsconfig.wasp.json
+++ b/waspc/data/Cli/starters/ts-minimal/tsconfig.wasp.json
@@ -9,6 +9,7 @@
     "noUnusedParameters": true,
     "module": "NodeNext",
     "noEmit": true,
+    "types": ["node"],
     "lib": ["ES2023"]
   },
   "include": ["main.wasp.ts"]

--- a/waspc/data/Cli/starters/ts-minimal/tsconfig.wasp.json
+++ b/waspc/data/Cli/starters/ts-minimal/tsconfig.wasp.json
@@ -9,7 +9,6 @@
     "noUnusedParameters": true,
     "module": "NodeNext",
     "noEmit": true,
-    "types": ["node"],
     "lib": ["ES2023"]
   },
   "include": ["main.wasp.ts"]

--- a/waspc/e2e-tests/FileSystem.hs
+++ b/waspc/e2e-tests/FileSystem.hs
@@ -5,6 +5,7 @@ module FileSystem
     SeedsFile,
     seedsDirInWaspProjectDir,
     mainWaspFileInWaspProjectDir,
+    mainWaspTsFileInWaspProjectDir,
     seedsFileInSeedsDir,
     TestOutputsDir,
     TestCaseDir,
@@ -71,6 +72,9 @@ seedsFileInSeedsDir = fromJust . parseRelFile
 
 mainWaspFileInWaspProjectDir :: Path' (Rel WaspProjectDir) File'
 mainWaspFileInWaspProjectDir = [relfile|main.wasp|]
+
+mainWaspTsFileInWaspProjectDir :: Path' (Rel WaspProjectDir) File'
+mainWaspTsFileInWaspProjectDir = [relfile|main.wasp.ts|]
 
 -- 'Test' tests file system
 

--- a/waspc/e2e-tests/Main.hs
+++ b/waspc/e2e-tests/Main.hs
@@ -22,6 +22,7 @@ import Tests.WaspDockerfileTest (waspDockerfileTest)
 import Tests.WaspInfoTest (waspInfoTest)
 import Tests.WaspNewTest (waspNewTest)
 import Tests.WaspTelemetryTest (waspTelemetryTest)
+import Tests.WaspTsSpecNodeEnvTest (waspTsSpecNodeEnvTest)
 import Tests.WaspVersionTest (waspVersionTest)
 
 main :: IO ()
@@ -59,6 +60,7 @@ e2eTests = do
         -- These will be fixed as part of the refactor to pure Haskell tests.
         -- FIXME: waspStartTest,
         waspBuildTest,
+        waspTsSpecNodeEnvTest,
         viteBuildTest,
         viteConfigTest,
         -- FIXME: waspBuildStartTest,

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -5,13 +5,12 @@
 module ShellCommands
   ( ShellCommand,
     ShellCommandBuilder (..),
-    WaspNewTemplate (..),
     buildShellCommand,
     (~|),
     (~&&),
     (~?),
     (~||),
-    createFile,
+    writeToFile,
     appendToFile,
     replaceLineInFile,
     waspCliNewInteractive,
@@ -56,6 +55,8 @@ import qualified Data.Text as T
 import FileSystem (GitRootDir, SnapshotDir, TestCaseDir, gitRootFromSnapshotDir, mainWaspFileInWaspProjectDir, mainWaspTsFileInWaspProjectDir, seedsDirInWaspProjectDir, seedsFileInSeedsDir)
 import StrongPath (Abs, Dir, File', Path', Rel, fromAbsDir, fromAbsFile, fromRelDir, parent, (</>))
 import System.FilePath (joinPath)
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
+import Wasp.Cli.Command.CreateNewProject.StarterTemplates (StarterTemplate)
 import Wasp.Generator.DbGenerator.Common (dbMigrationsDirInDbRootDir, dbRootDirInGeneratedAppDir)
 import Wasp.Project (WaspProjectDir)
 import Wasp.Project.Common (dotWaspDirInWaspProjectDir, generatedAppDirInDotWaspDir)
@@ -105,8 +106,8 @@ infixl 4 ~?
 
 -- General commands
 
-createFile :: Path' Abs File' -> T.Text -> ShellCommandBuilder context ShellCommand
-createFile file fileContent = return $ createParentDir ~&& writeContentsToFile
+writeToFile :: Path' Abs File' -> T.Text -> ShellCommandBuilder context ShellCommand
+writeToFile file fileContent = return $ createParentDir ~&& writeContentsToFile
   where
     createParentDir :: ShellCommand
     createParentDir = "mkdir -p " ++ fromAbsDir (parent file)
@@ -134,27 +135,13 @@ replaceLineInFile fileName lineNumber line =
 
     tempFileName = fileName ++ ".tmp"
 
-data WaspNewTemplate = Minimal | Basic | TsMinimal | SaaS
+waspCliNewInteractive :: String -> StarterTemplate -> ShellCommandBuilder context ShellCommand
+waspCliNewInteractive appName starterTemplate =
+  return $ unwords ["printf", "\"" ++ appName ++ "\n" ++ show starterTemplate ++ "\n\""] ~| "wasp-cli new"
 
-waspCliNewInteractive :: String -> WaspNewTemplate -> ShellCommandBuilder context ShellCommand
-waspCliNewInteractive appName template =
-  return $
-    unwords ["printf", "\"" ++ appName ++ "\n" ++ templateNumber ++ "\n\""] ~| "wasp-cli new"
-  where
-    templateNumber = case template of
-      Basic -> "1"
-      Minimal -> "2"
-      TsMinimal -> "3"
-      SaaS -> "4"
-
-waspCliNew :: String -> WaspNewTemplate -> ShellCommandBuilder context ShellCommand
-waspCliNew appName template = return $ unwords ["wasp-cli", "new", appName, "-t", templateName]
-  where
-    templateName = case template of
-      Basic -> "basic"
-      Minimal -> "minimal"
-      TsMinimal -> "ts-minimal"
-      SaaS -> "saas"
+waspCliNew :: String -> StarterTemplate -> ShellCommandBuilder context ShellCommand
+waspCliNew appName starterTemplate =
+  return $ unwords ["wasp-cli", "new", appName, "-t", show starterTemplate]
 
 waspCliCompletion :: ShellCommandBuilder context ShellCommand
 waspCliCompletion = return "wasp-cli completion"
@@ -254,21 +241,21 @@ createSeedFile fileName content = do
   let seedDir = context.waspProjectDir </> seedsDirInWaspProjectDir
       seedFile = seedDir </> seedsFileInSeedsDir fileName
 
-  createFile seedFile content
+  writeToFile seedFile content
 
 replaceMainWaspFile :: T.Text -> ShellCommandBuilder WaspProjectContext ShellCommand
 replaceMainWaspFile content = do
   context <- ask
   let mainWaspFile = context.waspProjectDir </> mainWaspFileInWaspProjectDir
 
-  createFile mainWaspFile content
+  writeToFile mainWaspFile content
 
 replaceMainWaspTsFile :: T.Text -> ShellCommandBuilder WaspProjectContext ShellCommand
 replaceMainWaspTsFile content = do
   context <- ask
   let mainWaspTsFile = context.waspProjectDir </> mainWaspTsFileInWaspProjectDir
 
-  createFile mainWaspTsFile content
+  writeToFile mainWaspTsFile content
 
 -- | Builds and deletes the Docker image for a Wasp app.
 -- Can be disabled via the @WASP_E2E_TESTS_SKIP_DOCKER@ environment variable.
@@ -301,7 +288,7 @@ inTestWaspProjectDir waspProjectCommandBuilders = do
       ~&& foldr1 (~&&) (buildShellCommand context.waspProjectContext $ sequence waspProjectCommandBuilders)
       ~&& unwords ["cd", fromAbsDir context.testCaseDir]
 
-createTestWaspProject :: WaspNewTemplate -> ShellCommandBuilder TestContext ShellCommand
+createTestWaspProject :: StarterTemplate -> ShellCommandBuilder TestContext ShellCommand
 createTestWaspProject template = do
   context <- ask
   waspCliNew context.waspProjectContext.waspProjectName template
@@ -317,7 +304,7 @@ data SnapshotTestContext = SnapshotTestContext
 createSnapshotWaspProjectFromMinimalStarter :: ShellCommandBuilder SnapshotTestContext ShellCommand
 createSnapshotWaspProjectFromMinimalStarter = do
   context <- ask
-  waspCliNew context.waspProjectContext.waspProjectName Minimal
+  waspCliNew context.waspProjectContext.waspProjectName minimalStarterTemplate
 
 inSnapshotWaspProjectDir ::
   [ShellCommandBuilder WaspProjectContext ShellCommand] ->

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -33,8 +33,10 @@ module ShellCommands
     waspCliDbStudio,
     waspCliInfo,
     waspCliDeps,
+    waspCliTsSetup,
     createSeedFile,
     replaceMainWaspFile,
+    replaceMainWaspTsFile,
     waspCliDockerfile,
     buildAndRemoveWaspProjectDockerImage,
     TestContext (..),
@@ -51,7 +53,7 @@ import Control.Monad.Reader (MonadReader (ask), Reader, runReader)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.Text as T
-import FileSystem (GitRootDir, SnapshotDir, TestCaseDir, gitRootFromSnapshotDir, mainWaspFileInWaspProjectDir, seedsDirInWaspProjectDir, seedsFileInSeedsDir)
+import FileSystem (GitRootDir, SnapshotDir, TestCaseDir, gitRootFromSnapshotDir, mainWaspFileInWaspProjectDir, mainWaspTsFileInWaspProjectDir, seedsDirInWaspProjectDir, seedsFileInSeedsDir)
 import StrongPath (Abs, Dir, File', Path', Rel, fromAbsDir, fromAbsFile, fromRelDir, parent, (</>))
 import System.FilePath (joinPath)
 import Wasp.Generator.DbGenerator.Common (dbMigrationsDirInDbRootDir, dbRootDirInGeneratedAppDir)
@@ -132,7 +134,7 @@ replaceLineInFile fileName lineNumber line =
 
     tempFileName = fileName ++ ".tmp"
 
-data WaspNewTemplate = Minimal | Basic | SaaS
+data WaspNewTemplate = Minimal | Basic | TsMinimal | SaaS
 
 waspCliNewInteractive :: String -> WaspNewTemplate -> ShellCommandBuilder context ShellCommand
 waspCliNewInteractive appName template =
@@ -142,7 +144,8 @@ waspCliNewInteractive appName template =
     templateNumber = case template of
       Basic -> "1"
       Minimal -> "2"
-      SaaS -> "3"
+      TsMinimal -> "3"
+      SaaS -> "4"
 
 waspCliNew :: String -> WaspNewTemplate -> ShellCommandBuilder context ShellCommand
 waspCliNew appName template = return $ unwords ["wasp-cli", "new", appName, "-t", templateName]
@@ -150,6 +153,7 @@ waspCliNew appName template = return $ unwords ["wasp-cli", "new", appName, "-t"
     templateName = case template of
       Basic -> "basic"
       Minimal -> "minimal"
+      TsMinimal -> "ts-minimal"
       SaaS -> "saas"
 
 waspCliCompletion :: ShellCommandBuilder context ShellCommand
@@ -234,6 +238,9 @@ waspCliDockerfile = return "wasp-cli dockerfile"
 waspCliStudio :: ShellCommandBuilder WaspProjectContext ShellCommand
 waspCliStudio = return "wasp-cli studio"
 
+waspCliTsSetup :: ShellCommandBuilder WaspProjectContext ShellCommand
+waspCliTsSetup = return "wasp-cli ts-setup"
+
 -- NOTE: Fragile, assumes line numbers do not change.
 setWaspDbToPSQL :: ShellCommandBuilder WaspProjectContext ShellCommand
 setWaspDbToPSQL = replaceLineInFile "schema.prisma" 2 "  provider = \"postgresql\""
@@ -255,6 +262,13 @@ replaceMainWaspFile content = do
   let mainWaspFile = context.waspProjectDir </> mainWaspFileInWaspProjectDir
 
   createFile mainWaspFile content
+
+replaceMainWaspTsFile :: T.Text -> ShellCommandBuilder WaspProjectContext ShellCommand
+replaceMainWaspTsFile content = do
+  context <- ask
+  let mainWaspTsFile = context.waspProjectDir </> mainWaspTsFileInWaspProjectDir
+
+  createFile mainWaspTsFile content
 
 -- | Builds and deletes the Docker image for a Wasp app.
 -- Can be disabled via the @WASP_E2E_TESTS_SKIP_DOCKER@ environment variable.

--- a/waspc/e2e-tests/Tests/SnapshotTests/WaspBuildSnapshotTest.hs
+++ b/waspc/e2e-tests/Tests/SnapshotTests/WaspBuildSnapshotTest.hs
@@ -10,11 +10,11 @@ import ShellCommands
     ShellCommandBuilder,
     WaspProjectContext (),
     buildAndRemoveWaspProjectDockerImage,
-    createFile,
     createSnapshotWaspProjectFromMinimalStarter,
     inSnapshotWaspProjectDir,
     setWaspDbToPSQL,
     waspCliBuild,
+    writeToFile,
   )
 import qualified ShellCommands as WaspProjectContext
 import SnapshotTest (SnapshotTest, makeSnapshotTest)
@@ -44,7 +44,7 @@ wrapViteConfigForDeterministicBuild :: ShellCommandBuilder WaspProjectContext Sh
 wrapViteConfigForDeterministicBuild = do
   waspProjectDir <- asks (.waspProjectDir)
 
-  createFile
+  writeToFile
     (waspProjectDir </> wrapperViteFile)
     [trimming|
       import { mergeConfig, type Plugin } from "vite";

--- a/waspc/e2e-tests/Tests/ViteBuildTest.hs
+++ b/waspc/e2e-tests/Tests/ViteBuildTest.hs
@@ -9,17 +9,17 @@ import ShellCommands
   ( ShellCommand,
     ShellCommandBuilder,
     TestContext,
-    WaspNewTemplate (..),
     WaspProjectContext (..),
-    createFile,
     createTestWaspProject,
     inTestWaspProjectDir,
     setWaspDbToPSQL,
     waspCliBuild,
+    writeToFile,
   )
 import StrongPath (relfile, (</>))
 import qualified StrongPath as SP
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 import Wasp.Generator.WebAppGenerator (viteBuildDirPath)
 import Wasp.Project.Env (dotEnvClient)
 
@@ -71,7 +71,7 @@ viteBuildTest =
     createViteBuildTestCase :: [ShellCommandBuilder WaspProjectContext ShellCommand] -> ShellCommandBuilder TestContext [ShellCommand]
     createViteBuildTestCase commands =
       sequence
-        [ createTestWaspProject Minimal,
+        [ createTestWaspProject minimalStarterTemplate,
           inTestWaspProjectDir $ [setWaspDbToPSQL, writeMainPageTsx, waspCliBuild] ++ commands
         ]
 
@@ -85,7 +85,7 @@ viteBuildTest =
     writeMainPageTsx = do
       waspProjectContext <- ask
       let testEnvVarKeyText = T.pack testEnvVarKey
-      createFile
+      writeToFile
         (waspProjectContext.waspProjectDir </> [relfile|src/MainPage.tsx|])
         [trimming|
           export function MainPage() {
@@ -96,7 +96,7 @@ viteBuildTest =
     writeDotEnvClientFile :: String -> ShellCommandBuilder WaspProjectContext ShellCommand
     writeDotEnvClientFile value = do
       waspProjectContext <- ask
-      createFile (waspProjectContext.waspProjectDir </> dotEnvClient) $
+      writeToFile (waspProjectContext.waspProjectDir </> dotEnvClient) $
         T.pack $
           testEnvVarKey ++ "=" ++ value
 

--- a/waspc/e2e-tests/Tests/ViteConfigTest.hs
+++ b/waspc/e2e-tests/Tests/ViteConfigTest.hs
@@ -7,15 +7,15 @@ import NeatInterpolation (trimming)
 import ShellCommands
   ( ShellCommand,
     ShellCommandBuilder,
-    WaspNewTemplate (..),
     WaspProjectContext (..),
-    createFile,
     createTestWaspProject,
     inTestWaspProjectDir,
     waspCliCompile,
+    writeToFile,
   )
 import StrongPath (relfile, (</>))
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 viteConfigTest :: Test
 viteConfigTest =
@@ -24,7 +24,7 @@ viteConfigTest =
     [ TestCase
         "fail-on-missing-vite-config"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ deleteViteConfig,
                   expectCommandFailure <$> waspCliCompile
@@ -34,7 +34,7 @@ viteConfigTest =
       TestCase
         "fail-on-missing-wasp-plugin-import"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ writeViteConfigWithoutPlugin,
                   expectCommandFailure <$> waspCliCompile
@@ -49,7 +49,7 @@ deleteViteConfig = return "rm vite.config.ts"
 writeViteConfigWithoutPlugin :: ShellCommandBuilder WaspProjectContext ShellCommand
 writeViteConfigWithoutPlugin = do
   context <- ask
-  createFile
+  writeToFile
     (context.waspProjectDir </> [relfile|vite.config.ts|])
     [trimming|
       import { defineConfig } from "vite";

--- a/waspc/e2e-tests/Tests/WaspBuildStartTest.hs
+++ b/waspc/e2e-tests/Tests/WaspBuildStartTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspBuildStartTest (waspBuildStartTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliBuild, waspCliBuildStart)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliBuild, waspCliBuildStart)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 -- FIXME: @waspCliBuildStart@ - figure out long lasting processes
 waspBuildStartTest :: Test
@@ -14,7 +15,7 @@ waspBuildStartTest =
       TestCase
         "fail-unbuilt-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ setWaspDbToPSQL,
                   return waspCliBuildStartFails
@@ -24,7 +25,7 @@ waspBuildStartTest =
       TestCase
         "succeed-built-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ setWaspDbToPSQL,
                   waspCliBuild,

--- a/waspc/e2e-tests/Tests/WaspBuildTest.hs
+++ b/waspc/e2e-tests/Tests/WaspBuildTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspBuildTest (waspBuildTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliBuild)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliBuild)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 waspBuildTest :: Test
 waspBuildTest =
@@ -13,14 +14,14 @@ waspBuildTest =
       TestCase
         "fail-sqlite-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir [return waspCliBuildFails]
             ]
         ),
       TestCase
         "succeed-postgresql-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ setWaspDbToPSQL,
                   waspCliBuild,

--- a/waspc/e2e-tests/Tests/WaspCleanTest.hs
+++ b/waspc/e2e-tests/Tests/WaspCleanTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspCleanTest (waspCleanTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, waspCliClean, waspCliCompile)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliClean, waspCliCompile)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 waspCleanTest :: Test
 waspCleanTest =
@@ -13,7 +14,7 @@ waspCleanTest =
       TestCase
         "succeed-uncompiled-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliClean,
                   return $ assertDirectoryDoesNotExist ".wasp",
@@ -24,7 +25,7 @@ waspCleanTest =
       TestCase
         "succeed-compiled-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliCompile,
                   waspCliClean,

--- a/waspc/e2e-tests/Tests/WaspCompileTest.hs
+++ b/waspc/e2e-tests/Tests/WaspCompileTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspCompileTest (waspCompileTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, waspCliCompile)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliCompile)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 waspCompileTest :: Test
 waspCompileTest =
@@ -13,7 +14,7 @@ waspCompileTest =
       TestCase
         "succeed-uncompiled-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliCompile,
                   return $ assertDirectoryExists ".wasp",
@@ -24,7 +25,7 @@ waspCompileTest =
       TestCase
         "succeed-compiled-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliCompile,
                   waspCliCompile,

--- a/waspc/e2e-tests/Tests/WaspDbMigrateDevTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDbMigrateDevTest.hs
@@ -5,9 +5,10 @@ module Tests.WaspDbMigrateDevTest (waspDbMigrateDevTest) where
 import Control.Monad.Reader (MonadReader (ask))
 import qualified Data.Text as T
 import NeatInterpolation (trimming)
-import ShellCommands (ShellCommand, ShellCommandBuilder, WaspNewTemplate (..), WaspProjectContext (..), appendToPrismaFile, createTestWaspProject, inTestWaspProjectDir, waspCliDbMigrateDev, (~&&))
+import ShellCommands (ShellCommand, ShellCommandBuilder, WaspProjectContext (..), appendToPrismaFile, createTestWaspProject, inTestWaspProjectDir, waspCliDbMigrateDev, (~&&))
 import StrongPath (fromAbsDir, (</>))
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 import Wasp.Generator.DbGenerator.Common
   ( dbMigrationsDirInDbRootDir,
     dbRootDirInGeneratedAppDir,
@@ -29,7 +30,7 @@ waspDbMigrateDevTest =
       TestCase
         "succeed-migrations-up-to-date"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliDbMigrateDev "no_migration"
                 ]
@@ -38,7 +39,7 @@ waspDbMigrateDevTest =
       TestCase
         "succeed-create-new-migration"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ appendToPrismaFile taskPrismaModel,
                   waspCliDbMigrateDev "yes_migration",

--- a/waspc/e2e-tests/Tests/WaspDbResetTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDbResetTest.hs
@@ -2,8 +2,9 @@ module Tests.WaspDbResetTest (waspDbResetTest) where
 
 import qualified Data.Text as T
 import NeatInterpolation (trimming)
-import ShellCommands (ShellCommand, WaspNewTemplate (..), appendToPrismaFile, createSeedFile, createTestWaspProject, inTestWaspProjectDir, replaceMainWaspFile, waspCliCompile, waspCliDbMigrateDev, waspCliDbReset, waspCliDbSeed)
+import ShellCommands (ShellCommand, appendToPrismaFile, createSeedFile, createTestWaspProject, inTestWaspProjectDir, replaceMainWaspFile, waspCliCompile, waspCliDbMigrateDev, waspCliDbReset, waspCliDbSeed)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 import Wasp.Version (waspVersion)
 
 -- | We include a seeding script as part of the e2e test,
@@ -28,7 +29,7 @@ waspDbResetTest =
       TestCase
         "succeed-reset-database"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliCompile,
                   appendToPrismaFile taskPrismaModel,

--- a/waspc/e2e-tests/Tests/WaspDbSeedTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDbSeedTest.hs
@@ -2,8 +2,9 @@ module Tests.WaspDbSeedTest (waspDbSeedTest) where
 
 import qualified Data.Text as T
 import NeatInterpolation (trimming)
-import ShellCommands (ShellCommand, WaspNewTemplate (..), appendToPrismaFile, createSeedFile, createTestWaspProject, inTestWaspProjectDir, replaceMainWaspFile, waspCliCompile, waspCliDbMigrateDev, waspCliDbSeed)
+import ShellCommands (ShellCommand, appendToPrismaFile, createSeedFile, createTestWaspProject, inTestWaspProjectDir, replaceMainWaspFile, waspCliCompile, waspCliDbMigrateDev, waspCliDbSeed)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 import Wasp.Version (waspVersion)
 
 waspDbSeedTest :: Test
@@ -26,7 +27,7 @@ waspDbSeedTest =
       TestCase
         "succeed-seed-database"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliCompile,
                   appendToPrismaFile taskPrismaModel,

--- a/waspc/e2e-tests/Tests/WaspDbStartTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDbStartTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspDbStartTest (waspDbStartTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliDbStart)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliDbStart)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 -- FIXME: @waspCliDbStart@ - figure out long lasting processes
 waspDbStartTest :: Test
@@ -14,7 +15,7 @@ waspDbStartTest =
       TestCase
         "succeed-sqlite-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliDbStart
                 ]
@@ -23,7 +24,7 @@ waspDbStartTest =
       TestCase
         "succeed-postgresql-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ setWaspDbToPSQL,
                   waspCliDbStart

--- a/waspc/e2e-tests/Tests/WaspDbStudioTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDbStudioTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspDbStudioTest (waspDbStudioTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, waspCliDbStudio)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliDbStudio)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 -- | NOTE: We don't test feature content since it's prisma feature.
 -- FIXME: @waspCliDbStudio@ - figure out long lasting processes
@@ -15,7 +16,7 @@ waspDbStudioTest =
       TestCase
         "succeed-uncompiled-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliDbStudio
                 ]

--- a/waspc/e2e-tests/Tests/WaspDepsTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDepsTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspDepsTest (waspDepsTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, waspCliDeps)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliDeps)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 -- TODO: Test that deps change with installs/uninstalls.
 waspDepsTest :: Test
@@ -14,7 +15,7 @@ waspDepsTest =
       TestCase
         "succeed-inside-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliDeps
                 ]

--- a/waspc/e2e-tests/Tests/WaspDockerfileTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDockerfileTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspDockerfileTest (waspDockerfileTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, waspCliDockerfile)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliDockerfile)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 -- TODO: Test `wasp dockerfile` content.
 waspDockerfileTest :: Test
@@ -14,7 +15,7 @@ waspDockerfileTest =
       TestCase
         "succeed-inside-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliDockerfile
                 ]

--- a/waspc/e2e-tests/Tests/WaspInfoTest.hs
+++ b/waspc/e2e-tests/Tests/WaspInfoTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspInfoTest (waspInfoTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, waspCliInfo)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliInfo)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 -- TODO: Test `wasp info` values change properly:
 -- name, database, project dir size, last compile.
@@ -15,7 +16,7 @@ waspInfoTest =
       TestCase
         "succeed-inside-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliInfo
                 ]

--- a/waspc/e2e-tests/Tests/WaspNewTest.hs
+++ b/waspc/e2e-tests/Tests/WaspNewTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspNewTest (waspNewTest) where
 
-import ShellCommands (WaspNewTemplate (..), waspCliNew, waspCliNewInteractive)
+import ShellCommands (waspCliNew, waspCliNewInteractive)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (basicStarterTemplate, minimalStarterTemplate)
 
 -- TODO: add "new ai" tests
 waspNewTest :: Test
@@ -10,16 +11,16 @@ waspNewTest =
     "wasp-new"
     [ TestCase
         "create-minimal"
-        (sequence [waspCliNew "wasp-app" Minimal]),
+        (sequence [waspCliNew "wasp-app" minimalStarterTemplate]),
       TestCase
         "create-minimal-interactive"
-        (sequence [waspCliNewInteractive "wasp-app" Minimal]),
+        (sequence [waspCliNewInteractive "wasp-app" minimalStarterTemplate]),
       TestCase
         "create-basic"
-        (sequence [waspCliNew "wasp-app" Basic]),
+        (sequence [waspCliNew "wasp-app" basicStarterTemplate]),
       TestCase
         "create-basic-interactive"
-        (sequence [waspCliNewInteractive "wasp-app" Basic])
+        (sequence [waspCliNewInteractive "wasp-app" basicStarterTemplate])
         -- FIXME(Franjo): These will fail because there "dev" opensaas template tag doesn't exist.
         -- We can't really test the `saas` template in `waspc` e2e tests.
         --   TestCase

--- a/waspc/e2e-tests/Tests/WaspStartTest.hs
+++ b/waspc/e2e-tests/Tests/WaspStartTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspStartTest (waspStartTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, waspCliCompile, waspCliStart)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliCompile, waspCliStart)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 -- FIXME: @waspCliStart@ - figure out long lasting processes
 waspStartTest :: Test
@@ -14,7 +15,7 @@ waspStartTest =
       TestCase
         "succeed-uncompiled-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliStart,
                   return $ assertDirectoryExists ".wasp",
@@ -25,7 +26,7 @@ waspStartTest =
       TestCase
         "succeed-compiled-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliCompile,
                   waspCliStart

--- a/waspc/e2e-tests/Tests/WaspStudioTest.hs
+++ b/waspc/e2e-tests/Tests/WaspStudioTest.hs
@@ -1,7 +1,8 @@
 module Tests.WaspStudioTest (waspStudioTest) where
 
-import ShellCommands (ShellCommand, WaspNewTemplate (..), createTestWaspProject, inTestWaspProjectDir, waspCliStudio)
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliStudio)
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
 -- | NOTE: Once it evolves it will probably have it's own
 -- playwright tests inside of the TS package.
@@ -17,7 +18,7 @@ waspStudioTest =
       TestCase
         "succeed-uncompiled-project"
         ( sequence
-            [ createTestWaspProject Minimal,
+            [ createTestWaspProject minimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliStudio
                 ]

--- a/waspc/e2e-tests/Tests/WaspTsSpecNodeEnvTest.hs
+++ b/waspc/e2e-tests/Tests/WaspTsSpecNodeEnvTest.hs
@@ -7,7 +7,6 @@ import NeatInterpolation (trimming)
 import ShellCommands
   ( ShellCommand,
     ShellCommandBuilder,
-    WaspNewTemplate (..),
     WaspProjectContext,
     createTestWaspProject,
     inTestWaspProjectDir,
@@ -19,6 +18,7 @@ import ShellCommands
     (~&&),
   )
 import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (tsMinimalStarterTemplate)
 import Wasp.Version (waspVersion)
 
 waspTsSpecNodeEnvTest :: Test
@@ -28,7 +28,7 @@ waspTsSpecNodeEnvTest =
     [ TestCase
         "node-env-is-development-on-compile"
         ( sequence
-            [ createTestWaspProject TsMinimal,
+            [ createTestWaspProject tsMinimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliTsSetup,
                   replaceMainWaspTsFile nodeEnvMainWaspTs,
@@ -39,7 +39,7 @@ waspTsSpecNodeEnvTest =
       TestCase
         "node-env-is-production-on-build"
         ( sequence
-            [ createTestWaspProject TsMinimal,
+            [ createTestWaspProject tsMinimalStarterTemplate,
               inTestWaspProjectDir
                 [ waspCliTsSetup,
                   setWaspDbToPSQL,
@@ -57,10 +57,10 @@ waspTsSpecNodeEnvTest =
     assertCommandOutputContains commandBuilder marker = do
       command <- commandBuilder
       let logFile = "main-wasp-ts.log"
-          logCommandOutputToAFile = command ++ " > " ++ logFile ++ " 2>&1"
+          logCommandOutputToFile = command ++ " > " ++ logFile ++ " 2>&1"
           searchMarkerInLogFile = "grep -qF '" ++ marker ++ "' " ++ logFile
 
-      return $ logCommandOutputToAFile ~&& searchMarkerInLogFile
+      return $ logCommandOutputToFile ~&& searchMarkerInLogFile
 
     nodeEnvMainWaspTs :: T.Text
     nodeEnvMainWaspTs =

--- a/waspc/e2e-tests/Tests/WaspTsSpecNodeEnvTest.hs
+++ b/waspc/e2e-tests/Tests/WaspTsSpecNodeEnvTest.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Tests.WaspTsSpecNodeEnvTest (waspTsSpecNodeEnvTest) where
+
+import qualified Data.Text as T
+import NeatInterpolation (trimming)
+import ShellCommands
+  ( ShellCommand,
+    ShellCommandBuilder,
+    WaspNewTemplate (..),
+    WaspProjectContext,
+    createTestWaspProject,
+    inTestWaspProjectDir,
+    replaceMainWaspTsFile,
+    setWaspDbToPSQL,
+    waspCliBuild,
+    waspCliCompile,
+    waspCliTsSetup,
+    (~&&),
+  )
+import Test (Test (..), TestCase (..))
+import Wasp.Version (waspVersion)
+
+waspTsSpecNodeEnvTest :: Test
+waspTsSpecNodeEnvTest =
+  Test
+    "wasp-ts-spec-node-env"
+    [ TestCase
+        "node-env-is-development-on-compile"
+        ( sequence
+            [ createTestWaspProject TsMinimal,
+              inTestWaspProjectDir
+                [ waspCliTsSetup,
+                  replaceMainWaspTsFile nodeEnvMainWaspTs,
+                  assertCommandOutputContains waspCliCompile "E2E-NODE-ENV=development"
+                ]
+            ]
+        ),
+      TestCase
+        "node-env-is-production-on-build"
+        ( sequence
+            [ createTestWaspProject TsMinimal,
+              inTestWaspProjectDir
+                [ waspCliTsSetup,
+                  setWaspDbToPSQL,
+                  replaceMainWaspTsFile nodeEnvMainWaspTs,
+                  assertCommandOutputContains waspCliBuild "E2E-NODE-ENV=production"
+                ]
+            ]
+        )
+    ]
+  where
+    assertCommandOutputContains ::
+      ShellCommandBuilder WaspProjectContext ShellCommand ->
+      String ->
+      ShellCommandBuilder WaspProjectContext ShellCommand
+    assertCommandOutputContains commandBuilder marker = do
+      command <- commandBuilder
+      let logFile = "main-wasp-ts.log"
+          logCommandOutputToAFile = command ++ " > " ++ logFile ++ " 2>&1"
+          searchMarkerInLogFile = "grep -qF '" ++ marker ++ "' " ++ logFile
+
+      return $ logCommandOutputToAFile ~&& searchMarkerInLogFile
+
+    nodeEnvMainWaspTs :: T.Text
+    nodeEnvMainWaspTs =
+      [trimming|
+        import { App } from "wasp-config";
+
+        console.log(`E2E-NODE-ENV=$${process.env.NODE_ENV}`);
+
+        const app = new App("envprobe", {
+          title: "envprobe",
+          wasp: { version: "^$textWaspVersion" },
+        });
+
+        const mainPage = app.page("MainPage", {
+          component: { import: "MainPage", from: "@src/MainPage" },
+        });
+
+        app.route("RootRoute", { path: "/", to: mainPage });
+
+        export default app;
+      |]
+
+    textWaspVersion :: T.Text
+    textWaspVersion = T.pack . show $ waspVersion

--- a/waspc/src/Wasp/CompileOptions.hs
+++ b/waspc/src/Wasp/CompileOptions.hs
@@ -13,7 +13,7 @@ import Wasp.Project.Common (WaspProjectDir)
 --   It would be easier to pass around if it is part of Wasp data. But is it semantically correct?
 --   Maybe it is, even more than this!
 data CompileOptions = CompileOptions
-  { waspProjectDirPath :: !(Path' Abs (Dir WaspProjectDir)),
+  { waspProjectDir :: !(Path' Abs (Dir WaspProjectDir)),
     buildType :: !BuildType.BuildType,
     -- We give the compiler the ability to send messages. The code that
     -- invokes the compiler (such as the CLI) can then implement a way

--- a/waspc/src/Wasp/Project/Analyze.hs
+++ b/waspc/src/Wasp/Project/Analyze.hs
@@ -63,7 +63,7 @@ analyzeWaspProject waspDir compileOptions = do
           EC.parseAndValidateExternalConfigs waspDir srcTsConfigPath >>= \case
             Left externalConfigErrors -> return (Left externalConfigErrors, [])
             Right externalConfigs ->
-              analyzeWaspFile waspDir prismaSchemaAst waspFilePath >>= \case
+              analyzeWaspFile compileOptions prismaSchemaAst waspFilePath >>= \case
                 Left errors -> return (Left errors, [])
                 Right declarations ->
                   constructAppSpec

--- a/waspc/src/Wasp/Project/WaspFile.hs
+++ b/waspc/src/Wasp/Project/WaspFile.hs
@@ -14,6 +14,7 @@ import StrongPath
   )
 import qualified Wasp.AppSpec as AS
 import Wasp.AppSpec.Core.Decl.JSON ()
+import qualified Wasp.CompileOptions as CompileOptions
 import Wasp.Project.Common
   ( CompileError,
     WaspFilePath (..),
@@ -52,10 +53,10 @@ findWaspFile projectDir = do
     makeInvalidFileNameMessage suffix = "Your Wasp file can't be called '" ++ suffix ++ "'. Please rename it to something like [name]" ++ suffix ++ "."
 
 analyzeWaspFile ::
-  Path' Abs (Dir WaspProjectDir) ->
+  CompileOptions.CompileOptions ->
   Psl.Schema.Schema ->
   WaspFilePath ->
   IO (Either [CompileError] [AS.Decl])
-analyzeWaspFile waspDir prismaSchemaAst = \case
+analyzeWaspFile compileOptions prismaSchemaAst = \case
   WaspLang waspFilePath -> analyzeWaspLangFile prismaSchemaAst waspFilePath
-  WaspTs waspFilePath -> analyzeWaspTsFile waspDir prismaSchemaAst waspFilePath
+  WaspTs waspFilePath -> analyzeWaspTsFile compileOptions prismaSchemaAst waspFilePath

--- a/waspc/src/Wasp/Project/WaspFile.hs
+++ b/waspc/src/Wasp/Project/WaspFile.hs
@@ -14,7 +14,7 @@ import StrongPath
   )
 import qualified Wasp.AppSpec as AS
 import Wasp.AppSpec.Core.Decl.JSON ()
-import qualified Wasp.CompileOptions as CompileOptions
+import Wasp.CompileOptions (CompileOptions)
 import Wasp.Project.Common
   ( CompileError,
     WaspFilePath (..),
@@ -53,7 +53,7 @@ findWaspFile projectDir = do
     makeInvalidFileNameMessage suffix = "Your Wasp file can't be called '" ++ suffix ++ "'. Please rename it to something like [name]" ++ suffix ++ "."
 
 analyzeWaspFile ::
-  CompileOptions.CompileOptions ->
+  CompileOptions ->
   Psl.Schema.Schema ->
   WaspFilePath ->
   IO (Either [CompileError] [AS.Decl])

--- a/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
+++ b/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module Wasp.Project.WaspFile.TypeScript
   ( analyzeWaspTsFile,
   )
@@ -27,10 +29,12 @@ import System.Exit (ExitCode (..))
 import qualified Wasp.Analyzer as Analyzer
 import qualified Wasp.AppSpec as AS
 import Wasp.AppSpec.Core.Decl.JSON ()
+import qualified Wasp.CompileOptions as CompileOptions
 import qualified Wasp.Job as J
 import Wasp.Job.IO (readJobMessagesAndPrintThemPrefixed)
-import Wasp.Job.Process (runNodeCommandAsJob)
+import Wasp.Job.Process (runNodeCommandAsJob, runNodeCommandAsJobWithExtraEnv)
 import Wasp.NodePackageFFI (InstallablePackage (WaspConfigPackage), getInstallablePackageScriptInProject)
+import qualified Wasp.Project.BuildType as BuildType
 import Wasp.Project.Common
   ( CompileError,
     WaspProjectDir,
@@ -50,15 +54,15 @@ data CompiledWaspJsFile
 data AppSpecDeclsJsonFile
 
 analyzeWaspTsFile ::
-  Path' Abs (Dir WaspProjectDir) ->
+  CompileOptions.CompileOptions ->
   Psl.Schema.Schema ->
   Path' Abs (File WaspTsFile) ->
   IO (Either [CompileError] [AS.Decl])
-analyzeWaspTsFile waspProjectDir prismaSchemaAst waspFilePath = runExceptT $ do
+analyzeWaspTsFile compileOptions prismaSchemaAst waspFilePath = runExceptT $ do
   -- TODO: I'm not yet sure where tsconfig.wasp.json location should come from
   -- because we also need that knowledge when generating a TS SDK project.
-  compiledWaspJsFile <- ExceptT $ compileWaspTsFile waspProjectDir [relfile|tsconfig.wasp.json|] waspFilePath
-  declsJsonFile <- ExceptT $ executeMainWaspJsFileAndGetDeclsFile waspProjectDir prismaSchemaAst compiledWaspJsFile
+  compiledWaspJsFile <- ExceptT $ compileWaspTsFile compileOptions.waspProjectDir [relfile|tsconfig.wasp.json|] waspFilePath
+  declsJsonFile <- ExceptT $ executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst compiledWaspJsFile
   ExceptT $ readDecls prismaSchemaAst declsJsonFile
 
 compileWaspTsFile ::
@@ -116,11 +120,11 @@ compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath =
           `orElse` error ("Couldn't calculate the compiled JS file path for " ++ fromAbsFile waspFilePath ++ ".")
 
 executeMainWaspJsFileAndGetDeclsFile ::
-  Path' Abs (Dir WaspProjectDir) ->
+  CompileOptions.CompileOptions ->
   Psl.Schema.Schema ->
   Path' Abs (File CompiledWaspJsFile) ->
   IO (Either [CompileError] (Path' Abs (File AppSpecDeclsJsonFile)))
-executeMainWaspJsFileAndGetDeclsFile waspProjectDir prismaSchemaAst absCompiledMainWaspJsFile = do
+executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst absCompiledMainWaspJsFile = do
   chan <- newChan
   (_, runExitCode) <- do
     concurrently
@@ -128,8 +132,9 @@ executeMainWaspJsFileAndGetDeclsFile waspProjectDir prismaSchemaAst absCompiledM
       -- We invoke the script directly via `node` instead of `npx` because
       -- `npx` requires the bin file to be executable, and `cabal install`
       -- strips executable permissions from data files.
-      ( runNodeCommandAsJob
-          waspProjectDir
+      ( runNodeCommandAsJobWithExtraEnv
+          [("NODE_ENV", nodeEnvForBuildType compileOptions.buildType)]
+          compileOptions.waspProjectDir
           "node"
           [ fromRelFile $ getInstallablePackageScriptInProject WaspConfigPackage,
             fromAbsFile absCompiledMainWaspJsFile,
@@ -146,8 +151,12 @@ executeMainWaspJsFileAndGetDeclsFile waspProjectDir prismaSchemaAst absCompiledM
     ExitFailure _status -> return $ Left ["Error while running the compiled *.wasp.ts file."]
     ExitSuccess -> return $ Right absDeclsOutputFile
   where
-    absDeclsOutputFile = waspProjectDir </> dotWaspDirInWaspProjectDir </> [relfile|decls.json|]
+    absDeclsOutputFile = compileOptions.waspProjectDir </> dotWaspDirInWaspProjectDir </> [relfile|decls.json|]
     allowedEntityNames = Psl.Schema.Model.getName . Psl.WithCtx.getNode <$> Psl.Schema.getModels prismaSchemaAst
+
+    nodeEnvForBuildType :: BuildType.BuildType -> String
+    nodeEnvForBuildType BuildType.Development = "development"
+    nodeEnvForBuildType BuildType.Production = "production"
 
 readDecls :: Psl.Schema.Schema -> Path' Abs (File AppSpecDeclsJsonFile) -> IO (Either [CompileError] [AS.Decl])
 readDecls prismaSchemaAst declsJsonFile = runExceptT $ do

--- a/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
+++ b/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
@@ -29,6 +29,7 @@ import System.Exit (ExitCode (..))
 import qualified Wasp.Analyzer as Analyzer
 import qualified Wasp.AppSpec as AS
 import Wasp.AppSpec.Core.Decl.JSON ()
+import Wasp.CompileOptions (CompileOptions)
 import qualified Wasp.CompileOptions as CompileOptions
 import qualified Wasp.Job as J
 import Wasp.Job.IO (readJobMessagesAndPrintThemPrefixed)
@@ -54,7 +55,7 @@ data CompiledWaspJsFile
 data AppSpecDeclsJsonFile
 
 analyzeWaspTsFile ::
-  CompileOptions.CompileOptions ->
+  CompileOptions ->
   Psl.Schema.Schema ->
   Path' Abs (File WaspTsFile) ->
   IO (Either [CompileError] [AS.Decl])
@@ -120,7 +121,7 @@ compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath =
           `orElse` error ("Couldn't calculate the compiled JS file path for " ++ fromAbsFile waspFilePath ++ ".")
 
 executeMainWaspJsFileAndGetDeclsFile ::
-  CompileOptions.CompileOptions ->
+  CompileOptions ->
   Psl.Schema.Schema ->
   Path' Abs (File CompiledWaspJsFile) ->
   IO (Either [CompileError] (Path' Abs (File AppSpecDeclsJsonFile)))
@@ -133,7 +134,14 @@ executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst absCompiledM
       -- `npx` requires the bin file to be executable, and `cabal install`
       -- strips executable permissions from data files.
       ( runNodeCommandAsJobWithExtraEnv
-          [("NODE_ENV", nodeEnvForBuildType compileOptions.buildType)]
+          [ -- `NODE_ENV` is a convention which allows code to assume what environment it's running in.
+            -- Not related to `node` itself, so we have to set it manually.
+            -- It enables users to write environment specific code in the TS config.
+            -- NOTE: Some consider it an antipattern, but other frameworks/tools (Next.js, Nuxt, Vite)
+            --       also provide the `NODE_ENV` values for the "configuration runtime".
+            --       Maybe consider using a different key, e.g. `WASP_MODE`?
+            ("NODE_ENV", nodeEnvForBuildType compileOptions.buildType)
+          ]
           compileOptions.waspProjectDir
           "node"
           [ fromRelFile $ getInstallablePackageScriptInProject WaspConfigPackage,

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -868,4 +868,5 @@ test-suite waspc-e2e-tests
     Tests.WaspStartTest
     Tests.WaspStudioTest
     Tests.WaspTelemetryTest
+    Tests.WaspTsSpecNodeEnvTest
     Tests.WaspVersionTest

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -825,6 +825,7 @@ test-suite waspc-e2e-tests
     base,
     base64-bytestring,
     bytestring,
+    cli-lib,
     dir-traverse ^>=0.2.3,
     directory,
     filepath,

--- a/web/docs/general/wasp-ts-config.md
+++ b/web/docs/general/wasp-ts-config.md
@@ -59,6 +59,7 @@ Wasp TS config is an **early preview** feature, meaning it is a little rough and
        "module": "NodeNext",
        "noEmit": true,
 
+       "types": ["node"],
        "lib": ["ES2023"]
      },
      "include": ["main.wasp.ts"]
@@ -106,6 +107,23 @@ If you run `wasp clean` or remove `node_modules` on  your own, you will have to 
 :::
 
 Got stuck on any of these steps? Let us know in our <DiscordLink /> and we will help!
+
+## Detecting the current environment
+
+Wasp sets the `NODE_ENV` environment variable based on which command you use to run Wasp:
+- `"development"` during `wasp start` (and any other command which may compile the project like `wasp db migrate-dev`).
+- `"production"` during `wasp build`.
+
+You can read this variable to switch config values per environment:
+
+```ts title="main.wasp.ts"
+const isProd = process.env.NODE_ENV === 'production'
+
+app.emailSender({
+  provider: isProd ? 'SMTP' : 'Dummy',
+  defaultFrom: { email: 'hi@example.com' },
+})
+```
 
 ## What next?
 

--- a/web/docs/general/wasp-ts-config.md
+++ b/web/docs/general/wasp-ts-config.md
@@ -59,7 +59,6 @@ Wasp TS config is an **early preview** feature, meaning it is a little rough and
        "module": "NodeNext",
        "noEmit": true,
 
-       "types": ["node"],
        "lib": ["ES2023"]
      },
      "include": ["main.wasp.ts"]


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Solves https://github.com/wasp-lang/wasp/issues/3860

Now Wasp sets the `NODE_ENV` environment variable for the `main.wasp.ts` execution depending on the `BuildType` value:
`Development` -> `development`
`Production` -> `production`

This is the same behavior as other frameworks (Next.js, Nuxt).

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [x] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
