### PR TITLE
Bump version command

### DIFF
--- a/waspc/run
+++ b/waspc/run
@@ -216,6 +216,8 @@ print_usage() {
     "Sets the correct version of GHC and Cabal for this project (via GHCup)."
   print_usage_cmd "get-waspc-version" \
     "Gets the current version of waspc from the Haskell project."
+  print_usage_cmd "version-bump <major | minor | patch>" \
+    "Bumps the Wasp version across waspc.cabal, libs, and example projects, then rebuilds libs and busts each project's libs cache."
 }
 
 exitStatusToString() {
@@ -367,6 +369,9 @@ case $COMMAND in
     ;;
   get-waspc-version)
     node "$SCRIPT_DIR/tools/get-waspc-version.ts"
+    ;;
+  version-bump)
+    node "$SCRIPT_DIR/tools/version-bump.ts" "${ARGS[@]}"
     ;;
   *)
     print_usage

--- a/waspc/tools/get-waspc-version.ts
+++ b/waspc/tools/get-waspc-version.ts
@@ -18,4 +18,4 @@ if (!match) {
   throw new Error("Could not find version in waspc.cabal");
 }
 
-console.log(match[1].trim());
+process.stdout.write(match[1].trim());

--- a/waspc/tools/get-waspc-version.ts
+++ b/waspc/tools/get-waspc-version.ts
@@ -5,17 +5,28 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getWaspcDirPath } from "./utils.ts";
 
-const waspcDir = getWaspcDirPath();
-const cabalFile = readFileSync(join(waspcDir, "waspc.cabal"), "utf-8");
+let waspcVersion: string | undefined;
+export function getWaspcVersion() {
+  if (waspcVersion !== undefined) return waspcVersion;
 
-// NOTE: It would be more precise to use something like:
-// `cabal repl waspc -v0 <<< 'putStrLn $ Data.Version.showVersion Paths_waspc.version'`
-// but running `cabal repl` was failing on Windows in the CI with the following error:
-// https://github.com/wasp-lang/wasp/pull/3648#discussion_r2717163122
-// We should investigate in the future if we can make it work again.
-const match = cabalFile.match(/^version:\s*(.+)$/m);
-if (!match) {
-  throw new Error("Could not find version in waspc.cabal");
+  const waspcDir = getWaspcDirPath();
+  const cabalFile = readFileSync(join(waspcDir, "waspc.cabal"), "utf-8");
+
+  // NOTE: It would be more precise to use something like:
+  // `cabal repl waspc -v0 <<< 'putStrLn $ Data.Version.showVersion Paths_waspc.version'`
+  // but running `cabal repl` was failing on Windows in the CI with the following error:
+  // https://github.com/wasp-lang/wasp/pull/3648#discussion_r2717163122
+  // We should investigate in the future if we can make it work again.
+  const match = cabalFile.match(/^version:\s*(.+)$/m);
+  if (!match) {
+    throw new Error("Could not find version in waspc.cabal");
+  }
+
+  waspcVersion = match[1].trim();
+  return waspcVersion;
 }
 
-process.stdout.write(match[1].trim());
+const isMain = import.meta.filename === process.argv[1];
+if (isMain) {
+  process.stdout.write(getWaspcVersion());
+}

--- a/waspc/tools/get-waspc-version.ts
+++ b/waspc/tools/get-waspc-version.ts
@@ -6,6 +6,13 @@ import { join } from "node:path";
 import { getWaspcDirPath } from "./utils.ts";
 
 let waspcVersion: string | undefined;
+
+/**
+ * Matches the `.cabal` files version line and
+ * captures the version value with a capture group.
+ */
+export const cabalVersionRegex = /^version:\s*(.+)$/m;
+
 export function getWaspcVersion() {
   if (waspcVersion !== undefined) return waspcVersion;
 
@@ -17,7 +24,7 @@ export function getWaspcVersion() {
   // but running `cabal repl` was failing on Windows in the CI with the following error:
   // https://github.com/wasp-lang/wasp/pull/3648#discussion_r2717163122
   // We should investigate in the future if we can make it work again.
-  const match = cabalFile.match(/^version:\s*(.+)$/m);
+  const match = cabalFile.match(cabalVersionRegex);
   if (!match) {
     throw new Error("Could not find version in waspc.cabal");
   }

--- a/waspc/tools/libs/build.ts
+++ b/waspc/tools/libs/build.ts
@@ -8,6 +8,7 @@ import {
   discoverSubDirs,
   getPackageJson,
   getWaspcDirPath,
+  getWaspcVersion,
   runCmd,
 } from "../utils.ts";
 
@@ -48,12 +49,6 @@ function assertLibVersionValid(libName: string, libVersion: string): void {
     );
     throw new Error();
   }
-}
-
-function getWaspcVersion(): string {
-  return runCmd("node", [join("tools", "get-waspc-version.ts")], {
-    cwd: waspcDirPath,
-  }).trim();
 }
 
 function rmExistingTarballsInDir(dir: string): void {

--- a/waspc/tools/libs/build.ts
+++ b/waspc/tools/libs/build.ts
@@ -7,13 +7,12 @@ import { join } from "node:path";
 import {
   discoverSubDirs,
   getPackageJson,
-  getWaspcDirPath,
   getWaspcVersion,
   runCmd,
 } from "../utils.ts";
+import { getDataLibsDirPath } from "./utils.ts";
 
-const waspcDirPath = getWaspcDirPath();
-const dataLibsDirPath = join(waspcDirPath, "data", "Generator", "libs");
+const dataLibsDirPath = getDataLibsDirPath();
 const waspcVersion = getWaspcVersion();
 
 buildLibs();

--- a/waspc/tools/libs/build.ts
+++ b/waspc/tools/libs/build.ts
@@ -4,20 +4,14 @@
 
 import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import {
-  discoverSubDirs,
-  getPackageJson,
-  getWaspcVersion,
-  runCmd,
-} from "../utils.ts";
+import { getWaspcVersion } from "../get-waspc-version.ts";
+import { discoverSubDirs, getPackageJson, runCmd } from "../utils.ts";
 import { getDataLibsDirPath } from "./utils.ts";
-
-const dataLibsDirPath = getDataLibsDirPath();
-const waspcVersion = getWaspcVersion();
 
 buildLibs();
 
 function buildLibs(): void {
+  const dataLibsDirPath = getDataLibsDirPath();
   const libDirs = discoverSubDirs(dataLibsDirPath);
 
   for (const libDir of libDirs) {
@@ -39,6 +33,8 @@ function buildLib(libDir: string): void {
 }
 
 function assertLibVersionValid(libName: string, libVersion: string): void {
+  const waspcVersion = getWaspcVersion();
+
   if (libVersion !== waspcVersion) {
     console.error(
       `ERROR: ${libName} lib version (${libVersion}) != current Wasp version (${waspcVersion}).`,

--- a/waspc/tools/libs/test.ts
+++ b/waspc/tools/libs/test.ts
@@ -1,16 +1,10 @@
 /// <reference types="node" />
 // Helper to test the waspc/libs/* packages locally and in CI.
 
-import { join } from "node:path";
-import {
-  discoverSubDirs,
-  getPackageJson,
-  getWaspcDirPath,
-  runCmd,
-} from "../utils.ts";
+import { discoverSubDirs, getPackageJson, runCmd } from "../utils.ts";
+import { getDataLibsDirPath } from "./utils.ts";
 
-const waspcDirPath = getWaspcDirPath();
-const dataLibsDirPath = join(waspcDirPath, "data", "Generator", "libs");
+const dataLibsDirPath = getDataLibsDirPath();
 
 testLibs();
 

--- a/waspc/tools/libs/test.ts
+++ b/waspc/tools/libs/test.ts
@@ -4,11 +4,10 @@
 import { discoverSubDirs, getPackageJson, runCmd } from "../utils.ts";
 import { getDataLibsDirPath } from "./utils.ts";
 
-const dataLibsDirPath = getDataLibsDirPath();
-
 testLibs();
 
 function testLibs(): void {
+  const dataLibsDirPath = getDataLibsDirPath();
   const libDirs = discoverSubDirs(dataLibsDirPath);
 
   for (const libDir of libDirs) {

--- a/waspc/tools/libs/utils.ts
+++ b/waspc/tools/libs/utils.ts
@@ -1,0 +1,7 @@
+import { join } from "node:path";
+import { getWaspcDirPath } from "../utils";
+
+export function getDataLibsDirPath(): string {
+  const waspcDirPath = getWaspcDirPath();
+  return join(waspcDirPath, "data", "Generator", "libs");
+}

--- a/waspc/tools/libs/utils.ts
+++ b/waspc/tools/libs/utils.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { getWaspcDirPath } from "../utils";
+import { getWaspcDirPath } from "../utils.ts";
 
 export function getDataLibsDirPath(): string {
   const waspcDirPath = getWaspcDirPath();

--- a/waspc/tools/utils.ts
+++ b/waspc/tools/utils.ts
@@ -5,8 +5,18 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+export function getRepoRootDirPath(): string {
+  return fileURLToPath(new URL("../..", import.meta.url));
+}
+
 export function getWaspcDirPath(): string {
   return fileURLToPath(new URL("..", import.meta.url));
+}
+
+export function getWaspcVersion(): string {
+  return runCmd("node", [join("tools", "get-waspc-version.ts")], {
+    cwd: getWaspcDirPath(),
+  }).trim();
 }
 
 export function discoverSubDirs(baseDirPath: string): string[] {

--- a/waspc/tools/utils.ts
+++ b/waspc/tools/utils.ts
@@ -16,7 +16,7 @@ export function getWaspcDirPath(): string {
 export function getWaspcVersion(): string {
   return runCmd("node", [join("tools", "get-waspc-version.ts")], {
     cwd: getWaspcDirPath(),
-  }).trim();
+  });
 }
 
 export function discoverSubDirs(baseDirPath: string): string[] {

--- a/waspc/tools/utils.ts
+++ b/waspc/tools/utils.ts
@@ -5,7 +5,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export function getRepoRootDirPath(): string {
+export function getRepoRootPath(): string {
   return fileURLToPath(new URL("../..", import.meta.url));
 }
 

--- a/waspc/tools/utils.ts
+++ b/waspc/tools/utils.ts
@@ -44,10 +44,10 @@ export function runCmd(
 const STARTING_SEARCH_LOCATIONS = ["examples", "mage"];
 const DIRS_TO_SKIP = new Set(["node_modules"]);
 export function findWaspProjectDirsAbsPathInRepo(): string[] {
-  const repoRootRootPath = getRepoRootPath();
+  const repoRootPath = getRepoRootPath();
 
   return STARTING_SEARCH_LOCATIONS.flatMap((searchRoot) =>
-    findWaspProjectDirs(join(repoRootRootPath, searchRoot)),
+    findWaspProjectDirs(join(repoRootPath, searchRoot)),
   );
 
   function findWaspProjectDirs(currentDir: string): string[] {

--- a/waspc/tools/utils.ts
+++ b/waspc/tools/utils.ts
@@ -13,12 +13,6 @@ export function getWaspcDirPath(): string {
   return fileURLToPath(new URL("..", import.meta.url));
 }
 
-export function getWaspcVersion(): string {
-  return runCmd("node", [join("tools", "get-waspc-version.ts")], {
-    cwd: getWaspcDirPath(),
-  });
-}
-
 export function discoverSubDirs(baseDirPath: string): string[] {
   return readdirSync(baseDirPath, { withFileTypes: true })
     .filter((dirEntry) => dirEntry.isDirectory())

--- a/waspc/tools/utils.ts
+++ b/waspc/tools/utils.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -39,4 +39,41 @@ export function runCmd(
     // Required for Windows to find `npm` and `node` binaries.
     shell: true,
   });
+}
+
+const STARTING_SEARCH_LOCATIONS = ["examples", "mage"];
+const DIRS_TO_SKIP = new Set(["node_modules"]);
+
+export function findWaspProjectDirsAbsPathInRepo(): string[] {
+  const repoRootRootPath = getRepoRootPath();
+
+  return STARTING_SEARCH_LOCATIONS.flatMap((searchRoot) =>
+    findWaspProjectDirs(join(repoRootRootPath, searchRoot)),
+  );
+
+  function findWaspProjectDirs(currentDir: string): string[] {
+    if (isWaspProjectDir(currentDir)) {
+      return [currentDir];
+    }
+
+    const possibleWaspProjectDirs = readdirSync(currentDir, {
+      withFileTypes: true,
+    })
+      .filter(
+        (entry) =>
+          entry.isDirectory() &&
+          !entry.name.startsWith(".") &&
+          !DIRS_TO_SKIP.has(entry.name),
+      )
+      .map((subDir) => join(currentDir, subDir.name));
+
+    return possibleWaspProjectDirs.flatMap((possibleWaspProjectDir) =>
+      findWaspProjectDirs(possibleWaspProjectDir),
+    );
+  }
+}
+
+const WASP_PROJECT_FILE_NAMES = ["main.wasp", "main.wasp.ts"];
+export function isWaspProjectDir(dir: string): boolean {
+  return WASP_PROJECT_FILE_NAMES.some((name) => existsSync(join(dir, name)));
 }

--- a/waspc/tools/utils.ts
+++ b/waspc/tools/utils.ts
@@ -43,7 +43,6 @@ export function runCmd(
 
 const STARTING_SEARCH_LOCATIONS = ["examples", "mage"];
 const DIRS_TO_SKIP = new Set(["node_modules"]);
-
 export function findWaspProjectDirsAbsPathInRepo(): string[] {
   const repoRootRootPath = getRepoRootPath();
 

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -1,0 +1,141 @@
+/// <reference types="node" />
+
+import assert from "node:assert";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  discoverSubDirs,
+  getRepoRootDirPath,
+  getWaspcDirPath,
+  getWaspcVersion,
+  runCmd,
+} from "./utils.ts";
+
+const waspcDir = getWaspcDirPath();
+const repoRootDir = getRepoRootDirPath();
+const runScriptFile = join(waspcDir, "run");
+const waspProjectDirsFromRepoRoot = [
+  "examples/tutorials/TodoApp",
+  "examples/tutorials/TodoAppTs",
+  "examples/waspello",
+  "examples/waspleau",
+  "examples/websockets-realtime-voting",
+  "examples/ask-the-documents",
+  "examples/kitchen-sink",
+  "mage",
+];
+
+type BumpType = "major" | "minor" | "patch";
+
+const [_node, _filename, bumpTypeArg] = process.argv;
+assert(isBumpType(bumpTypeArg), "Usage: version-bump <major | minor | patch>");
+
+versionBump(bumpTypeArg);
+
+function versionBump(bumpType: BumpType): void {
+  const currentVersion = getWaspcVersion();
+  const nextVersion = bumpVersion(currentVersion, bumpType);
+  console.log(`Bumping Wasp version: ${currentVersion} -> ${nextVersion}`);
+
+  // Bumping versions
+  bumpWaspcCabalVersion(nextVersion);
+  bumpLibsVersion(nextVersion);
+  bumpWaspProjectsVersion(nextVersion);
+
+  // Busting old libs cache
+  rebuildLibs();
+  bustWaspProjectsLibsCache();
+}
+
+function bumpWaspcCabalVersion(nextVersion: string): void {
+  const cabalFilePath = join(waspcDir, "waspc.cabal");
+  const cabalFileContent = readFileSync(cabalFilePath, "utf-8");
+  const updatedCabalFileContent = cabalFileContent.replace(
+    /^version:\s*.+$/m,
+    `version: ${nextVersion}`,
+  );
+  writeFileSync(cabalFilePath, updatedCabalFileContent);
+}
+
+function bumpLibsVersion(nextVersion: string): void {
+  const libsDir = join(waspcDir, "data", "Generator", "libs");
+  for (const libDir of discoverSubDirs(libsDir)) {
+    bumpPackageJsonVersion(libDir, nextVersion);
+  }
+}
+
+function bumpWaspProjectsVersion(nextVersion: string): void {
+  for (const projectDirFromRepoRoot of waspProjectDirsFromRepoRoot) {
+    const projectDir = join(repoRootDir, projectDirFromRepoRoot);
+    bumpWaspProjectVersion(projectDir, nextVersion);
+  }
+}
+
+function bumpPackageJsonVersion(dir: string, nextVersion: string): void {
+  const packageJsonPath = join(dir, "package.json");
+  const content = readFileSync(packageJsonPath, "utf-8");
+  const updated = content.replace(
+    /("version":\s*)"[^"]+"/,
+    `$1"${nextVersion}"`,
+  );
+  writeFileSync(packageJsonPath, updated);
+}
+
+function bumpWaspProjectVersion(projectDir: string, nextVersion: string): void {
+  const waspFilePath = findWaspFilePath(projectDir);
+  const waspFileContent = readFileSync(waspFilePath, "utf-8");
+  // Matches the version string inside the `wasp: { ... }` block. The same
+  // pattern works for both `main.wasp` (multi-line) and `main.wasp.ts`
+  // (inline), since both express it as `wasp: { version: "^X.Y.Z" }`.
+  const updatedWaspFileContent = waspFileContent.replace(
+    /(wasp:\s*\{[^}]*version:\s*)"[^"]+"/,
+    `$1"^${nextVersion}"`,
+  );
+  writeFileSync(waspFilePath, updatedWaspFileContent);
+}
+
+function findWaspFilePath(projectDir: string): string {
+  for (const fileName of ["main.wasp.ts", "main.wasp"]) {
+    const path = join(projectDir, fileName);
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+  throw new Error(`No main.wasp or main.wasp.ts file in ${projectDir}`);
+}
+
+function rebuildLibs(): void {
+  runCmd("node", [join("tools", "libs", "build.ts")], {
+    cwd: waspcDir,
+  });
+}
+
+function bustWaspProjectsLibsCache(): void {
+  for (const projectDirFromRepoRoot of waspProjectDirsFromRepoRoot) {
+    runCmd(runScriptFile, ["bust-libs-cache"], {
+      cwd: join(repoRootDir, projectDirFromRepoRoot),
+    });
+  }
+}
+
+function bumpVersion(version: string, bumpType: BumpType): string {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Invalid version format: ${version}`);
+  }
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  switch (bumpType) {
+    case "major":
+      return `${major + 1}.0.0`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "patch":
+      return `${major}.${minor}.${patch + 1}`;
+  }
+}
+
+function isBumpType(value: string | undefined): value is BumpType {
+  return value === "major" || value === "minor" || value === "patch";
+}

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -113,6 +113,7 @@ function bustWaspProjectsLibsCache(): void {
   for (const projectDirFromRepoRoot of waspProjectDirsFromRepoRoot) {
     runCmd(runScriptFile, ["bust-libs-cache"], {
       cwd: join(repoRootDir, projectDirFromRepoRoot),
+      stdio: "inherit",
     });
   }
 }

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -6,14 +6,14 @@ import { join } from "node:path";
 import { getDataLibsDirPath } from "./libs/utils.ts";
 import {
   discoverSubDirs,
-  getRepoRootDirPath,
+  getRepoRootPath,
   getWaspcDirPath,
   getWaspcVersion,
   runCmd,
 } from "./utils.ts";
 
 const waspcDir = getWaspcDirPath();
-const repoRootDir = getRepoRootDirPath();
+const repoRootDir = getRepoRootPath();
 const runScriptFile = join(waspcDir, "run");
 const waspProjectDirsFromRepoRoot = [
   "examples/tutorials/TodoApp",

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -3,6 +3,7 @@
 import assert from "node:assert";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { getDataLibsDirPath } from "./libs/utils.ts";
 import {
   discoverSubDirs,
   getRepoRootDirPath,
@@ -58,8 +59,8 @@ function bumpWaspcCabalVersion(nextVersion: string): void {
 }
 
 function bumpLibsVersion(nextVersion: string): void {
-  const libsDir = join(waspcDir, "data", "Generator", "libs");
-  for (const libDir of discoverSubDirs(libsDir)) {
+  const dataLibsDir = getDataLibsDirPath();
+  for (const libDir of discoverSubDirs(dataLibsDir)) {
     bumpPackageJsonVersion(libDir, nextVersion);
   }
 }
@@ -84,12 +85,10 @@ function bumpPackageJsonVersion(dir: string, nextVersion: string): void {
 function bumpWaspProjectVersion(projectDir: string, nextVersion: string): void {
   const waspFilePath = findWaspFilePath(projectDir);
   const waspFileContent = readFileSync(waspFilePath, "utf-8");
-  // Matches the version string inside the `wasp: { ... }` block. The same
-  // pattern works for both `main.wasp` (multi-line) and `main.wasp.ts`
-  // (inline), since both express it as `wasp: { version: "^X.Y.Z" }`.
+  // A bit unstable, but it should be good enough for our "controlled environment".
   const updatedWaspFileContent = waspFileContent.replace(
-    /(wasp:\s*\{[^}]*version:\s*)"[^"]+"/,
-    `$1"^${nextVersion}"`,
+    /(wasp:\s*\{[^}]*version:\s*)["'`][^"'`]+["'`]/,
+    `$1"${nextVersion}"`,
   );
   writeFileSync(waspFilePath, updatedWaspFileContent);
 }

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -118,6 +118,9 @@ function bustWaspProjectsLibsCache(): void {
   }
 }
 
+// TODO: Consider using `semver` package in future.
+// So far the `tools` project only has dev dependencies.
+// Adding runtime dependencies would change the workflow.
 function bumpVersion(version: string, bumpType: BumpType): string {
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
   if (!match) {

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -12,10 +12,10 @@ import {
   runCmd,
 } from "./utils.ts";
 
-const waspcDir = getWaspcDirPath();
-const repoRootDir = getRepoRootPath();
-const runScriptFile = join(waspcDir, "run");
-const waspProjectDirsFromRepoRoot = [
+const waspcDirPath = getWaspcDirPath();
+const repoRootDirPath = getRepoRootPath();
+const runScriptFilePath = join(waspcDirPath, "run");
+const waspProjectDirsPathFromRepoRoot = [
   "examples/tutorials/TodoApp",
   "examples/tutorials/TodoAppTs",
   "examples/waspello",
@@ -31,9 +31,9 @@ type BumpType = "major" | "minor" | "patch";
 const [_node, _filename, bumpTypeArg] = process.argv;
 assert(isBumpType(bumpTypeArg), "Usage: version-bump <major | minor | patch>");
 
-versionBump(bumpTypeArg);
+bumpWaspVersion(bumpTypeArg);
 
-function versionBump(bumpType: BumpType): void {
+function bumpWaspVersion(bumpType: BumpType): void {
   const currentVersion = getWaspcVersion();
   const nextVersion = bumpVersion(currentVersion, bumpType);
   console.log(`Bumping Wasp version: ${currentVersion} -> ${nextVersion}`);
@@ -49,47 +49,60 @@ function versionBump(bumpType: BumpType): void {
 }
 
 function bumpWaspcCabalVersion(nextVersion: string): void {
-  const cabalFilePath = join(waspcDir, "waspc.cabal");
+  const cabalFilePath = join(waspcDirPath, "waspc.cabal");
   const cabalFileContent = readFileSync(cabalFilePath, "utf-8");
+
   const updatedCabalFileContent = cabalFileContent.replace(
     /^version:\s*.+$/m,
     `version: ${nextVersion}`,
   );
+  if (cabalFileContent === updatedCabalFileContent) {
+    throw new Error(`Failed to update the ${cabalFilePath} version`);
+  }
+
   writeFileSync(cabalFilePath, updatedCabalFileContent);
 }
 
 function bumpLibsVersion(nextVersion: string): void {
-  const dataLibsDir = getDataLibsDirPath();
-  for (const libDir of discoverSubDirs(dataLibsDir)) {
-    bumpPackageJsonVersion(libDir, nextVersion);
+  const dataLibsDirPath = getDataLibsDirPath();
+  for (const libDirPath of discoverSubDirs(dataLibsDirPath)) {
+    bumpPackageJsonVersion(libDirPath, nextVersion);
   }
 }
 
 function bumpWaspProjectsVersion(nextVersion: string): void {
-  for (const projectDirFromRepoRoot of waspProjectDirsFromRepoRoot) {
-    const projectDir = join(repoRootDir, projectDirFromRepoRoot);
-    bumpWaspProjectVersion(projectDir, nextVersion);
+  for (const projectDirPathFromRepoRoot of waspProjectDirsPathFromRepoRoot) {
+    const projectDirPath = join(repoRootDirPath, projectDirPathFromRepoRoot);
+    bumpWaspProjectVersion(projectDirPath, nextVersion);
   }
 }
 
 function bumpPackageJsonVersion(dir: string, nextVersion: string): void {
   const packageJsonPath = join(dir, "package.json");
-  const content = readFileSync(packageJsonPath, "utf-8");
-  const updated = content.replace(
-    /("version":\s*)"[^"]+"/,
-    `$1"${nextVersion}"`,
-  );
-  writeFileSync(packageJsonPath, updated);
+  const packageJsonContent = readFileSync(packageJsonPath, "utf-8");
+  const packageJson: { version?: string } = JSON.parse(packageJsonContent);
+
+  if (!packageJson.version) {
+    throw new Error(`Failed to update the ${packageJsonPath} version`);
+  }
+  packageJson.version = nextVersion;
+
+  writeFileSync(packageJsonPath, JSON.stringify(packageJson));
 }
 
 function bumpWaspProjectVersion(projectDir: string, nextVersion: string): void {
   const waspFilePath = findWaspFilePath(projectDir);
   const waspFileContent = readFileSync(waspFilePath, "utf-8");
+
   // A bit unstable, but it should be good enough for our "controlled environment".
   const updatedWaspFileContent = waspFileContent.replace(
     /(wasp:\s*\{[^}]*version:\s*)["'`][^"'`]+["'`]/,
     `$1"${nextVersion}"`,
   );
+  if (waspFileContent === updatedWaspFileContent) {
+    throw new Error(`Failed to update the ${waspFilePath} Wasp version`);
+  }
+
   writeFileSync(waspFilePath, updatedWaspFileContent);
 }
 
@@ -105,14 +118,15 @@ function findWaspFilePath(projectDir: string): string {
 
 function rebuildLibs(): void {
   runCmd("node", [join("tools", "libs", "build.ts")], {
-    cwd: waspcDir,
+    cwd: waspcDirPath,
+    stdio: "inherit",
   });
 }
 
 function bustWaspProjectsLibsCache(): void {
-  for (const projectDirFromRepoRoot of waspProjectDirsFromRepoRoot) {
-    runCmd(runScriptFile, ["bust-libs-cache"], {
-      cwd: join(repoRootDir, projectDirFromRepoRoot),
+  for (const projectDirFromRepoRoot of waspProjectDirsPathFromRepoRoot) {
+    runCmd(runScriptFilePath, ["bust-libs-cache"], {
+      cwd: join(repoRootDirPath, projectDirFromRepoRoot),
       stdio: "inherit",
     });
   }

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -3,12 +3,12 @@
 import assert from "node:assert";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { getWaspcVersion } from "./get-waspc-version.ts";
 import { getDataLibsDirPath } from "./libs/utils.ts";
 import {
   discoverSubDirs,
   getRepoRootPath,
   getWaspcDirPath,
-  getWaspcVersion,
   runCmd,
 } from "./utils.ts";
 

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -3,7 +3,7 @@
 import assert from "node:assert";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { getWaspcVersion } from "./get-waspc-version.ts";
+import { cabalVersionRegex, getWaspcVersion } from "./get-waspc-version.ts";
 import { getDataLibsDirPath } from "./libs/utils.ts";
 import {
   discoverSubDirs,
@@ -53,7 +53,7 @@ function bumpWaspcCabalVersion(nextVersion: string): void {
   const cabalFileContent = readFileSync(cabalFilePath, "utf-8");
 
   const updatedCabalFileContent = cabalFileContent.replace(
-    /^version:\s*.+$/m,
+    cabalVersionRegex,
     `version: ${nextVersion}`,
   );
   if (cabalFileContent === updatedCabalFileContent) {

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -7,6 +7,7 @@ import { cabalVersionRegex, getWaspcVersion } from "./get-waspc-version.ts";
 import { getDataLibsDirPath } from "./libs/utils.ts";
 import {
   discoverSubDirs,
+  findWaspProjectDirsAbsPathInRepo as findWaspProjectDirsPathsInRepo,
   getRepoRootPath,
   getWaspcDirPath,
   runCmd,
@@ -14,17 +15,7 @@ import {
 
 const waspcDirPath = getWaspcDirPath();
 const repoRootDirPath = getRepoRootPath();
-const runScriptFilePath = join(waspcDirPath, "run");
-const waspProjectDirsPathFromRepoRoot = [
-  "examples/tutorials/TodoApp",
-  "examples/tutorials/TodoAppTs",
-  "examples/waspello",
-  "examples/waspleau",
-  "examples/websockets-realtime-voting",
-  "examples/ask-the-documents",
-  "examples/kitchen-sink",
-  "mage",
-];
+const waspProjectDirsPaths = findWaspProjectDirsPathsInRepo();
 
 type BumpType = "major" | "minor" | "patch";
 
@@ -71,9 +62,8 @@ function bumpLibsVersion(nextVersion: string): void {
 }
 
 function bumpWaspProjectsVersion(nextVersion: string): void {
-  for (const projectDirPathFromRepoRoot of waspProjectDirsPathFromRepoRoot) {
-    const projectDirPath = join(repoRootDirPath, projectDirPathFromRepoRoot);
-    bumpWaspProjectVersion(projectDirPath, nextVersion);
+  for (const waspProjectDirAbsPath of waspProjectDirsPaths) {
+    bumpWaspProjectVersion(waspProjectDirAbsPath, nextVersion);
   }
 }
 
@@ -124,9 +114,11 @@ function rebuildLibs(): void {
 }
 
 function bustWaspProjectsLibsCache(): void {
-  for (const projectDirFromRepoRoot of waspProjectDirsPathFromRepoRoot) {
+  const runScriptFilePath = join(waspcDirPath, "run");
+
+  for (const waspProjectDirPath of waspProjectDirsPaths) {
     runCmd(runScriptFilePath, ["bust-libs-cache"], {
-      cwd: join(repoRootDirPath, projectDirFromRepoRoot),
+      cwd: waspProjectDirPath,
       stdio: "inherit",
     });
   }

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -77,7 +77,10 @@ function bumpPackageJsonVersion(dir: string, nextVersion: string): void {
   }
   packageJson.version = nextVersion;
 
-  writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+  writeFileSync(
+    packageJsonPath,
+    JSON.stringify(packageJson, undefined, 2) + "\n",
+  );
 }
 
 function bumpWaspProjectVersion(projectDir: string, nextVersion: string): void {

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -8,13 +8,11 @@ import { getDataLibsDirPath } from "./libs/utils.ts";
 import {
   discoverSubDirs,
   findWaspProjectDirsAbsPathInRepo as findWaspProjectDirsPathsInRepo,
-  getRepoRootPath,
   getWaspcDirPath,
   runCmd,
 } from "./utils.ts";
 
 const waspcDirPath = getWaspcDirPath();
-const repoRootDirPath = getRepoRootPath();
 const waspProjectDirsPaths = findWaspProjectDirsPathsInRepo();
 
 type BumpType = "major" | "minor" | "patch";

--- a/waspc/tools/version-bump.ts
+++ b/waspc/tools/version-bump.ts
@@ -27,13 +27,12 @@ function bumpWaspVersion(bumpType: BumpType): void {
   const nextVersion = bumpVersion(currentVersion, bumpType);
   console.log(`Bumping Wasp version: ${currentVersion} -> ${nextVersion}`);
 
-  // Bumping versions
   bumpWaspcCabalVersion(nextVersion);
-  bumpLibsVersion(nextVersion);
-  bumpWaspProjectsVersion(nextVersion);
 
-  // Busting old libs cache
+  bumpLibsVersion(nextVersion);
   rebuildLibs();
+
+  bumpWaspProjectsVersion(nextVersion);
   bustWaspProjectsLibsCache();
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Adds a command which:
- bumps the `waspc.cabal` version
- bumps the Wasp projects version
- bumps the libs version
- rebuilds the libs
- busts the libs cache for each Wasp project

Yeah, our process is pretty long.
The command takes a bit to execute (due to libs cache busting), e.g. my two test runs:
```
node version-bump.ts patch  33.22s user 7.03s system 116% cpu 34.614 total
node version-bump.ts minor  55.32s user 11.06s system 127% cpu 52.076 total
```

NOTE, as agreed previously:
- It sets the Wasp project Wasp version to be the same as the `waspc.cabal` version. 
- It sets the Wasp project Wasp version to exact version, i.e. `0.25.0` NOT `^0.25.0`. 
	- Having it `^0.25.0` wouldn't do anything, as the Wasp project Wasp version will always be identical to `waspc.cabal` version. So in that sense, they have the same version range. 

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
