### PR TITLE
Try `.mjs` for Prettier, because web also tries to use `prettier` to format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "wasp-repo",
+  "type": "module",
   "scripts": {
     "check:prettier": "prettier --ignore-unknown --check --config prettier.config.mjs .",
     "format:prettier": "prettier --ignore-unknown --write --config prettier.config.mjs ."

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "wasp-repo",
   "scripts": {
-    "check:prettier": "prettier --ignore-unknown --check --config prettier.config.ts .",
-    "format:prettier": "prettier --ignore-unknown --write --config prettier.config.ts ."
+    "check:prettier": "prettier --ignore-unknown --check --config prettier.config.mjs .",
+    "format:prettier": "prettier --ignore-unknown --write --config prettier.config.mjs ."
   },
   "devDependencies": {
     "prettier": "3.5.3",

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,6 +1,7 @@
-import { type Config } from "prettier";
-
-const config: Config = {
+/**
+ * @type {import("prettier").Config}
+ */
+const config = {
   plugins: [
     "prettier-plugin-organize-imports",
     "prettier-plugin-pkg",

--- a/waspc/data/Cli/starters/basic/prettier.config.mjs
+++ b/waspc/data/Cli/starters/basic/prettier.config.mjs
@@ -1,6 +1,8 @@
-import { type Config } from "prettier";
 
-const config: Config = {
+/**
+ * @type {import("prettier").Config}
+ */
+const config = {
   "plugins": ["prettier-plugin-tailwindcss"]
 }
 

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -25,6 +25,7 @@ data-files:
   --   and also files with no extension.
   --   Check https://github.com/haskell/cabal/issues/5883 for more details.
   Cli/starters/**/*.css
+  Cli/starters/**/*.mjs
   Cli/starters/**/*.js
   Cli/starters/**/*.json
   Cli/starters/**/*.md

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -25,10 +25,10 @@ data-files:
   --   and also files with no extension.
   --   Check https://github.com/haskell/cabal/issues/5883 for more details.
   Cli/starters/**/*.css
-  Cli/starters/**/*.mjs
   Cli/starters/**/*.js
   Cli/starters/**/*.json
   Cli/starters/**/*.md
+  Cli/starters/**/*.mjs
   Cli/starters/**/*.prisma
   Cli/starters/**/*.svg
   Cli/starters/**/*.ts

--- a/web/package.json
+++ b/web/package.json
@@ -60,7 +60,7 @@
     "marked": "^17.0.3",
     "mdast": "^2.3.2",
     "mdast-util-mdx": "^3.0.0",
-    "prettier": "^3.0.3",
+    "prettier": "3.5.3",
     "remark-cli": "^11.0.0",
     "remark-validate-links": "^12.1.1",
     "tsx": "^4.20.3",


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

After we change `.prettierrc` to `prettier.config.ts`, Miho noticed that the `main` didn't manage to deploy `web/` to cloudflare properly.
So I went to investigate.

Problems:
- Our `web/` deployment was pinned to `NODE_VERSION=20` on Cloudflare via environment variables. This caused us to error when trying to import config from `prettier.config.ts` since that version of node can't work with TypeScript natively.
	- I find `NODE_VERSION` problematic since it diverges from `.nvmrc` version defined in the repo. Also as this version only exists in Cloudflare, so it's hard to track and remember.
	- Cloudflare by default searches for `.nvmrc` if `NODE_VERSION` is not set. So if we just delete the `NODE_VERSION` env var, the `web/` node version should follow the repo version. Which I did.

- The `prettier.config.ts` file imports the `Config` type from the `prettier` package, which means that if we don't `npm i` in the project root, loading `prettier.config.ts` will fail, since `prettier` package it tries to import type from does not exist. This means it becomes necessary to `npm i` to load the config.
	- I find this a regression to behavior from `.prettierrc`, so I converted TypeScript to JavaScript, which should work without any packages installed. I did the same for our `Basic` starter template.



## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
