### PR TITLE
Expand default Haskell langauge extensions

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/News/Display.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/News/Display.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedRecordDot #-}
-
 module Wasp.Cli.Command.News.Display (showNewsEntry) where
 
 import qualified Data.Text as T

--- a/waspc/cli/src/Wasp/Cli/Command/News/Listing.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/News/Listing.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Wasp.Cli.Command.News.Listing
   ( -- * News Listing
 

--- a/waspc/cli/src/Wasp/Cli/Command/News/LocalNewsState.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/News/LocalNewsState.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module Wasp.Cli.Command.News.LocalNewsState
   ( LocalNewsState,

--- a/waspc/cli/tests/Wasp/Cli/Command/News/ListingTest.hs
+++ b/waspc/cli/tests/Wasp/Cli/Command/News/ListingTest.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedRecordDot #-}
-
 module Wasp.Cli.Command.News.ListingTest where
 
 import Data.List (subsequences)

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module ShellCommands
   ( ShellCommand,

--- a/waspc/e2e-tests/SnapshotTest.hs
+++ b/waspc/e2e-tests/SnapshotTest.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module SnapshotTest
   ( SnapshotTest,

--- a/waspc/e2e-tests/Test.hs
+++ b/waspc/e2e-tests/Test.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module Test
   ( Test (..),

--- a/waspc/e2e-tests/Tests/SnapshotTests/WaspBuildSnapshotTest.hs
+++ b/waspc/e2e-tests/Tests/SnapshotTests/WaspBuildSnapshotTest.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedRecordDot #-}
-
 module Tests.SnapshotTests.WaspBuildSnapshotTest (waspBuildSnapshotTest) where
 
 import Control.Monad.Reader (asks)

--- a/waspc/e2e-tests/Tests/ViteBuildTest.hs
+++ b/waspc/e2e-tests/Tests/ViteBuildTest.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedRecordDot #-}
-
 module Tests.ViteBuildTest (viteBuildTest) where
 
 import Control.Monad.Reader (ask)

--- a/waspc/e2e-tests/Tests/ViteConfigTest.hs
+++ b/waspc/e2e-tests/Tests/ViteConfigTest.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedRecordDot #-}
-
 module Tests.ViteConfigTest (viteConfigTest) where
 
 import Control.Monad.Reader (ask)

--- a/waspc/e2e-tests/Tests/WaspDbMigrateDevTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDbMigrateDevTest.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedRecordDot #-}
-
 module Tests.WaspDbMigrateDevTest (waspDbMigrateDevTest) where
 
 import Control.Monad.Reader (MonadReader (ask))

--- a/waspc/src/Wasp/AppSpec/App/Auth.hs
+++ b/waspc/src/Wasp/AppSpec/App/Auth.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module Wasp.AppSpec.App.Auth
   ( Auth (..),

--- a/waspc/src/Wasp/AppSpec/Job.hs
+++ b/waspc/src/Wasp/AppSpec/Job.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module Wasp.AppSpec.Job
   ( Job (..),

--- a/waspc/src/Wasp/JsImport.hs
+++ b/waspc/src/Wasp/JsImport.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 
 module Wasp.JsImport
   ( JsImport (..),

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -100,6 +100,8 @@ common common-all
     FlexibleContexts
     LambdaCase
     MultiParamTypeClasses
+    NamedFieldPuns
+    OverloadedRecordDot
     OverloadedStrings
     QuasiQuotes
     ScopedTypeVariables


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Changes
- `NamedFieldPuns` 
  - it allows compacting `Foo {x = x}` to `Foo {x}` 
  - this allows us to use the same name for the function param as the record field
    - e.g. a function accepts `foo` param which constructs a record with `foo` field
- `OverloadedRecordDot` - reinterprets `record.field` (no spaces) as `field record`
  - we already use this one a lot 


## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
