### PR TITLE
Add ergonomic imports MVP

### DIFF
--- a/waspc/data/Cli/starters/ts-minimal/main.wasp.ts
+++ b/waspc/data/Cli/starters/ts-minimal/main.wasp.ts
@@ -1,5 +1,5 @@
 import { App } from "wasp-config";
-import { MainPage } from "./src/MainPage";
+import { MainPage } from "@src/MainPage";
 
 const app = new App("__waspAppName__", {
   title: "__waspProjectName__",

--- a/waspc/data/Cli/starters/ts-minimal/main.wasp.ts
+++ b/waspc/data/Cli/starters/ts-minimal/main.wasp.ts
@@ -1,4 +1,5 @@
 import { App } from "wasp-config";
+import { MainPage } from "./src/MainPage";
 
 const app = new App("__waspAppName__", {
   title: "__waspProjectName__",
@@ -6,9 +7,7 @@ const app = new App("__waspAppName__", {
   head: ["<link rel='icon' href='/favicon.ico' />"],
 });
 
-const mainPage = app.page("MainPage", {
-  component: { import: "MainPage", from: "@src/MainPage" },
-});
+const mainPage = app.page("MainPage", { component: MainPage });
 
 app.route("RootRoute", { path: "/", to: mainPage });
 

--- a/waspc/data/Cli/starters/ts-minimal/tsconfig.wasp.json
+++ b/waspc/data/Cli/starters/ts-minimal/tsconfig.wasp.json
@@ -7,9 +7,13 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "module": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "jsx": "preserve",
     "noEmit": true,
-    "lib": ["ES2023"]
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": ["vite/client", "react"]
   },
   "include": ["main.wasp.ts"]
 }

--- a/waspc/data/Cli/starters/ts-minimal/tsconfig.wasp.json
+++ b/waspc/data/Cli/starters/ts-minimal/tsconfig.wasp.json
@@ -12,7 +12,11 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "noEmit": true,
+    "baseUrl": ".",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@src/*": ["src/*"]
+    },
     "types": ["vite/client", "react"]
   },
   "include": ["main.wasp.ts"]

--- a/waspc/data/packages/wasp-config/__tests__/appSpec/extImportDescriptor.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/appSpec/extImportDescriptor.unit.test.ts
@@ -63,4 +63,13 @@ describe("mapAuthoredExtImport", () => {
     if (result.status !== "error") return;
     expect(formatExtImportDescriptorError(result.reason)).toMatch(message);
   });
+
+  test("formats unrewritten import-form value diagnostics with @src guidance", () => {
+    expect(formatExtImportDescriptorError("functionValue")).toContain(
+      "top-level @src/* import",
+    );
+    expect(formatExtImportDescriptorError("objectValue")).toContain(
+      "top-level @src/* import",
+    );
+  });
 });

--- a/waspc/data/packages/wasp-config/__tests__/appSpec/extImportDescriptor.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/appSpec/extImportDescriptor.unit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import {
+  AuthoredExtImport,
+  formatExtImportDescriptorError,
+  mapAuthoredExtImport,
+} from "../../src/appSpec/extImportDescriptor.js";
+
+describe("mapAuthoredExtImport", () => {
+  test("maps named descriptors with alias metadata", () => {
+    expect(
+      mapAuthoredExtImport({
+        import: "archive",
+        from: "@src/operations",
+        alias: "archiveTask",
+      }),
+    ).toEqual({
+      status: "ok",
+      value: {
+        kind: "named",
+        name: "archive",
+        path: "@src/operations",
+        alias: "archiveTask",
+      },
+    });
+  });
+
+  test("maps default descriptors", () => {
+    expect(
+      mapAuthoredExtImport({
+        importDefault: "MainPage",
+        from: "@src/MainPage",
+      }),
+    ).toEqual({
+      status: "ok",
+      value: {
+        kind: "default",
+        name: "MainPage",
+        path: "@src/MainPage",
+      },
+    });
+  });
+
+  test.each([
+    {
+      extImport: (() => null) as AuthoredExtImport,
+      reason: "functionValue",
+      message: /got a function at runtime/,
+    },
+    {
+      extImport: { import: "archive", from: "@src/operations", alias: 42 },
+      reason: "descriptorLikeObject",
+      message: /Invalid ExtImport descriptor/,
+    },
+    {
+      extImport: { parse: () => ({}) },
+      reason: "objectValue",
+      message: /got an object at runtime/,
+    },
+  ])("returns $reason for invalid values", ({ extImport, reason, message }) => {
+    const result = mapAuthoredExtImport(extImport as AuthoredExtImport);
+
+    expect(result).toEqual({ status: "error", reason });
+    if (result.status !== "error") return;
+    expect(formatExtImportDescriptorError(result.reason)).toMatch(message);
+  });
+});

--- a/waspc/data/packages/wasp-config/__tests__/legacy/mapTsAppSpecToAppSpecDecls.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/legacy/mapTsAppSpecToAppSpecDecls.unit.test.ts
@@ -1009,6 +1009,14 @@ describe("mapExtImport", () => {
     testMapExtImport(Fixtures.getExtImport("full", "default"));
   });
 
+  test("should map alias metadata when present", () => {
+    testMapExtImport({
+      import: "archive",
+      alias: "archiveTask",
+      from: "@src/operations",
+    });
+  });
+
   test("should throw for missing import kind", () => {
     const extImport: TsAppSpec.ExtImport = {
       from: "@src/myModule",
@@ -1016,6 +1024,38 @@ describe("mapExtImport", () => {
 
     testMapExtImport(extImport, {
       shouldError: true,
+      errorMessage: /Invalid ExtImport descriptor/,
+    });
+  });
+
+  test("should throw for invalid alias metadata", () => {
+    const extImport = {
+      import: "archive",
+      alias: 42,
+      from: "@src/operations",
+    } as unknown as TsAppSpec.ExtImport;
+
+    testMapExtImport(extImport, {
+      shouldError: true,
+      errorMessage: /Invalid ExtImport descriptor/,
+    });
+  });
+
+  test("should throw an actionable error for an unrewritten function value", () => {
+    const extImport = (() => null) as TsAppSpec.AuthoredExtImport;
+
+    testMapExtImport(extImport, {
+      shouldError: true,
+      errorMessage: /got a function at runtime/,
+    });
+  });
+
+  test("should throw an actionable error for an unrewritten object value", () => {
+    const extImport = { parse: () => ({}) } as TsAppSpec.AuthoredExtImport;
+
+    testMapExtImport(extImport, {
+      shouldError: true,
+      errorMessage: /got an object at runtime/,
     });
   });
 
@@ -1024,7 +1064,7 @@ describe("mapExtImport", () => {
     const extImport = {
       ...Fixtures.getExtImport("full", "named"),
       ...Fixtures.getExtImport("full", "default"),
-    };
+    } as unknown as TsAppSpec.ExtImport;
 
     testMapExtImport(extImport, {
       shouldError: true,
@@ -1044,10 +1084,11 @@ describe("mapExtImport", () => {
   });
 
   function testMapExtImport(
-    extImport: TsAppSpec.ExtImport,
+    extImport: TsAppSpec.AuthoredExtImport,
     options:
       | {
           shouldError: boolean | undefined;
+          errorMessage?: RegExp;
         }
       | undefined = {
       shouldError: false,
@@ -1056,23 +1097,26 @@ describe("mapExtImport", () => {
     const { shouldError } = options;
 
     if (shouldError) {
-      expect(() => mapExtImport(extImport)).toThrowError();
+      expect(() => mapExtImport(extImport)).toThrowError(options.errorMessage);
       return;
     }
 
-    const result = mapExtImport(extImport);
+    const descriptor = extImport as TsAppSpec.ExtImport;
+    const result = mapExtImport(descriptor);
 
-    if ("import" in extImport) {
+    if ("import" in descriptor) {
       expect(result).toStrictEqual({
         kind: "named",
-        name: extImport.import,
-        path: extImport.from,
+        name: descriptor.import,
+        path: descriptor.from,
+        ...(descriptor.alias ? { alias: descriptor.alias } : {}),
       } satisfies AppSpec.ExtImport);
-    } else if ("importDefault" in extImport) {
+    } else if ("importDefault" in descriptor) {
       expect(result).toStrictEqual({
         kind: "default",
-        name: extImport.importDefault,
-        path: extImport.from,
+        name: descriptor.importDefault,
+        path: descriptor.from,
+        ...(descriptor.alias ? { alias: descriptor.alias } : {}),
       } satisfies AppSpec.ExtImport);
     }
   }

--- a/waspc/data/packages/wasp-config/__tests__/legacy/testFixtures.test-d.ts
+++ b/waspc/data/packages/wasp-config/__tests__/legacy/testFixtures.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, test } from "vitest";
 import { Branded } from "../../src/branded.js";
+import * as TsAppSpec from "../../src/legacy/publicApi/tsAppSpec.js";
 import { FullConfig, MinimalConfig } from "./testFixtures.js";
 
 describe("MinimalConfig<T>", () => {
@@ -15,6 +16,10 @@ describe("MinimalConfig<T>", () => {
 
   test("should not affect branded types", async () => {
     expectTypeOf<MinimalConfig<BrandedType>>().toEqualTypeOf<BrandedType>();
+  });
+
+  test("should not affect function types", async () => {
+    expectTypeOf<MinimalConfig<FunctionType>>().toEqualTypeOf<FunctionType>();
   });
 
   test("should convert no props object to EmptyObject", async () => {
@@ -64,6 +69,10 @@ describe("FullConfig<T>", () => {
     expectTypeOf<FullConfig<BrandedType>>().toEqualTypeOf<BrandedType>();
   });
 
+  test("should not affect function types", async () => {
+    expectTypeOf<FullConfig<FunctionType>>().toEqualTypeOf<FunctionType>();
+  });
+
   test("should not affect required props", async () => {
     expectTypeOf<
       FullConfig<ObjectWithRequiredPrimitiveProperties>
@@ -91,6 +100,51 @@ describe("FullConfig<T>", () => {
   });
 });
 
+describe("import-form authored value types", () => {
+  test("should accept functions at callable ExtImport use sites", async () => {
+    const component = () => null;
+    const operation = async () => null;
+
+    const pageConfig = { component } satisfies TsAppSpec.PageConfig;
+    const actionConfig = { fn: operation } satisfies TsAppSpec.ActionConfig;
+
+    expectTypeOf(
+      pageConfig.component,
+    ).toMatchTypeOf<TsAppSpec.FunctionExtImport>();
+    expectTypeOf(actionConfig.fn).toMatchTypeOf<TsAppSpec.FunctionExtImport>();
+  });
+
+  test("should accept objects at object ExtImport use sites", async () => {
+    const envValidationSchema = { parse: (env: unknown) => env };
+
+    const serverConfig = {
+      envValidationSchema,
+    } satisfies TsAppSpec.ServerConfig;
+
+    expectTypeOf(
+      serverConfig.envValidationSchema,
+    ).toMatchTypeOf<TsAppSpec.ObjectExtImport>();
+  });
+
+  test("should reject functions at object ExtImport use sites", async () => {
+    const serverConfig: TsAppSpec.ServerConfig = {
+      // @ts-expect-error object ExtImport use sites must not accept callables.
+      envValidationSchema: () => null,
+    };
+
+    expectTypeOf(serverConfig).toMatchTypeOf<TsAppSpec.ServerConfig>();
+  });
+
+  test("should reject malformed descriptor-like objects", async () => {
+    const serverConfig: TsAppSpec.ServerConfig = {
+      // @ts-expect-error descriptor-like objects must still satisfy ExtImport.
+      envValidationSchema: { from: 42, importDefault: "X" },
+    };
+
+    expectTypeOf(serverConfig).toMatchTypeOf<TsAppSpec.ServerConfig>();
+  });
+});
+
 type ObjectWithRequiredPrimitiveProperties = {
   prop: unknown;
   anotherProp: unknown;
@@ -100,6 +154,8 @@ type ObjectWithOptionalPrimitiveProperties =
   Partial<ObjectWithRequiredPrimitiveProperties>;
 
 type BrandedType = Branded<string, "BrandedString">;
+
+type FunctionType = (value: string) => number;
 
 /**
  * Represents an empty object type in TypeScript.

--- a/waspc/data/packages/wasp-config/__tests__/legacy/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/legacy/testFixtures.ts
@@ -1064,13 +1064,18 @@ type FullNamedConfig<T> = {
 export type MinimalConfig<T> =
   T extends Branded<unknown, unknown>
     ? T
-    : T extends Array<infer ArrayItem>
-      ? Array<MinimalConfig<ArrayItem>>
-      : T extends object
-        ? keyof T extends never
-          ? EmptyObject
-          : MinimalConfigObject<T>
-        : T;
+    : T extends TsAppSpec.ExtImport
+      ? T
+      : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        T extends (...args: any[]) => any
+        ? T
+        : T extends Array<infer ArrayItem>
+          ? Array<MinimalConfig<ArrayItem>>
+          : T extends object
+            ? keyof T extends never
+              ? EmptyObject
+              : MinimalConfigObject<T>
+            : T;
 
 type MinimalConfigObject<T> = {
   [K in keyof T as EmptyObject extends Pick<T, K> ? never : K]: MinimalConfig<
@@ -1131,11 +1136,16 @@ type EmptyObject = Record<string, never>;
 export type FullConfig<T> =
   T extends Branded<unknown, unknown>
     ? T
-    : T extends Array<infer ArrayItem>
-      ? Array<FullConfig<ArrayItem>>
-      : T extends object
-        ? FullConfigObject<T>
-        : T;
+    : T extends TsAppSpec.ExtImport
+      ? T
+      : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        T extends (...args: any[]) => any
+        ? T
+        : T extends Array<infer ArrayItem>
+          ? Array<FullConfig<ArrayItem>>
+          : T extends object
+            ? FullConfigObject<T>
+            : T;
 
 type FullConfigObject<T> = {
   [K in keyof T]-?: FullConfig<T[K]>;

--- a/waspc/data/packages/wasp-config/__tests__/spec-pipeline/importLoweringPlan.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec-pipeline/importLoweringPlan.unit.test.ts
@@ -5,9 +5,9 @@ describe("planImportLowering", () => {
   test("plans descriptor declarations for supported import shapes", () => {
     const result = planImportLowering(
       [
-        `import MainPage from "./src/MainPage";`,
-        `import { getTasks, archive as archiveTask } from "./src/operations";`,
-        `import * as ops from "./src/operations";`,
+        `import MainPage from "@src/MainPage";`,
+        `import { getTasks, archive as archiveTask } from "@src/operations";`,
+        `import * as ops from "@src/operations";`,
         ``,
       ].join("\n"),
     );
@@ -54,41 +54,44 @@ describe("planImportLowering", () => {
     expect(result).toEqual({ status: "ok", plan: { replacements: [] } });
   });
 
+  test("leaves non-@src imports and re-exports out of the plan", () => {
+    const result = planImportLowering(
+      [
+        `import helper from "./helpers";`,
+        `import MainPage from "./src/MainPage";`,
+        `export { helper } from "./helpers";`,
+        ``,
+      ].join("\n"),
+    );
+
+    expect(result).toEqual({ status: "ok", plan: { replacements: [] } });
+  });
+
   test.each([
     {
-      source: `import "./src/setup";\n`,
+      source: `import "@src/setup";\n`,
       reason: "sideEffectImport",
-      specifier: "./src/setup",
+      specifier: "@src/setup",
     },
     {
-      source: `import type { Props } from "./src/MainPage";\n`,
+      source: `import type { Props } from "@src/MainPage";\n`,
       reason: "typeOnlyImport",
-      specifier: "./src/MainPage",
+      specifier: "@src/MainPage",
     },
     {
-      source: `import { type Props, MainPage } from "./src/MainPage";\n`,
+      source: `import { type Props, MainPage } from "@src/MainPage";\n`,
       reason: "mixedTypeAndValueImport",
-      specifier: "./src/MainPage",
+      specifier: "@src/MainPage",
     },
     {
-      source: `import {} from "./src/MainPage";\n`,
+      source: `import {} from "@src/MainPage";\n`,
       reason: "emptyNamedImport",
-      specifier: "./src/MainPage",
+      specifier: "@src/MainPage",
     },
     {
-      source: `export { MainPage } from "./src/MainPage";\n`,
+      source: `export { MainPage } from "@src/MainPage";\n`,
       reason: "srcReExport",
-      specifier: "./src/MainPage",
-    },
-    {
-      source: `import helper from "./helpers";\n`,
-      reason: "relativeImportOutsideSrc",
-      specifier: "./helpers",
-    },
-    {
-      source: `export { helper } from "./helpers";\n`,
-      reason: "relativeReExportOutsideSrc",
-      specifier: "./helpers",
+      specifier: "@src/MainPage",
     },
   ])("returns a diagnostic for $reason", ({ source, reason, specifier }) => {
     const result = planImportLowering(source);

--- a/waspc/data/packages/wasp-config/__tests__/spec-pipeline/importLoweringPlan.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec-pipeline/importLoweringPlan.unit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+import { planImportLowering } from "../../src/spec-pipeline/importLoweringPlan.js";
+
+describe("planImportLowering", () => {
+  test("plans descriptor declarations for supported import shapes", () => {
+    const result = planImportLowering(
+      [
+        `import MainPage from "./src/MainPage";`,
+        `import { getTasks, archive as archiveTask } from "./src/operations";`,
+        `import * as ops from "./src/operations";`,
+        ``,
+      ].join("\n"),
+    );
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+
+    expect(
+      result.plan.replacements.flatMap(
+        (replacement) => replacement.declarations,
+      ),
+    ).toEqual([
+      {
+        kind: "descriptor",
+        localName: "MainPage",
+        descriptor: { importDefault: "MainPage", from: "@src/MainPage" },
+      },
+      {
+        kind: "descriptor",
+        localName: "getTasks",
+        descriptor: { import: "getTasks", from: "@src/operations" },
+      },
+      {
+        kind: "descriptor",
+        localName: "archiveTask",
+        descriptor: {
+          import: "archive",
+          from: "@src/operations",
+          alias: "archiveTask",
+        },
+      },
+      {
+        kind: "namespace",
+        localName: "ops",
+        descriptorPath: "@src/operations",
+        aliasPrefix: "ops_",
+      },
+    ]);
+  });
+
+  test("leaves package imports out of the plan", () => {
+    const result = planImportLowering(`import { App } from "wasp-config";\n`);
+
+    expect(result).toEqual({ status: "ok", plan: { replacements: [] } });
+  });
+
+  test.each([
+    {
+      source: `import "./src/setup";\n`,
+      reason: "sideEffectImport",
+      specifier: "./src/setup",
+    },
+    {
+      source: `import type { Props } from "./src/MainPage";\n`,
+      reason: "typeOnlyImport",
+      specifier: "./src/MainPage",
+    },
+    {
+      source: `import { type Props, MainPage } from "./src/MainPage";\n`,
+      reason: "mixedTypeAndValueImport",
+      specifier: "./src/MainPage",
+    },
+    {
+      source: `import {} from "./src/MainPage";\n`,
+      reason: "emptyNamedImport",
+      specifier: "./src/MainPage",
+    },
+    {
+      source: `export { MainPage } from "./src/MainPage";\n`,
+      reason: "srcReExport",
+      specifier: "./src/MainPage",
+    },
+    {
+      source: `import helper from "./helpers";\n`,
+      reason: "relativeImportOutsideSrc",
+      specifier: "./helpers",
+    },
+    {
+      source: `export { helper } from "./helpers";\n`,
+      reason: "relativeReExportOutsideSrc",
+      specifier: "./helpers",
+    },
+  ])("returns a diagnostic for $reason", ({ source, reason, specifier }) => {
+    const result = planImportLowering(source);
+
+    expect(result.status).toBe("error");
+    if (result.status !== "error") return;
+
+    expect(result.diagnostics).toEqual([
+      {
+        reason,
+        specifier,
+        location: { line: 1, column: 1 },
+      },
+    ]);
+  });
+});

--- a/waspc/data/packages/wasp-config/__tests__/spec-pipeline/pipeline.integration.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec-pipeline/pipeline.integration.test.ts
@@ -22,11 +22,11 @@ const specSource = () =>
   [
     `// @ts-ignore: This test imports the local TS source through Vitest.`,
     `import { App } from ${JSON.stringify(waspConfigEntryUrl)};`,
-    `import MainPage from "./src/MainPage";`,
-    `import { getTasks } from "./src/operations";`,
-    `import { archive as archiveTask } from "./src/operations";`,
-    `import { archive as archiveLegacyTask } from "./src/legacyOperations";`,
-    `import * as ops from "./src/operations";`,
+    `import MainPage from "@src/MainPage";`,
+    `import { getTasks } from "@src/operations";`,
+    `import { archive as archiveTask } from "@src/operations";`,
+    `import { archive as archiveLegacyTask } from "@src/legacyOperations";`,
+    `import * as ops from "@src/operations";`,
     ``,
     `const app = new App("demo", {`,
     `  title: "Demo",`,
@@ -149,11 +149,11 @@ describe("end-to-end import-form pipeline", () => {
     const sourcePath = join(tempDir, "main.wasp.ts");
     const rewrittenPath = join(tempDir, "main.wasp.rewritten.ts");
 
-    writeFileSync(sourcePath, `import helper from "./helpers";\n`, "utf8");
+    writeFileSync(sourcePath, `import "@src/setup";\n`, "utf8");
 
     await expect(
       runWaspConfig(["node", "run.js", "rewrite", sourcePath, rewrittenPath]),
-    ).rejects.toThrowError(/Relative imports outside \.\/src/);
+    ).rejects.toThrowError(/Side-effect imports/);
   });
 
   test("type-checks the rewritten spec shape before execution", () => {
@@ -161,7 +161,7 @@ describe("end-to-end import-form pipeline", () => {
     mkdirSync(join(tempDir, "src"));
 
     const source = [
-      `import { appTitle } from "./src/title";`,
+      `import { appTitle } from "@src/title";`,
       ``,
       `declare function makeApp(config: { title: string }): void;`,
       `makeApp({ title: appTitle });`,
@@ -180,6 +180,25 @@ describe("end-to-end import-form pipeline", () => {
 
     expect(runTscExpectingError(tempDir, "tsconfig.rewritten.json")).toContain(
       "is not assignable to type 'string'",
+    );
+  });
+
+  test("type-checks @src imports against real source files", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wasp-spec-src-import-"));
+    mkdirSync(join(tempDir, "src"));
+
+    writeFileSync(
+      join(tempDir, "main.wasp.ts"),
+      `import { typoedTitle } from "@src/title";\ntypoedTitle;\n`,
+    );
+    writeFileSync(
+      join(tempDir, "src", "title.ts"),
+      `export const appTitle = "Demo";\n`,
+    );
+    writeTsConfig(tempDir, "tsconfig.original.json", "main.wasp.ts");
+
+    expect(runTscExpectingError(tempDir, "tsconfig.original.json")).toContain(
+      "has no exported member 'typoedTitle'",
     );
   });
 });
@@ -218,7 +237,7 @@ async function runSpecThroughRunTs(
   await runWaspConfig(["node", "run.js", "rewrite", sourcePath, rewrittenPath]);
 
   const rewrittenSource = readFileSync(rewrittenPath, "utf8");
-  expect(rewrittenSource).not.toMatch(/from\s+"\.\/src\//);
+  expect(rewrittenSource).not.toMatch(/^import\s+(?:.+\s+from\s+)?["']@src\//m);
 
   const outDir = sourceFileName.replace(/\.ts$/, "-dist");
   const tsconfigFileName = sourceFileName.replace(/\.ts$/, ".tsconfig.json");
@@ -254,6 +273,10 @@ function writeTsConfig(
         moduleResolution: "bundler",
         strict: true,
         noEmit: options.noEmit ?? true,
+        baseUrl: ".",
+        paths: {
+          "@src/*": ["src/*"],
+        },
         ...(options.outDir ? { outDir: options.outDir } : {}),
       },
       include: [include],

--- a/waspc/data/packages/wasp-config/__tests__/spec-pipeline/pipeline.integration.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec-pipeline/pipeline.integration.test.ts
@@ -1,0 +1,281 @@
+import { execFileSync } from "child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
+import { createRequire } from "module";
+import { tmpdir } from "os";
+import { join } from "path";
+import { pathToFileURL } from "url";
+import { describe, expect, test } from "vitest";
+import * as AppSpec from "../../src/appSpec.js";
+import { main as runWaspConfig } from "../../src/run.js";
+import { rewrite } from "../../src/spec-pipeline/rewrite.js";
+
+// We use the absolute file:// URL of the local wasp-config source so the
+// rewritten spec file does not rely on node_modules resolution from a temp dir.
+const waspConfigEntryUrl = pathToFileURL(
+  join(__dirname, "..", "..", "src", "index.ts"),
+).href;
+
+const require = createRequire(import.meta.url);
+const tscPath = require.resolve("typescript/lib/tsc.js");
+
+const specSource = () =>
+  [
+    `// @ts-ignore: This test imports the local TS source through Vitest.`,
+    `import { App } from ${JSON.stringify(waspConfigEntryUrl)};`,
+    `import MainPage from "./src/MainPage";`,
+    `import { getTasks } from "./src/operations";`,
+    `import { archive as archiveTask } from "./src/operations";`,
+    `import { archive as archiveLegacyTask } from "./src/legacyOperations";`,
+    `import * as ops from "./src/operations";`,
+    ``,
+    `const app = new App("demo", {`,
+    `  title: "Demo",`,
+    `  wasp: { version: "^0.16.0" },`,
+    `});`,
+    ``,
+    `const mainPage = app.page("MainPage", { component: MainPage });`,
+    `app.route("RootRoute", { path: "/", to: mainPage });`,
+    `app.query("getTasks", { fn: getTasks, entities: [] });`,
+    `app.action("archiveTask", { fn: archiveTask, entities: [] });`,
+    `app.action("archiveLegacyTask", { fn: archiveLegacyTask, entities: [] });`,
+    `app.action("logout", { fn: ops.logout, entities: [] });`,
+    ``,
+    `export default app;`,
+  ].join("\n");
+
+const descriptorSpecSource = () =>
+  [
+    `// @ts-ignore: This test imports the local TS source through Vitest.`,
+    `import { App } from ${JSON.stringify(waspConfigEntryUrl)};`,
+    `const MainPage = { importDefault: "MainPage", from: "@src/MainPage" } as const;`,
+    `const getTasks = { import: "getTasks", from: "@src/operations" } as const;`,
+    `const archiveTask = { import: "archive", from: "@src/operations", alias: "archiveTask" } as const;`,
+    `const archiveLegacyTask = { import: "archive", from: "@src/legacyOperations", alias: "archiveLegacyTask" } as const;`,
+    ``,
+    `const app = new App("demo", {`,
+    `  title: "Demo",`,
+    `  wasp: { version: "^0.16.0" },`,
+    `});`,
+    ``,
+    `const mainPage = app.page("MainPage", { component: MainPage });`,
+    `app.route("RootRoute", { path: "/", to: mainPage });`,
+    `app.query("getTasks", { fn: getTasks, entities: [] });`,
+    `app.action("archiveTask", { fn: archiveTask, entities: [] });`,
+    `app.action("archiveLegacyTask", { fn: archiveLegacyTask, entities: [] });`,
+    `app.action("logout", {`,
+    `  fn: { import: "logout", from: "@src/operations", alias: "ops_logout" } as const,`,
+    `  entities: [],`,
+    `});`,
+    ``,
+    `export default app;`,
+  ].join("\n");
+
+describe("end-to-end import-form pipeline", () => {
+  test("runs rewrite, type-check, and execute commands for every import shape", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wasp-spec-pipeline-"));
+    writePackageJson(tempDir);
+
+    const importDecls = await runSpecThroughRunTs(
+      tempDir,
+      "main.wasp.ts",
+      specSource(),
+      "import-decls.json",
+    );
+    const descriptorDecls = await runSpecThroughRunTs(
+      tempDir,
+      "main.wasp.descriptor.ts",
+      descriptorSpecSource(),
+      "descriptor-decls.json",
+    );
+
+    expect(importDecls).toEqual(descriptorDecls);
+
+    const decls = importDecls;
+    const declsByType = groupByType(decls);
+
+    expect(declsByType["Page"]).toEqual([
+      {
+        declType: "Page",
+        declName: "MainPage",
+        declValue: {
+          component: {
+            kind: "default",
+            name: "MainPage",
+            path: "@src/MainPage",
+          },
+          authRequired: undefined,
+        },
+      },
+    ]);
+
+    const queryDecl = declsByType["Query"]?.[0];
+    expect(queryDecl?.declName).toBe("getTasks");
+    expect(queryDecl?.declValue.fn).toEqual({
+      kind: "named",
+      name: "getTasks",
+      path: "@src/operations",
+    });
+
+    const actionDecls = declsByType["Action"] ?? [];
+    const archiveAction = actionDecls.find((d) => d.declName === "archiveTask");
+    expect(archiveAction?.declValue.fn).toEqual({
+      kind: "named",
+      name: "archive",
+      alias: "archiveTask",
+      path: "@src/operations",
+    });
+
+    const archiveLegacyAction = actionDecls.find(
+      (d) => d.declName === "archiveLegacyTask",
+    );
+    expect(archiveLegacyAction?.declValue.fn).toEqual({
+      kind: "named",
+      name: "archive",
+      alias: "archiveLegacyTask",
+      path: "@src/legacyOperations",
+    });
+
+    const logoutAction = actionDecls.find((d) => d.declName === "logout");
+    expect(logoutAction?.declValue.fn).toEqual({
+      kind: "named",
+      name: "logout",
+      alias: "ops_logout",
+      path: "@src/operations",
+    });
+  });
+
+  test("rejects unsupported imports through the run.ts rewrite command", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wasp-spec-pipeline-error-"));
+    const sourcePath = join(tempDir, "main.wasp.ts");
+    const rewrittenPath = join(tempDir, "main.wasp.rewritten.ts");
+
+    writeFileSync(sourcePath, `import helper from "./helpers";\n`, "utf8");
+
+    await expect(
+      runWaspConfig(["node", "run.js", "rewrite", sourcePath, rewrittenPath]),
+    ).rejects.toThrowError(/Relative imports outside \.\/src/);
+  });
+
+  test("type-checks the rewritten spec shape before execution", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wasp-spec-typecheck-"));
+    mkdirSync(join(tempDir, "src"));
+
+    const source = [
+      `import { appTitle } from "./src/title";`,
+      ``,
+      `declare function makeApp(config: { title: string }): void;`,
+      `makeApp({ title: appTitle });`,
+    ].join("\n");
+
+    writeFileSync(
+      join(tempDir, "src", "title.ts"),
+      `export const appTitle = "Demo";\n`,
+    );
+    writeFileSync(join(tempDir, "main.wasp.ts"), source);
+    writeTsConfig(tempDir, "tsconfig.original.json", "main.wasp.ts");
+    runTsc(tempDir, "tsconfig.original.json");
+
+    writeFileSync(join(tempDir, "main.wasp.rewritten.ts"), rewrite(source));
+    writeTsConfig(tempDir, "tsconfig.rewritten.json", "main.wasp.rewritten.ts");
+
+    expect(runTscExpectingError(tempDir, "tsconfig.rewritten.json")).toContain(
+      "is not assignable to type 'string'",
+    );
+  });
+});
+
+type DeclWithValue = AppSpec.Decl & { declValue: { [k: string]: unknown } };
+
+function groupByType(
+  decls: AppSpec.Decl[],
+): Record<string, DeclWithValue[] | undefined> {
+  const out: Record<string, DeclWithValue[]> = {};
+  for (const decl of decls) {
+    const list = out[decl.declType] ?? (out[decl.declType] = []);
+    list.push(decl as DeclWithValue);
+  }
+  return out;
+}
+
+function writePackageJson(tempDir: string): void {
+  writeFileSync(
+    join(tempDir, "package.json"),
+    JSON.stringify({ type: "module" }),
+  );
+}
+
+async function runSpecThroughRunTs(
+  tempDir: string,
+  sourceFileName: string,
+  sourceText: string,
+  outputFileName: string,
+): Promise<AppSpec.Decl[]> {
+  const sourcePath = join(tempDir, sourceFileName);
+  const rewrittenFileName = sourceFileName.replace(/\.ts$/, ".rewritten.ts");
+  const rewrittenPath = join(tempDir, rewrittenFileName);
+
+  writeFileSync(sourcePath, sourceText, "utf8");
+  await runWaspConfig(["node", "run.js", "rewrite", sourcePath, rewrittenPath]);
+
+  const rewrittenSource = readFileSync(rewrittenPath, "utf8");
+  expect(rewrittenSource).not.toMatch(/from\s+"\.\/src\//);
+
+  const outDir = sourceFileName.replace(/\.ts$/, "-dist");
+  const tsconfigFileName = sourceFileName.replace(/\.ts$/, ".tsconfig.json");
+  writeTsConfig(tempDir, tsconfigFileName, rewrittenFileName, {
+    noEmit: false,
+    outDir,
+  });
+  runTsc(tempDir, tsconfigFileName);
+
+  const compiledPath = join(
+    tempDir,
+    outDir,
+    rewrittenFileName.replace(/\.ts$/, ".js"),
+  );
+  const outputPath = join(tempDir, outputFileName);
+  await runWaspConfig(["node", "run.js", compiledPath, outputPath, "[]"]);
+
+  return JSON.parse(readFileSync(outputPath, "utf8")) as AppSpec.Decl[];
+}
+
+function writeTsConfig(
+  tempDir: string,
+  filename: string,
+  include: string,
+  options: { noEmit?: boolean; outDir?: string } = {},
+): void {
+  writeFileSync(
+    join(tempDir, filename),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        strict: true,
+        noEmit: options.noEmit ?? true,
+        ...(options.outDir ? { outDir: options.outDir } : {}),
+      },
+      include: [include],
+    }),
+  );
+}
+
+function runTsc(cwd: string, project: string): void {
+  execFileSync(process.execPath, [tscPath, "-p", project], {
+    cwd,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+}
+
+function runTscExpectingError(cwd: string, project: string): string {
+  try {
+    runTsc(cwd, project);
+  } catch (error) {
+    const processError = error as { stdout?: string; stderr?: string };
+    return `${processError.stdout ?? ""}${processError.stderr ?? ""}`;
+  }
+
+  throw new Error("Expected TypeScript to reject the rewritten spec.");
+}

--- a/waspc/data/packages/wasp-config/__tests__/spec-pipeline/rewrite.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec-pipeline/rewrite.unit.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "vitest";
+import { rewrite } from "../../src/spec-pipeline/rewrite.js";
+
+describe("rewrite", () => {
+  test("lowers a default import into an importDefault descriptor", () => {
+    const input = `import MainPage from "./src/MainPage";\n`;
+    const output = rewrite(input);
+    expect(output).toBe(
+      `const MainPage = { importDefault: "MainPage", from: "@src/MainPage" } as const;\n`,
+    );
+  });
+
+  test("lowers a single named import into an import descriptor", () => {
+    const input = `import { getTasks } from "./src/operations";\n`;
+    const output = rewrite(input);
+    expect(output).toBe(
+      `const getTasks = { import: "getTasks", from: "@src/operations" } as const;\n`,
+    );
+  });
+
+  test("lowers an aliased named import with alias metadata", () => {
+    const input = `import { archive as archiveTask } from "./src/operations";\n`;
+    const output = rewrite(input);
+    expect(output).toBe(
+      `const archiveTask = { import: "archive", from: "@src/operations", alias: "archiveTask" } as const;\n`,
+    );
+  });
+
+  test("lowers same exported name aliases from different modules", () => {
+    const input = [
+      `import { archive as archiveTask } from "./src/operations";`,
+      `import { archive as archiveLegacyTask } from "./src/legacyOperations";`,
+      ``,
+    ].join("\n");
+    const output = rewrite(input);
+    expect(output).toBe(
+      [
+        `const archiveTask = { import: "archive", from: "@src/operations", alias: "archiveTask" } as const;`,
+        `const archiveLegacyTask = { import: "archive", from: "@src/legacyOperations", alias: "archiveLegacyTask" } as const;`,
+        ``,
+      ].join("\n"),
+    );
+  });
+
+  test("lowers multiple named imports into separate descriptor consts", () => {
+    const input = `import { getTasks, createTask } from "./src/operations";\n`;
+    const output = rewrite(input);
+    expect(output).toBe(
+      `const getTasks = { import: "getTasks", from: "@src/operations" } as const;\nconst createTask = { import: "createTask", from: "@src/operations" } as const;\n`,
+    );
+  });
+
+  test("lowers a default + named import together", () => {
+    const input = `import MainPage, { Helper } from "./src/MainPage";\n`;
+    const output = rewrite(input);
+    expect(output).toBe(
+      `const MainPage = { importDefault: "MainPage", from: "@src/MainPage" } as const;\nconst Helper = { import: "Helper", from: "@src/MainPage" } as const;\n`,
+    );
+  });
+
+  test("lowers a namespace import into a Proxy", () => {
+    const input = `import * as ops from "./src/operations";\n`;
+    const output = rewrite(input);
+    expect(output).toBe(
+      `const ops = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: "@src/operations", alias: "ops_" + String(k) } as const) }) as Record<string, { import: string; from: "@src/operations"; alias: string }>;\n`,
+    );
+  });
+
+  test("lowers same exported name through different namespaces", () => {
+    const input = [
+      `import * as ops from "./src/operations";`,
+      `import * as legacyOps from "./src/legacyOperations";`,
+      ``,
+    ].join("\n");
+    const output = rewrite(input);
+    expect(output).toBe(
+      [
+        `const ops = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: "@src/operations", alias: "ops_" + String(k) } as const) }) as Record<string, { import: string; from: "@src/operations"; alias: string }>;`,
+        `const legacyOps = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: "@src/legacyOperations", alias: "legacyOps_" + String(k) } as const) }) as Record<string, { import: string; from: "@src/legacyOperations"; alias: string }>;`,
+        ``,
+      ].join("\n"),
+    );
+  });
+
+  test("leaves wasp-config imports untouched", () => {
+    const input = `import { App } from "wasp-config";\n`;
+    expect(rewrite(input)).toBe(input);
+  });
+
+  test("leaves package imports untouched", () => {
+    const input = `import z from "zod";\nimport { App } from "wasp-config";\n`;
+    expect(rewrite(input)).toBe(input);
+  });
+
+  test("rejects relative imports outside ./src", () => {
+    const input = `import helper from "./helpers";\n`;
+
+    expect(() => rewrite(input)).toThrowError(
+      /Relative imports outside \.\/src/,
+    );
+  });
+
+  test("rejects relative re-exports outside ./src", () => {
+    const input = `export { helper } from "./helpers";\n`;
+
+    expect(() => rewrite(input)).toThrowError(/Relative re-exports/);
+  });
+
+  test("rewrites only the matching import in a mixed file", () => {
+    const input = [
+      `import { App } from "wasp-config";`,
+      `import MainPage from "./src/MainPage";`,
+      `import { getTasks } from "./src/operations";`,
+      `import * as ops from "./src/operations";`,
+      ``,
+      `const app = new App("demo", { title: "Demo", wasp: { version: "^0.16.0" } });`,
+      `app.page("MainPage", { component: MainPage });`,
+      `app.query("getTasks", { fn: getTasks });`,
+      `app.action("logout", { fn: ops.logout });`,
+      `export default app;`,
+      ``,
+    ].join("\n");
+    const output = rewrite(input);
+    expect(output).toContain(
+      `const MainPage = { importDefault: "MainPage", from: "@src/MainPage" } as const;`,
+    );
+    expect(output).toContain(
+      `const getTasks = { import: "getTasks", from: "@src/operations" } as const;`,
+    );
+    expect(output).toContain(
+      `const ops = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: "@src/operations", alias: "ops_" + String(k) } as const) }) as Record<string, { import: string; from: "@src/operations"; alias: string }>;`,
+    );
+    expect(output).toContain(`import { App } from "wasp-config";`);
+    expect(output).toContain(`export default app;`);
+    expect(output).not.toMatch(/from\s+"\.\/src\//);
+  });
+
+  test("is a no-op on a descriptor-form spec file", () => {
+    const input = [
+      `import { App } from "wasp-config";`,
+      ``,
+      `const app = new App("demo", { title: "Demo", wasp: { version: "^0.16.0" } });`,
+      `app.page("MainPage", { component: { import: "MainPage", from: "@src/MainPage" } });`,
+      `export default app;`,
+      ``,
+    ].join("\n");
+    expect(rewrite(input)).toBe(input);
+  });
+
+  test("rejects side-effect imports from ./src", () => {
+    const input = `import "./src/setup";\n`;
+
+    expect(() => rewrite(input)).toThrowError(/Side-effect imports/);
+  });
+
+  test("rejects re-exports from ./src", () => {
+    const input = `export { MainPage } from "./src/MainPage";\n`;
+
+    expect(() => rewrite(input)).toThrowError(/Re-exports/);
+  });
+
+  test("rejects type-only imports from ./src", () => {
+    const input = `import type { MainPageProps } from "./src/MainPage";\n`;
+
+    expect(() => rewrite(input)).toThrowError(/Type-only imports/);
+  });
+
+  test("rejects mixed type and value imports from ./src", () => {
+    const input = `import { type MainPageProps, MainPage } from "./src/MainPage";\n`;
+
+    expect(() => rewrite(input)).toThrowError(/Mixed type\/value imports/);
+  });
+
+  test("rejects empty named imports from ./src", () => {
+    const input = `import {} from "./src/MainPage";\n`;
+
+    expect(() => rewrite(input)).toThrowError(/Empty named imports/);
+  });
+});

--- a/waspc/data/packages/wasp-config/__tests__/spec-pipeline/rewrite.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec-pipeline/rewrite.unit.test.ts
@@ -3,7 +3,7 @@ import { rewrite } from "../../src/spec-pipeline/rewrite.js";
 
 describe("rewrite", () => {
   test("lowers a default import into an importDefault descriptor", () => {
-    const input = `import MainPage from "./src/MainPage";\n`;
+    const input = `import MainPage from "@src/MainPage";\n`;
     const output = rewrite(input);
     expect(output).toBe(
       `const MainPage = { importDefault: "MainPage", from: "@src/MainPage" } as const;\n`,
@@ -11,7 +11,7 @@ describe("rewrite", () => {
   });
 
   test("lowers a single named import into an import descriptor", () => {
-    const input = `import { getTasks } from "./src/operations";\n`;
+    const input = `import { getTasks } from "@src/operations";\n`;
     const output = rewrite(input);
     expect(output).toBe(
       `const getTasks = { import: "getTasks", from: "@src/operations" } as const;\n`,
@@ -19,7 +19,7 @@ describe("rewrite", () => {
   });
 
   test("lowers an aliased named import with alias metadata", () => {
-    const input = `import { archive as archiveTask } from "./src/operations";\n`;
+    const input = `import { archive as archiveTask } from "@src/operations";\n`;
     const output = rewrite(input);
     expect(output).toBe(
       `const archiveTask = { import: "archive", from: "@src/operations", alias: "archiveTask" } as const;\n`,
@@ -28,8 +28,8 @@ describe("rewrite", () => {
 
   test("lowers same exported name aliases from different modules", () => {
     const input = [
-      `import { archive as archiveTask } from "./src/operations";`,
-      `import { archive as archiveLegacyTask } from "./src/legacyOperations";`,
+      `import { archive as archiveTask } from "@src/operations";`,
+      `import { archive as archiveLegacyTask } from "@src/legacyOperations";`,
       ``,
     ].join("\n");
     const output = rewrite(input);
@@ -43,7 +43,7 @@ describe("rewrite", () => {
   });
 
   test("lowers multiple named imports into separate descriptor consts", () => {
-    const input = `import { getTasks, createTask } from "./src/operations";\n`;
+    const input = `import { getTasks, createTask } from "@src/operations";\n`;
     const output = rewrite(input);
     expect(output).toBe(
       `const getTasks = { import: "getTasks", from: "@src/operations" } as const;\nconst createTask = { import: "createTask", from: "@src/operations" } as const;\n`,
@@ -51,7 +51,7 @@ describe("rewrite", () => {
   });
 
   test("lowers a default + named import together", () => {
-    const input = `import MainPage, { Helper } from "./src/MainPage";\n`;
+    const input = `import MainPage, { Helper } from "@src/MainPage";\n`;
     const output = rewrite(input);
     expect(output).toBe(
       `const MainPage = { importDefault: "MainPage", from: "@src/MainPage" } as const;\nconst Helper = { import: "Helper", from: "@src/MainPage" } as const;\n`,
@@ -59,7 +59,7 @@ describe("rewrite", () => {
   });
 
   test("lowers a namespace import into a Proxy", () => {
-    const input = `import * as ops from "./src/operations";\n`;
+    const input = `import * as ops from "@src/operations";\n`;
     const output = rewrite(input);
     expect(output).toBe(
       `const ops = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: "@src/operations", alias: "ops_" + String(k) } as const) }) as Record<string, { import: string; from: "@src/operations"; alias: string }>;\n`,
@@ -68,8 +68,8 @@ describe("rewrite", () => {
 
   test("lowers same exported name through different namespaces", () => {
     const input = [
-      `import * as ops from "./src/operations";`,
-      `import * as legacyOps from "./src/legacyOperations";`,
+      `import * as ops from "@src/operations";`,
+      `import * as legacyOps from "@src/legacyOperations";`,
       ``,
     ].join("\n");
     const output = rewrite(input);
@@ -92,26 +92,31 @@ describe("rewrite", () => {
     expect(rewrite(input)).toBe(input);
   });
 
-  test("rejects relative imports outside ./src", () => {
+  test("leaves relative imports untouched", () => {
     const input = `import helper from "./helpers";\n`;
 
-    expect(() => rewrite(input)).toThrowError(
-      /Relative imports outside \.\/src/,
-    );
+    expect(rewrite(input)).toBe(input);
   });
 
-  test("rejects relative re-exports outside ./src", () => {
+  test("leaves relative re-exports untouched", () => {
     const input = `export { helper } from "./helpers";\n`;
 
-    expect(() => rewrite(input)).toThrowError(/Relative re-exports/);
+    expect(rewrite(input)).toBe(input);
+  });
+
+  test("leaves ./src imports untouched", () => {
+    const input = `import MainPage from "./src/MainPage";\n`;
+
+    expect(rewrite(input)).toBe(input);
   });
 
   test("rewrites only the matching import in a mixed file", () => {
     const input = [
       `import { App } from "wasp-config";`,
-      `import MainPage from "./src/MainPage";`,
-      `import { getTasks } from "./src/operations";`,
-      `import * as ops from "./src/operations";`,
+      `import MainPage from "@src/MainPage";`,
+      `import { getTasks } from "@src/operations";`,
+      `import * as ops from "@src/operations";`,
+      `import helper from "./helpers";`,
       ``,
       `const app = new App("demo", { title: "Demo", wasp: { version: "^0.16.0" } });`,
       `app.page("MainPage", { component: MainPage });`,
@@ -131,8 +136,9 @@ describe("rewrite", () => {
       `const ops = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: "@src/operations", alias: "ops_" + String(k) } as const) }) as Record<string, { import: string; from: "@src/operations"; alias: string }>;`,
     );
     expect(output).toContain(`import { App } from "wasp-config";`);
+    expect(output).toContain(`import helper from "./helpers";`);
     expect(output).toContain(`export default app;`);
-    expect(output).not.toMatch(/from\s+"\.\/src\//);
+    expect(output).not.toMatch(/^import\s+(?:.+\s+from\s+)?["']@src\//m);
   });
 
   test("is a no-op on a descriptor-form spec file", () => {
@@ -147,32 +153,32 @@ describe("rewrite", () => {
     expect(rewrite(input)).toBe(input);
   });
 
-  test("rejects side-effect imports from ./src", () => {
-    const input = `import "./src/setup";\n`;
+  test("rejects side-effect imports from @src", () => {
+    const input = `import "@src/setup";\n`;
 
     expect(() => rewrite(input)).toThrowError(/Side-effect imports/);
   });
 
-  test("rejects re-exports from ./src", () => {
-    const input = `export { MainPage } from "./src/MainPage";\n`;
+  test("rejects re-exports from @src", () => {
+    const input = `export { MainPage } from "@src/MainPage";\n`;
 
     expect(() => rewrite(input)).toThrowError(/Re-exports/);
   });
 
-  test("rejects type-only imports from ./src", () => {
-    const input = `import type { MainPageProps } from "./src/MainPage";\n`;
+  test("rejects type-only imports from @src", () => {
+    const input = `import type { MainPageProps } from "@src/MainPage";\n`;
 
     expect(() => rewrite(input)).toThrowError(/Type-only imports/);
   });
 
-  test("rejects mixed type and value imports from ./src", () => {
-    const input = `import { type MainPageProps, MainPage } from "./src/MainPage";\n`;
+  test("rejects mixed type and value imports from @src", () => {
+    const input = `import { type MainPageProps, MainPage } from "@src/MainPage";\n`;
 
     expect(() => rewrite(input)).toThrowError(/Mixed type\/value imports/);
   });
 
-  test("rejects empty named imports from ./src", () => {
-    const input = `import {} from "./src/MainPage";\n`;
+  test("rejects empty named imports from @src", () => {
+    const input = `import {} from "@src/MainPage";\n`;
 
     expect(() => rewrite(input)).toThrowError(/Empty named imports/);
   });

--- a/waspc/data/packages/wasp-config/src/appSpec.ts
+++ b/waspc/data/packages/wasp-config/src/appSpec.ts
@@ -109,6 +109,7 @@ export type ExtImport = {
   kind: ExtImportKind;
   name: string;
   path: `@src/${string}`;
+  alias?: string;
 };
 
 export type JobExecutor = "PgBoss";

--- a/waspc/data/packages/wasp-config/src/appSpec/extImportDescriptor.ts
+++ b/waspc/data/packages/wasp-config/src/appSpec/extImportDescriptor.ts
@@ -1,0 +1,165 @@
+import type * as AppSpec from "../appSpec.js";
+
+export type ExtImportDescriptor =
+  | {
+      import: string;
+      from: AppSpec.ExtImport["path"];
+      alias?: string;
+    }
+  | {
+      importDefault: string;
+      from: AppSpec.ExtImport["path"];
+      alias?: string;
+    };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFunction = (...args: any[]) => any;
+
+type NonDescriptorObject = object & {
+  import?: never;
+  importDefault?: never;
+  from?: never;
+  call?: never;
+  apply?: never;
+  bind?: never;
+};
+
+export type FunctionExtImport = ExtImportDescriptor | AnyFunction;
+export type ObjectExtImport = ExtImportDescriptor | NonDescriptorObject;
+export type AuthoredExtImport = FunctionExtImport | ObjectExtImport;
+
+export type ExtImportDescriptorResult =
+  | { status: "ok"; value: AppSpec.ExtImport }
+  | { status: "error"; reason: ExtImportDescriptorErrorReason };
+
+export type ExtImportDescriptorErrorReason =
+  | "functionValue"
+  | "descriptorLikeObject"
+  | "objectValue";
+
+type NamedExtImportDescriptor = Extract<
+  ExtImportDescriptor,
+  { import: string }
+>;
+type DefaultExtImportDescriptor = Extract<
+  ExtImportDescriptor,
+  { importDefault: string }
+>;
+
+export function mapAuthoredExtImport(
+  extImport: AuthoredExtImport,
+): ExtImportDescriptorResult {
+  if (isNamedExtImportDescriptor(extImport)) {
+    return {
+      status: "ok",
+      value: {
+        kind: "named",
+        name: extImport.import,
+        path: extImport.from,
+        ...mapAlias(extImport),
+      },
+    };
+  }
+
+  if (isDefaultExtImportDescriptor(extImport)) {
+    return {
+      status: "ok",
+      value: {
+        kind: "default",
+        name: extImport.importDefault,
+        path: extImport.from,
+        ...mapAlias(extImport),
+      },
+    };
+  }
+
+  return { status: "error", reason: getInvalidDescriptorReason(extImport) };
+}
+
+export function formatExtImportDescriptorError(
+  reason: ExtImportDescriptorErrorReason,
+): string {
+  switch (reason) {
+    case "functionValue":
+      return (
+        "Invalid ExtImport value: got a function at runtime. " +
+        "Import-form values must come from a supported top-level ./src/* import so Wasp can rewrite them before execution. " +
+        'Alternatively, use descriptor form: { import: "name", from: "@src/file" }.'
+      );
+    case "descriptorLikeObject":
+      return (
+        'Invalid ExtImport descriptor: expected either { import: "name", from: "@src/file" } ' +
+        'or { importDefault: "name", from: "@src/file" }.'
+      );
+    case "objectValue":
+      return (
+        "Invalid ExtImport value: got an object at runtime. " +
+        "Import-form values must come from a supported top-level ./src/* import so Wasp can rewrite them before execution. " +
+        'Alternatively, use descriptor form: { import: "name", from: "@src/file" }.'
+      );
+  }
+}
+
+function isNamedExtImportDescriptor(
+  extImport: AuthoredExtImport,
+): extImport is NamedExtImportDescriptor {
+  return (
+    typeof extImport === "object" &&
+    extImport !== null &&
+    "import" in extImport &&
+    "from" in extImport &&
+    typeof extImport.import === "string" &&
+    typeof extImport.from === "string" &&
+    hasValidAlias(extImport)
+  );
+}
+
+function isDefaultExtImportDescriptor(
+  extImport: AuthoredExtImport,
+): extImport is DefaultExtImportDescriptor {
+  return (
+    typeof extImport === "object" &&
+    extImport !== null &&
+    "importDefault" in extImport &&
+    "from" in extImport &&
+    typeof extImport.importDefault === "string" &&
+    typeof extImport.from === "string" &&
+    hasValidAlias(extImport)
+  );
+}
+
+function hasValidAlias(extImport: object): boolean {
+  return !("alias" in extImport) || typeof extImport.alias === "string";
+}
+
+function mapAlias(
+  extImport: ExtImportDescriptor,
+): Partial<Pick<AppSpec.ExtImport, "alias">> {
+  return "alias" in extImport && extImport.alias !== undefined
+    ? { alias: extImport.alias }
+    : {};
+}
+
+function getInvalidDescriptorReason(
+  extImport: AuthoredExtImport,
+): ExtImportDescriptorErrorReason {
+  if (typeof extImport === "function") {
+    return "functionValue";
+  }
+
+  if (isDescriptorLikeObject(extImport)) {
+    return "descriptorLikeObject";
+  }
+
+  return "objectValue";
+}
+
+function isDescriptorLikeObject(extImport: AuthoredExtImport): boolean {
+  return (
+    typeof extImport === "object" &&
+    extImport !== null &&
+    ("import" in extImport ||
+      "importDefault" in extImport ||
+      "from" in extImport)
+  );
+}

--- a/waspc/data/packages/wasp-config/src/appSpec/extImportDescriptor.ts
+++ b/waspc/data/packages/wasp-config/src/appSpec/extImportDescriptor.ts
@@ -83,7 +83,7 @@ export function formatExtImportDescriptorError(
     case "functionValue":
       return (
         "Invalid ExtImport value: got a function at runtime. " +
-        "Import-form values must come from a supported top-level ./src/* import so Wasp can rewrite them before execution. " +
+        "Import-form values must come from a supported top-level @src/* import so Wasp can rewrite them before execution. " +
         'Alternatively, use descriptor form: { import: "name", from: "@src/file" }.'
       );
     case "descriptorLikeObject":
@@ -94,7 +94,7 @@ export function formatExtImportDescriptorError(
     case "objectValue":
       return (
         "Invalid ExtImport value: got an object at runtime. " +
-        "Import-form values must come from a supported top-level ./src/* import so Wasp can rewrite them before execution. " +
+        "Import-form values must come from a supported top-level @src/* import so Wasp can rewrite them before execution. " +
         'Alternatively, use descriptor form: { import: "name", from: "@src/file" }.'
       );
   }

--- a/waspc/data/packages/wasp-config/src/legacy/mapTsAppSpecToAppSpecDecls.ts
+++ b/waspc/data/packages/wasp-config/src/legacy/mapTsAppSpecToAppSpecDecls.ts
@@ -130,25 +130,105 @@ export function mapOperation(
 }
 
 export function mapExtImport(
-  extImport: TsAppSpec.ExtImport,
+  extImport: TsAppSpec.AuthoredExtImport,
 ): AppSpec.ExtImport {
-  if ("import" in extImport) {
+  if (isNamedExtImport(extImport)) {
     return {
       kind: "named",
       name: extImport.import,
       path: extImport.from,
+      ...mapAlias(extImport),
     };
-  } else if ("importDefault" in extImport) {
+  } else if (isDefaultExtImport(extImport)) {
     return {
       kind: "default",
       name: extImport.importDefault,
       path: extImport.from,
+      ...mapAlias(extImport),
     };
   } else {
-    throw new Error(
-      "Invalid ExtImport: neither `import` nor `importDefault` is defined",
+    throw new Error(getInvalidExtImportMessage(extImport));
+  }
+}
+
+type NamedExtImport = Extract<TsAppSpec.ExtImport, { import: string }>;
+type DefaultExtImport = Extract<TsAppSpec.ExtImport, { importDefault: string }>;
+
+function isNamedExtImport(
+  extImport: TsAppSpec.AuthoredExtImport,
+): extImport is NamedExtImport {
+  return (
+    typeof extImport === "object" &&
+    extImport !== null &&
+    "import" in extImport &&
+    "from" in extImport &&
+    typeof extImport.import === "string" &&
+    typeof extImport.from === "string" &&
+    hasValidAlias(extImport)
+  );
+}
+
+function isDefaultExtImport(
+  extImport: TsAppSpec.AuthoredExtImport,
+): extImport is DefaultExtImport {
+  return (
+    typeof extImport === "object" &&
+    extImport !== null &&
+    "importDefault" in extImport &&
+    "from" in extImport &&
+    typeof extImport.importDefault === "string" &&
+    typeof extImport.from === "string" &&
+    hasValidAlias(extImport)
+  );
+}
+
+function hasValidAlias(extImport: object): boolean {
+  return !("alias" in extImport) || typeof extImport.alias === "string";
+}
+
+function mapAlias(
+  extImport: TsAppSpec.ExtImport,
+): Partial<Pick<AppSpec.ExtImport, "alias">> {
+  return "alias" in extImport && extImport.alias !== undefined
+    ? { alias: extImport.alias }
+    : {};
+}
+
+function getInvalidExtImportMessage(
+  extImport: TsAppSpec.AuthoredExtImport,
+): string {
+  if (typeof extImport === "function") {
+    return (
+      "Invalid ExtImport value: got a function at runtime. " +
+      "Import-form values must come from a supported top-level ./src/* import so Wasp can rewrite them before execution. " +
+      'Alternatively, use descriptor form: { import: "name", from: "@src/file" }.'
     );
   }
+
+  if (isDescriptorLikeObject(extImport)) {
+    return (
+      'Invalid ExtImport descriptor: expected either { import: "name", from: "@src/file" } ' +
+      'or { importDefault: "name", from: "@src/file" }.'
+    );
+  }
+
+  return (
+    "Invalid ExtImport value: got an object at runtime. " +
+    "Import-form values must come from a supported top-level ./src/* import so Wasp can rewrite them before execution. " +
+    'Alternatively, use descriptor form: { import: "name", from: "@src/file" }.'
+  );
+}
+
+function isDescriptorLikeObject(
+  extImport: TsAppSpec.AuthoredExtImport,
+): boolean {
+  return (
+    typeof extImport === "object" &&
+    extImport !== null &&
+    ("import" in extImport ||
+      "importDefault" in extImport ||
+      "from" in extImport)
+  );
 }
 
 export function mapHttpRoute(

--- a/waspc/data/packages/wasp-config/src/legacy/mapTsAppSpecToAppSpecDecls.ts
+++ b/waspc/data/packages/wasp-config/src/legacy/mapTsAppSpecToAppSpecDecls.ts
@@ -4,6 +4,10 @@
  */
 
 import * as AppSpec from "../appSpec.js";
+import {
+  formatExtImportDescriptorError,
+  mapAuthoredExtImport,
+} from "../appSpec/extImportDescriptor.js";
 import * as TsAppSpec from "./publicApi/tsAppSpec.js";
 
 export function mapTsAppSpecToAppSpecDecls(
@@ -132,103 +136,10 @@ export function mapOperation(
 export function mapExtImport(
   extImport: TsAppSpec.AuthoredExtImport,
 ): AppSpec.ExtImport {
-  if (isNamedExtImport(extImport)) {
-    return {
-      kind: "named",
-      name: extImport.import,
-      path: extImport.from,
-      ...mapAlias(extImport),
-    };
-  } else if (isDefaultExtImport(extImport)) {
-    return {
-      kind: "default",
-      name: extImport.importDefault,
-      path: extImport.from,
-      ...mapAlias(extImport),
-    };
-  } else {
-    throw new Error(getInvalidExtImportMessage(extImport));
-  }
-}
+  const result = mapAuthoredExtImport(extImport);
+  if (result.status === "ok") return result.value;
 
-type NamedExtImport = Extract<TsAppSpec.ExtImport, { import: string }>;
-type DefaultExtImport = Extract<TsAppSpec.ExtImport, { importDefault: string }>;
-
-function isNamedExtImport(
-  extImport: TsAppSpec.AuthoredExtImport,
-): extImport is NamedExtImport {
-  return (
-    typeof extImport === "object" &&
-    extImport !== null &&
-    "import" in extImport &&
-    "from" in extImport &&
-    typeof extImport.import === "string" &&
-    typeof extImport.from === "string" &&
-    hasValidAlias(extImport)
-  );
-}
-
-function isDefaultExtImport(
-  extImport: TsAppSpec.AuthoredExtImport,
-): extImport is DefaultExtImport {
-  return (
-    typeof extImport === "object" &&
-    extImport !== null &&
-    "importDefault" in extImport &&
-    "from" in extImport &&
-    typeof extImport.importDefault === "string" &&
-    typeof extImport.from === "string" &&
-    hasValidAlias(extImport)
-  );
-}
-
-function hasValidAlias(extImport: object): boolean {
-  return !("alias" in extImport) || typeof extImport.alias === "string";
-}
-
-function mapAlias(
-  extImport: TsAppSpec.ExtImport,
-): Partial<Pick<AppSpec.ExtImport, "alias">> {
-  return "alias" in extImport && extImport.alias !== undefined
-    ? { alias: extImport.alias }
-    : {};
-}
-
-function getInvalidExtImportMessage(
-  extImport: TsAppSpec.AuthoredExtImport,
-): string {
-  if (typeof extImport === "function") {
-    return (
-      "Invalid ExtImport value: got a function at runtime. " +
-      "Import-form values must come from a supported top-level ./src/* import so Wasp can rewrite them before execution. " +
-      'Alternatively, use descriptor form: { import: "name", from: "@src/file" }.'
-    );
-  }
-
-  if (isDescriptorLikeObject(extImport)) {
-    return (
-      'Invalid ExtImport descriptor: expected either { import: "name", from: "@src/file" } ' +
-      'or { importDefault: "name", from: "@src/file" }.'
-    );
-  }
-
-  return (
-    "Invalid ExtImport value: got an object at runtime. " +
-    "Import-form values must come from a supported top-level ./src/* import so Wasp can rewrite them before execution. " +
-    'Alternatively, use descriptor form: { import: "name", from: "@src/file" }.'
-  );
-}
-
-function isDescriptorLikeObject(
-  extImport: TsAppSpec.AuthoredExtImport,
-): boolean {
-  return (
-    typeof extImport === "object" &&
-    extImport !== null &&
-    ("import" in extImport ||
-      "importDefault" in extImport ||
-      "from" in extImport)
-  );
+  throw new Error(formatExtImportDescriptorError(result.reason));
 }
 
 export function mapHttpRoute(

--- a/waspc/data/packages/wasp-config/src/legacy/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/legacy/publicApi/tsAppSpec.ts
@@ -1,4 +1,10 @@
 import * as AppSpec from "../../appSpec.js";
+import type {
+  AuthoredExtImport,
+  ExtImportDescriptor,
+  FunctionExtImport,
+  ObjectExtImport,
+} from "../../appSpec/extImportDescriptor.js";
 import { Branded } from "../../branded.js";
 
 export type TsAppSpec = {
@@ -189,33 +195,8 @@ export type WebsocketConfig = {
   autoConnect?: boolean;
 };
 
-export type ExtImport =
-  | {
-      import: string;
-      from: AppSpec.ExtImport["path"];
-      alias?: string;
-    }
-  | {
-      importDefault: string;
-      from: AppSpec.ExtImport["path"];
-      alias?: string;
-    };
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyFunction = (...args: any[]) => any;
-
-type NonDescriptorObject = object & {
-  import?: never;
-  importDefault?: never;
-  from?: never;
-  call?: never;
-  apply?: never;
-  bind?: never;
-};
-
-export type FunctionExtImport = ExtImport | AnyFunction;
-export type ObjectExtImport = ExtImport | NonDescriptorObject;
-export type AuthoredExtImport = FunctionExtImport | ObjectExtImport;
+export type ExtImport = ExtImportDescriptor;
+export type { AuthoredExtImport, FunctionExtImport, ObjectExtImport };
 
 export type EmailFromField = {
   name?: string;

--- a/waspc/data/packages/wasp-config/src/legacy/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/legacy/publicApi/tsAppSpec.ts
@@ -26,19 +26,19 @@ export type AppConfig = {
 };
 
 export type ActionConfig = {
-  fn: ExtImport;
+  fn: FunctionExtImport;
   entities?: string[];
   auth?: boolean;
 };
 
 export type ApiNamespaceConfig = {
-  middlewareConfigFn: ExtImport;
+  middlewareConfigFn: FunctionExtImport;
   path: string;
 };
 
 export type ApiConfig = {
-  fn: ExtImport;
-  middlewareConfigFn?: ExtImport;
+  fn: FunctionExtImport;
+  middlewareConfigFn?: FunctionExtImport;
   entities?: string[];
   httpRoute: HttpRoute;
   auth?: boolean;
@@ -55,12 +55,12 @@ export type AuthConfig = {
   externalAuthEntity?: string;
   onAuthFailedRedirectTo: string;
   onAuthSucceededRedirectTo?: string;
-  onBeforeSignup?: ExtImport;
-  onAfterSignup?: ExtImport;
-  onAfterEmailVerified?: ExtImport;
-  onBeforeOAuthRedirect?: ExtImport;
-  onBeforeLogin?: ExtImport;
-  onAfterLogin?: ExtImport;
+  onBeforeSignup?: FunctionExtImport;
+  onAfterSignup?: FunctionExtImport;
+  onAfterEmailVerified?: FunctionExtImport;
+  onBeforeOAuthRedirect?: FunctionExtImport;
+  onBeforeLogin?: FunctionExtImport;
+  onAfterLogin?: FunctionExtImport;
 };
 
 export type AuthMethods = {
@@ -74,36 +74,36 @@ export type AuthMethods = {
 };
 
 export type UsernameAndPasswordConfig = {
-  userSignupFields?: ExtImport;
+  userSignupFields?: ObjectExtImport;
 };
 
 export type EmailAuthConfig = {
-  userSignupFields?: ExtImport;
+  userSignupFields?: ObjectExtImport;
   fromField: EmailFromField;
   emailVerification: EmailVerificationConfig;
   passwordReset: PasswordResetConfig;
 };
 
 export type EmailVerificationConfig = {
-  getEmailContentFn?: ExtImport;
+  getEmailContentFn?: FunctionExtImport;
   clientRoute: string;
 };
 
 export type PasswordResetConfig = {
-  getEmailContentFn?: ExtImport;
+  getEmailContentFn?: FunctionExtImport;
   clientRoute: string;
 };
 
 export type ExternalAuthConfig = {
-  configFn?: ExtImport;
-  userSignupFields?: ExtImport;
+  configFn?: FunctionExtImport;
+  userSignupFields?: ObjectExtImport;
 };
 
 export type ClientConfig = {
-  rootComponent?: ExtImport;
-  setupFn?: ExtImport;
+  rootComponent?: FunctionExtImport;
+  setupFn?: FunctionExtImport;
   baseDir?: `/${string}`;
-  envValidationSchema?: ExtImport;
+  envValidationSchema?: ObjectExtImport;
 };
 
 export type CrudConfig = {
@@ -121,12 +121,12 @@ export type CrudOperations = {
 
 export type CrudOperationOptions = {
   isPublic?: boolean;
-  overrideFn?: ExtImport;
+  overrideFn?: FunctionExtImport;
 };
 
 export type DbConfig = {
-  seeds?: ExtImport[];
-  prismaSetupFn?: ExtImport;
+  seeds?: FunctionExtImport[];
+  prismaSetupFn?: FunctionExtImport;
 };
 
 export type EmailSenderConfig = {
@@ -142,7 +142,7 @@ export type JobConfig = {
 };
 
 export type Perform = {
-  fn: ExtImport;
+  fn: FunctionExtImport;
   executorOptions?: ExecutorOptions;
 };
 
@@ -159,12 +159,12 @@ export type ExecutorOptions = {
 };
 
 export type PageConfig = {
-  component: ExtImport;
+  component: FunctionExtImport;
   authRequired?: boolean;
 };
 
 export type QueryConfig = {
-  fn: ExtImport;
+  fn: FunctionExtImport;
   entities?: string[];
   auth?: boolean;
 };
@@ -179,13 +179,13 @@ export type RouteConfig = {
 export type PageName = Branded<string, "PageName">;
 
 export type ServerConfig = {
-  setupFn?: ExtImport;
-  middlewareConfigFn?: ExtImport;
-  envValidationSchema?: ExtImport;
+  setupFn?: FunctionExtImport;
+  middlewareConfigFn?: FunctionExtImport;
+  envValidationSchema?: ObjectExtImport;
 };
 
 export type WebsocketConfig = {
-  fn: ExtImport;
+  fn: FunctionExtImport;
   autoConnect?: boolean;
 };
 
@@ -193,11 +193,29 @@ export type ExtImport =
   | {
       import: string;
       from: AppSpec.ExtImport["path"];
+      alias?: string;
     }
   | {
       importDefault: string;
       from: AppSpec.ExtImport["path"];
+      alias?: string;
     };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFunction = (...args: any[]) => any;
+
+type NonDescriptorObject = object & {
+  import?: never;
+  importDefault?: never;
+  from?: never;
+  call?: never;
+  apply?: never;
+  bind?: never;
+};
+
+export type FunctionExtImport = ExtImport | AnyFunction;
+export type ObjectExtImport = ExtImport | NonDescriptorObject;
+export type AuthoredExtImport = FunctionExtImport | ObjectExtImport;
 
 export type EmailFromField = {
   name?: string;

--- a/waspc/data/packages/wasp-config/src/run.ts
+++ b/waspc/data/packages/wasp-config/src/run.ts
@@ -1,20 +1,49 @@
 #!/usr/bin/env node
 
-import { writeFileSync } from "fs";
+import { readFileSync, realpathSync, writeFileSync } from "fs";
+import { fileURLToPath, pathToFileURL } from "url";
 import { parseProcessArgsOrThrow } from "./cli.js";
 import { analyzeApp } from "./legacy/appAnalyzer.js";
+import { rewrite } from "./spec-pipeline/rewrite.js";
 
-main(process.argv);
+if (isDirectRun(process.argv)) {
+  main(process.argv).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}
+
+function isDirectRun(args: string[]): boolean {
+  const entrypointPath = args[1];
+  if (!entrypointPath) return false;
+
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url)) ===
+      realpathSync(entrypointPath)
+    );
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Main function that processes command line arguments, analyzes the user app,
  * and writes the output to a file.
  */
-async function main(args: string[]): Promise<void> {
+export async function main(args: string[]): Promise<void> {
+  if (args[2] === "rewrite") {
+    rewriteSpecFile(args);
+    return;
+  }
+
   const { waspTsSpecPath, outputFilePath, entityNames } =
     parseProcessArgsOrThrow(args);
 
-  const declsResult = await analyzeApp(waspTsSpecPath, entityNames);
+  const declsResult = await analyzeApp(
+    pathToFileURL(waspTsSpecPath).href,
+    entityNames,
+  );
 
   if (declsResult.status === "error") {
     console.error(declsResult.error);
@@ -22,4 +51,19 @@ async function main(args: string[]): Promise<void> {
   }
 
   writeFileSync(outputFilePath, JSON.stringify(declsResult.value));
+}
+
+function rewriteSpecFile(args: string[]): void {
+  if (args.length !== 5) {
+    throw new Error("Usage: node run.js rewrite <input file> <output file>");
+  }
+
+  const [_node, _runJs, _command, inputPath, outputPath] = args;
+  if (typeof inputPath !== "string" || typeof outputPath !== "string") {
+    throw new Error("Rewrite input and output paths must be strings.");
+  }
+
+  const sourceText = readFileSync(inputPath, "utf8");
+  const rewritten = rewrite(sourceText);
+  writeFileSync(outputPath, rewritten, "utf8");
 }

--- a/waspc/data/packages/wasp-config/src/spec-pipeline/importLoweringPlan.ts
+++ b/waspc/data/packages/wasp-config/src/spec-pipeline/importLoweringPlan.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import type { ExtImportDescriptor } from "../appSpec/extImportDescriptor.js";
 
-const SRC_IMPORT_PREFIX = "./src/";
+const SRC_IMPORT_PREFIX = "@src/";
 const SRC_DESCRIPTOR_PREFIX = "@src/";
 
 export type ImportLoweringResult =
@@ -42,9 +42,7 @@ export type ImportDiagnosticReason =
   | "typeOnlyImport"
   | "mixedTypeAndValueImport"
   | "emptyNamedImport"
-  | "srcReExport"
-  | "relativeImportOutsideSrc"
-  | "relativeReExportOutsideSrc";
+  | "srcReExport";
 
 export type SourceLocation = {
   line: number;
@@ -75,8 +73,6 @@ export function planImportLowering(sourceText: string): ImportLoweringResult {
     if (!specifier) continue;
 
     if (!isSrcImportSpecifier(specifier)) {
-      const diagnostic = getNonSrcImportDiagnostic(sourceFile, stmt, specifier);
-      if (diagnostic) diagnostics.push(diagnostic);
       continue;
     }
 
@@ -114,25 +110,6 @@ function getStringModuleSpecifier(
 
 function isSrcImportSpecifier(specifier: string): boolean {
   return specifier.startsWith(SRC_IMPORT_PREFIX);
-}
-
-function isRelativeImportSpecifier(specifier: string): boolean {
-  return specifier.startsWith("./") || specifier.startsWith("../");
-}
-
-function getNonSrcImportDiagnostic(
-  sourceFile: ts.SourceFile,
-  stmt: ts.ImportDeclaration,
-  specifier: string,
-): ImportDiagnostic | undefined {
-  if (!isRelativeImportSpecifier(specifier)) return undefined;
-
-  return makeDiagnostic(
-    sourceFile,
-    stmt,
-    specifier,
-    "relativeImportOutsideSrc",
-  );
 }
 
 function getSrcImportDiagnostic(
@@ -178,14 +155,7 @@ function getExportDiagnostic(
 
   const specifier = stmt.moduleSpecifier.text;
   if (!isSrcImportSpecifier(specifier)) {
-    return isRelativeImportSpecifier(specifier)
-      ? makeDiagnostic(
-          sourceFile,
-          stmt,
-          specifier,
-          "relativeReExportOutsideSrc",
-        )
-      : undefined;
+    return undefined;
   }
 
   return makeDiagnostic(sourceFile, stmt, specifier, "srcReExport");

--- a/waspc/data/packages/wasp-config/src/spec-pipeline/importLoweringPlan.ts
+++ b/waspc/data/packages/wasp-config/src/spec-pipeline/importLoweringPlan.ts
@@ -1,0 +1,256 @@
+import * as ts from "typescript";
+import type { ExtImportDescriptor } from "../appSpec/extImportDescriptor.js";
+
+const SRC_IMPORT_PREFIX = "./src/";
+const SRC_DESCRIPTOR_PREFIX = "@src/";
+
+export type ImportLoweringResult =
+  | { status: "ok"; plan: ImportLoweringPlan }
+  | { status: "error"; diagnostics: ImportDiagnostic[] };
+
+export type ImportLoweringPlan = {
+  replacements: ImportReplacement[];
+};
+
+export type ImportReplacement = {
+  start: number;
+  end: number;
+  declarations: DescriptorDeclaration[];
+};
+
+export type DescriptorDeclaration =
+  | {
+      kind: "descriptor";
+      localName: string;
+      descriptor: ExtImportDescriptor;
+    }
+  | {
+      kind: "namespace";
+      localName: string;
+      descriptorPath: ExtImportDescriptor["from"];
+      aliasPrefix: string;
+    };
+
+export type ImportDiagnostic = {
+  reason: ImportDiagnosticReason;
+  specifier: string;
+  location: SourceLocation;
+};
+
+export type ImportDiagnosticReason =
+  | "sideEffectImport"
+  | "typeOnlyImport"
+  | "mixedTypeAndValueImport"
+  | "emptyNamedImport"
+  | "srcReExport"
+  | "relativeImportOutsideSrc"
+  | "relativeReExportOutsideSrc";
+
+export type SourceLocation = {
+  line: number;
+  column: number;
+};
+
+export function planImportLowering(sourceText: string): ImportLoweringResult {
+  const sourceFile = ts.createSourceFile(
+    "input.ts",
+    sourceText,
+    ts.ScriptTarget.ES2022,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const replacements: ImportReplacement[] = [];
+  const diagnostics: ImportDiagnostic[] = [];
+
+  for (const stmt of sourceFile.statements) {
+    if (ts.isExportDeclaration(stmt)) {
+      const diagnostic = getExportDiagnostic(sourceFile, stmt);
+      if (diagnostic) diagnostics.push(diagnostic);
+      continue;
+    }
+
+    if (!ts.isImportDeclaration(stmt)) continue;
+    const specifier = getStringModuleSpecifier(stmt.moduleSpecifier);
+    if (!specifier) continue;
+
+    if (!isSrcImportSpecifier(specifier)) {
+      const diagnostic = getNonSrcImportDiagnostic(sourceFile, stmt, specifier);
+      if (diagnostic) diagnostics.push(diagnostic);
+      continue;
+    }
+
+    const diagnostic = getSrcImportDiagnostic(sourceFile, stmt, specifier);
+    if (diagnostic) {
+      diagnostics.push(diagnostic);
+      continue;
+    }
+
+    const clause = stmt.importClause;
+    if (!clause) continue;
+
+    replacements.push({
+      start: stmt.getStart(sourceFile),
+      end: stmt.getEnd(),
+      declarations: getDescriptorDeclarations(
+        clause,
+        toDescriptorPath(specifier),
+      ),
+    });
+  }
+
+  if (diagnostics.length > 0) {
+    return { status: "error", diagnostics };
+  }
+
+  return { status: "ok", plan: { replacements } };
+}
+
+function getStringModuleSpecifier(
+  moduleSpecifier: ts.Expression,
+): string | undefined {
+  return ts.isStringLiteral(moduleSpecifier) ? moduleSpecifier.text : undefined;
+}
+
+function isSrcImportSpecifier(specifier: string): boolean {
+  return specifier.startsWith(SRC_IMPORT_PREFIX);
+}
+
+function isRelativeImportSpecifier(specifier: string): boolean {
+  return specifier.startsWith("./") || specifier.startsWith("../");
+}
+
+function getNonSrcImportDiagnostic(
+  sourceFile: ts.SourceFile,
+  stmt: ts.ImportDeclaration,
+  specifier: string,
+): ImportDiagnostic | undefined {
+  if (!isRelativeImportSpecifier(specifier)) return undefined;
+
+  return makeDiagnostic(
+    sourceFile,
+    stmt,
+    specifier,
+    "relativeImportOutsideSrc",
+  );
+}
+
+function getSrcImportDiagnostic(
+  sourceFile: ts.SourceFile,
+  stmt: ts.ImportDeclaration,
+  specifier: string,
+): ImportDiagnostic | undefined {
+  const clause = stmt.importClause;
+  if (!clause) {
+    return makeDiagnostic(sourceFile, stmt, specifier, "sideEffectImport");
+  }
+
+  if (clause.isTypeOnly) {
+    return makeDiagnostic(sourceFile, stmt, specifier, "typeOnlyImport");
+  }
+
+  const bindings = clause.namedBindings;
+  if (bindings && ts.isNamedImports(bindings)) {
+    if (!clause.name && bindings.elements.length === 0) {
+      return makeDiagnostic(sourceFile, stmt, specifier, "emptyNamedImport");
+    }
+
+    if (bindings.elements.some((element) => element.isTypeOnly)) {
+      return makeDiagnostic(
+        sourceFile,
+        stmt,
+        specifier,
+        "mixedTypeAndValueImport",
+      );
+    }
+  }
+
+  return undefined;
+}
+
+function getExportDiagnostic(
+  sourceFile: ts.SourceFile,
+  stmt: ts.ExportDeclaration,
+): ImportDiagnostic | undefined {
+  if (!stmt.moduleSpecifier || !ts.isStringLiteral(stmt.moduleSpecifier)) {
+    return undefined;
+  }
+
+  const specifier = stmt.moduleSpecifier.text;
+  if (!isSrcImportSpecifier(specifier)) {
+    return isRelativeImportSpecifier(specifier)
+      ? makeDiagnostic(
+          sourceFile,
+          stmt,
+          specifier,
+          "relativeReExportOutsideSrc",
+        )
+      : undefined;
+  }
+
+  return makeDiagnostic(sourceFile, stmt, specifier, "srcReExport");
+}
+
+function makeDiagnostic(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  specifier: string,
+  reason: ImportDiagnosticReason,
+): ImportDiagnostic {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+    node.getStart(sourceFile),
+  );
+  return {
+    reason,
+    specifier,
+    location: { line: line + 1, column: character + 1 },
+  };
+}
+
+function getDescriptorDeclarations(
+  clause: ts.ImportClause,
+  descriptorPath: ExtImportDescriptor["from"],
+): DescriptorDeclaration[] {
+  const declarations: DescriptorDeclaration[] = [];
+
+  if (clause.name) {
+    const name = clause.name.text;
+    declarations.push({
+      kind: "descriptor",
+      localName: name,
+      descriptor: { importDefault: name, from: descriptorPath },
+    });
+  }
+
+  const bindings = clause.namedBindings;
+  if (bindings && ts.isNamespaceImport(bindings)) {
+    const name = bindings.name.text;
+    declarations.push({
+      kind: "namespace",
+      localName: name,
+      descriptorPath,
+      aliasPrefix: `${name}_`,
+    });
+  } else if (bindings) {
+    for (const spec of bindings.elements) {
+      const localName = spec.name.text;
+      const importedName = spec.propertyName?.text ?? localName;
+      declarations.push({
+        kind: "descriptor",
+        localName,
+        descriptor: {
+          import: importedName,
+          from: descriptorPath,
+          ...(importedName === localName ? {} : { alias: localName }),
+        },
+      });
+    }
+  }
+
+  return declarations;
+}
+
+function toDescriptorPath(specifier: string): ExtImportDescriptor["from"] {
+  return (SRC_DESCRIPTOR_PREFIX +
+    specifier.slice(SRC_IMPORT_PREFIX.length)) as ExtImportDescriptor["from"];
+}

--- a/waspc/data/packages/wasp-config/src/spec-pipeline/rewrite.ts
+++ b/waspc/data/packages/wasp-config/src/spec-pipeline/rewrite.ts
@@ -8,12 +8,10 @@ import type {
 import { planImportLowering } from "./importLoweringPlan.js";
 
 const ACCEPTED_IMPORT_SHAPES =
-  "Use default, named, aliased named, or namespace imports from ./src/*.";
-const SUPPORTED_IMPORTS =
-  "Use package imports for dependencies and ./src/* imports for external Wasp code references.";
+  "Use default, named, aliased named, or namespace imports from @src/*.";
 
 /**
- * Rewrites top-level imports of the form `./src/*` into inline ExtImport
+ * Rewrites top-level imports of the form `@src/*` into inline ExtImport
  * descriptor consts so the file no longer depends on user source modules at
  * runtime. The rewriter is purely textual: it parses a single SourceFile,
  * collects edit ranges for matching ImportDeclarations, and splices them.
@@ -70,15 +68,11 @@ function renderAlias(descriptor: ExtImportDescriptor): string {
 }
 
 function formatImportDiagnostic(diagnostic: ImportDiagnostic): string {
-  return `Unsupported ./src import in main.wasp.ts at ${diagnostic.location.line}:${diagnostic.location.column}: ${formatImportDiagnosticReason(diagnostic.reason)} Found ${JSON.stringify(diagnostic.specifier)}. ${ACCEPTED_IMPORT_SHAPES}`;
+  return `Unsupported @src import in main.wasp.ts at ${diagnostic.location.line}:${diagnostic.location.column}: ${formatImportDiagnosticReason(diagnostic.reason)} Found ${JSON.stringify(diagnostic.specifier)}. ${ACCEPTED_IMPORT_SHAPES}`;
 }
 
 function formatImportDiagnosticReason(reason: ImportDiagnosticReason): string {
   switch (reason) {
-    case "relativeImportOutsideSrc":
-      return `Relative imports outside ./src/* are not supported. ${SUPPORTED_IMPORTS}`;
-    case "relativeReExportOutsideSrc":
-      return `Relative re-exports are not supported. ${SUPPORTED_IMPORTS}`;
     case "sideEffectImport":
       return "Side-effect imports are not supported.";
     case "typeOnlyImport":

--- a/waspc/data/packages/wasp-config/src/spec-pipeline/rewrite.ts
+++ b/waspc/data/packages/wasp-config/src/spec-pipeline/rewrite.ts
@@ -1,0 +1,212 @@
+import * as ts from "typescript";
+
+const SRC_IMPORT_PREFIX = "./src/";
+const SRC_DESCRIPTOR_PREFIX = "@src/";
+const ACCEPTED_IMPORT_SHAPES =
+  "Use default, named, aliased named, or namespace imports from ./src/*.";
+const SUPPORTED_IMPORTS =
+  "Use package imports for dependencies and ./src/* imports for external Wasp code references.";
+
+/**
+ * Rewrites top-level imports of the form `./src/*` into inline ExtImport
+ * descriptor consts so the file no longer depends on user source modules at
+ * runtime. The rewriter is purely textual: it parses a single SourceFile,
+ * collects edit ranges for matching ImportDeclarations, and splices them.
+ */
+export function rewrite(sourceText: string): string {
+  const sourceFile = ts.createSourceFile(
+    "input.ts",
+    sourceText,
+    ts.ScriptTarget.ES2022,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const edits: Edit[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isExportDeclaration(stmt)) {
+      validateExportDeclaration(sourceFile, stmt);
+      continue;
+    }
+
+    if (!ts.isImportDeclaration(stmt)) continue;
+    const specifier = getStringModuleSpecifier(stmt.moduleSpecifier);
+    if (!specifier) continue;
+    if (!isSrcImportSpecifier(specifier)) {
+      validateNonSrcImport(sourceFile, stmt, specifier);
+      continue;
+    }
+
+    validateImportDeclaration(sourceFile, stmt, specifier);
+
+    const descriptorPath =
+      SRC_DESCRIPTOR_PREFIX + specifier.slice(SRC_IMPORT_PREFIX.length);
+    edits.push({
+      start: stmt.getStart(sourceFile),
+      end: stmt.getEnd(),
+      replacement: emitConsts(stmt.importClause!, descriptorPath),
+    });
+  }
+
+  return applyEdits(sourceText, edits);
+}
+
+type Edit = { start: number; end: number; replacement: string };
+
+function getStringModuleSpecifier(
+  moduleSpecifier: ts.Expression,
+): string | undefined {
+  return ts.isStringLiteral(moduleSpecifier) ? moduleSpecifier.text : undefined;
+}
+
+function isSrcImportSpecifier(specifier: string): boolean {
+  return specifier.startsWith(SRC_IMPORT_PREFIX);
+}
+
+function isRelativeImportSpecifier(specifier: string): boolean {
+  return specifier.startsWith("./") || specifier.startsWith("../");
+}
+
+function validateNonSrcImport(
+  sourceFile: ts.SourceFile,
+  stmt: ts.ImportDeclaration,
+  specifier: string,
+): void {
+  if (!isRelativeImportSpecifier(specifier)) return;
+
+  throwUnsupportedImport(
+    sourceFile,
+    stmt,
+    specifier,
+    `Relative imports outside ./src/* are not supported. ${SUPPORTED_IMPORTS}`,
+  );
+}
+
+function validateImportDeclaration(
+  sourceFile: ts.SourceFile,
+  stmt: ts.ImportDeclaration,
+  specifier: string,
+): void {
+  const clause = stmt.importClause;
+  if (!clause) {
+    throwUnsupportedImport(
+      sourceFile,
+      stmt,
+      specifier,
+      "Side-effect imports are not supported.",
+    );
+  }
+
+  if (clause.isTypeOnly) {
+    throwUnsupportedImport(
+      sourceFile,
+      stmt,
+      specifier,
+      "Type-only imports are not supported.",
+    );
+  }
+
+  const bindings = clause.namedBindings;
+  if (bindings && ts.isNamedImports(bindings)) {
+    if (!clause.name && bindings.elements.length === 0) {
+      throwUnsupportedImport(
+        sourceFile,
+        stmt,
+        specifier,
+        "Empty named imports are not supported.",
+      );
+    }
+
+    if (bindings.elements.some((element) => element.isTypeOnly)) {
+      throwUnsupportedImport(
+        sourceFile,
+        stmt,
+        specifier,
+        "Mixed type/value imports are not supported.",
+      );
+    }
+  }
+}
+
+function validateExportDeclaration(
+  sourceFile: ts.SourceFile,
+  stmt: ts.ExportDeclaration,
+): void {
+  if (!stmt.moduleSpecifier || !ts.isStringLiteral(stmt.moduleSpecifier))
+    return;
+  const specifier = stmt.moduleSpecifier.text;
+  if (!isSrcImportSpecifier(specifier)) {
+    if (isRelativeImportSpecifier(specifier)) {
+      throwUnsupportedImport(
+        sourceFile,
+        stmt,
+        specifier,
+        `Relative re-exports are not supported. ${SUPPORTED_IMPORTS}`,
+      );
+    }
+    return;
+  }
+
+  throwUnsupportedImport(
+    sourceFile,
+    stmt,
+    specifier,
+    "Re-exports are not supported.",
+  );
+}
+
+function throwUnsupportedImport(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  specifier: string,
+  reason: string,
+): never {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+    node.getStart(sourceFile),
+  );
+  throw new Error(
+    `Unsupported ./src import in main.wasp.ts at ${line + 1}:${character + 1}: ${reason} Found ${JSON.stringify(specifier)}. ${ACCEPTED_IMPORT_SHAPES}`,
+  );
+}
+
+function applyEdits(text: string, edits: Edit[]): string {
+  edits.sort((a, b) => a.start - b.start);
+  let out = "";
+  let cursor = 0;
+  for (const e of edits) {
+    out += text.slice(cursor, e.start) + e.replacement;
+    cursor = e.end;
+  }
+  return out + text.slice(cursor);
+}
+
+function emitConsts(clause: ts.ImportClause, descriptorPath: string): string {
+  const lines: string[] = [];
+
+  if (clause.name) {
+    const name = clause.name.text;
+    lines.push(
+      `const ${name} = { importDefault: ${JSON.stringify(name)}, from: ${JSON.stringify(descriptorPath)} } as const;`,
+    );
+  }
+
+  const bindings = clause.namedBindings;
+  if (bindings && ts.isNamespaceImport(bindings)) {
+    const name = bindings.name.text;
+    lines.push(
+      `const ${name} = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: ${JSON.stringify(descriptorPath)}, alias: ${JSON.stringify(`${name}_`)} + String(k) } as const) }) as Record<string, { import: string; from: ${JSON.stringify(descriptorPath)}; alias: string }>;`,
+    );
+  } else if (bindings) {
+    for (const spec of bindings.elements) {
+      const local = spec.name.text;
+      const imported = spec.propertyName?.text ?? local;
+      const alias =
+        imported === local ? "" : `, alias: ${JSON.stringify(local)}`;
+      lines.push(
+        `const ${local} = { import: ${JSON.stringify(imported)}, from: ${JSON.stringify(descriptorPath)}${alias} } as const;`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/waspc/data/packages/wasp-config/src/spec-pipeline/rewrite.ts
+++ b/waspc/data/packages/wasp-config/src/spec-pipeline/rewrite.ts
@@ -1,7 +1,12 @@
-import * as ts from "typescript";
+import type { ExtImportDescriptor } from "../appSpec/extImportDescriptor.js";
+import type {
+  DescriptorDeclaration,
+  ImportDiagnostic,
+  ImportDiagnosticReason,
+  ImportLoweringPlan,
+} from "./importLoweringPlan.js";
+import { planImportLowering } from "./importLoweringPlan.js";
 
-const SRC_IMPORT_PREFIX = "./src/";
-const SRC_DESCRIPTOR_PREFIX = "@src/";
 const ACCEPTED_IMPORT_SHAPES =
   "Use default, named, aliased named, or namespace imports from ./src/*.";
 const SUPPORTED_IMPORTS =
@@ -14,199 +19,75 @@ const SUPPORTED_IMPORTS =
  * collects edit ranges for matching ImportDeclarations, and splices them.
  */
 export function rewrite(sourceText: string): string {
-  const sourceFile = ts.createSourceFile(
-    "input.ts",
-    sourceText,
-    ts.ScriptTarget.ES2022,
-    true,
-    ts.ScriptKind.TS,
-  );
-
-  const edits: Edit[] = [];
-  for (const stmt of sourceFile.statements) {
-    if (ts.isExportDeclaration(stmt)) {
-      validateExportDeclaration(sourceFile, stmt);
-      continue;
-    }
-
-    if (!ts.isImportDeclaration(stmt)) continue;
-    const specifier = getStringModuleSpecifier(stmt.moduleSpecifier);
-    if (!specifier) continue;
-    if (!isSrcImportSpecifier(specifier)) {
-      validateNonSrcImport(sourceFile, stmt, specifier);
-      continue;
-    }
-
-    validateImportDeclaration(sourceFile, stmt, specifier);
-
-    const descriptorPath =
-      SRC_DESCRIPTOR_PREFIX + specifier.slice(SRC_IMPORT_PREFIX.length);
-    edits.push({
-      start: stmt.getStart(sourceFile),
-      end: stmt.getEnd(),
-      replacement: emitConsts(stmt.importClause!, descriptorPath),
-    });
+  const result = planImportLowering(sourceText);
+  if (result.status === "error") {
+    throw new Error(formatImportDiagnostic(result.diagnostics[0]!));
   }
 
-  return applyEdits(sourceText, edits);
+  return renderPlan(sourceText, result.plan);
 }
 
-type Edit = { start: number; end: number; replacement: string };
-
-function getStringModuleSpecifier(
-  moduleSpecifier: ts.Expression,
-): string | undefined {
-  return ts.isStringLiteral(moduleSpecifier) ? moduleSpecifier.text : undefined;
-}
-
-function isSrcImportSpecifier(specifier: string): boolean {
-  return specifier.startsWith(SRC_IMPORT_PREFIX);
-}
-
-function isRelativeImportSpecifier(specifier: string): boolean {
-  return specifier.startsWith("./") || specifier.startsWith("../");
-}
-
-function validateNonSrcImport(
-  sourceFile: ts.SourceFile,
-  stmt: ts.ImportDeclaration,
-  specifier: string,
-): void {
-  if (!isRelativeImportSpecifier(specifier)) return;
-
-  throwUnsupportedImport(
-    sourceFile,
-    stmt,
-    specifier,
-    `Relative imports outside ./src/* are not supported. ${SUPPORTED_IMPORTS}`,
-  );
-}
-
-function validateImportDeclaration(
-  sourceFile: ts.SourceFile,
-  stmt: ts.ImportDeclaration,
-  specifier: string,
-): void {
-  const clause = stmt.importClause;
-  if (!clause) {
-    throwUnsupportedImport(
-      sourceFile,
-      stmt,
-      specifier,
-      "Side-effect imports are not supported.",
-    );
-  }
-
-  if (clause.isTypeOnly) {
-    throwUnsupportedImport(
-      sourceFile,
-      stmt,
-      specifier,
-      "Type-only imports are not supported.",
-    );
-  }
-
-  const bindings = clause.namedBindings;
-  if (bindings && ts.isNamedImports(bindings)) {
-    if (!clause.name && bindings.elements.length === 0) {
-      throwUnsupportedImport(
-        sourceFile,
-        stmt,
-        specifier,
-        "Empty named imports are not supported.",
-      );
-    }
-
-    if (bindings.elements.some((element) => element.isTypeOnly)) {
-      throwUnsupportedImport(
-        sourceFile,
-        stmt,
-        specifier,
-        "Mixed type/value imports are not supported.",
-      );
-    }
-  }
-}
-
-function validateExportDeclaration(
-  sourceFile: ts.SourceFile,
-  stmt: ts.ExportDeclaration,
-): void {
-  if (!stmt.moduleSpecifier || !ts.isStringLiteral(stmt.moduleSpecifier))
-    return;
-  const specifier = stmt.moduleSpecifier.text;
-  if (!isSrcImportSpecifier(specifier)) {
-    if (isRelativeImportSpecifier(specifier)) {
-      throwUnsupportedImport(
-        sourceFile,
-        stmt,
-        specifier,
-        `Relative re-exports are not supported. ${SUPPORTED_IMPORTS}`,
-      );
-    }
-    return;
-  }
-
-  throwUnsupportedImport(
-    sourceFile,
-    stmt,
-    specifier,
-    "Re-exports are not supported.",
-  );
-}
-
-function throwUnsupportedImport(
-  sourceFile: ts.SourceFile,
-  node: ts.Node,
-  specifier: string,
-  reason: string,
-): never {
-  const { line, character } = sourceFile.getLineAndCharacterOfPosition(
-    node.getStart(sourceFile),
-  );
-  throw new Error(
-    `Unsupported ./src import in main.wasp.ts at ${line + 1}:${character + 1}: ${reason} Found ${JSON.stringify(specifier)}. ${ACCEPTED_IMPORT_SHAPES}`,
-  );
-}
-
-function applyEdits(text: string, edits: Edit[]): string {
-  edits.sort((a, b) => a.start - b.start);
+function renderPlan(text: string, plan: ImportLoweringPlan): string {
+  const replacements = [...plan.replacements].sort((a, b) => a.start - b.start);
   let out = "";
   let cursor = 0;
-  for (const e of edits) {
-    out += text.slice(cursor, e.start) + e.replacement;
-    cursor = e.end;
+
+  for (const replacement of replacements) {
+    out +=
+      text.slice(cursor, replacement.start) +
+      renderDeclarations(replacement.declarations);
+    cursor = replacement.end;
   }
+
   return out + text.slice(cursor);
 }
 
-function emitConsts(clause: ts.ImportClause, descriptorPath: string): string {
-  const lines: string[] = [];
+function renderDeclarations(declarations: DescriptorDeclaration[]): string {
+  return declarations.map(renderDeclaration).join("\n");
+}
 
-  if (clause.name) {
-    const name = clause.name.text;
-    lines.push(
-      `const ${name} = { importDefault: ${JSON.stringify(name)}, from: ${JSON.stringify(descriptorPath)} } as const;`,
-    );
+function renderDeclaration(declaration: DescriptorDeclaration): string {
+  switch (declaration.kind) {
+    case "descriptor":
+      return `const ${declaration.localName} = ${renderDescriptor(declaration.descriptor)} as const;`;
+    case "namespace":
+      return `const ${declaration.localName} = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: ${JSON.stringify(declaration.descriptorPath)}, alias: ${JSON.stringify(declaration.aliasPrefix)} + String(k) } as const) }) as Record<string, { import: string; from: ${JSON.stringify(declaration.descriptorPath)}; alias: string }>;`;
+  }
+}
+
+function renderDescriptor(descriptor: ExtImportDescriptor): string {
+  if ("import" in descriptor) {
+    return `{ import: ${JSON.stringify(descriptor.import)}, from: ${JSON.stringify(descriptor.from)}${renderAlias(descriptor)} }`;
   }
 
-  const bindings = clause.namedBindings;
-  if (bindings && ts.isNamespaceImport(bindings)) {
-    const name = bindings.name.text;
-    lines.push(
-      `const ${name} = new Proxy({}, { get: (_t, k) => ({ import: String(k), from: ${JSON.stringify(descriptorPath)}, alias: ${JSON.stringify(`${name}_`)} + String(k) } as const) }) as Record<string, { import: string; from: ${JSON.stringify(descriptorPath)}; alias: string }>;`,
-    );
-  } else if (bindings) {
-    for (const spec of bindings.elements) {
-      const local = spec.name.text;
-      const imported = spec.propertyName?.text ?? local;
-      const alias =
-        imported === local ? "" : `, alias: ${JSON.stringify(local)}`;
-      lines.push(
-        `const ${local} = { import: ${JSON.stringify(imported)}, from: ${JSON.stringify(descriptorPath)}${alias} } as const;`,
-      );
-    }
-  }
+  return `{ importDefault: ${JSON.stringify(descriptor.importDefault)}, from: ${JSON.stringify(descriptor.from)}${renderAlias(descriptor)} }`;
+}
 
-  return lines.join("\n");
+function renderAlias(descriptor: ExtImportDescriptor): string {
+  return "alias" in descriptor && descriptor.alias !== undefined
+    ? `, alias: ${JSON.stringify(descriptor.alias)}`
+    : "";
+}
+
+function formatImportDiagnostic(diagnostic: ImportDiagnostic): string {
+  return `Unsupported ./src import in main.wasp.ts at ${diagnostic.location.line}:${diagnostic.location.column}: ${formatImportDiagnosticReason(diagnostic.reason)} Found ${JSON.stringify(diagnostic.specifier)}. ${ACCEPTED_IMPORT_SHAPES}`;
+}
+
+function formatImportDiagnosticReason(reason: ImportDiagnosticReason): string {
+  switch (reason) {
+    case "relativeImportOutsideSrc":
+      return `Relative imports outside ./src/* are not supported. ${SUPPORTED_IMPORTS}`;
+    case "relativeReExportOutsideSrc":
+      return `Relative re-exports are not supported. ${SUPPORTED_IMPORTS}`;
+    case "sideEffectImport":
+      return "Side-effect imports are not supported.";
+    case "typeOnlyImport":
+      return "Type-only imports are not supported.";
+    case "mixedTypeAndValueImport":
+      return "Mixed type/value imports are not supported.";
+    case "emptyNamedImport":
+      return "Empty named imports are not supported.";
+    case "srcReExport":
+      return "Re-exports are not supported.";
+  }
 }

--- a/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedExpr/Combinators.hs
+++ b/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedExpr/Combinators.hs
@@ -161,7 +161,7 @@ extImport = evaluation' . withCtx $ \ctx -> \case
     --   figure out that is better (it sounds/feels like it could be).
     case AppSpec.ExtImport.parseExtImportPath extImportPath of
       Left err -> mkParseError ctx err
-      Right importPath -> pure $ AppSpec.ExtImport.ExtImport name importPath
+      Right importPath -> pure $ AppSpec.ExtImport.ExtImport name importPath Nothing
   expr -> Left $ ER.mkEvaluationError ctx $ ER.ExpectedType T.ExtImportType (TypedAST.exprType expr)
   where
     mkParseError ctx msg = Left $ ER.mkEvaluationError ctx $ ER.ParseError $ ER.EvaluationParseError msg

--- a/waspc/src/Wasp/AppSpec/ExtImport.hs
+++ b/waspc/src/Wasp/AppSpec/ExtImport.hs
@@ -11,7 +11,7 @@ module Wasp.AppSpec.ExtImport
 where
 
 import Control.Arrow (left)
-import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
 import Data.Aeson.Types (ToJSON)
 import Data.Data (Data)
 import Data.List (stripPrefix)
@@ -24,7 +24,9 @@ data ExtImport = ExtImport
   { -- | What is being imported.
     name :: ExtImportName,
     -- | Path from which we are importing.
-    path :: ExtImportPath
+    path :: ExtImportPath,
+    -- | Local alias used in the Wasp config.
+    alias :: Maybe Identifier
   }
   deriving (Show, Eq, Data)
 
@@ -33,9 +35,10 @@ instance FromJSON ExtImport where
     kindStr <- o .: "kind"
     nameStr <- o .: "name"
     pathStr <- o .: "path"
+    aliasStr <- o .:? "alias"
     extImportName <- parseExtImportName kindStr nameStr
     extImportPath <- either fail pure $ parseExtImportPath pathStr
-    return $ ExtImport extImportName extImportPath
+    return $ ExtImport extImportName extImportPath aliasStr
     where
       parseExtImportName kindStr nameStr = case kindStr of
         "default" -> pure $ ExtImportModule nameStr
@@ -54,9 +57,11 @@ data ExtImportName
   deriving (Show, Eq, Data, Generic, FromJSON, ToJSON)
 
 importIdentifier :: ExtImport -> Identifier
-importIdentifier (ExtImport importName _) = case importName of
-  ExtImportModule n -> n
-  ExtImportField n -> n
+importIdentifier (ExtImport importName _ maybeAlias) = case maybeAlias of
+  Just aliasName -> aliasName
+  Nothing -> case importName of
+    ExtImportModule n -> n
+    ExtImportField n -> n
 
 parseExtImportPath :: String -> Either String ExtImportPath
 parseExtImportPath extImportPath = case stripImportPrefix extImportPath of

--- a/waspc/src/Wasp/Generator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/JsImport.hs
@@ -57,7 +57,7 @@ jsImportToImportJson maybeJsImport = maybe notDefinedValue mkTmplData maybeJsImp
             ]
 
 extImportToRelativeSrcImportFromViteExecution :: EI.ExtImport -> JsImport
-extImportToRelativeSrcImportFromViteExecution extImport@(EI.ExtImport extImportName extImportPath) =
+extImportToRelativeSrcImportFromViteExecution extImport@(EI.ExtImport extImportName extImportPath _) =
   JsImport
     { _path = RelativeImportPath relativePath,
       _name = importName,

--- a/waspc/src/Wasp/Generator/SdkGenerator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/JsImport.hs
@@ -30,7 +30,7 @@ extOperationImportToImportJson =
     . extImportToJsImport
 
 extImportToJsImport :: EI.ExtImport -> JsImport
-extImportToJsImport extImport@(EI.ExtImport extImportName extImportPath) =
+extImportToJsImport extImport@(EI.ExtImport extImportName extImportPath _) =
   JsImport
     { _path = ModuleImportPath importPath,
       _name = importName,

--- a/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
+++ b/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
@@ -7,6 +7,7 @@ import Control.Arrow (left)
 import Control.Concurrent (newChan)
 import Control.Concurrent.Async (concurrently)
 import Control.Monad.Except (ExceptT (ExceptT), liftEither, runExceptT)
+import Control.Monad.IO.Class (liftIO)
 import qualified Data.Aeson as Aeson
 import StrongPath
   ( Abs,
@@ -17,7 +18,6 @@ import StrongPath
     Rel,
     basename,
     castFile,
-    fromAbsDir,
     fromAbsFile,
     fromRelFile,
     relfile,
@@ -30,7 +30,7 @@ import Wasp.AppSpec.Core.Decl.JSON ()
 import qualified Wasp.Job as J
 import Wasp.Job.IO (readJobMessagesAndPrintThemPrefixed)
 import Wasp.Job.Process (runNodeCommandAsJob)
-import Wasp.NodePackageFFI (InstallablePackage (WaspConfigPackage), getInstallablePackageScriptInProject)
+import Wasp.NodePackageFFI (InstallablePackage (WaspConfigPackage), ensurePackageIsAtInstallationPathInProject, getInstallablePackageScriptInProject)
 import Wasp.Project.Common
   ( CompileError,
     WaspProjectDir,
@@ -47,6 +47,8 @@ import Wasp.Util.StrongPath (replaceRelExtension)
 
 data CompiledWaspJsFile
 
+data RewrittenWaspTsFile
+
 data AppSpecDeclsJsonFile
 
 analyzeWaspTsFile ::
@@ -57,14 +59,71 @@ analyzeWaspTsFile ::
 analyzeWaspTsFile waspProjectDir prismaSchemaAst waspFilePath = runExceptT $ do
   -- TODO: I'm not yet sure where tsconfig.wasp.json location should come from
   -- because we also need that knowledge when generating a TS SDK project.
-  compiledWaspJsFile <- ExceptT $ compileWaspTsFile waspProjectDir [relfile|tsconfig.wasp.json|] waspFilePath
+  liftIO $ ensurePackageIsAtInstallationPathInProject waspProjectDir WaspConfigPackage
+  (rewrittenWaspTsFile, compilationTsConfigFile) <- ExceptT $ prepareWaspTsFileForCompilation waspProjectDir [relfile|tsconfig.wasp.json|] waspFilePath
+  compiledWaspJsFile <- ExceptT $ compileWaspTsFile waspProjectDir compilationTsConfigFile rewrittenWaspTsFile
   declsJsonFile <- ExceptT $ executeMainWaspJsFileAndGetDeclsFile waspProjectDir prismaSchemaAst compiledWaspJsFile
   ExceptT $ readDecls prismaSchemaAst declsJsonFile
+
+prepareWaspTsFileForCompilation ::
+  Path' Abs (Dir WaspProjectDir) ->
+  Path' (Rel WaspProjectDir) File' ->
+  Path' Abs (File WaspTsFile) ->
+  IO (Either [CompileError] (Path' Abs (File RewrittenWaspTsFile), Path' (Rel WaspProjectDir) File'))
+prepareWaspTsFileForCompilation waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath = do
+  let rewrittenWaspTsFile = waspProjectDir </> rewrittenWaspTsFileInDotWaspDir
+      compilationTsConfigFile = waspProjectDir </> compilationTsConfigFileInDotWaspDir
+  rewriteResult <- rewriteWaspTsFile waspProjectDir waspFilePath rewrittenWaspTsFile
+  case rewriteResult of
+    Left errors -> return $ Left errors
+    Right () -> do
+      IOUtil.writeFile compilationTsConfigFile $ mkCompilationTsConfigJson tsconfigNodeFileInWaspProjectDir rewrittenWaspTsFile
+      return $ Right (rewrittenWaspTsFile, compilationTsConfigFileInDotWaspDir)
+
+rewriteWaspTsFile ::
+  Path' Abs (Dir WaspProjectDir) ->
+  Path' Abs (File WaspTsFile) ->
+  Path' Abs (File RewrittenWaspTsFile) ->
+  IO (Either [CompileError] ())
+rewriteWaspTsFile waspProjectDir waspFilePath rewrittenWaspTsFile = do
+  chan <- newChan
+  (_, rewriteExitCode) <-
+    concurrently
+      (readJobMessagesAndPrintThemPrefixed chan)
+      ( runNodeCommandAsJob
+          waspProjectDir
+          "node"
+          [ fromRelFile $ getInstallablePackageScriptInProject WaspConfigPackage,
+            "rewrite",
+            fromAbsFile waspFilePath,
+            fromAbsFile rewrittenWaspTsFile
+          ]
+          J.Wasp
+          chan
+      )
+  return $ case rewriteExitCode of
+    ExitFailure _status -> Left ["Error while rewriting " ++ fromAbsFile waspFilePath ++ "."]
+    ExitSuccess -> Right ()
+
+mkCompilationTsConfigJson ::
+  Path' (Rel WaspProjectDir) File' ->
+  Path' Abs (File RewrittenWaspTsFile) ->
+  String
+mkCompilationTsConfigJson tsconfigNodeFileInWaspProjectDir rewrittenWaspTsFile =
+  unlines
+    [ "{",
+      "  \"extends\": \"../" ++ fromRelFile tsconfigNodeFileInWaspProjectDir ++ "\",",
+      "  \"compilerOptions\": {",
+      "    \"noEmit\": false",
+      "  },",
+      "  \"include\": [\"" ++ fromRelFile (basename rewrittenWaspTsFile) ++ "\"]",
+      "}"
+    ]
 
 compileWaspTsFile ::
   Path' Abs (Dir WaspProjectDir) ->
   Path' (Rel WaspProjectDir) File' ->
-  Path' Abs (File WaspTsFile) ->
+  Path' Abs (File sourceWaspTsFile) ->
   IO (Either [CompileError] (Path' Abs (File CompiledWaspJsFile)))
 compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath = do
   chan <- newChan
@@ -88,16 +147,11 @@ compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath =
           [ "tsc",
             "-p",
             fromAbsFile (waspProjectDir </> tsconfigNodeFileInWaspProjectDir),
-            -- The tsconfig.wasp.json file has the noEmit flag on.
-            -- The file only exists IDE support, and we don't want users to
-            -- accidentally chage the outDir.
-            --
-            -- Here, to actually generate the JS file in the desired location,
-            -- we must turn off the noEmit flag and specify the outDir.
+            -- The generated tsconfig turns off the noEmit flag from
+            -- tsconfig.wasp.json, so tsc emits the JS file next to the
+            -- rewritten TS file in .wasp/.
             "--noEmit",
-            "false",
-            "--outDir",
-            fromAbsDir outDir
+            "false"
           ]
           J.Wasp
           chan
@@ -106,14 +160,19 @@ compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath =
     ExitFailure _status -> Left ["Got TypeScript compiler errors for " ++ fromAbsFile waspFilePath ++ "."]
     ExitSuccess -> Right absCompiledWaspJsFile
   where
-    outDir = waspProjectDir </> dotWaspDirInWaspProjectDir
     -- We know this will be the output JS file's location because it's how TSC
-    -- works (assuming we've specified the outDir, which we did).
-    absCompiledWaspJsFile = outDir </> compiledWaspJsFileInDotWaspDir
+    -- works: it emits the JS file next to the rewritten TS file in .wasp/.
+    absCompiledWaspJsFile = waspProjectDir </> dotWaspDirInWaspProjectDir </> compiledWaspJsFileInDotWaspDir
     compiledWaspJsFileInDotWaspDir =
       castFile $
         replaceRelExtension (basename waspFilePath) ".js"
           `orElse` error ("Couldn't calculate the compiled JS file path for " ++ fromAbsFile waspFilePath ++ ".")
+
+rewrittenWaspTsFileInDotWaspDir :: Path' (Rel WaspProjectDir) (File RewrittenWaspTsFile)
+rewrittenWaspTsFileInDotWaspDir = dotWaspDirInWaspProjectDir </> [relfile|main.wasp.rewritten.ts|]
+
+compilationTsConfigFileInDotWaspDir :: Path' (Rel WaspProjectDir) File'
+compilationTsConfigFileInDotWaspDir = dotWaspDirInWaspProjectDir </> [relfile|tsconfig.wasp.generated.json|]
 
 executeMainWaspJsFileAndGetDeclsFile ::
   Path' Abs (Dir WaspProjectDir) ->

--- a/waspc/tests/Analyzer/EvaluatorTest.hs
+++ b/waspc/tests/Analyzer/EvaluatorTest.hs
@@ -209,8 +209,8 @@ spec_Evaluator = do
           `shouldBe` Right
             [ ( "Test",
                 Special
-                  [ ExtImport (ExtImportField "field") (fromJust $ SP.parseRelFileP "main.js"),
-                    ExtImport (ExtImportModule "main") (fromJust $ SP.parseRelFileP "main.js")
+                  [ ExtImport (ExtImportField "field") (fromJust $ SP.parseRelFileP "main.js") Nothing,
+                    ExtImport (ExtImportModule "main") (fromJust $ SP.parseRelFileP "main.js") Nothing
                   ]
                   (JSON $ Aeson.object ["key" Aeson..= (1 :: Integer)])
               )

--- a/waspc/tests/AnalyzerTest.hs
+++ b/waspc/tests/AnalyzerTest.hs
@@ -143,7 +143,7 @@ spec_Analyzer = do
                                 { Auth.usernameAndPassword =
                                     Just
                                       Auth.UsernameAndPasswordConfig
-                                        { Auth.userSignupFields = Just $ ExtImport (ExtImportField "getUserFields") (fromJust $ SP.parseRelFileP "auth/signup")
+                                        { Auth.userSignupFields = Just $ ExtImport (ExtImportField "getUserFields") (fromJust $ SP.parseRelFileP "auth/signup") Nothing
                                         },
                                   Auth.slack = Nothing,
                                   Auth.discord = Nothing,
@@ -169,7 +169,8 @@ spec_Analyzer = do
                               Just $
                                 ExtImport
                                   (ExtImportField "setupServer")
-                                  (fromJust $ SP.parseRelFileP "bar"),
+                                  (fromJust $ SP.parseRelFileP "bar")
+                                  Nothing,
                             Server.middlewareConfigFn = Nothing,
                             Server.envValidationSchema = Nothing
                           },
@@ -178,10 +179,10 @@ spec_Analyzer = do
                         Client.Client
                           { Client.setupFn =
                               Just $
-                                ExtImport (ExtImportField "setupClient") (fromJust $ SP.parseRelFileP "baz"),
+                                ExtImport (ExtImportField "setupClient") (fromJust $ SP.parseRelFileP "baz") Nothing,
                             Client.rootComponent =
                               Just $
-                                ExtImport (ExtImportField "App") (fromJust $ SP.parseRelFileP "App"),
+                                ExtImport (ExtImportField "App") (fromJust $ SP.parseRelFileP "App") Nothing,
                             Client.baseDir = Just "/",
                             Client.envValidationSchema = Nothing
                           },
@@ -193,12 +194,14 @@ spec_Analyzer = do
                                 [ ExtImport
                                     (ExtImportField "devSeedSimple")
                                     (fromJust $ SP.parseRelFileP "dbSeeds")
+                                    Nothing
                                 ],
                             Db.prismaSetupFn =
                               Just $
                                 ExtImport
                                   (ExtImportField "setUpPrisma")
                                   (fromJust $ SP.parseRelFileP "setUpPrisma")
+                                  Nothing
                           },
                     App.emailSender =
                       Just
@@ -223,7 +226,8 @@ spec_Analyzer = do
                   { Page.component =
                       ExtImport
                         (ExtImportModule "Home")
-                        (fromJust $ SP.parseRelFileP "pages/Main"),
+                        (fromJust $ SP.parseRelFileP "pages/Main")
+                        Nothing,
                     Page.authRequired = Nothing
                   }
               ),
@@ -232,7 +236,8 @@ spec_Analyzer = do
                   { Page.component =
                       ExtImport
                         (ExtImportField "profilePage")
-                        (fromJust $ SP.parseRelFileP "pages/Profile"),
+                        (fromJust $ SP.parseRelFileP "pages/Profile")
+                        Nothing,
                     Page.authRequired = Just True
                   }
               )
@@ -255,7 +260,8 @@ spec_Analyzer = do
                   { Query.fn =
                       ExtImport
                         (ExtImportField "getAllUsers")
-                        (fromJust $ SP.parseRelFileP "foo"),
+                        (fromJust $ SP.parseRelFileP "foo")
+                        Nothing,
                     Query.entities = Just [Ref "User"],
                     Query.auth = Nothing
                   }
@@ -269,7 +275,8 @@ spec_Analyzer = do
                   { Action.fn =
                       ExtImport
                         (ExtImportField "updateUser")
-                        (fromJust $ SP.parseRelFileP "foo"),
+                        (fromJust $ SP.parseRelFileP "foo")
+                        Nothing,
                     Action.entities = Just [Ref "User"],
                     Action.auth = Just True
                   }
@@ -282,6 +289,7 @@ spec_Analyzer = do
               ( ExtImport
                   (ExtImportField "backgroundJob")
                   (fromJust $ SP.parseRelFileP "jobs/baz")
+                  Nothing
               )
               ( Just $
                   Job.ExecutorOptions

--- a/waspc/tests/AppSpec/FromJSONTest.hs
+++ b/waspc/tests/AppSpec/FromJSONTest.hs
@@ -30,7 +30,17 @@ spec_AppSpecFromJSON = do
         `shouldDecodeTo` Just
           ( ExtImport.ExtImport
               { ExtImport.name = ExtImport.ExtImportField "foo",
-                ExtImport.path = [relfileP|folder/file.js|]
+                ExtImport.path = [relfileP|folder/file.js|],
+                ExtImport.alias = Nothing
+              }
+          )
+    it "parses a valid aliased ext import" $
+      extAliasedImportJson
+        `shouldDecodeTo` Just
+          ( ExtImport.ExtImport
+              { ExtImport.name = ExtImport.ExtImportField "foo",
+                ExtImport.path = [relfileP|folder/file.js|],
+                ExtImport.alias = Just "bar"
               }
           )
     it "parses a valid default ext import" $
@@ -38,7 +48,8 @@ spec_AppSpecFromJSON = do
         `shouldDecodeTo` Just
           ( ExtImport.ExtImport
               { ExtImport.name = ExtImport.ExtImportModule "foo",
-                ExtImport.path = [relfileP|folder/subfolder/file.js|]
+                ExtImport.path = [relfileP|folder/subfolder/file.js|],
+                ExtImport.alias = Nothing
               }
           )
     it "fails to parse an invalid of import" $ do
@@ -377,6 +388,7 @@ spec_AppSpecFromJSON = do
           )
   where
     extNamedImportJson = [trimming| { "kind": "named", "name" : "foo", "path": "@src/folder/file.js" }|]
+    extAliasedImportJson = [trimming| { "kind": "named", "name" : "foo", "path": "@src/folder/file.js", "alias": "bar" }|]
     extDefaultImportJson = [trimming| { "kind": "default", "name" : "foo", "path": "@src/folder/subfolder/file.js" }|]
 
     fooEntityRef = [trimming| { "name": "foo", "declType": "Entity" }|]

--- a/waspc/tests/AppSpec/ValidTest.hs
+++ b/waspc/tests/AppSpec/ValidTest.hs
@@ -655,7 +655,8 @@ spec_AppSpecValid = do
         { AS.Page.component =
             AS.ExtImport.ExtImport
               (AS.ExtImport.ExtImportModule "Home")
-              (fromJust $ SP.parseRelFileP "pages/Main"),
+              (fromJust $ SP.parseRelFileP "pages/Main")
+              Nothing,
           AS.Page.authRequired = Nothing
         }
 
@@ -762,3 +763,4 @@ spec_AppSpecValid = do
       AS.ExtImport.ExtImport
         (AS.ExtImport.ExtImportModule "Dummy")
         (fromJust $ SP.parseRelFileP "dummy/File")
+        Nothing

--- a/waspc/tests/Generator/CrudTest.hs
+++ b/waspc/tests/Generator/CrudTest.hs
@@ -79,7 +79,8 @@ spec_GeneratorCrudTest = do
                               Just $
                                 AS.ExtImport.ExtImport
                                   { AS.ExtImport.name = AS.ExtImport.ExtImportField "getTask",
-                                    AS.ExtImport.path = SP.castRel [relfileP|bla/tasks.js|]
+                                    AS.ExtImport.path = SP.castRel [relfileP|bla/tasks.js|],
+                                    AS.ExtImport.alias = Nothing
                                   }
                           }
                       ),

--- a/waspc/tests/Generator/JsImportTest.hs
+++ b/waspc/tests/Generator/JsImportTest.hs
@@ -17,7 +17,8 @@ spec_GeneratorJsImportTest = do
         extImport =
           ExtImport
             { name = ExtImportModule "test",
-              path = [SP.relfileP|folder/test.js|]
+              path = [SP.relfileP|folder/test.js|],
+              alias = Nothing
             }
     it "makes a JsImport from ExtImport" $ do
       extImportToJsImport pathToExtCodeDir pathFromImportLocationToExtCodeDir extImport
@@ -26,3 +27,11 @@ spec_GeneratorJsImportTest = do
             JI._name = JsImportModule "test",
             JI._importAlias = Nothing
           }
+    it "uses alias metadata for generated ExtImport identifiers" $ do
+      getAliasedExtImportIdentifier extImport {alias = Just "testAlias"}
+        `shouldBe` "testAlias_ext"
+    it "avoids collisions for same exported name with different aliases" $ do
+      let firstImport = extImport {name = ExtImportField "handler", path = [SP.relfileP|one.js|], alias = Just "oneHandler"}
+          secondImport = extImport {name = ExtImportField "handler", path = [SP.relfileP|two.js|], alias = Just "twoHandler"}
+      getAliasedExtImportIdentifier <$> [firstImport, secondImport]
+        `shouldBe` ["oneHandler_ext", "twoHandler_ext"]


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Replace this message here, and write a high-level overview with any additional
context (motivation, trade-offs, approaches considered, concerns, ...).

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
