### PR TITLE
[1/7] Extract new spec ExtImport mapper

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import type * as AppSpec from "../../src/appSpec.js";
+import { mapExtImport } from "../../src/spec/extImport.js";
+import type * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
+import * as Fixtures from "./testFixtures.js";
+
+describe("mapExtImport", () => {
+  test("should map minimal named import correctly", () => {
+    testMapExtImport(Fixtures.getExtImport("minimal", "named"));
+  });
+
+  test("should map full named import correctly", () => {
+    testMapExtImport(Fixtures.getExtImport("full", "named"));
+  });
+
+  test("should map minimal default import correctly", () => {
+    testMapExtImport(Fixtures.getExtImport("minimal", "default"));
+  });
+
+  test("should map full default import correctly", () => {
+    testMapExtImport(Fixtures.getExtImport("full", "default"));
+  });
+
+  function testMapExtImport(extImport: TsAppSpec.ExtImport): void {
+    const result = mapExtImport(extImport);
+
+    if ("import" in extImport) {
+      expect(result).toStrictEqual({
+        kind: "named",
+        name: extImport.import,
+        path: extImport.from,
+      } satisfies AppSpec.ExtImport);
+    } else {
+      expect(result).toStrictEqual({
+        kind: "default",
+        name: extImport.importDefault,
+        path: extImport.from,
+      } satisfies AppSpec.ExtImport);
+    }
+  }
+});

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -21,6 +21,12 @@ describe("mapExtImport", () => {
     testMapExtImport(Fixtures.getExtImport("full", "default"));
   });
 
+  test("should throw for invalid descriptors", () => {
+    expect(() =>
+      mapExtImport({ from: "@src/external" } as unknown as TsAppSpec.ExtImport),
+    ).toThrow("Invalid ExtImport");
+  });
+
   function testMapExtImport(extImport: TsAppSpec.ExtImport): void {
     const result = mapExtImport(extImport);
 

--- a/waspc/data/packages/wasp-config/__tests__/spec/mapApp.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/mapApp.unit.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "vitest";
 import * as AppSpec from "../../src/appSpec.js";
+import { mapExtImport } from "../../src/spec/extImport.js";
 import {
   deriveExtImportName,
   makeRefParser,
   mapAction,
   mapApp,
-  mapExtImport,
   mapPage,
   mapQuery,
   mapRoute,
@@ -268,41 +268,5 @@ describe("mapAction", () => {
       entities: action.entities?.map(entityRefParser),
       auth: action.auth,
     } satisfies AppSpec.Action);
-  }
-});
-
-describe("mapExtImport", () => {
-  test("should map minimal named import correctly", () => {
-    testMapExtImport(Fixtures.getExtImport("minimal", "named"));
-  });
-
-  test("should map full named import correctly", () => {
-    testMapExtImport(Fixtures.getExtImport("full", "named"));
-  });
-
-  test("should map minimal default import correctly", () => {
-    testMapExtImport(Fixtures.getExtImport("minimal", "default"));
-  });
-
-  test("should map full default import correctly", () => {
-    testMapExtImport(Fixtures.getExtImport("full", "default"));
-  });
-
-  function testMapExtImport(extImport: TsAppSpec.ExtImport): void {
-    const result = mapExtImport(extImport);
-
-    if ("import" in extImport) {
-      expect(result).toStrictEqual({
-        kind: "named",
-        name: extImport.import,
-        path: extImport.from,
-      } satisfies AppSpec.ExtImport);
-    } else {
-      expect(result).toStrictEqual({
-        kind: "default",
-        name: extImport.importDefault,
-        path: extImport.from,
-      } satisfies AppSpec.ExtImport);
-    }
   }
 });

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -14,21 +14,34 @@ export interface DefaultExtImport {
 }
 
 export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
-  if ("import" in extImport) {
+  if (isNamedExtImport(extImport)) {
     return {
       kind: "named",
       name: extImport.import,
       path: extImport.from,
     };
-  } else if ("importDefault" in extImport) {
-    return {
-      kind: "default",
-      name: extImport.importDefault,
-      path: extImport.from,
-    };
-  } else {
-    throw new Error(
-      "Invalid ExtImport: neither `import` nor `importDefault` is defined",
-    );
   }
+
+  return {
+    kind: "default",
+    name: extImport.importDefault,
+    path: extImport.from,
+  };
+}
+
+export function isNamedExtImport(value: unknown): value is NamedExtImport {
+  return (
+    isObject(value) &&
+    typeof value.import === "string" &&
+    typeof value.from === "string" &&
+    hasValidAlias(value)
+  );
+}
+
+function hasValidAlias(value: Record<string, unknown>): boolean {
+  return value.alias === undefined || typeof value.alias === "string";
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === "[object Object]";
 }

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -1,0 +1,34 @@
+import type * as AppSpec from "../appSpec.js";
+
+export type ExtImport = NamedExtImport | DefaultExtImport;
+
+export interface NamedExtImport {
+  import: string;
+  alias?: string;
+  from: AppSpec.ExtImport["path"];
+}
+
+export interface DefaultExtImport {
+  importDefault: string;
+  from: AppSpec.ExtImport["path"];
+}
+
+export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
+  if ("import" in extImport) {
+    return {
+      kind: "named",
+      name: extImport.import,
+      path: extImport.from,
+    };
+  } else if ("importDefault" in extImport) {
+    return {
+      kind: "default",
+      name: extImport.importDefault,
+      path: extImport.from,
+    };
+  } else {
+    throw new Error(
+      "Invalid ExtImport: neither `import` nor `importDefault` is defined",
+    );
+  }
+}

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -20,13 +20,17 @@ export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
       name: extImport.import,
       path: extImport.from,
     };
+  } else if (isDefaultExtImport(extImport)) {
+    return {
+      kind: "default",
+      name: extImport.importDefault,
+      path: extImport.from,
+    };
+  } else {
+    throw new Error(
+      "Invalid ExtImport: neither `import` nor `importDefault` is defined",
+    );
   }
-
-  return {
-    kind: "default",
-    name: extImport.importDefault,
-    path: extImport.from,
-  };
 }
 
 export function isNamedExtImport(value: unknown): value is NamedExtImport {
@@ -35,6 +39,14 @@ export function isNamedExtImport(value: unknown): value is NamedExtImport {
     typeof value.import === "string" &&
     typeof value.from === "string" &&
     hasValidAlias(value)
+  );
+}
+
+function isDefaultExtImport(value: unknown): value is DefaultExtImport {
+  return (
+    isObject(value) &&
+    typeof value.importDefault === "string" &&
+    typeof value.from === "string"
   );
 }
 

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -4,6 +4,7 @@
  */
 
 import * as AppSpec from "../appSpec.js";
+import { mapExtImport } from "./extImport.js";
 import * as TsAppSpec from "./publicApi/tsAppSpec.js";
 
 export function mapApp(
@@ -167,28 +168,6 @@ export function mapAction(
     entities: entities?.map(entityRefParser),
     auth,
   };
-}
-
-export function mapExtImport(
-  extImport: TsAppSpec.ExtImport,
-): AppSpec.ExtImport {
-  if ("import" in extImport) {
-    return {
-      kind: "named",
-      name: extImport.import,
-      path: extImport.from,
-    };
-  } else if ("importDefault" in extImport) {
-    return {
-      kind: "default",
-      name: extImport.importDefault,
-      path: extImport.from,
-    };
-  } else {
-    throw new Error(
-      "Invalid ExtImport: neither `import` nor `importDefault` is defined",
-    );
-  }
 }
 
 export type RefParser<T extends AppSpec.DeclType> = (

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -1,3 +1,5 @@
+import type { ExtImport as SpecExtImport } from "../extImport.js";
+
 export type App = {
   name: string;
   wasp: { version: string };
@@ -11,7 +13,7 @@ export type Part = Page | Route | Query | Action;
 export type Page = MakePart<
   "page",
   {
-    component: ExtImport;
+    component: SpecExtImport;
     authRequired?: boolean;
   }
 >;
@@ -30,7 +32,7 @@ export type Route = MakePart<
 export type Query = MakePart<
   "query",
   {
-    fn: ExtImport;
+    fn: SpecExtImport;
     entities?: string[];
     auth?: boolean;
   }
@@ -39,22 +41,17 @@ export type Query = MakePart<
 export type Action = MakePart<
   "action",
   {
-    fn: ExtImport;
+    fn: SpecExtImport;
     entities?: string[];
     auth?: boolean;
   }
 >;
 
-export type ExtImport = NamedExtImport | DefaultExtImport;
-export interface NamedExtImport {
-  import: string;
-  alias?: string;
-  from: `@src/${string}`;
-}
-export interface DefaultExtImport {
-  importDefault: string;
-  from: `@src/${string}`;
-}
+export type {
+  DefaultExtImport,
+  ExtImport,
+  NamedExtImport,
+} from "../extImport.js";
 
 /**
  * We need the kind to differentiate between parts with the same structure. One

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -1,4 +1,4 @@
-import type { ExtImport as SpecExtImport } from "../extImport.js";
+import type { ExtImport } from "../extImport.js";
 
 export type App = {
   name: string;
@@ -13,7 +13,7 @@ export type Part = Page | Route | Query | Action;
 export type Page = MakePart<
   "page",
   {
-    component: SpecExtImport;
+    component: ExtImport;
     authRequired?: boolean;
   }
 >;
@@ -32,7 +32,7 @@ export type Route = MakePart<
 export type Query = MakePart<
   "query",
   {
-    fn: SpecExtImport;
+    fn: ExtImport;
     entities?: string[];
     auth?: boolean;
   }
@@ -41,7 +41,7 @@ export type Query = MakePart<
 export type Action = MakePart<
   "action",
   {
-    fn: SpecExtImport;
+    fn: ExtImport;
     entities?: string[];
     auth?: boolean;
   }


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Extracts the new TS spec ExtImport literal type and mapper into `src/spec/extImport.ts`.

This gives later PRs one place for ExtImport literal mapping and import-form input handling.

Stack:

1. https://github.com/wasp-lang/wasp/pull/4112 (this PR)
2. https://github.com/wasp-lang/wasp/pull/4113
3. https://github.com/wasp-lang/wasp/pull/4114
4. https://github.com/wasp-lang/wasp/pull/4115
5. https://github.com/wasp-lang/wasp/pull/4116
6. https://github.com/wasp-lang/wasp/pull/4117
7. https://github.com/wasp-lang/wasp/pull/4118

Validation:

- `npm run build` in `waspc/data/packages/wasp-config`
- `npm test -- __tests__/spec/extImport.unit.test.ts __tests__/spec/mapApp.unit.test.ts` in `waspc/data/packages/wasp-config`

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.