### PR TITLE
[2/7] Add ExtImport alias metadata

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/legacy/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/legacy/testFixtures.ts
@@ -954,6 +954,7 @@ export function getExtImport(
       return {
         ...importObject,
         from: "@src/external",
+        alias: "externalAlias",
       } satisfies FullConfig<TsAppSpec.ExtImport>;
     default:
       assertUnreachable(scope);

--- a/waspc/data/packages/wasp-config/__tests__/legacy/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/legacy/testFixtures.ts
@@ -954,7 +954,6 @@ export function getExtImport(
       return {
         ...importObject,
         from: "@src/external",
-        alias: "externalAlias",
       } satisfies FullConfig<TsAppSpec.ExtImport>;
     default:
       assertUnreachable(scope);

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -35,14 +35,14 @@ describe("mapExtImport", () => {
         kind: "named",
         name: extImport.import,
         path: extImport.from,
-        ...(extImport.alias ? { alias: extImport.alias } : {}),
+        alias: extImport.alias,
       } satisfies AppSpec.ExtImport);
     } else {
       expect(result).toStrictEqual({
         kind: "default",
         name: extImport.importDefault,
         path: extImport.from,
-        ...(extImport.alias ? { alias: extImport.alias } : {}),
+        alias: extImport.alias,
       } satisfies AppSpec.ExtImport);
     }
   }

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -35,12 +35,14 @@ describe("mapExtImport", () => {
         kind: "named",
         name: extImport.import,
         path: extImport.from,
+        ...(extImport.alias ? { alias: extImport.alias } : {}),
       } satisfies AppSpec.ExtImport);
     } else {
       expect(result).toStrictEqual({
         kind: "default",
         name: extImport.importDefault,
         path: extImport.from,
+        ...(extImport.alias ? { alias: extImport.alias } : {}),
       } satisfies AppSpec.ExtImport);
     }
   }

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -42,7 +42,6 @@ describe("mapExtImport", () => {
         kind: "default",
         name: extImport.importDefault,
         path: extImport.from,
-        alias: extImport.alias,
       } satisfies AppSpec.ExtImport);
     }
   }

--- a/waspc/data/packages/wasp-config/src/appSpec.ts
+++ b/waspc/data/packages/wasp-config/src/appSpec.ts
@@ -109,6 +109,7 @@ export type ExtImport = {
   kind: ExtImportKind;
   name: string;
   path: `@src/${string}`;
+  alias?: string;
 };
 
 export type JobExecutor = "PgBoss";

--- a/waspc/data/packages/wasp-config/src/appSpec.ts
+++ b/waspc/data/packages/wasp-config/src/appSpec.ts
@@ -105,11 +105,17 @@ export type App = {
 };
 
 export type ExtImportKind = "named" | "default";
-export type ExtImport = {
-  kind: ExtImportKind;
+export type ExtImport = NamedExtImport | DefaultExtImport;
+export type NamedExtImport = {
+  kind: "named";
   name: string;
   path: `@src/${string}`;
   alias?: string;
+};
+export type DefaultExtImport = {
+  kind: "default";
+  name: string;
+  path: `@src/${string}`;
 };
 
 export type JobExecutor = "PgBoss";

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -20,14 +20,14 @@ export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
       kind: "named",
       name: extImport.import,
       path: extImport.from,
-      ...mapAlias(extImport),
+      alias: extImport.alias,
     };
   } else if (isDefaultExtImport(extImport)) {
     return {
       kind: "default",
       name: extImport.importDefault,
       path: extImport.from,
-      ...mapAlias(extImport),
+      alias: extImport.alias,
     };
   } else {
     throw new Error(
@@ -60,10 +60,4 @@ function hasValidAlias(value: Record<string, unknown>): boolean {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return Object.prototype.toString.call(value) === "[object Object]";
-}
-
-function mapAlias(
-  extImport: ExtImport,
-): Partial<Pick<AppSpec.ExtImport, "alias">> {
-  return extImport.alias !== undefined ? { alias: extImport.alias } : {};
 }

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -11,7 +11,6 @@ export interface NamedExtImport {
 export interface DefaultExtImport {
   importDefault: string;
   from: AppSpec.ExtImport["path"];
-  alias?: string;
 }
 
 export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
@@ -27,7 +26,6 @@ export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
       kind: "default",
       name: extImport.importDefault,
       path: extImport.from,
-      alias: extImport.alias,
     };
   } else {
     throw new Error(
@@ -49,8 +47,7 @@ function isDefaultExtImport(value: unknown): value is DefaultExtImport {
   return (
     isObject(value) &&
     typeof value.importDefault === "string" &&
-    typeof value.from === "string" &&
-    hasValidAlias(value)
+    typeof value.from === "string"
   );
 }
 

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -11,6 +11,7 @@ export interface NamedExtImport {
 export interface DefaultExtImport {
   importDefault: string;
   from: AppSpec.ExtImport["path"];
+  alias?: string;
 }
 
 export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
@@ -19,12 +20,14 @@ export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
       kind: "named",
       name: extImport.import,
       path: extImport.from,
+      ...mapAlias(extImport),
     };
   } else if (isDefaultExtImport(extImport)) {
     return {
       kind: "default",
       name: extImport.importDefault,
       path: extImport.from,
+      ...mapAlias(extImport),
     };
   } else {
     throw new Error(
@@ -46,7 +49,8 @@ function isDefaultExtImport(value: unknown): value is DefaultExtImport {
   return (
     isObject(value) &&
     typeof value.importDefault === "string" &&
-    typeof value.from === "string"
+    typeof value.from === "string" &&
+    hasValidAlias(value)
   );
 }
 
@@ -56,4 +60,10 @@ function hasValidAlias(value: Record<string, unknown>): boolean {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+function mapAlias(
+  extImport: ExtImport,
+): Partial<Pick<AppSpec.ExtImport, "alias">> {
+  return extImport.alias !== undefined ? { alias: extImport.alias } : {};
 }

--- a/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedExpr/Combinators.hs
+++ b/waspc/src/Wasp/Analyzer/Evaluator/Evaluation/TypedExpr/Combinators.hs
@@ -161,7 +161,7 @@ extImport = evaluation' . withCtx $ \ctx -> \case
     --   figure out that is better (it sounds/feels like it could be).
     case AppSpec.ExtImport.parseExtImportPath extImportPath of
       Left err -> mkParseError ctx err
-      Right importPath -> pure $ AppSpec.ExtImport.ExtImport name importPath
+      Right importPath -> pure $ AppSpec.ExtImport.ExtImport name importPath Nothing
   expr -> Left $ ER.mkEvaluationError ctx $ ER.ExpectedType T.ExtImportType (TypedAST.exprType expr)
   where
     mkParseError ctx msg = Left $ ER.mkEvaluationError ctx $ ER.ParseError $ ER.EvaluationParseError msg

--- a/waspc/src/Wasp/AppSpec/ExtImport.hs
+++ b/waspc/src/Wasp/AppSpec/ExtImport.hs
@@ -11,7 +11,7 @@ module Wasp.AppSpec.ExtImport
 where
 
 import Control.Arrow (left)
-import Data.Aeson (FromJSON (parseJSON), withObject, (.:))
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
 import Data.Aeson.Types (ToJSON)
 import Data.Data (Data)
 import Data.List (stripPrefix)
@@ -24,7 +24,9 @@ data ExtImport = ExtImport
   { -- | What is being imported.
     name :: ExtImportName,
     -- | Path from which we are importing.
-    path :: ExtImportPath
+    path :: ExtImportPath,
+    -- | Local alias used in the Wasp config.
+    alias :: Maybe Identifier
   }
   deriving (Show, Eq, Data)
 
@@ -33,9 +35,10 @@ instance FromJSON ExtImport where
     kindStr <- o .: "kind"
     nameStr <- o .: "name"
     pathStr <- o .: "path"
+    aliasStr <- o .:? "alias"
     extImportName <- parseExtImportName kindStr nameStr
     extImportPath <- either fail pure $ parseExtImportPath pathStr
-    return $ ExtImport extImportName extImportPath
+    return $ ExtImport extImportName extImportPath aliasStr
     where
       parseExtImportName kindStr nameStr = case kindStr of
         "default" -> pure $ ExtImportModule nameStr
@@ -54,9 +57,11 @@ data ExtImportName
   deriving (Show, Eq, Data, Generic, FromJSON, ToJSON)
 
 importIdentifier :: ExtImport -> Identifier
-importIdentifier (ExtImport importName _) = case importName of
-  ExtImportModule n -> n
-  ExtImportField n -> n
+importIdentifier (ExtImport importName _ maybeAlias) = case maybeAlias of
+  Just aliasName -> aliasName
+  Nothing -> case importName of
+    ExtImportModule n -> n
+    ExtImportField n -> n
 
 parseExtImportPath :: String -> Either String ExtImportPath
 parseExtImportPath extImportPath = case stripImportPrefix extImportPath of

--- a/waspc/src/Wasp/Generator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/JsImport.hs
@@ -17,12 +17,11 @@ import Wasp.Generator.Common (GeneratedAppComponentSrcDir, dropExtensionFromImpo
 import Wasp.Generator.ExternalCodeGenerator.Common (GeneratedExternalCodeDir)
 import Wasp.JsImport
   ( JsImport (..),
-    JsImportKind (..),
     JsImportName (JsImportField, JsImportModule),
     JsImportPath (RelativeImportPath),
     getJsDynamicImportExpression,
     getJsImportStmtAndIdentifier,
-    makeValueJsImport,
+    makeJsImport,
   )
 import Wasp.Project.Common (srcDirInWaspProjectDir)
 
@@ -32,24 +31,23 @@ extImportToJsImport ::
   Path Posix (Rel importLocation) (Dir d) ->
   EI.ExtImport ->
   JsImport
-extImportToJsImport pathFromSrcDirToExtCodeDir pathFromImportLocationToSrcDir extImport = makeValueJsImport (RelativeImportPath importPath) importName
+extImportToJsImport pathFromSrcDirToExtCodeDir pathFromImportLocationToSrcDir extImport = makeJsImport (RelativeImportPath importPath) importName
   where
+    userDefinedPathInExtSrcDir = SP.castRel $ EI.path extImport :: Path Posix (Rel GeneratedExternalCodeDir) File'
     importName = extImportNameToJsImportName $ EI.name extImport
     importPath = SP.castRel $ pathFromImportLocationToSrcDir </> pathFromSrcDirToExtCodeDir </> userDefinedPathInExtSrcDir
-    userDefinedPathInExtSrcDir = SP.castRel $ EI.path extImport :: Path Posix (Rel GeneratedExternalCodeDir) File'
 
 extImportNameToJsImportName :: EI.ExtImportName -> JsImportName
 extImportNameToJsImportName (EI.ExtImportModule name) = JsImportModule name
 extImportNameToJsImportName (EI.ExtImportField name) = JsImportField name
 
 jsImportToImportJson :: Maybe JsImport -> Aeson.Value
-jsImportToImportJson = maybe notDefinedImportJsonData mkImportJsonData
+jsImportToImportJson maybeJsImport = maybe notDefinedValue mkTmplData maybeJsImport
   where
-    notDefinedImportJsonData :: Aeson.Value
-    notDefinedImportJsonData = object ["isDefined" .= False]
+    notDefinedValue = object ["isDefined" .= False]
 
-    mkImportJsonData :: JsImport -> Aeson.Value
-    mkImportJsonData jsImport =
+    mkTmplData :: JsImport -> Aeson.Value
+    mkTmplData jsImport =
       let (jsImportStmt, jsImportIdentifier) = getJsImportStmtAndIdentifier jsImport
        in object
             [ "isDefined" .= True,
@@ -59,17 +57,16 @@ jsImportToImportJson = maybe notDefinedImportJsonData mkImportJsonData
             ]
 
 extImportToRelativeSrcImportFromViteExecution :: EI.ExtImport -> JsImport
-extImportToRelativeSrcImportFromViteExecution extImport@(EI.ExtImport extImportName extImportPath) =
+extImportToRelativeSrcImportFromViteExecution extImport@(EI.ExtImport extImportName extImportPath _) =
   JsImport
-    { _kind = ValueImport,
-      _path = RelativeImportPath importPath,
+    { _path = RelativeImportPath relativePath,
       _name = importName,
       _importAlias = Just $ getAliasedExtImportIdentifier extImport
     }
   where
-    importName = extImportNameToJsImportName extImportName
-    importPath = SP.castRel $ dropExtensionFromImportPath $ projectSrcDir </> extImportPath
+    relativePath = SP.castRel $ dropExtensionFromImportPath $ projectSrcDir </> extImportPath
     projectSrcDir = fromJust (SP.relDirToPosix srcDirInWaspProjectDir)
+    importName = extImportNameToJsImportName extImportName
 
 getAliasedExtImportIdentifier :: EI.ExtImport -> String
 getAliasedExtImportIdentifier extImport = EI.importIdentifier extImport ++ "_ext"

--- a/waspc/src/Wasp/Generator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/JsImport.hs
@@ -17,11 +17,12 @@ import Wasp.Generator.Common (GeneratedAppComponentSrcDir, dropExtensionFromImpo
 import Wasp.Generator.ExternalCodeGenerator.Common (GeneratedExternalCodeDir)
 import Wasp.JsImport
   ( JsImport (..),
+    JsImportKind (..),
     JsImportName (JsImportField, JsImportModule),
     JsImportPath (RelativeImportPath),
     getJsDynamicImportExpression,
     getJsImportStmtAndIdentifier,
-    makeJsImport,
+    makeValueJsImport,
   )
 import Wasp.Project.Common (srcDirInWaspProjectDir)
 
@@ -31,23 +32,24 @@ extImportToJsImport ::
   Path Posix (Rel importLocation) (Dir d) ->
   EI.ExtImport ->
   JsImport
-extImportToJsImport pathFromSrcDirToExtCodeDir pathFromImportLocationToSrcDir extImport = makeJsImport (RelativeImportPath importPath) importName
+extImportToJsImport pathFromSrcDirToExtCodeDir pathFromImportLocationToSrcDir extImport = makeValueJsImport (RelativeImportPath importPath) importName
   where
-    userDefinedPathInExtSrcDir = SP.castRel $ EI.path extImport :: Path Posix (Rel GeneratedExternalCodeDir) File'
     importName = extImportNameToJsImportName $ EI.name extImport
     importPath = SP.castRel $ pathFromImportLocationToSrcDir </> pathFromSrcDirToExtCodeDir </> userDefinedPathInExtSrcDir
+    userDefinedPathInExtSrcDir = SP.castRel $ EI.path extImport :: Path Posix (Rel GeneratedExternalCodeDir) File'
 
 extImportNameToJsImportName :: EI.ExtImportName -> JsImportName
 extImportNameToJsImportName (EI.ExtImportModule name) = JsImportModule name
 extImportNameToJsImportName (EI.ExtImportField name) = JsImportField name
 
 jsImportToImportJson :: Maybe JsImport -> Aeson.Value
-jsImportToImportJson maybeJsImport = maybe notDefinedValue mkTmplData maybeJsImport
+jsImportToImportJson = maybe notDefinedImportJsonData mkImportJsonData
   where
-    notDefinedValue = object ["isDefined" .= False]
+    notDefinedImportJsonData :: Aeson.Value
+    notDefinedImportJsonData = object ["isDefined" .= False]
 
-    mkTmplData :: JsImport -> Aeson.Value
-    mkTmplData jsImport =
+    mkImportJsonData :: JsImport -> Aeson.Value
+    mkImportJsonData jsImport =
       let (jsImportStmt, jsImportIdentifier) = getJsImportStmtAndIdentifier jsImport
        in object
             [ "isDefined" .= True,
@@ -59,14 +61,15 @@ jsImportToImportJson maybeJsImport = maybe notDefinedValue mkTmplData maybeJsImp
 extImportToRelativeSrcImportFromViteExecution :: EI.ExtImport -> JsImport
 extImportToRelativeSrcImportFromViteExecution extImport@(EI.ExtImport extImportName extImportPath _) =
   JsImport
-    { _path = RelativeImportPath relativePath,
+    { _kind = ValueImport,
+      _path = RelativeImportPath importPath,
       _name = importName,
       _importAlias = Just $ getAliasedExtImportIdentifier extImport
     }
   where
-    relativePath = SP.castRel $ dropExtensionFromImportPath $ projectSrcDir </> extImportPath
-    projectSrcDir = fromJust (SP.relDirToPosix srcDirInWaspProjectDir)
     importName = extImportNameToJsImportName extImportName
+    importPath = SP.castRel $ dropExtensionFromImportPath $ projectSrcDir </> extImportPath
+    projectSrcDir = fromJust (SP.relDirToPosix srcDirInWaspProjectDir)
 
 getAliasedExtImportIdentifier :: EI.ExtImport -> String
 getAliasedExtImportIdentifier extImport = EI.importIdentifier extImport ++ "_ext"

--- a/waspc/src/Wasp/Generator/SdkGenerator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/JsImport.hs
@@ -16,7 +16,7 @@ import Wasp.Generator.SdkGenerator.Common
   ( extSrcDirInSdkRootDir,
     makeSdkImportPath,
   )
-import Wasp.JsImport (JsImport (..), JsImportKind (ValueImport), JsImportPath (..))
+import Wasp.JsImport (JsImport (..), JsImportPath (..))
 
 extImportToImportJson :: Maybe EI.ExtImport -> Aeson.Value
 extImportToImportJson maybeExtImport = GJI.jsImportToImportJson jsImport
@@ -30,10 +30,9 @@ extOperationImportToImportJson =
     . extImportToJsImport
 
 extImportToJsImport :: EI.ExtImport -> JsImport
-extImportToJsImport extImport@(EI.ExtImport extImportName extImportPath) =
+extImportToJsImport extImport@(EI.ExtImport extImportName extImportPath _) =
   JsImport
-    { _kind = ValueImport,
-      _path = ModuleImportPath importPath,
+    { _path = ModuleImportPath importPath,
       _name = importName,
       _importAlias = Just $ getAliasedExtImportIdentifier extImport
     }

--- a/waspc/src/Wasp/Generator/SdkGenerator/JsImport.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/JsImport.hs
@@ -16,7 +16,7 @@ import Wasp.Generator.SdkGenerator.Common
   ( extSrcDirInSdkRootDir,
     makeSdkImportPath,
   )
-import Wasp.JsImport (JsImport (..), JsImportPath (..))
+import Wasp.JsImport (JsImport (..), JsImportKind (ValueImport), JsImportPath (..))
 
 extImportToImportJson :: Maybe EI.ExtImport -> Aeson.Value
 extImportToImportJson maybeExtImport = GJI.jsImportToImportJson jsImport
@@ -32,7 +32,8 @@ extOperationImportToImportJson =
 extImportToJsImport :: EI.ExtImport -> JsImport
 extImportToJsImport extImport@(EI.ExtImport extImportName extImportPath _) =
   JsImport
-    { _path = ModuleImportPath importPath,
+    { _kind = ValueImport,
+      _path = ModuleImportPath importPath,
       _name = importName,
       _importAlias = Just $ getAliasedExtImportIdentifier extImport
     }

--- a/waspc/tests/Analyzer/EvaluatorTest.hs
+++ b/waspc/tests/Analyzer/EvaluatorTest.hs
@@ -209,8 +209,8 @@ spec_Evaluator = do
           `shouldBe` Right
             [ ( "Test",
                 Special
-                  [ ExtImport (ExtImportField "field") (fromJust $ SP.parseRelFileP "main.js"),
-                    ExtImport (ExtImportModule "main") (fromJust $ SP.parseRelFileP "main.js")
+                  [ ExtImport (ExtImportField "field") (fromJust $ SP.parseRelFileP "main.js") Nothing,
+                    ExtImport (ExtImportModule "main") (fromJust $ SP.parseRelFileP "main.js") Nothing
                   ]
                   (JSON $ Aeson.object ["key" Aeson..= (1 :: Integer)])
               )

--- a/waspc/tests/AnalyzerTest.hs
+++ b/waspc/tests/AnalyzerTest.hs
@@ -143,7 +143,7 @@ spec_Analyzer = do
                                 { Auth.usernameAndPassword =
                                     Just
                                       Auth.UsernameAndPasswordConfig
-                                        { Auth.userSignupFields = Just $ ExtImport (ExtImportField "getUserFields") (fromJust $ SP.parseRelFileP "auth/signup")
+                                        { Auth.userSignupFields = Just $ ExtImport (ExtImportField "getUserFields") (fromJust $ SP.parseRelFileP "auth/signup") Nothing
                                         },
                                   Auth.slack = Nothing,
                                   Auth.discord = Nothing,
@@ -169,7 +169,8 @@ spec_Analyzer = do
                               Just $
                                 ExtImport
                                   (ExtImportField "setupServer")
-                                  (fromJust $ SP.parseRelFileP "bar"),
+                                  (fromJust $ SP.parseRelFileP "bar")
+                                  Nothing,
                             Server.middlewareConfigFn = Nothing,
                             Server.envValidationSchema = Nothing
                           },
@@ -178,10 +179,10 @@ spec_Analyzer = do
                         Client.Client
                           { Client.setupFn =
                               Just $
-                                ExtImport (ExtImportField "setupClient") (fromJust $ SP.parseRelFileP "baz"),
+                                ExtImport (ExtImportField "setupClient") (fromJust $ SP.parseRelFileP "baz") Nothing,
                             Client.rootComponent =
                               Just $
-                                ExtImport (ExtImportField "App") (fromJust $ SP.parseRelFileP "App"),
+                                ExtImport (ExtImportField "App") (fromJust $ SP.parseRelFileP "App") Nothing,
                             Client.baseDir = Just "/",
                             Client.envValidationSchema = Nothing
                           },
@@ -193,12 +194,14 @@ spec_Analyzer = do
                                 [ ExtImport
                                     (ExtImportField "devSeedSimple")
                                     (fromJust $ SP.parseRelFileP "dbSeeds")
+                                    Nothing
                                 ],
                             Db.prismaSetupFn =
                               Just $
                                 ExtImport
                                   (ExtImportField "setUpPrisma")
                                   (fromJust $ SP.parseRelFileP "setUpPrisma")
+                                  Nothing
                           },
                     App.emailSender =
                       Just
@@ -223,7 +226,8 @@ spec_Analyzer = do
                   { Page.component =
                       ExtImport
                         (ExtImportModule "Home")
-                        (fromJust $ SP.parseRelFileP "pages/Main"),
+                        (fromJust $ SP.parseRelFileP "pages/Main")
+                        Nothing,
                     Page.authRequired = Nothing
                   }
               ),
@@ -232,7 +236,8 @@ spec_Analyzer = do
                   { Page.component =
                       ExtImport
                         (ExtImportField "profilePage")
-                        (fromJust $ SP.parseRelFileP "pages/Profile"),
+                        (fromJust $ SP.parseRelFileP "pages/Profile")
+                        Nothing,
                     Page.authRequired = Just True
                   }
               )
@@ -255,7 +260,8 @@ spec_Analyzer = do
                   { Query.fn =
                       ExtImport
                         (ExtImportField "getAllUsers")
-                        (fromJust $ SP.parseRelFileP "foo"),
+                        (fromJust $ SP.parseRelFileP "foo")
+                        Nothing,
                     Query.entities = Just [Ref "User"],
                     Query.auth = Nothing
                   }
@@ -269,7 +275,8 @@ spec_Analyzer = do
                   { Action.fn =
                       ExtImport
                         (ExtImportField "updateUser")
-                        (fromJust $ SP.parseRelFileP "foo"),
+                        (fromJust $ SP.parseRelFileP "foo")
+                        Nothing,
                     Action.entities = Just [Ref "User"],
                     Action.auth = Just True
                   }
@@ -282,6 +289,7 @@ spec_Analyzer = do
               ( ExtImport
                   (ExtImportField "backgroundJob")
                   (fromJust $ SP.parseRelFileP "jobs/baz")
+                  Nothing
               )
               ( Just $
                   Job.ExecutorOptions

--- a/waspc/tests/AppSpec/FromJSONTest.hs
+++ b/waspc/tests/AppSpec/FromJSONTest.hs
@@ -30,7 +30,17 @@ spec_AppSpecFromJSON = do
         `shouldDecodeTo` Just
           ( ExtImport.ExtImport
               { ExtImport.name = ExtImport.ExtImportField "foo",
-                ExtImport.path = [relfileP|folder/file.js|]
+                ExtImport.path = [relfileP|folder/file.js|],
+                ExtImport.alias = Nothing
+              }
+          )
+    it "parses a valid aliased ext import" $
+      extAliasedImportJson
+        `shouldDecodeTo` Just
+          ( ExtImport.ExtImport
+              { ExtImport.name = ExtImport.ExtImportField "foo",
+                ExtImport.path = [relfileP|folder/file.js|],
+                ExtImport.alias = Just "bar"
               }
           )
     it "parses a valid default ext import" $
@@ -38,7 +48,8 @@ spec_AppSpecFromJSON = do
         `shouldDecodeTo` Just
           ( ExtImport.ExtImport
               { ExtImport.name = ExtImport.ExtImportModule "foo",
-                ExtImport.path = [relfileP|folder/subfolder/file.js|]
+                ExtImport.path = [relfileP|folder/subfolder/file.js|],
+                ExtImport.alias = Nothing
               }
           )
     it "fails to parse an invalid of import" $ do
@@ -377,6 +388,7 @@ spec_AppSpecFromJSON = do
           )
   where
     extNamedImportJson = [trimming| { "kind": "named", "name" : "foo", "path": "@src/folder/file.js" }|]
+    extAliasedImportJson = [trimming| { "kind": "named", "name" : "foo", "path": "@src/folder/file.js", "alias": "bar" }|]
     extDefaultImportJson = [trimming| { "kind": "default", "name" : "foo", "path": "@src/folder/subfolder/file.js" }|]
 
     fooEntityRef = [trimming| { "name": "foo", "declType": "Entity" }|]

--- a/waspc/tests/AppSpec/ValidTest.hs
+++ b/waspc/tests/AppSpec/ValidTest.hs
@@ -655,7 +655,8 @@ spec_AppSpecValid = do
         { AS.Page.component =
             AS.ExtImport.ExtImport
               (AS.ExtImport.ExtImportModule "Home")
-              (fromJust $ SP.parseRelFileP "pages/Main"),
+              (fromJust $ SP.parseRelFileP "pages/Main")
+              Nothing,
           AS.Page.authRequired = Nothing
         }
 
@@ -762,3 +763,4 @@ spec_AppSpecValid = do
       AS.ExtImport.ExtImport
         (AS.ExtImport.ExtImportModule "Dummy")
         (fromJust $ SP.parseRelFileP "dummy/File")
+        Nothing

--- a/waspc/tests/Generator/CrudTest.hs
+++ b/waspc/tests/Generator/CrudTest.hs
@@ -79,7 +79,8 @@ spec_GeneratorCrudTest = do
                               Just $
                                 AS.ExtImport.ExtImport
                                   { AS.ExtImport.name = AS.ExtImport.ExtImportField "getTask",
-                                    AS.ExtImport.path = SP.castRel [relfileP|bla/tasks.js|]
+                                    AS.ExtImport.path = SP.castRel [relfileP|bla/tasks.js|],
+                                    AS.ExtImport.alias = Nothing
                                   }
                           }
                       ),

--- a/waspc/tests/Generator/JsImportTest.hs
+++ b/waspc/tests/Generator/JsImportTest.hs
@@ -17,13 +17,21 @@ spec_GeneratorJsImportTest = do
         extImport =
           ExtImport
             { name = ExtImportModule "test",
-              path = [SP.relfileP|folder/test.js|]
+              path = [SP.relfileP|folder/test.js|],
+              alias = Nothing
             }
     it "makes a JsImport from ExtImport" $ do
       extImportToJsImport pathToExtCodeDir pathFromImportLocationToExtCodeDir extImport
         `shouldBe` JI.JsImport
-          { JI._kind = JI.ValueImport,
-            JI._path = JI.RelativeImportPath [SP.relfileP|../src/folder/test.js|],
+          { JI._path = JI.RelativeImportPath [SP.relfileP|../src/folder/test.js|],
             JI._name = JsImportModule "test",
             JI._importAlias = Nothing
           }
+    it "uses alias metadata for generated ExtImport identifiers" $ do
+      getAliasedExtImportIdentifier extImport {alias = Just "testAlias"}
+        `shouldBe` "testAlias_ext"
+    it "avoids collisions for same exported name with different aliases" $ do
+      let firstImport = extImport {name = ExtImportField "handler", path = [SP.relfileP|one.js|], alias = Just "oneHandler"}
+          secondImport = extImport {name = ExtImportField "handler", path = [SP.relfileP|two.js|], alias = Just "twoHandler"}
+      getAliasedExtImportIdentifier <$> [firstImport, secondImport]
+        `shouldBe` ["oneHandler_ext", "twoHandler_ext"]

--- a/waspc/tests/Generator/JsImportTest.hs
+++ b/waspc/tests/Generator/JsImportTest.hs
@@ -23,7 +23,8 @@ spec_GeneratorJsImportTest = do
     it "makes a JsImport from ExtImport" $ do
       extImportToJsImport pathToExtCodeDir pathFromImportLocationToExtCodeDir extImport
         `shouldBe` JI.JsImport
-          { JI._path = JI.RelativeImportPath [SP.relfileP|../src/folder/test.js|],
+          { JI._kind = JI.ValueImport,
+            JI._path = JI.RelativeImportPath [SP.relfileP|../src/folder/test.js|],
             JI._name = JsImportModule "test",
             JI._importAlias = Nothing
           }


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Adds alias metadata to internal ExtImport values and maps aliases from new-spec ExtImport literals.

This preserves current generated import behavior while allowing later import lowering to keep local alias information.

Stack:

1. https://github.com/wasp-lang/wasp/pull/4112
2. https://github.com/wasp-lang/wasp/pull/4113 (this PR)
3. https://github.com/wasp-lang/wasp/pull/4114
4. https://github.com/wasp-lang/wasp/pull/4115
5. https://github.com/wasp-lang/wasp/pull/4116
6. https://github.com/wasp-lang/wasp/pull/4117
7. https://github.com/wasp-lang/wasp/pull/4118

Validation:

- `npm run build` in `waspc/data/packages/wasp-config`
- `npm test -- __tests__/spec/extImport.unit.test.ts __tests__/spec/mapApp.unit.test.ts __tests__/spec-pipeline/importLoweringPlan.unit.test.ts __tests__/spec-pipeline/lowerSrcImports.unit.test.ts __tests__/spec-pipeline/pipeline.integration.test.ts __tests__/cli.unit.test.ts` in `waspc/data/packages/wasp-config`
- `./run build:hs`
- `git diff --check`

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.