### PR TITLE
[3/7] Accept new spec ExtImport input values

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
@@ -14,10 +14,20 @@ describe("ExtImport input types", () => {
 
     expectTypeOf(
       pageConfig.component,
-    ).toMatchTypeOf<TsAppSpec.CallableExtImportInput>();
-    expectTypeOf(
-      actionConfig.fn,
-    ).toMatchTypeOf<TsAppSpec.CallableExtImportInput>();
+    ).toExtend<TsAppSpec.CallableExtImportInput>();
+    expectTypeOf(actionConfig.fn).toExtend<TsAppSpec.CallableExtImportInput>();
+  });
+
+  test("should reject objects at callable ExtImport use sites", async () => {
+    const component = { render: () => null };
+
+    const pageConfig: TsAppSpec.Page = {
+      kind: "page",
+      // @ts-expect-error callable ExtImport sites accept descriptors or functions.
+      component,
+    };
+
+    expectTypeOf(pageConfig).toExtend<TsAppSpec.Page>();
   });
 
   test("should reject malformed descriptor-like objects", async () => {
@@ -27,6 +37,6 @@ describe("ExtImport input types", () => {
       component: { from: 42, importDefault: "X" },
     };
 
-    expectTypeOf(pageConfig).toMatchTypeOf<TsAppSpec.Page>();
+    expectTypeOf(pageConfig).toExtend<TsAppSpec.Page>();
   });
 });

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
@@ -1,0 +1,32 @@
+import { describe, expectTypeOf, test } from "vitest";
+import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
+
+describe("ExtImport input types", () => {
+  test("should accept functions at callable ExtImport use sites", async () => {
+    const component = () => null;
+    const operation = async () => null;
+
+    const pageConfig = { kind: "page", component } satisfies TsAppSpec.Page;
+    const actionConfig = {
+      kind: "action",
+      fn: operation,
+    } satisfies TsAppSpec.Action;
+
+    expectTypeOf(
+      pageConfig.component,
+    ).toMatchTypeOf<TsAppSpec.CallableExtImportInput>();
+    expectTypeOf(
+      actionConfig.fn,
+    ).toMatchTypeOf<TsAppSpec.CallableExtImportInput>();
+  });
+
+  test("should reject malformed descriptor-like objects", async () => {
+    const pageConfig: TsAppSpec.Page = {
+      kind: "page",
+      // @ts-expect-error descriptor-like objects must still satisfy ExtImport.
+      component: { from: 42, importDefault: "X" },
+    };
+
+    expectTypeOf(pageConfig).toMatchTypeOf<TsAppSpec.Page>();
+  });
+});

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, test } from "vitest";
-import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
+import type * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
 import type { AnyFunction } from "../../src/typeUtils.js";
 
 describe("ExtImport input types", () => {
@@ -19,7 +19,7 @@ describe("ExtImport input types", () => {
     expectTypeOf(actionConfig.fn).toExtend<TsAppSpec.ExtImport | AnyFunction>();
   });
 
-  test("should reject objects at ExtImport use sites", async () => {
+  test("should reject objects that are not ExtImport objects at ExtImport use sites", async () => {
     const component = { render: () => null };
 
     const pageConfig: TsAppSpec.Page = {

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
@@ -1,10 +1,11 @@
 import { describe, expectTypeOf, test } from "vitest";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
+import type { AnyFunction } from "../../src/typeUtils.js";
 
 describe("ExtImport input types", () => {
-  test("should accept functions at callable ExtImport use sites", async () => {
+  test("should accept functions at ExtImport use sites", async () => {
     const component = () => null;
-    const operation = async () => null;
+    const operation = async (_args: { id: string }) => null;
 
     const pageConfig = { kind: "page", component } satisfies TsAppSpec.Page;
     const actionConfig = {
@@ -12,18 +13,18 @@ describe("ExtImport input types", () => {
       fn: operation,
     } satisfies TsAppSpec.Action;
 
-    expectTypeOf(
-      pageConfig.component,
-    ).toExtend<TsAppSpec.CallableExtImportInput>();
-    expectTypeOf(actionConfig.fn).toExtend<TsAppSpec.CallableExtImportInput>();
+    expectTypeOf(pageConfig.component).toExtend<
+      TsAppSpec.ExtImport | AnyFunction
+    >();
+    expectTypeOf(actionConfig.fn).toExtend<TsAppSpec.ExtImport | AnyFunction>();
   });
 
-  test("should reject objects at callable ExtImport use sites", async () => {
+  test("should reject objects at ExtImport use sites", async () => {
     const component = { render: () => null };
 
     const pageConfig: TsAppSpec.Page = {
       kind: "page",
-      // @ts-expect-error callable ExtImport sites accept descriptors or functions.
+      // @ts-expect-error ExtImport use sites accept descriptors or functions.
       component,
     };
 

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -30,20 +30,10 @@ describe("mapExtImport", () => {
     const result = tryMapExtImport(extImport);
 
     assert(result.status === "error");
-    expect(result.error).toContain("runtime value");
+    expect(result.error).toContain(
+      "Got an import in the Wasp file that we couldn't process",
+    );
     expect(() => mapExtImport(extImport)).toThrowError(result.error);
-  });
-
-  test("formats invalid value diagnostics with import-form guidance", () => {
-    const result = tryMapExtImport(() => null);
-    assert(result.status === "error");
-    const message = result.error;
-
-    expect(message).toContain("runtime value");
-    expect(message).toContain("@src/*");
-    expect(message).toContain("ExtImport object");
-    expect(message).toContain("{ import, from, alias }");
-    expect(message).toContain("alias is optional");
   });
 
   function testMapExtImport(extImport: TsAppSpec.ExtImport): void {

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -26,16 +26,13 @@ describe("mapExtImport", () => {
     { extImport: () => null },
     { extImport: { parse: () => ({}) } },
     { extImport: { from: "@src/external" } },
-  ])(
-    "returns an error for invalid runtime values",
-    ({ extImport }) => {
-      const result = tryMapExtImport(extImport);
+  ])("returns an error for invalid runtime values", ({ extImport }) => {
+    const result = tryMapExtImport(extImport);
 
-      assert(result.status === "error");
-      expect(result.error).toContain("runtime value");
-      expect(() => mapExtImport(extImport)).toThrowError(result.error);
-    },
-  );
+    assert(result.status === "error");
+    expect(result.error).toContain("runtime value");
+    expect(() => mapExtImport(extImport)).toThrowError(result.error);
+  });
 
   test("formats invalid value diagnostics with import-form guidance", () => {
     const result = tryMapExtImport(() => null);

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -26,13 +26,16 @@ describe("mapExtImport", () => {
     { extImport: () => null },
     { extImport: { parse: () => ({}) } },
     { extImport: { from: "@src/external" } },
-  ])("returns an error for invalid runtime values", ({ extImport }) => {
-    const result = tryMapExtImport(extImport);
+  ])(
+    "returns an error for invalid runtime values",
+    ({ extImport }) => {
+      const result = tryMapExtImport(extImport);
 
-    assert(result.status === "error");
-    expect(result.error).toContain("runtime value");
-    expect(() => mapExtImport(extImport)).toThrowError(result.error);
-  });
+      assert(result.status === "error");
+      expect(result.error).toContain("runtime value");
+      expect(() => mapExtImport(extImport)).toThrowError(result.error);
+    },
+  );
 
   test("formats invalid value diagnostics with import-form guidance", () => {
     const result = tryMapExtImport(() => null);

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.unit.test.ts
@@ -1,6 +1,7 @@
+import assert from "node:assert";
 import { describe, expect, test } from "vitest";
 import type * as AppSpec from "../../src/appSpec.js";
-import { mapExtImport } from "../../src/spec/extImport.js";
+import { mapExtImport, tryMapExtImport } from "../../src/spec/extImport.js";
 import type * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
 import * as Fixtures from "./testFixtures.js";
 
@@ -21,10 +22,28 @@ describe("mapExtImport", () => {
     testMapExtImport(Fixtures.getExtImport("full", "default"));
   });
 
-  test("should throw for invalid descriptors", () => {
-    expect(() =>
-      mapExtImport({ from: "@src/external" } as unknown as TsAppSpec.ExtImport),
-    ).toThrow("Invalid ExtImport");
+  test.each([
+    { extImport: () => null },
+    { extImport: { parse: () => ({}) } },
+    { extImport: { from: "@src/external" } },
+  ])("returns an error for invalid runtime values", ({ extImport }) => {
+    const result = tryMapExtImport(extImport);
+
+    assert(result.status === "error");
+    expect(result.error).toContain("runtime value");
+    expect(() => mapExtImport(extImport)).toThrowError(result.error);
+  });
+
+  test("formats invalid value diagnostics with import-form guidance", () => {
+    const result = tryMapExtImport(() => null);
+    assert(result.status === "error");
+    const message = result.error;
+
+    expect(message).toContain("runtime value");
+    expect(message).toContain("@src/*");
+    expect(message).toContain("ExtImport object");
+    expect(message).toContain("{ import, from, alias }");
+    expect(message).toContain("alias is optional");
   });
 
   function testMapExtImport(extImport: TsAppSpec.ExtImport): void {

--- a/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
@@ -141,13 +141,17 @@ export type Config<T> = MinimalConfig<T> | FullConfig<T>;
 export type MinimalConfig<T> =
   T extends Branded<unknown, unknown>
     ? T
-    : T extends Array<infer Item>
-      ? Array<MinimalConfig<Item>>
-      : T extends object
-        ? keyof T extends never
-          ? EmptyObject
-          : MinimalConfigObject<T>
-        : T;
+    : T extends TsAppSpec.ExtImport
+      ? T
+      : T extends CallableValue
+        ? T
+        : T extends Array<infer Item>
+          ? Array<MinimalConfig<Item>>
+          : T extends object
+            ? keyof T extends never
+              ? EmptyObject
+              : MinimalConfigObject<T>
+            : T;
 
 type MinimalConfigObject<T> = {
   [K in keyof T as EmptyObject extends Pick<T, K> ? never : K]: MinimalConfig<
@@ -171,11 +175,15 @@ type EmptyObject = Record<string, never>;
 export type FullConfig<T> =
   T extends Branded<unknown, unknown>
     ? T
-    : T extends Array<infer Item>
-      ? Array<FullConfig<Item>>
-      : T extends object
-        ? FullConfigObject<T>
-        : T;
+    : T extends TsAppSpec.ExtImport
+      ? T
+      : T extends CallableValue
+        ? T
+        : T extends Array<infer Item>
+          ? Array<FullConfig<Item>>
+          : T extends object
+            ? FullConfigObject<T>
+            : T;
 
 type FullConfigObject<T> = {
   [K in keyof T]-?: FullConfig<T[K]>;
@@ -195,3 +203,6 @@ type ConfigScope = (typeof CONFIG_SCOPES)[number];
 function assertUnreachable(value: never): never {
   throw new Error(`Unhandled case: ${value}`);
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CallableValue = (...args: any[]) => any;

--- a/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
@@ -143,7 +143,7 @@ export type MinimalConfig<T> =
     ? T
     : T extends TsAppSpec.ExtImport
       ? T
-      : T extends CallableValue
+      : T extends AnyFunction
         ? T
         : T extends Array<infer Item>
           ? Array<MinimalConfig<Item>>
@@ -177,7 +177,7 @@ export type FullConfig<T> =
     ? T
     : T extends TsAppSpec.ExtImport
       ? T
-      : T extends CallableValue
+      : T extends AnyFunction
         ? T
         : T extends Array<infer Item>
           ? Array<FullConfig<Item>>
@@ -204,5 +204,4 @@ function assertUnreachable(value: never): never {
   throw new Error(`Unhandled case: ${value}`);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type CallableValue = (...args: any[]) => any;
+type AnyFunction = (...args: never[]) => unknown;

--- a/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
@@ -14,6 +14,7 @@ import {
   route,
 } from "../../src/spec/publicApi/index.js";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
+import type { AnyFunction } from "../../src/typeUtils.js";
 
 export function getMinimalApp(): TsAppSpec.App {
   return app({
@@ -203,5 +204,3 @@ type ConfigScope = (typeof CONFIG_SCOPES)[number];
 function assertUnreachable(value: never): never {
   throw new Error(`Unhandled case: ${value}`);
 }
-
-type AnyFunction = (...args: never[]) => unknown;

--- a/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
@@ -138,21 +138,20 @@ export type Config<T> = MinimalConfig<T> | FullConfig<T>;
  * - Arrays recurse into element type.
  * - Objects keep only required keys (collapse to EmptyObject when none remain).
  * - Primitives pass through.
+ * - Functions pass through.
  */
 export type MinimalConfig<T> =
   T extends Branded<unknown, unknown>
     ? T
-    : T extends TsAppSpec.ExtImport
+    : T extends AnyFunction
       ? T
-      : T extends AnyFunction
-        ? T
-        : T extends Array<infer Item>
-          ? Array<MinimalConfig<Item>>
-          : T extends object
-            ? keyof T extends never
-              ? EmptyObject
-              : MinimalConfigObject<T>
-            : T;
+      : T extends Array<infer Item>
+        ? Array<MinimalConfig<Item>>
+        : T extends object
+          ? keyof T extends never
+            ? EmptyObject
+            : MinimalConfigObject<T>
+          : T;
 
 type MinimalConfigObject<T> = {
   [K in keyof T as EmptyObject extends Pick<T, K> ? never : K]: MinimalConfig<
@@ -172,19 +171,18 @@ type EmptyObject = Record<string, never>;
  * - Arrays recurse into element type.
  * - Objects strip every `?` and recurse.
  * - Primitives pass through.
+ * - Functions pass through.
  */
 export type FullConfig<T> =
   T extends Branded<unknown, unknown>
     ? T
-    : T extends TsAppSpec.ExtImport
+    : T extends AnyFunction
       ? T
-      : T extends AnyFunction
-        ? T
-        : T extends Array<infer Item>
-          ? Array<FullConfig<Item>>
-          : T extends object
-            ? FullConfigObject<T>
-            : T;
+      : T extends Array<infer Item>
+        ? Array<FullConfig<Item>>
+        : T extends object
+          ? FullConfigObject<T>
+          : T;
 
 type FullConfigObject<T> = {
   [K in keyof T]-?: FullConfig<T[K]>;

--- a/waspc/data/packages/wasp-config/src/result.ts
+++ b/waspc/data/packages/wasp-config/src/result.ts
@@ -1,0 +1,7 @@
+/**
+ * Use Result instead of exceptions when expected failures should be reported
+ * without stack traces and kept visible in the type system.
+ */
+export type Result<Value, Error> =
+  | { status: "ok"; value: Value }
+  | { status: "error"; error: Error };

--- a/waspc/data/packages/wasp-config/src/spec/appAnalyzer.ts
+++ b/waspc/data/packages/wasp-config/src/spec/appAnalyzer.ts
@@ -1,4 +1,5 @@
 import * as AppSpec from "../appSpec.js";
+import type { Result } from "../result.js";
 import { mapApp } from "./mapApp.js";
 import * as TsAppSpec from "./publicApi/tsAppSpec.js";
 
@@ -61,12 +62,3 @@ function isApp(value: unknown): value is TsAppSpec.App {
     "parts" in value
   );
 }
-
-/**
- * Result type is used instead of exceptions for the normal control flow because:
- * - The error users see with the Result type is nicer (no stack trace).
- * - Exceptions can slip through the type system.
- */
-type Result<Value, Error> =
-  | { status: "ok"; value: Value }
-  | { status: "error"; error: Error };

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -1,4 +1,5 @@
 import type * as AppSpec from "../appSpec.js";
+import type { Result } from "../result.js";
 
 export type ExtImport = NamedExtImport | DefaultExtImport;
 
@@ -13,24 +14,40 @@ export interface DefaultExtImport {
   from: AppSpec.ExtImport["path"];
 }
 
-export function mapExtImport(extImport: ExtImport): AppSpec.ExtImport {
+export function mapExtImport(extImport: unknown): AppSpec.ExtImport {
+  const result = tryMapExtImport(extImport);
+  if (result.status === "ok") return result.value;
+
+  throw new Error(result.error);
+}
+
+export function tryMapExtImport(
+  extImport: unknown,
+): Result<AppSpec.ExtImport, string> {
   if (isNamedExtImport(extImport)) {
     return {
-      kind: "named",
-      name: extImport.import,
-      path: extImport.from,
-      alias: extImport.alias,
+      status: "ok",
+      value: {
+        kind: "named",
+        name: extImport.import,
+        path: extImport.from,
+        alias: extImport.alias,
+      },
     };
   } else if (isDefaultExtImport(extImport)) {
     return {
-      kind: "default",
-      name: extImport.importDefault,
-      path: extImport.from,
+      status: "ok",
+      value: {
+        kind: "default",
+        name: extImport.importDefault,
+        path: extImport.from,
+      },
     };
   } else {
-    throw new Error(
-      "Invalid ExtImport: neither `import` nor `importDefault` is defined",
-    );
+    return {
+      status: "error",
+      error: invalidExtImportError,
+    };
   }
 }
 
@@ -50,6 +67,12 @@ function isDefaultExtImport(value: unknown): value is DefaultExtImport {
     typeof value.from === "string"
   );
 }
+
+const invalidExtImportError =
+  "Invalid ExtImport value: got a runtime value that is not a valid ExtImport. " +
+  "Import values from @src/* so Wasp can rewrite them automatically, " +
+  "or provide an ExtImport object directly: " +
+  "{ import, from, alias } or { importDefault, from } (alias is optional for named imports).";
 
 function hasValidAlias(value: Record<string, unknown>): boolean {
   return value.alias === undefined || typeof value.alias === "string";

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -44,6 +44,10 @@ export function tryMapExtImport(
       },
     };
   } else {
+    const invalidExtImportError =
+      "Got an import in the Wasp file that we couldn't process: " +
+      JSON.stringify(extImport) +
+      "\nYou either used a value you imported from outside of @src/ or didn't write the ExtImport object correctly.";
     return {
       status: "error",
       error: invalidExtImportError,
@@ -67,12 +71,6 @@ function isDefaultExtImport(value: unknown): value is DefaultExtImport {
     typeof value.from === "string"
   );
 }
-
-const invalidExtImportError =
-  "Invalid ExtImport value: got a runtime value that is not a valid ExtImport. " +
-  "Import values from @src/* so Wasp can rewrite them automatically, " +
-  "or provide an ExtImport object directly: " +
-  "{ import, from, alias } or { importDefault, from } (alias is optional for named imports).";
 
 function hasValidAlias(value: Record<string, unknown>): boolean {
   return value.alias === undefined || typeof value.alias === "string";

--- a/waspc/data/packages/wasp-config/src/spec/extImport.ts
+++ b/waspc/data/packages/wasp-config/src/spec/extImport.ts
@@ -47,7 +47,7 @@ export function tryMapExtImport(
     const invalidExtImportError =
       "Got an import in the Wasp file that we couldn't process: " +
       JSON.stringify(extImport) +
-      "\nYou either used a value you imported from outside of @src/ or didn't write the ExtImport object correctly.";
+      '\nYou either used a value you imported from outside of "@src/" or didn\'t write the ExtImport object correctly.';
     return {
       status: "error",
       error: invalidExtImportError,

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -7,7 +7,7 @@ import * as AppSpec from "../appSpec.js";
 import {
   formatExtImportInputError,
   mapExtImport,
-  mapExtImportInput,
+  tryMapExtImport,
 } from "./extImport.js";
 import * as TsAppSpec from "./publicApi/tsAppSpec.js";
 
@@ -221,9 +221,9 @@ function mapToDecls<T, DeclType extends AppSpec.Decl["declType"]>(
 export function deriveExtImportName(
   extImport: TsAppSpec.CallableExtImportInput,
 ): string {
-  const result = mapExtImportInput(extImport);
+  const result = tryMapExtImport(extImport);
   if (result.status === "error") {
-    throw new Error(formatExtImportInputError(result.reason));
+    throw new Error(formatExtImportInputError(result.error));
   }
 
   return result.value.alias ?? result.value.name;

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -4,7 +4,11 @@
  */
 
 import * as AppSpec from "../appSpec.js";
-import { mapExtImport } from "./extImport.js";
+import {
+  formatExtImportInputError,
+  mapExtImport,
+  mapExtImportInput,
+} from "./extImport.js";
 import * as TsAppSpec from "./publicApi/tsAppSpec.js";
 
 export function mapApp(
@@ -214,11 +218,15 @@ function mapToDecls<T, DeclType extends AppSpec.Decl["declType"]>(
   }));
 }
 
-export function deriveExtImportName(extImport: TsAppSpec.ExtImport): string {
-  if ("import" in extImport) {
-    return extImport.alias ?? extImport.import;
+export function deriveExtImportName(
+  extImport: TsAppSpec.CallableExtImportInput,
+): string {
+  const result = mapExtImportInput(extImport);
+  if (result.status === "error") {
+    throw new Error(formatExtImportInputError(result.reason));
   }
-  return extImport.importDefault;
+
+  return result.value.alias ?? result.value.name;
 }
 
 /**

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -4,6 +4,7 @@
  */
 
 import * as AppSpec from "../appSpec.js";
+import type { AnyFunction } from "../typeUtils.js";
 import {
   formatExtImportInputError,
   mapExtImport,
@@ -219,7 +220,7 @@ function mapToDecls<T, DeclType extends AppSpec.Decl["declType"]>(
 }
 
 export function deriveExtImportName(
-  extImport: TsAppSpec.CallableExtImportInput,
+  extImport: TsAppSpec.ExtImport | AnyFunction,
 ): string {
   const result = tryMapExtImport(extImport);
   if (result.status === "error") {

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -5,11 +5,7 @@
 
 import * as AppSpec from "../appSpec.js";
 import type { AnyFunction } from "../typeUtils.js";
-import {
-  formatExtImportInputError,
-  mapExtImport,
-  tryMapExtImport,
-} from "./extImport.js";
+import { mapExtImport, tryMapExtImport } from "./extImport.js";
 import * as TsAppSpec from "./publicApi/tsAppSpec.js";
 
 export function mapApp(
@@ -224,7 +220,7 @@ export function deriveExtImportName(
 ): string {
   const result = tryMapExtImport(extImport);
   if (result.status === "error") {
-    throw new Error(formatExtImportInputError(result.error));
+    throw new Error(result.error);
   }
 
   return result.value.alias ?? result.value.name;

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -223,7 +223,9 @@ export function deriveExtImportName(
     throw new Error(result.error);
   }
 
-  return result.value.alias ?? result.value.name;
+  return "alias" in result.value
+    ? (result.value.alias ?? result.value.name)
+    : result.value.name;
 }
 
 /**

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -1,4 +1,4 @@
-import type { ExtImport } from "../extImport.js";
+import type { CallableExtImportInput } from "../extImport.js";
 
 export type App = {
   name: string;
@@ -13,7 +13,7 @@ export type Part = Page | Route | Query | Action;
 export type Page = MakePart<
   "page",
   {
-    component: ExtImport;
+    component: CallableExtImportInput;
     authRequired?: boolean;
   }
 >;
@@ -32,7 +32,7 @@ export type Route = MakePart<
 export type Query = MakePart<
   "query",
   {
-    fn: ExtImport;
+    fn: CallableExtImportInput;
     entities?: string[];
     auth?: boolean;
   }
@@ -41,13 +41,14 @@ export type Query = MakePart<
 export type Action = MakePart<
   "action",
   {
-    fn: ExtImport;
+    fn: CallableExtImportInput;
     entities?: string[];
     auth?: boolean;
   }
 >;
 
 export type {
+  CallableExtImportInput,
   DefaultExtImport,
   ExtImport,
   NamedExtImport,

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -1,4 +1,5 @@
-import type { CallableExtImportInput } from "../extImport.js";
+import type { AnyFunction } from "../../typeUtils.js";
+import type { ExtImport } from "../extImport.js";
 
 export type App = {
   name: string;
@@ -13,7 +14,7 @@ export type Part = Page | Route | Query | Action;
 export type Page = MakePart<
   "page",
   {
-    component: CallableExtImportInput;
+    component: ExtImport | AnyFunction;
     authRequired?: boolean;
   }
 >;
@@ -32,7 +33,7 @@ export type Route = MakePart<
 export type Query = MakePart<
   "query",
   {
-    fn: CallableExtImportInput;
+    fn: ExtImport | AnyFunction;
     entities?: string[];
     auth?: boolean;
   }
@@ -41,14 +42,13 @@ export type Query = MakePart<
 export type Action = MakePart<
   "action",
   {
-    fn: CallableExtImportInput;
+    fn: ExtImport | AnyFunction;
     entities?: string[];
     auth?: boolean;
   }
 >;
 
 export type {
-  CallableExtImportInput,
   DefaultExtImport,
   ExtImport,
   NamedExtImport,

--- a/waspc/data/packages/wasp-config/src/typeUtils.ts
+++ b/waspc/data/packages/wasp-config/src/typeUtils.ts
@@ -1,0 +1,1 @@
+export type AnyFunction = (...args: never[]) => unknown;


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Lets new TS spec callable ExtImport fields accept either ExtImport literals or imported function values.

If an imported value reaches the mapper at runtime, Wasp reports an actionable error. That means import lowering did not run successfully.

Stack:

1. https://github.com/wasp-lang/wasp/pull/4112
2. https://github.com/wasp-lang/wasp/pull/4113
3. https://github.com/wasp-lang/wasp/pull/4114 (this PR)
4. https://github.com/wasp-lang/wasp/pull/4115
5. https://github.com/wasp-lang/wasp/pull/4116
6. https://github.com/wasp-lang/wasp/pull/4117
7. https://github.com/wasp-lang/wasp/pull/4118

Validation:

- `npm run build` in `waspc/data/packages/wasp-config`
- `npm test -- __tests__/spec/extImport.unit.test.ts __tests__/spec/extImport.test-d.ts __tests__/spec/mapApp.unit.test.ts __tests__/spec-pipeline/importLoweringPlan.unit.test.ts __tests__/spec-pipeline/lowerSrcImports.unit.test.ts __tests__/spec-pipeline/pipeline.integration.test.ts __tests__/cli.unit.test.ts` in `waspc/data/packages/wasp-config`
- `./run build:hs`
- `git diff --check`

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.