### PR TITLE
[6/7] Analyze Wasp TS specs in one Node invocation

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/cli.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/cli.unit.test.ts
@@ -7,6 +7,7 @@ describe("parseProcessArgsOrThrow", () => {
       "analyze",
       "main.wasp.ts",
       "tsconfig.wasp.json",
+      "main.wasp.js",
       "output.json",
       JSON.stringify(["entity1"]),
     ]);
@@ -17,12 +18,13 @@ describe("parseProcessArgsOrThrow", () => {
       "analyze",
       "main.wasp.ts",
       "tsconfig.wasp.json",
+      "main.wasp.js",
       "output.json",
       "[]",
     ]);
   });
 
-  test("should throw an error if less than 7 arguments", () => {
+  test("should throw an error if less than 8 arguments", () => {
     expectParseProcessArgsToError([
       "analyze",
       "main.wasp.ts",
@@ -31,11 +33,12 @@ describe("parseProcessArgsOrThrow", () => {
     ]);
   });
 
-  test("should throw an error if more than 7 arguments", () => {
+  test("should throw an error if more than 8 arguments", () => {
     expectParseProcessArgsToError([
       "analyze",
       "main.wasp.ts",
       "tsconfig.wasp.json",
+      "main.wasp.js",
       "output.json",
       "[]",
       "extraArg",
@@ -47,6 +50,7 @@ describe("parseProcessArgsOrThrow", () => {
       "compile",
       "main.wasp.ts",
       "tsconfig.wasp.json",
+      "main.wasp.js",
       "output.json",
       "[]",
     ]);
@@ -57,6 +61,7 @@ describe("parseProcessArgsOrThrow", () => {
       "analyze",
       undefined,
       "tsconfig.wasp.json",
+      "main.wasp.js",
       "output.json",
       JSON.stringify(["entity1"]),
     ] as string[]);
@@ -66,6 +71,18 @@ describe("parseProcessArgsOrThrow", () => {
     expectParseProcessArgsToError([
       "analyze",
       "main.wasp.ts",
+      undefined,
+      "main.wasp.js",
+      "output.json",
+      JSON.stringify(["entity1"]),
+    ] as string[]);
+  });
+
+  test("should throw an error if compiledWaspTsSpecPath is not a string", () => {
+    expectParseProcessArgsToError([
+      "analyze",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
       undefined,
       "output.json",
       JSON.stringify(["entity1"]),
@@ -77,6 +94,7 @@ describe("parseProcessArgsOrThrow", () => {
       "analyze",
       "main.wasp.ts",
       "tsconfig.wasp.json",
+      "main.wasp.js",
       undefined,
       JSON.stringify(["entity1"]),
     ] as string[]);
@@ -87,6 +105,7 @@ describe("parseProcessArgsOrThrow", () => {
       "analyze",
       "main.wasp.ts",
       "tsconfig.wasp.json",
+      "main.wasp.js",
       "output.json",
       undefined,
     ] as string[]);
@@ -97,6 +116,7 @@ describe("parseProcessArgsOrThrow", () => {
       "analyze",
       "main.wasp.ts",
       "tsconfig.wasp.json",
+      "main.wasp.js",
       "output.json",
       JSON.stringify({ entity1: "entity1" }),
     ]);
@@ -105,11 +125,18 @@ describe("parseProcessArgsOrThrow", () => {
   function expectParseProcessArgsToSucceed(args: string[]) {
     const result = parseProcessArgsOrThrow(["node", "run.js", ...args]);
 
-    const [_command, waspTsSpecPath, tsconfigPath, declsJsonPath, entityNames] =
-      args;
+    const [
+      _command,
+      waspTsSpecPath,
+      tsconfigPath,
+      compiledWaspTsSpecPath,
+      declsJsonPath,
+      entityNames,
+    ] = args;
     expect(result).toEqual({
       waspTsSpecPath,
       tsconfigPath,
+      compiledWaspTsSpecPath,
       declsJsonPath,
       entityNames: entityNames && JSON.parse(entityNames),
     });

--- a/waspc/data/packages/wasp-config/__tests__/cli.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/cli.unit.test.ts
@@ -105,8 +105,13 @@ describe("parseProcessArgsOrThrow", () => {
   function expectParseProcessArgsToSucceed(args: string[]) {
     const result = parseProcessArgsOrThrow(["node", "run.js", ...args]);
 
-    const [_command, waspTsSpecPath, tsconfigPath, outputFilePath, entityNames] =
-      args;
+    const [
+      _command,
+      waspTsSpecPath,
+      tsconfigPath,
+      outputFilePath,
+      entityNames,
+    ] = args;
     expect(result).toEqual({
       waspTsSpecPath,
       tsconfigPath,

--- a/waspc/data/packages/wasp-config/__tests__/cli.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/cli.unit.test.ts
@@ -4,31 +4,68 @@ import { parseProcessArgsOrThrow } from "../src/cli.js";
 describe("parseProcessArgsOrThrow", () => {
   test("should parse arguments correctly", () => {
     expectParseProcessArgsToSucceed([
-      "main.wasp.js",
+      "analyze",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
       "output.json",
       JSON.stringify(["entity1"]),
     ]);
   });
 
   test("should parse 0 entities correctly", () => {
-    expectParseProcessArgsToSucceed(["main.wasp.js", "output.json", "[]"]);
+    expectParseProcessArgsToSucceed([
+      "analyze",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
+      "output.json",
+      "[]",
+    ]);
   });
 
-  test("should throw an error if less than 5 arguments", () => {
-    expectParseProcessArgsToError(["main.wasp.js", "output.json"]);
-  });
-
-  test("should throw an error if more than 5 arguments", () => {
+  test("should throw an error if less than 7 arguments", () => {
     expectParseProcessArgsToError([
-      "main.wasp.js",
+      "analyze",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
+      "output.json",
+    ]);
+  });
+
+  test("should throw an error if more than 7 arguments", () => {
+    expectParseProcessArgsToError([
+      "analyze",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
       "output.json",
       "[]",
       "extraArg",
     ]);
   });
 
+  test("should throw an error if command is unsupported", () => {
+    expectParseProcessArgsToError([
+      "compile",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
+      "output.json",
+      "[]",
+    ]);
+  });
+
   test("should throw an error if waspTsSpecPath is not a string", () => {
     expectParseProcessArgsToError([
+      "analyze",
+      undefined,
+      "tsconfig.wasp.json",
+      "output.json",
+      JSON.stringify(["entity1"]),
+    ] as string[]);
+  });
+
+  test("should throw an error if tsconfigPath is not a string", () => {
+    expectParseProcessArgsToError([
+      "analyze",
+      "main.wasp.ts",
       undefined,
       "output.json",
       JSON.stringify(["entity1"]),
@@ -37,7 +74,9 @@ describe("parseProcessArgsOrThrow", () => {
 
   test("should throw an error if outputFilePath is not a string", () => {
     expectParseProcessArgsToError([
-      "main.wasp.js",
+      "analyze",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
       undefined,
       JSON.stringify(["entity1"]),
     ] as string[]);
@@ -45,7 +84,9 @@ describe("parseProcessArgsOrThrow", () => {
 
   test("should throw an error if any entityNames is not a string", () => {
     expectParseProcessArgsToError([
-      "main.wasp.js",
+      "analyze",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
       "output.json",
       undefined,
     ] as string[]);
@@ -53,7 +94,9 @@ describe("parseProcessArgsOrThrow", () => {
 
   test("should throw an error if the entity names JSON is not an array", () => {
     expectParseProcessArgsToError([
-      "main.wasp.js",
+      "analyze",
+      "main.wasp.ts",
+      "tsconfig.wasp.json",
       "output.json",
       JSON.stringify({ entity1: "entity1" }),
     ]);
@@ -62,9 +105,11 @@ describe("parseProcessArgsOrThrow", () => {
   function expectParseProcessArgsToSucceed(args: string[]) {
     const result = parseProcessArgsOrThrow(["node", "run.js", ...args]);
 
-    const [waspTsSpecPath, outputFilePath, entityNames] = args;
+    const [_command, waspTsSpecPath, tsconfigPath, outputFilePath, entityNames] =
+      args;
     expect(result).toEqual({
       waspTsSpecPath,
+      tsconfigPath,
       outputFilePath,
       entityNames: entityNames && JSON.parse(entityNames),
     });

--- a/waspc/data/packages/wasp-config/__tests__/cli.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/cli.unit.test.ts
@@ -72,7 +72,7 @@ describe("parseProcessArgsOrThrow", () => {
     ] as string[]);
   });
 
-  test("should throw an error if outputFilePath is not a string", () => {
+  test("should throw an error if declsJsonPath is not a string", () => {
     expectParseProcessArgsToError([
       "analyze",
       "main.wasp.ts",
@@ -105,17 +105,12 @@ describe("parseProcessArgsOrThrow", () => {
   function expectParseProcessArgsToSucceed(args: string[]) {
     const result = parseProcessArgsOrThrow(["node", "run.js", ...args]);
 
-    const [
-      _command,
-      waspTsSpecPath,
-      tsconfigPath,
-      outputFilePath,
-      entityNames,
-    ] = args;
+    const [_command, waspTsSpecPath, tsconfigPath, declsJsonPath, entityNames] =
+      args;
     expect(result).toEqual({
       waspTsSpecPath,
       tsconfigPath,
-      outputFilePath,
+      declsJsonPath,
       entityNames: entityNames && JSON.parse(entityNames),
     });
   }

--- a/waspc/data/packages/wasp-config/src/cli.ts
+++ b/waspc/data/packages/wasp-config/src/cli.ts
@@ -1,12 +1,12 @@
 export function parseProcessArgsOrThrow(args: string[]): {
   waspTsSpecPath: string;
   tsconfigPath: string;
-  outputFilePath: string;
+  declsJsonPath: string;
   entityNames: string[];
 } {
   if (args.length !== 7 || args[2] !== "analyze") {
     throw new Error(
-      "Usage: node run.js analyze <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to output file> <entity names json>",
+      "Usage: node run.js analyze <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to declarations JSON file> <entity names json>",
     );
   }
 
@@ -16,17 +16,17 @@ export function parseProcessArgsOrThrow(args: string[]): {
     _command,
     waspTsSpecPath,
     tsconfigPath,
-    outputFilePath,
+    declsJsonPath,
     entityNamesJson,
   ] = args;
   if (
     typeof waspTsSpecPath !== "string" ||
     typeof tsconfigPath !== "string" ||
-    typeof outputFilePath !== "string" ||
+    typeof declsJsonPath !== "string" ||
     typeof entityNamesJson !== "string"
   ) {
     throw new Error(
-      "All arguments must be strings: <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to output file> <entity names json>",
+      "All arguments must be strings: <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to declarations JSON file> <entity names json>",
     );
   }
 
@@ -35,7 +35,7 @@ export function parseProcessArgsOrThrow(args: string[]): {
   return {
     waspTsSpecPath,
     tsconfigPath,
-    outputFilePath,
+    declsJsonPath,
     entityNames,
   };
 }

--- a/waspc/data/packages/wasp-config/src/cli.ts
+++ b/waspc/data/packages/wasp-config/src/cli.ts
@@ -1,12 +1,13 @@
 export function parseProcessArgsOrThrow(args: string[]): {
   waspTsSpecPath: string;
   tsconfigPath: string;
+  compiledWaspTsSpecPath: string;
   declsJsonPath: string;
   entityNames: string[];
 } {
-  if (args.length !== 7 || args[2] !== "analyze") {
+  if (args.length !== 8 || args[2] !== "analyze") {
     throw new Error(
-      "Usage: node run.js analyze <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to declarations JSON file> <entity names json>",
+      "Usage: node run.js analyze <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to compiled main.wasp.js> <path to declarations JSON file> <entity names json>",
     );
   }
 
@@ -16,17 +17,19 @@ export function parseProcessArgsOrThrow(args: string[]): {
     _command,
     waspTsSpecPath,
     tsconfigPath,
+    compiledWaspTsSpecPath,
     declsJsonPath,
     entityNamesJson,
   ] = args;
   if (
     typeof waspTsSpecPath !== "string" ||
     typeof tsconfigPath !== "string" ||
+    typeof compiledWaspTsSpecPath !== "string" ||
     typeof declsJsonPath !== "string" ||
     typeof entityNamesJson !== "string"
   ) {
     throw new Error(
-      "All arguments must be strings: <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to declarations JSON file> <entity names json>",
+      "All arguments must be strings: <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to compiled main.wasp.js> <path to declarations JSON file> <entity names json>",
     );
   }
 
@@ -35,6 +38,7 @@ export function parseProcessArgsOrThrow(args: string[]): {
   return {
     waspTsSpecPath,
     tsconfigPath,
+    compiledWaspTsSpecPath,
     declsJsonPath,
     entityNames,
   };

--- a/waspc/data/packages/wasp-config/src/cli.ts
+++ b/waspc/data/packages/wasp-config/src/cli.ts
@@ -1,22 +1,32 @@
 export function parseProcessArgsOrThrow(args: string[]): {
   waspTsSpecPath: string;
+  tsconfigPath: string;
   outputFilePath: string;
   entityNames: string[];
 } {
-  if (args.length !== 5) {
+  if (args.length !== 7 || args[2] !== "analyze") {
     throw new Error(
-      "Usage: node run.js <path to main.wasp.js> <path to output file> <entity names json>",
+      "Usage: node run.js analyze <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to output file> <entity names json>",
     );
   }
 
-  const [_node, _runjs, waspTsSpecPath, outputFilePath, entityNamesJson] = args;
+  const [
+    _node,
+    _runjs,
+    _command,
+    waspTsSpecPath,
+    tsconfigPath,
+    outputFilePath,
+    entityNamesJson,
+  ] = args;
   if (
     typeof waspTsSpecPath !== "string" ||
+    typeof tsconfigPath !== "string" ||
     typeof outputFilePath !== "string" ||
     typeof entityNamesJson !== "string"
   ) {
     throw new Error(
-      "All arguments must be strings: <path to main.wasp.js> <path to output file> <entity names json>",
+      "All arguments must be strings: <path to main.wasp.ts> <path to tsconfig.wasp.json> <path to output file> <entity names json>",
     );
   }
 
@@ -24,6 +34,7 @@ export function parseProcessArgsOrThrow(args: string[]): {
 
   return {
     waspTsSpecPath,
+    tsconfigPath,
     outputFilePath,
     entityNames,
   };

--- a/waspc/data/packages/wasp-config/src/run.ts
+++ b/waspc/data/packages/wasp-config/src/run.ts
@@ -17,21 +17,21 @@ main(process.argv).catch((error: unknown) => {
  * and writes the output to a file.
  */
 async function main(args: string[]): Promise<void> {
-  const { waspTsSpecPath, tsconfigPath, outputFilePath, entityNames } =
+  const { waspTsSpecPath, tsconfigPath, declsJsonPath, entityNames } =
     parseProcessArgsOrThrow(args);
-  const compiledWaspJsPath = getCompiledWaspJsPath({
+  const compiledTsSpecPath = getCompiledTsSpecPath({
     waspTsSpecPath,
-    outputFilePath,
+    declsJsonPath,
   });
 
   await compileWaspTsFileToJsFile({
     inputPath: waspTsSpecPath,
     tsconfigPath,
-    outputPath: compiledWaspJsPath,
+    outputPath: compiledTsSpecPath,
   });
 
   const declsResult = await analyzeApp(
-    pathToFileURL(compiledWaspJsPath).href,
+    pathToFileURL(compiledTsSpecPath).href,
     entityNames,
   );
 
@@ -39,18 +39,18 @@ async function main(args: string[]): Promise<void> {
     throw new Error(declsResult.error);
   }
 
-  writeFileSync(outputFilePath, JSON.stringify(declsResult.value));
+  writeFileSync(declsJsonPath, JSON.stringify(declsResult.value));
 }
 
-function getCompiledWaspJsPath({
+function getCompiledTsSpecPath({
   waspTsSpecPath,
-  outputFilePath,
+  declsJsonPath,
 }: {
   waspTsSpecPath: string;
-  outputFilePath: string;
+  declsJsonPath: string;
 }): string {
   return join(
-    dirname(outputFilePath),
+    dirname(declsJsonPath),
     basename(waspTsSpecPath).replace(/\.ts$/, ".js"),
   );
 }

--- a/waspc/data/packages/wasp-config/src/run.ts
+++ b/waspc/data/packages/wasp-config/src/run.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { writeFileSync } from "fs";
-import { basename, dirname, join } from "path";
 import { pathToFileURL } from "url";
 import { parseProcessArgsOrThrow } from "./cli.js";
 import { analyzeApp } from "./legacy/appAnalyzer.js";
@@ -17,21 +16,22 @@ main(process.argv).catch((error: unknown) => {
  * and writes the output to a file.
  */
 async function main(args: string[]): Promise<void> {
-  const { waspTsSpecPath, tsconfigPath, declsJsonPath, entityNames } =
-    parseProcessArgsOrThrow(args);
-  const compiledTsSpecPath = getCompiledTsSpecPath({
+  const {
     waspTsSpecPath,
+    tsconfigPath,
+    compiledWaspTsSpecPath,
     declsJsonPath,
-  });
+    entityNames,
+  } = parseProcessArgsOrThrow(args);
 
   await compileWaspTsFileToJsFile({
     inputPath: waspTsSpecPath,
     tsconfigPath,
-    outputPath: compiledTsSpecPath,
+    outputPath: compiledWaspTsSpecPath,
   });
 
   const declsResult = await analyzeApp(
-    pathToFileURL(compiledTsSpecPath).href,
+    pathToFileURL(compiledWaspTsSpecPath).href,
     entityNames,
   );
 
@@ -40,17 +40,4 @@ async function main(args: string[]): Promise<void> {
   }
 
   writeFileSync(declsJsonPath, JSON.stringify(declsResult.value));
-}
-
-function getCompiledTsSpecPath({
-  waspTsSpecPath,
-  declsJsonPath,
-}: {
-  waspTsSpecPath: string;
-  declsJsonPath: string;
-}): string {
-  return join(
-    dirname(declsJsonPath),
-    basename(waspTsSpecPath).replace(/\.ts$/, ".js"),
-  );
 }

--- a/waspc/data/packages/wasp-config/src/run.ts
+++ b/waspc/data/packages/wasp-config/src/run.ts
@@ -5,7 +5,7 @@ import { basename, dirname, join } from "path";
 import { pathToFileURL } from "url";
 import { parseProcessArgsOrThrow } from "./cli.js";
 import { analyzeApp } from "./legacy/appAnalyzer.js";
-import { compileWaspTsToJs } from "./spec-pipeline/compile.js";
+import { compileWaspTsFileToJsFile } from "./spec-pipeline/compile/index.js";
 
 main(process.argv).catch((error: unknown) => {
   console.error(error instanceof Error ? error.message : error);
@@ -24,7 +24,7 @@ async function main(args: string[]): Promise<void> {
     outputFilePath,
   });
 
-  compileWaspTsToJs({
+  await compileWaspTsFileToJsFile({
     inputPath: waspTsSpecPath,
     tsconfigPath,
     outputPath: compiledWaspJsPath,

--- a/waspc/data/packages/wasp-config/src/run.ts
+++ b/waspc/data/packages/wasp-config/src/run.ts
@@ -1,25 +1,56 @@
 #!/usr/bin/env node
 
 import { writeFileSync } from "fs";
+import { basename, dirname, join } from "path";
+import { pathToFileURL } from "url";
 import { parseProcessArgsOrThrow } from "./cli.js";
 import { analyzeApp } from "./legacy/appAnalyzer.js";
+import { compileWaspTsToJs } from "./spec-pipeline/compile.js";
 
-main(process.argv);
+main(process.argv).catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});
 
 /**
  * Main function that processes command line arguments, analyzes the user app,
  * and writes the output to a file.
  */
 async function main(args: string[]): Promise<void> {
-  const { waspTsSpecPath, outputFilePath, entityNames } =
+  const { waspTsSpecPath, tsconfigPath, outputFilePath, entityNames } =
     parseProcessArgsOrThrow(args);
+  const compiledWaspJsPath = getCompiledWaspJsPath({
+    waspTsSpecPath,
+    outputFilePath,
+  });
 
-  const declsResult = await analyzeApp(waspTsSpecPath, entityNames);
+  compileWaspTsToJs({
+    inputPath: waspTsSpecPath,
+    tsconfigPath,
+    outputPath: compiledWaspJsPath,
+  });
+
+  const declsResult = await analyzeApp(
+    pathToFileURL(compiledWaspJsPath).href,
+    entityNames,
+  );
 
   if (declsResult.status === "error") {
-    console.error(declsResult.error);
-    process.exit(1);
+    throw new Error(declsResult.error);
   }
 
   writeFileSync(outputFilePath, JSON.stringify(declsResult.value));
+}
+
+function getCompiledWaspJsPath({
+  waspTsSpecPath,
+  outputFilePath,
+}: {
+  waspTsSpecPath: string;
+  outputFilePath: string;
+}): string {
+  return join(
+    dirname(outputFilePath),
+    basename(waspTsSpecPath).replace(/\.ts$/, ".js"),
+  );
 }

--- a/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
+++ b/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
@@ -9,6 +9,7 @@ import Control.Arrow (left)
 import Control.Concurrent (newChan)
 import Control.Concurrent.Async (concurrently)
 import Control.Monad.Except (ExceptT (ExceptT), liftEither, runExceptT)
+import Control.Monad.IO.Class (liftIO)
 import qualified Data.Aeson as Aeson
 import Data.Maybe (fromJust)
 import StrongPath
@@ -19,7 +20,6 @@ import StrongPath
     Rel,
     basename,
     castFile,
-    fromAbsDir,
     fromAbsFile,
     fromRelFile,
     relfile,
@@ -34,7 +34,7 @@ import qualified Wasp.CompileOptions as CompileOptions
 import qualified Wasp.Job as J
 import Wasp.Job.IO (readJobMessagesAndPrintThemPrefixed)
 import Wasp.Job.Process (runNodeCommandAsJob, runNodeCommandAsJobWithExtraEnv)
-import Wasp.NodePackageFFI (InstallablePackage (WaspConfigPackage), getInstallablePackageScriptInProject)
+import Wasp.NodePackageFFI (InstallablePackage (WaspConfigPackage), ensurePackageIsAtInstallationPathInProject, getInstallablePackageScriptInProject)
 import qualified Wasp.Project.BuildType as BuildType
 import Wasp.Project.Common
   ( CompileError,
@@ -63,6 +63,7 @@ analyzeWaspTsFile ::
   Path' Abs (File WaspTsFile) ->
   IO (Either [CompileError] [AS.Decl])
 analyzeWaspTsFile compileOptions prismaSchemaAst waspFilePath = runExceptT $ do
+  liftIO $ ensurePackageIsAtInstallationPathInProject compileOptions.waspProjectDir WaspConfigPackage
   compiledWaspJsFile <- ExceptT $ compileWaspTsFile compileOptions.waspProjectDir waspTsConfigFile waspFilePath
   declsJsonFile <- ExceptT $ executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst compiledWaspJsFile
   ExceptT $ readDecls prismaSchemaAst declsJsonFile
@@ -81,31 +82,12 @@ compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath =
       (readJobMessagesAndPrintThemPrefixed chan)
       ( runNodeCommandAsJob
           waspProjectDir
-          "npx"
-          -- We're using tsc to compile the *.wasp.ts file into a JS file.
-          --
-          -- The tsconfig.wasp.json is configured to give our users with the
-          -- best possible IDE support while coding the *.wasp.ts file.
-          --
-          -- When we actually want to compile the *.wasp.ts file, we must
-          -- override some of those rules.
-          --
-          -- Tehnically, some overrides could have been specified
-          -- in the tsconfig.wasp.json file, but we decided to keep them here
-          -- because it helps users avoid accidentally breaking things.
-          [ "tsc",
-            "-p",
+          "node"
+          [ fromRelFile $ getInstallablePackageScriptInProject WaspConfigPackage,
+            "compile",
+            fromAbsFile waspFilePath,
             fromAbsFile (waspProjectDir </> tsconfigNodeFileInWaspProjectDir),
-            -- The tsconfig.wasp.json file has the noEmit flag on.
-            -- The file only exists IDE support, and we don't want users to
-            -- accidentally chage the outDir.
-            --
-            -- Here, to actually generate the JS file in the desired location,
-            -- we must turn off the noEmit flag and specify the outDir.
-            "--noEmit",
-            "false",
-            "--outDir",
-            fromAbsDir outDir
+            fromAbsFile absCompiledWaspJsFile
           ]
           J.Wasp
           chan
@@ -114,10 +96,7 @@ compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath =
     ExitFailure _status -> Left ["Got TypeScript compiler errors for " ++ fromAbsFile waspFilePath ++ "."]
     ExitSuccess -> Right absCompiledWaspJsFile
   where
-    outDir = waspProjectDir </> dotWaspDirInWaspProjectDir
-    -- We know this will be the output JS file's location because it's how TSC
-    -- works (assuming we've specified the outDir, which we did).
-    absCompiledWaspJsFile = outDir </> compiledWaspJsFileInDotWaspDir
+    absCompiledWaspJsFile = waspProjectDir </> dotWaspDirInWaspProjectDir </> compiledWaspJsFileInDotWaspDir
     compiledWaspJsFileInDotWaspDir =
       castFile $
         replaceRelExtension (basename waspFilePath) ".js"

--- a/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
+++ b/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
@@ -14,12 +14,9 @@ import qualified Data.Aeson as Aeson
 import Data.Maybe (fromJust)
 import StrongPath
   ( Abs,
-    Dir,
     File,
     Path',
     Rel,
-    basename,
-    castFile,
     fromAbsFile,
     fromRelFile,
     relfile,
@@ -33,7 +30,7 @@ import Wasp.CompileOptions (CompileOptions)
 import qualified Wasp.CompileOptions as CompileOptions
 import qualified Wasp.Job as J
 import Wasp.Job.IO (readJobMessagesAndPrintThemPrefixed)
-import Wasp.Job.Process (runNodeCommandAsJob, runNodeCommandAsJobWithExtraEnv)
+import Wasp.Job.Process (runNodeCommandAsJobWithExtraEnv)
 import Wasp.NodePackageFFI (InstallablePackage (WaspConfigPackage), ensurePackageIsAtInstallationPathInProject, getInstallablePackageScriptInProject)
 import qualified Wasp.Project.BuildType as BuildType
 import Wasp.Project.Common
@@ -48,12 +45,8 @@ import Wasp.Project.Common
 import qualified Wasp.Psl.Ast.Model as Psl.Schema.Model
 import qualified Wasp.Psl.Ast.Schema as Psl.Schema
 import qualified Wasp.Psl.Ast.WithCtx as Psl.WithCtx
-import Wasp.Util (orElse)
 import Wasp.Util.Aeson (encodeToString)
 import qualified Wasp.Util.IO as IOUtil
-import Wasp.Util.StrongPath (replaceRelExtension)
-
-data CompiledWaspJsFile
 
 data AppSpecDeclsJsonFile
 
@@ -64,50 +57,18 @@ analyzeWaspTsFile ::
   IO (Either [CompileError] [AS.Decl])
 analyzeWaspTsFile compileOptions prismaSchemaAst waspFilePath = runExceptT $ do
   liftIO $ ensurePackageIsAtInstallationPathInProject compileOptions.waspProjectDir WaspConfigPackage
-  compiledWaspJsFile <- ExceptT $ compileWaspTsFile compileOptions.waspProjectDir waspTsConfigFile waspFilePath
-  declsJsonFile <- ExceptT $ executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst compiledWaspJsFile
+  declsJsonFile <- ExceptT $ runWaspConfigAnalyzerAndGetDeclsFile compileOptions prismaSchemaAst waspTsConfigFile waspFilePath
   ExceptT $ readDecls prismaSchemaAst declsJsonFile
   where
     waspTsConfigFile = fromJust tsConfigPathsInWaspTsProjects.waspTsConfig
 
-compileWaspTsFile ::
-  Path' Abs (Dir WaspProjectDir) ->
-  Path' (Rel WaspProjectDir) (File WaspTsConfigFile) ->
-  Path' Abs (File WaspTsFile) ->
-  IO (Either [CompileError] (Path' Abs (File CompiledWaspJsFile)))
-compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath = do
-  chan <- newChan
-  (_, tscExitCode) <-
-    concurrently
-      (readJobMessagesAndPrintThemPrefixed chan)
-      ( runNodeCommandAsJob
-          waspProjectDir
-          "node"
-          [ fromRelFile $ getInstallablePackageScriptInProject WaspConfigPackage,
-            "compile",
-            fromAbsFile waspFilePath,
-            fromAbsFile (waspProjectDir </> tsconfigNodeFileInWaspProjectDir),
-            fromAbsFile absCompiledWaspJsFile
-          ]
-          J.Wasp
-          chan
-      )
-  return $ case tscExitCode of
-    ExitFailure _status -> Left ["Got TypeScript compiler errors for " ++ fromAbsFile waspFilePath ++ "."]
-    ExitSuccess -> Right absCompiledWaspJsFile
-  where
-    absCompiledWaspJsFile = waspProjectDir </> dotWaspDirInWaspProjectDir </> compiledWaspJsFileInDotWaspDir
-    compiledWaspJsFileInDotWaspDir =
-      castFile $
-        replaceRelExtension (basename waspFilePath) ".js"
-          `orElse` error ("Couldn't calculate the compiled JS file path for " ++ fromAbsFile waspFilePath ++ ".")
-
-executeMainWaspJsFileAndGetDeclsFile ::
+runWaspConfigAnalyzerAndGetDeclsFile ::
   CompileOptions ->
   Psl.Schema.Schema ->
-  Path' Abs (File CompiledWaspJsFile) ->
+  Path' (Rel WaspProjectDir) (File WaspTsConfigFile) ->
+  Path' Abs (File WaspTsFile) ->
   IO (Either [CompileError] (Path' Abs (File AppSpecDeclsJsonFile)))
-executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst absCompiledMainWaspJsFile = do
+runWaspConfigAnalyzerAndGetDeclsFile compileOptions prismaSchemaAst tsconfigNodeFileInWaspProjectDir waspFilePath = do
   chan <- newChan
   (_, runExitCode) <- do
     concurrently
@@ -127,7 +88,9 @@ executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst absCompiledM
           compileOptions.waspProjectDir
           "node"
           [ fromRelFile $ getInstallablePackageScriptInProject WaspConfigPackage,
-            fromAbsFile absCompiledMainWaspJsFile,
+            "analyze",
+            fromAbsFile waspFilePath,
+            fromAbsFile (compileOptions.waspProjectDir </> tsconfigNodeFileInWaspProjectDir),
             fromAbsFile absDeclsOutputFile,
             -- When the user is coding main.wasp.ts, TypeScript must know about
             -- all the available entities to warn the user if they use an
@@ -138,7 +101,7 @@ executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst absCompiledM
           chan
       )
   case runExitCode of
-    ExitFailure _status -> return $ Left ["Error while running the compiled *.wasp.ts file."]
+    ExitFailure _status -> return $ Left ["Error while analyzing the *.wasp.ts file."]
     ExitSuccess -> return $ Right absDeclsOutputFile
   where
     absDeclsOutputFile = compileOptions.waspProjectDir </> dotWaspDirInWaspProjectDir </> [relfile|decls.json|]

--- a/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
+++ b/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
@@ -17,12 +17,15 @@ import StrongPath
     File,
     Path',
     Rel,
+    basename,
     fromAbsFile,
     fromRelFile,
+    parseRelFile,
     relfile,
     (</>),
   )
 import System.Exit (ExitCode (..))
+import qualified System.FilePath as FP
 import qualified Wasp.Analyzer as Analyzer
 import qualified Wasp.AppSpec as AS
 import Wasp.AppSpec.Core.Decl.JSON ()
@@ -50,12 +53,15 @@ import qualified Wasp.Util.IO as IOUtil
 
 data AppSpecDeclsJsonFile
 
+data CompiledWaspTsSpecFile
+
 analyzeWaspTsFile ::
   CompileOptions ->
   Psl.Schema.Schema ->
   Path' Abs (File WaspTsFile) ->
   IO (Either [CompileError] [AS.Decl])
 analyzeWaspTsFile compileOptions prismaSchemaAst waspFilePath = runExceptT $ do
+  -- TODO: replace this with require WaspConfigAvailable
   liftIO $ ensurePackageIsAtInstallationPathInProject compileOptions.waspProjectDir WaspConfigPackage
   declsJsonFile <- ExceptT $ runWaspConfigAnalyzerAndGetDeclsFile compileOptions prismaSchemaAst waspTsConfigFile waspFilePath
   ExceptT $ readDecls prismaSchemaAst declsJsonFile
@@ -68,7 +74,7 @@ runWaspConfigAnalyzerAndGetDeclsFile ::
   Path' (Rel WaspProjectDir) (File WaspTsConfigFile) ->
   Path' Abs (File WaspTsFile) ->
   IO (Either [CompileError] (Path' Abs (File AppSpecDeclsJsonFile)))
-runWaspConfigAnalyzerAndGetDeclsFile compileOptions prismaSchemaAst tsconfigNodeFileInWaspProjectDir waspFilePath = do
+runWaspConfigAnalyzerAndGetDeclsFile compileOptions prismaSchemaAst waspTsConfigFile waspFilePath = do
   chan <- newChan
   (_, runExitCode) <- do
     concurrently
@@ -90,7 +96,8 @@ runWaspConfigAnalyzerAndGetDeclsFile compileOptions prismaSchemaAst tsconfigNode
           [ fromRelFile $ getInstallablePackageScriptInProject WaspConfigPackage,
             "analyze",
             fromAbsFile waspFilePath,
-            fromAbsFile (compileOptions.waspProjectDir </> tsconfigNodeFileInWaspProjectDir),
+            fromAbsFile (compileOptions.waspProjectDir </> waspTsConfigFile),
+            fromAbsFile absCompiledWaspTsSpecOutputFile,
             fromAbsFile absDeclsOutputFile,
             -- When the user is coding main.wasp.ts, TypeScript must know about
             -- all the available entities to warn the user if they use an
@@ -105,6 +112,10 @@ runWaspConfigAnalyzerAndGetDeclsFile compileOptions prismaSchemaAst tsconfigNode
     ExitSuccess -> return $ Right absDeclsOutputFile
   where
     absDeclsOutputFile = compileOptions.waspProjectDir </> dotWaspDirInWaspProjectDir </> [relfile|decls.json|]
+    absCompiledWaspTsSpecOutputFile = compileOptions.waspProjectDir </> dotWaspDirInWaspProjectDir </> compiledWaspTsSpecOutputFile
+    compiledWaspTsSpecOutputFile :: Path' (Rel dotWaspDir) (File CompiledWaspTsSpecFile)
+    compiledWaspTsSpecOutputFile =
+      fromJust . parseRelFile . (`FP.replaceExtension` "js") . fromRelFile $ basename waspFilePath
     allowedEntityNames = Psl.Schema.Model.getName . Psl.WithCtx.getNode <$> Psl.Schema.getModels prismaSchemaAst
 
     nodeEnvForBuildType :: BuildType.BuildType -> String


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Adds `run.js analyze <main.wasp.ts> <tsconfig.wasp.json> <compiled main.wasp.js> <decls.json> <entity names json>` as the `wasp-config` entrypoint for Wasp TS analysis.

The command lowers and compiles Wasp TS through the virtual compile helper, writes the emitted JS to the explicit compiled spec path, runs the existing analyzer on that JS file, and writes `decls.json`. The Haskell analyzer now owns the `.wasp/` compiled JS location and passes it to `wasp-config` explicitly instead of letting `wasp-config` derive it from the declarations JSON path.

Stack:

1. https://github.com/wasp-lang/wasp/pull/4112
2. https://github.com/wasp-lang/wasp/pull/4113
3. https://github.com/wasp-lang/wasp/pull/4114
4. https://github.com/wasp-lang/wasp/pull/4115
5. https://github.com/wasp-lang/wasp/pull/4116
6. https://github.com/wasp-lang/wasp/pull/4117 (this PR)
7. https://github.com/wasp-lang/wasp/pull/4118

Validation:

- `npm run build` in `waspc/data/packages/wasp-config`
- `npm run test:unit -- cli` in `waspc/data/packages/wasp-config`
- `npm run test:integration -- pipeline` in `waspc/data/packages/wasp-config`
- `./run check:ormolu`
- `./run build`
- Targeted Prettier check on touched TS files
- `git diff --check`

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- CLI parser coverage. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.