### PR TITLE
Fix `validateEnv` plugin potentially keeping the Vite dev server alive

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -36,10 +36,21 @@ export function validateEnv(): Plugin {
         configFile: false,
         plugins: resolvedConfig.plugins
           .filter((plugin) => plugin.name !== PLUGIN_NAME)
+          // Vite's `configureServer`/`configurePreviewServer` hooks let plugins
+          // wire long-lived behavior into a dev or preview server: middleware,
+          // websocket handlers, file watchers, and similar background tasks.
+          //
+          // Plugins are supposed to clean these up by returning a teardown
+          // function from the hook, but some forget to, so resources they
+          // allocate end up outliving the server. This forces the original
+          // Vite process to be alive indefinitely.
+          //
+          // We don't need either hook to validate the client env schema.
+          // We only need module resolution and transforms.
           .map((plugin) => ({
-            ...plugin,                         // Strip hooks that are meant for long-lived dev/preview servers.
-            configureServer: undefined,        // Some plugins use them to start background tasks they never close.
-            configurePreviewServer: undefined, // This would keep our build hanging even after it's done.
+            ...plugin,
+            configureServer: undefined,
+            configurePreviewServer: undefined,
           })),
         // Minimize side effects from spinning up a temporary dev server.
         appType: 'custom',      // avoid HTML handling

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -34,9 +34,13 @@ export function validateEnv(): Plugin {
         // To ensure we pick up all user-defined plugins (resolution matches the main build)
         // while avoiding recursion. This includes the `wasp` plugin.
         configFile: false,
-        plugins: resolvedConfig.plugins.filter(
-          (plugin) => plugin.name !== PLUGIN_NAME
-        ),
+        plugins: resolvedConfig.plugins
+          .filter((plugin) => plugin.name !== PLUGIN_NAME)
+          .map((plugin) => ({
+            ...plugin,                         // Strip hooks that are meant for long-lived dev/preview servers.
+            configureServer: undefined,        // Some plugins use them to start background tasks they never close.
+            configurePreviewServer: undefined, // This would keep our build hanging even after it's done.
+          })),
         // Minimize side effects from spinning up a temporary dev server.
         appType: 'custom',      // avoid HTML handling
         server: { 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -753,7 +753,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/validateEnv.ts"
         ],
-        "e29136c690aa3c9a65692a9a680c78a92e15040db611af166798d2b5bf8c76bd"
+        "0fdf894207303eb8f9b072786a2fa3b69da84795db85631fdf32394686f3d863"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -33,9 +33,24 @@ export function validateEnv(): Plugin {
         // To ensure we pick up all user-defined plugins (resolution matches the main build)
         // while avoiding recursion. This includes the `wasp` plugin.
         configFile: false,
-        plugins: resolvedConfig.plugins.filter(
-          (plugin) => plugin.name !== PLUGIN_NAME
-        ),
+        plugins: resolvedConfig.plugins
+          .filter((plugin) => plugin.name !== PLUGIN_NAME)
+          // Vite's `configureServer`/`configurePreviewServer` hooks let plugins
+          // wire long-lived behavior into a dev or preview server: middleware,
+          // websocket handlers, file watchers, and similar background tasks.
+          //
+          // Plugins are supposed to clean these up by returning a teardown
+          // function from the hook, but some forget to, so resources they
+          // allocate end up outliving the server. This forces the original
+          // Vite process to be alive indefinitely.
+          //
+          // We don't need either hook to validate the client env schema.
+          // We only need module resolution and transforms.
+          .map((plugin) => ({
+            ...plugin,
+            configureServer: undefined,
+            configurePreviewServer: undefined,
+          })),
         // Minimize side effects from spinning up a temporary dev server.
         appType: 'custom',      // avoid HTML handling
         server: { 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/validateEnv.ts"
         ],
-        "e29136c690aa3c9a65692a9a680c78a92e15040db611af166798d2b5bf8c76bd"
+        "0fdf894207303eb8f9b072786a2fa3b69da84795db85631fdf32394686f3d863"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -33,9 +33,24 @@ export function validateEnv(): Plugin {
         // To ensure we pick up all user-defined plugins (resolution matches the main build)
         // while avoiding recursion. This includes the `wasp` plugin.
         configFile: false,
-        plugins: resolvedConfig.plugins.filter(
-          (plugin) => plugin.name !== PLUGIN_NAME
-        ),
+        plugins: resolvedConfig.plugins
+          .filter((plugin) => plugin.name !== PLUGIN_NAME)
+          // Vite's `configureServer`/`configurePreviewServer` hooks let plugins
+          // wire long-lived behavior into a dev or preview server: middleware,
+          // websocket handlers, file watchers, and similar background tasks.
+          //
+          // Plugins are supposed to clean these up by returning a teardown
+          // function from the hook, but some forget to, so resources they
+          // allocate end up outliving the server. This forces the original
+          // Vite process to be alive indefinitely.
+          //
+          // We don't need either hook to validate the client env schema.
+          // We only need module resolution and transforms.
+          .map((plugin) => ({
+            ...plugin,
+            configureServer: undefined,
+            configurePreviewServer: undefined,
+          })),
         // Minimize side effects from spinning up a temporary dev server.
         appType: 'custom',      // avoid HTML handling
         server: { 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/validateEnv.ts"
         ],
-        "e29136c690aa3c9a65692a9a680c78a92e15040db611af166798d2b5bf8c76bd"
+        "0fdf894207303eb8f9b072786a2fa3b69da84795db85631fdf32394686f3d863"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -33,9 +33,24 @@ export function validateEnv(): Plugin {
         // To ensure we pick up all user-defined plugins (resolution matches the main build)
         // while avoiding recursion. This includes the `wasp` plugin.
         configFile: false,
-        plugins: resolvedConfig.plugins.filter(
-          (plugin) => plugin.name !== PLUGIN_NAME
-        ),
+        plugins: resolvedConfig.plugins
+          .filter((plugin) => plugin.name !== PLUGIN_NAME)
+          // Vite's `configureServer`/`configurePreviewServer` hooks let plugins
+          // wire long-lived behavior into a dev or preview server: middleware,
+          // websocket handlers, file watchers, and similar background tasks.
+          //
+          // Plugins are supposed to clean these up by returning a teardown
+          // function from the hook, but some forget to, so resources they
+          // allocate end up outliving the server. This forces the original
+          // Vite process to be alive indefinitely.
+          //
+          // We don't need either hook to validate the client env schema.
+          // We only need module resolution and transforms.
+          .map((plugin) => ({
+            ...plugin,
+            configureServer: undefined,
+            configurePreviewServer: undefined,
+          })),
         // Minimize side effects from spinning up a temporary dev server.
         appType: 'custom',      // avoid HTML handling
         server: { 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/validateEnv.ts"
         ],
-        "e29136c690aa3c9a65692a9a680c78a92e15040db611af166798d2b5bf8c76bd"
+        "0fdf894207303eb8f9b072786a2fa3b69da84795db85631fdf32394686f3d863"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -33,9 +33,24 @@ export function validateEnv(): Plugin {
         // To ensure we pick up all user-defined plugins (resolution matches the main build)
         // while avoiding recursion. This includes the `wasp` plugin.
         configFile: false,
-        plugins: resolvedConfig.plugins.filter(
-          (plugin) => plugin.name !== PLUGIN_NAME
-        ),
+        plugins: resolvedConfig.plugins
+          .filter((plugin) => plugin.name !== PLUGIN_NAME)
+          // Vite's `configureServer`/`configurePreviewServer` hooks let plugins
+          // wire long-lived behavior into a dev or preview server: middleware,
+          // websocket handlers, file watchers, and similar background tasks.
+          //
+          // Plugins are supposed to clean these up by returning a teardown
+          // function from the hook, but some forget to, so resources they
+          // allocate end up outliving the server. This forces the original
+          // Vite process to be alive indefinitely.
+          //
+          // We don't need either hook to validate the client env schema.
+          // We only need module resolution and transforms.
+          .map((plugin) => ({
+            ...plugin,
+            configureServer: undefined,
+            configurePreviewServer: undefined,
+          })),
         // Minimize side effects from spinning up a temporary dev server.
         appType: 'custom',      // avoid HTML handling
         server: { 


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Solves https://github.com/wasp-lang/wasp/issues/4122

While this does solve this bug, I'd rather change our approach to be more similar to Astro.
They handle the environment validation separately (and before) bundle time.
That would be ideal, as we do try to treat it as such (we validate before any artifacts are created). This requires moving the env validation schema definitions outside of user's Wasp project.
Related: https://github.com/wasp-lang/wasp/issues/4093

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
