### PR TITLE
Use tsconfig.wasp.json path from Project.Common

### DIFF
--- a/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
+++ b/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
@@ -10,11 +10,11 @@ import Control.Concurrent (newChan)
 import Control.Concurrent.Async (concurrently)
 import Control.Monad.Except (ExceptT (ExceptT), liftEither, runExceptT)
 import qualified Data.Aeson as Aeson
+import Data.Maybe (fromJust)
 import StrongPath
   ( Abs,
     Dir,
     File,
-    File',
     Path',
     Rel,
     basename,
@@ -38,9 +38,12 @@ import Wasp.NodePackageFFI (InstallablePackage (WaspConfigPackage), getInstallab
 import qualified Wasp.Project.BuildType as BuildType
 import Wasp.Project.Common
   ( CompileError,
+    TsConfigPaths (..),
     WaspProjectDir,
+    WaspTsConfigFile,
     WaspTsFile,
     dotWaspDirInWaspProjectDir,
+    tsConfigPathsInWaspTsProjects,
   )
 import qualified Wasp.Psl.Ast.Model as Psl.Schema.Model
 import qualified Wasp.Psl.Ast.Schema as Psl.Schema
@@ -60,15 +63,15 @@ analyzeWaspTsFile ::
   Path' Abs (File WaspTsFile) ->
   IO (Either [CompileError] [AS.Decl])
 analyzeWaspTsFile compileOptions prismaSchemaAst waspFilePath = runExceptT $ do
-  -- TODO: I'm not yet sure where tsconfig.wasp.json location should come from
-  -- because we also need that knowledge when generating a TS SDK project.
-  compiledWaspJsFile <- ExceptT $ compileWaspTsFile compileOptions.waspProjectDir [relfile|tsconfig.wasp.json|] waspFilePath
+  compiledWaspJsFile <- ExceptT $ compileWaspTsFile compileOptions.waspProjectDir waspTsConfigFile waspFilePath
   declsJsonFile <- ExceptT $ executeMainWaspJsFileAndGetDeclsFile compileOptions prismaSchemaAst compiledWaspJsFile
   ExceptT $ readDecls prismaSchemaAst declsJsonFile
+  where
+    waspTsConfigFile = fromJust tsConfigPathsInWaspTsProjects.waspTsConfig
 
 compileWaspTsFile ::
   Path' Abs (Dir WaspProjectDir) ->
-  Path' (Rel WaspProjectDir) File' ->
+  Path' (Rel WaspProjectDir) (File WaspTsConfigFile) ->
   Path' Abs (File WaspTsFile) ->
   IO (Either [CompileError] (Path' Abs (File CompiledWaspJsFile)))
 compileWaspTsFile waspProjectDir tsconfigNodeFileInWaspProjectDir waspFilePath = do


### PR DESCRIPTION
## Description

Small follow-up to #3911. `analyzeWaspTsFile` was hardcoding `tsconfig.wasp.json` with a `TODO` about where the path should come from — turns out the path is now exposed as `tsConfigPathsInWaspTsProjects.waspTsConfig` in `Project.Common`, so we just use that. Also tightens `compileWaspTsFile`'s parameter type from `File'` to `File WaspTsConfigFile`.

No behavior change.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in \`examples/kitchen-sink/e2e-tests\`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in \`waspc/data/Cli/templates\`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in \`examples/\`, as needed.
    - [ ] _(if you updated \`examples/tutorials\`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in \`web/docs/\`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated \`waspc/ChangeLog.md\` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in \`web/docs/migration-guides/\`.
  - [ ] I **bumped the \`version\`** in \`waspc/waspc.cabal\` to reflect the changes I introduced.