### PR TITLE
Move query client initialization out of routes.tsx into queryClient.ts (#3986)

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/hooks.ts
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-query";
 import { Action, Query } from "./rpc";
 import { makeQueryCacheKey } from "./queries/core";
-export { configureQueryClient } from "./queryClient";
+export { configureQueryClient } from "./queryClient.config";
 
 // PUBLIC API
 export function useQuery<Input, Output>(

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/index.ts
@@ -15,6 +15,9 @@ export {
 export {
     // PUBLIC API
     configureQueryClient,
+} from './queryClient.config'
+
+export {
     // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/index.ts
@@ -16,7 +16,5 @@ export {
     // PUBLIC API
     configureQueryClient,
     // PRIVATE API (framework code)
-    initializeQueryClient,
-    // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.config.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.config.ts
@@ -1,0 +1,21 @@
+import type { QueryClientConfig } from '@tanstack/react-query'
+
+let queryClientConfig: QueryClientConfig | undefined;
+let isFrozen = false;
+
+// PUBLIC API
+export function configureQueryClient(config: QueryClientConfig): void {
+  if (isFrozen) {
+    throw new Error(
+      "Attempted to configure the QueryClient after initialization"
+    );
+  }
+
+  queryClientConfig = config;
+}
+
+// PRIVATE API (framework code) — only queryClient.ts should call this
+export function freezeAndGetConfig(): QueryClientConfig | undefined {
+  isFrozen = true;
+  return queryClientConfig;
+}

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.ts
@@ -1,34 +1,21 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+{{={= =}=}}
+import { QueryClient } from '@tanstack/react-query'
+import { freezeAndGetConfig } from './queryClient.config'
+
+{=# setupFn.isDefined =}
+{=& setupFn.importStatement =}
+
+await {= setupFn.importIdentifier =}()
+{=/ setupFn.isDefined =}
 
 const defaultQueryClientConfig = {};
 
-let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
+const queryClient = new QueryClient(
+  freezeAndGetConfig() ?? defaultQueryClientConfig
 );
 
-// PUBLIC API
-export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
-    throw new Error(
-      "Attempted to configure the QueryClient after initialization"
-    );
-  }
-
-  queryClientConfig = config;
-}
-
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
-}
+export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
+
+// PUBLIC API
+export { configureQueryClient } from './queryClient.config';

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.ts
@@ -16,6 +16,3 @@ const queryClient = new QueryClient(
 
 // PRIVATE API (framework code)
 export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
-
-// PUBLIC API
-export { configureQueryClient } from './queryClient.config';

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,6 +1,5 @@
 {{={= =}=}}
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
 
 {=# isAuthEnabled =}
@@ -10,10 +9,6 @@ import { createAuthRequiredPage } from "wasp/client/app"
 {=# rootComponent.isDefined =}
 {=& rootComponent.importStatement =}
 {=/ rootComponent.isDefined =}
-
-{=# setupFn.isDefined =}
-{=& setupFn.importStatement =}
-{=/ setupFn.isDefined =}
 
 {=# routes =}
 {=^ isLazy =}
@@ -52,12 +47,6 @@ const routesMapping = {
   {=/ isLazy =}
   {=/ routes =}
 } as const;
-
-{=# setupFn.isDefined =}
-await {= setupFn.importIdentifier =}()
-{=/ setupFn.isDefined =}
-
-initializeQueryClient()
 
 const rootElement =
   {=# rootComponent.isDefined =}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
@@ -111,6 +111,7 @@ wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
 wasp-app/.wasp/out/sdk/wasp/client/operations/internal/updateHandlersMap.js
 wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/queries/index.ts
+wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
 wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
@@ -468,6 +469,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.js
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.js

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -620,7 +620,7 @@
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "18055fc92d894ad5698840d99bb65f9d5a21bd96ba1e11d1e2e3433629df669d"
+        "8583719e957a42b3b1a6c1c9c76b57501ad99f37769cfba8ef837294c6645684"
     ],
     [
         [
@@ -669,7 +669,7 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "eedd0207c95b08b814b96b4c3337e995d83d8d52daf015db5bf35368f690f063"
+        "9e7fb55eddf69ee17792f81aee2b86e4d9a2444ea987511044f6489d8e07c8b9"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -613,14 +613,14 @@
             "file",
             "sdk/wasp/client/operations/hooks.ts"
         ],
-        "afb77720c5d690911c13a752996b93a8b0f5c8a02568ed59c45c1c401bb2b3fd"
+        "aa38f51bc28318b54e46669ad59028a4246e835ab7439d647608f0d5e067d3e5"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "edcdc3798590e62b778115b3818df8cc69fa5a8bb3a7fe9fa6d6d5ea706d14c4"
+        "18055fc92d894ad5698840d99bb65f9d5a21bd96ba1e11d1e2e3433629df669d"
     ],
     [
         [
@@ -660,9 +660,16 @@
     [
         [
             "file",
+            "sdk/wasp/client/operations/queryClient.config.ts"
+        ],
+        "d8b3d21f56cdcc240f80b8a8421610a990d10f02dfc1a1f5d33db92b001a292c"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "eedd0207c95b08b814b96b4c3337e995d83d8d52daf015db5bf35368f690f063"
     ],
     [
         [
@@ -788,7 +795,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "8a0c3b2d8606092106bbc604fc7d3052b3f5c4801871fc1622e26eff738f7062"
+        "71c2cd1f1f43cff9c3c843ab52833adb3a05a122b2b85ad6ff18dfff3282b78f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-query";
 import { Action, Query } from "./rpc";
 import { makeQueryCacheKey } from "./queries/core";
-export { configureQueryClient } from "./queryClient";
+export { configureQueryClient } from "./queryClient.config";
 
 // PUBLIC API
 export function useQuery<Input, Output>(

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -15,6 +15,9 @@ export {
 export {
     // PUBLIC API
     configureQueryClient,
+} from './queryClient.config'
+
+export {
     // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -16,7 +16,5 @@ export {
     // PUBLIC API
     configureQueryClient,
     // PRIVATE API (framework code)
-    initializeQueryClient,
-    // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
@@ -1,0 +1,21 @@
+import type { QueryClientConfig } from '@tanstack/react-query'
+
+let queryClientConfig: QueryClientConfig | undefined;
+let isFrozen = false;
+
+// PUBLIC API
+export function configureQueryClient(config: QueryClientConfig): void {
+  if (isFrozen) {
+    throw new Error(
+      "Attempted to configure the QueryClient after initialization"
+    );
+  }
+
+  queryClientConfig = config;
+}
+
+// PRIVATE API (framework code) — only queryClient.ts should call this
+export function freezeAndGetConfig(): QueryClientConfig | undefined {
+  isFrozen = true;
+  return queryClientConfig;
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -1,34 +1,18 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
+import { freezeAndGetConfig } from './queryClient.config'
+
+import { setup as setup_ext } from 'wasp/src/clientSetup'
+
+await setup_ext()
 
 const defaultQueryClientConfig = {};
 
-let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
+const queryClient = new QueryClient(
+  freezeAndGetConfig() ?? defaultQueryClientConfig
 );
 
-// PUBLIC API
-export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
-    throw new Error(
-      "Attempted to configure the QueryClient after initialization"
-    );
-  }
-
-  queryClientConfig = config;
-}
-
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
-}
+export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
+
+// PUBLIC API
+export { configureQueryClient } from './queryClient.config';

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -13,6 +13,3 @@ const queryClient = new QueryClient(
 
 // PRIVATE API (framework code)
 export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
-
-// PUBLIC API
-export { configureQueryClient } from './queryClient.config';

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,12 +1,9 @@
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
 
 import { createAuthRequiredPage } from "wasp/client/app"
 
 import { App as App_ext } from './src/App'
-
-import { setup as setup_ext } from './src/clientSetup'
 
 import { EagerPage } from './src/features/lazy-loading/pages/EagerPage'
 
@@ -176,10 +173,6 @@ const routesMapping = {
       ),
   },
 } as const;
-
-await setup_ext()
-
-initializeQueryClient()
 
 const rootElement =
   <App_ext />

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
@@ -34,6 +34,7 @@ wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
 wasp-app/.wasp/out/sdk/wasp/client/operations/internal/updateHandlersMap.js
 wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/queries/index.ts
+wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
 wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
@@ -160,6 +161,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.js
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.js

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -172,14 +172,14 @@
             "file",
             "sdk/wasp/client/operations/hooks.ts"
         ],
-        "afb77720c5d690911c13a752996b93a8b0f5c8a02568ed59c45c1c401bb2b3fd"
+        "aa38f51bc28318b54e46669ad59028a4246e835ab7439d647608f0d5e067d3e5"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "edcdc3798590e62b778115b3818df8cc69fa5a8bb3a7fe9fa6d6d5ea706d14c4"
+        "18055fc92d894ad5698840d99bb65f9d5a21bd96ba1e11d1e2e3433629df669d"
     ],
     [
         [
@@ -219,9 +219,16 @@
     [
         [
             "file",
+            "sdk/wasp/client/operations/queryClient.config.ts"
+        ],
+        "d8b3d21f56cdcc240f80b8a8421610a990d10f02dfc1a1f5d33db92b001a292c"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "8c4aebd988017167eb57f168946fa63b76f55a846b083c7097c651e429d29fd4"
     ],
     [
         [
@@ -347,7 +354,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "1da18649210169b8383b876b5c5fe708528e28e47f3acec333b7bb84304a8e8b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "18055fc92d894ad5698840d99bb65f9d5a21bd96ba1e11d1e2e3433629df669d"
+        "8583719e957a42b3b1a6c1c9c76b57501ad99f37769cfba8ef837294c6645684"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "8c4aebd988017167eb57f168946fa63b76f55a846b083c7097c651e429d29fd4"
+        "6828f0901620950b62198b719a592334658b85058c108bc5b95819b48173a8b0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-query";
 import { Action, Query } from "./rpc";
 import { makeQueryCacheKey } from "./queries/core";
-export { configureQueryClient } from "./queryClient";
+export { configureQueryClient } from "./queryClient.config";
 
 // PUBLIC API
 export function useQuery<Input, Output>(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -15,6 +15,9 @@ export {
 export {
     // PUBLIC API
     configureQueryClient,
+} from './queryClient.config'
+
+export {
     // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -16,7 +16,5 @@ export {
     // PUBLIC API
     configureQueryClient,
     // PRIVATE API (framework code)
-    initializeQueryClient,
-    // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
@@ -1,0 +1,21 @@
+import type { QueryClientConfig } from '@tanstack/react-query'
+
+let queryClientConfig: QueryClientConfig | undefined;
+let isFrozen = false;
+
+// PUBLIC API
+export function configureQueryClient(config: QueryClientConfig): void {
+  if (isFrozen) {
+    throw new Error(
+      "Attempted to configure the QueryClient after initialization"
+    );
+  }
+
+  queryClientConfig = config;
+}
+
+// PRIVATE API (framework code) — only queryClient.ts should call this
+export function freezeAndGetConfig(): QueryClientConfig | undefined {
+  isFrozen = true;
+  return queryClientConfig;
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -1,34 +1,15 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
+import { freezeAndGetConfig } from './queryClient.config'
+
 
 const defaultQueryClientConfig = {};
 
-let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
+const queryClient = new QueryClient(
+  freezeAndGetConfig() ?? defaultQueryClientConfig
 );
 
-// PUBLIC API
-export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
-    throw new Error(
-      "Attempted to configure the QueryClient after initialization"
-    );
-  }
-
-  queryClientConfig = config;
-}
-
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
-}
+export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
+
+// PUBLIC API
+export { configureQueryClient } from './queryClient.config';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -10,6 +10,3 @@ const queryClient = new QueryClient(
 
 // PRIVATE API (framework code)
 export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
-
-// PUBLIC API
-export { configureQueryClient } from './queryClient.config';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,7 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
-
 
 
 
@@ -15,9 +13,6 @@ const routesMapping = {
       ),
   },
 } as const;
-
-
-initializeQueryClient()
 
 const rootElement =
   undefined

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -276,17 +276,11 @@ function getSessionIdFromAuthorizationHeader(header) {
   }
 }
 const defaultQueryClientConfig = {};
-let resolveQueryClientInitialized;
-const queryClientInitialized = new Promise((resolve) => {
-  resolveQueryClientInitialized = resolve;
-});
-function initializeQueryClient() {
-  const queryClient = new QueryClient(defaultQueryClientConfig);
-  resolveQueryClientInitialized(queryClient);
-}
+const queryClient = new QueryClient(defaultQueryClientConfig);
+const queryClientInitialized = Promise.resolve(queryClient);
 function WaspApp({ children }) {
-  const queryClient = use(queryClientInitialized);
-  return /* @__PURE__ */ jsx(QueryClientProvider, { client: queryClient, children });
+  const queryClient2 = use(queryClientInitialized);
+  return /* @__PURE__ */ jsx(QueryClientProvider, { client: queryClient2, children });
 }
 const scriptRel = "modulepreload";
 const assetsURL = function(dep) {
@@ -394,7 +388,6 @@ const routesMapping = {
     )
   }
 };
-initializeQueryClient();
 const rootElement = void 0;
 const routeObjects = getRouteObjects({
   routesMapping,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
@@ -32,6 +32,7 @@ wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
 wasp-app/.wasp/out/sdk/wasp/client/operations/internal/updateHandlersMap.js
 wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/queries/index.ts
+wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
 wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
@@ -158,6 +159,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.js
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.js

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -172,14 +172,14 @@
             "file",
             "sdk/wasp/client/operations/hooks.ts"
         ],
-        "afb77720c5d690911c13a752996b93a8b0f5c8a02568ed59c45c1c401bb2b3fd"
+        "aa38f51bc28318b54e46669ad59028a4246e835ab7439d647608f0d5e067d3e5"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "edcdc3798590e62b778115b3818df8cc69fa5a8bb3a7fe9fa6d6d5ea706d14c4"
+        "18055fc92d894ad5698840d99bb65f9d5a21bd96ba1e11d1e2e3433629df669d"
     ],
     [
         [
@@ -219,9 +219,16 @@
     [
         [
             "file",
+            "sdk/wasp/client/operations/queryClient.config.ts"
+        ],
+        "d8b3d21f56cdcc240f80b8a8421610a990d10f02dfc1a1f5d33db92b001a292c"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "8c4aebd988017167eb57f168946fa63b76f55a846b083c7097c651e429d29fd4"
     ],
     [
         [
@@ -347,7 +354,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "1da18649210169b8383b876b5c5fe708528e28e47f3acec333b7bb84304a8e8b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "18055fc92d894ad5698840d99bb65f9d5a21bd96ba1e11d1e2e3433629df669d"
+        "8583719e957a42b3b1a6c1c9c76b57501ad99f37769cfba8ef837294c6645684"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "8c4aebd988017167eb57f168946fa63b76f55a846b083c7097c651e429d29fd4"
+        "6828f0901620950b62198b719a592334658b85058c108bc5b95819b48173a8b0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-query";
 import { Action, Query } from "./rpc";
 import { makeQueryCacheKey } from "./queries/core";
-export { configureQueryClient } from "./queryClient";
+export { configureQueryClient } from "./queryClient.config";
 
 // PUBLIC API
 export function useQuery<Input, Output>(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -15,6 +15,9 @@ export {
 export {
     // PUBLIC API
     configureQueryClient,
+} from './queryClient.config'
+
+export {
     // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -16,7 +16,5 @@ export {
     // PUBLIC API
     configureQueryClient,
     // PRIVATE API (framework code)
-    initializeQueryClient,
-    // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
@@ -1,0 +1,21 @@
+import type { QueryClientConfig } from '@tanstack/react-query'
+
+let queryClientConfig: QueryClientConfig | undefined;
+let isFrozen = false;
+
+// PUBLIC API
+export function configureQueryClient(config: QueryClientConfig): void {
+  if (isFrozen) {
+    throw new Error(
+      "Attempted to configure the QueryClient after initialization"
+    );
+  }
+
+  queryClientConfig = config;
+}
+
+// PRIVATE API (framework code) — only queryClient.ts should call this
+export function freezeAndGetConfig(): QueryClientConfig | undefined {
+  isFrozen = true;
+  return queryClientConfig;
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -1,34 +1,15 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
+import { freezeAndGetConfig } from './queryClient.config'
+
 
 const defaultQueryClientConfig = {};
 
-let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
+const queryClient = new QueryClient(
+  freezeAndGetConfig() ?? defaultQueryClientConfig
 );
 
-// PUBLIC API
-export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
-    throw new Error(
-      "Attempted to configure the QueryClient after initialization"
-    );
-  }
-
-  queryClientConfig = config;
-}
-
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
-}
+export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
+
+// PUBLIC API
+export { configureQueryClient } from './queryClient.config';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -10,6 +10,3 @@ const queryClient = new QueryClient(
 
 // PRIVATE API (framework code)
 export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
-
-// PUBLIC API
-export { configureQueryClient } from './queryClient.config';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,7 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
-
 
 
 
@@ -15,9 +13,6 @@ const routesMapping = {
       ),
   },
 } as const;
-
-
-initializeQueryClient()
 
 const rootElement =
   undefined

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
@@ -38,6 +38,7 @@ wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
 wasp-app/.wasp/out/sdk/wasp/client/operations/internal/updateHandlersMap.js
 wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/queries/index.ts
+wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
 wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
 wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
@@ -165,6 +166,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queries/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.js
+wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.config.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/operations/queryClient.js

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -172,14 +172,14 @@
             "file",
             "sdk/wasp/client/operations/hooks.ts"
         ],
-        "afb77720c5d690911c13a752996b93a8b0f5c8a02568ed59c45c1c401bb2b3fd"
+        "aa38f51bc28318b54e46669ad59028a4246e835ab7439d647608f0d5e067d3e5"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "edcdc3798590e62b778115b3818df8cc69fa5a8bb3a7fe9fa6d6d5ea706d14c4"
+        "18055fc92d894ad5698840d99bb65f9d5a21bd96ba1e11d1e2e3433629df669d"
     ],
     [
         [
@@ -219,9 +219,16 @@
     [
         [
             "file",
+            "sdk/wasp/client/operations/queryClient.config.ts"
+        ],
+        "d8b3d21f56cdcc240f80b8a8421610a990d10f02dfc1a1f5d33db92b001a292c"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "8c4aebd988017167eb57f168946fa63b76f55a846b083c7097c651e429d29fd4"
     ],
     [
         [
@@ -347,7 +354,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "1da18649210169b8383b876b5c5fe708528e28e47f3acec333b7bb84304a8e8b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -179,7 +179,7 @@
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "18055fc92d894ad5698840d99bb65f9d5a21bd96ba1e11d1e2e3433629df669d"
+        "8583719e957a42b3b1a6c1c9c76b57501ad99f37769cfba8ef837294c6645684"
     ],
     [
         [
@@ -228,7 +228,7 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "8c4aebd988017167eb57f168946fa63b76f55a846b083c7097c651e429d29fd4"
+        "6828f0901620950b62198b719a592334658b85058c108bc5b95819b48173a8b0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-query";
 import { Action, Query } from "./rpc";
 import { makeQueryCacheKey } from "./queries/core";
-export { configureQueryClient } from "./queryClient";
+export { configureQueryClient } from "./queryClient.config";
 
 // PUBLIC API
 export function useQuery<Input, Output>(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -15,6 +15,9 @@ export {
 export {
     // PUBLIC API
     configureQueryClient,
+} from './queryClient.config'
+
+export {
     // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -16,7 +16,5 @@ export {
     // PUBLIC API
     configureQueryClient,
     // PRIVATE API (framework code)
-    initializeQueryClient,
-    // PRIVATE API (framework code)
     queryClientInitialized
 } from './queryClient'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.config.ts
@@ -1,0 +1,21 @@
+import type { QueryClientConfig } from '@tanstack/react-query'
+
+let queryClientConfig: QueryClientConfig | undefined;
+let isFrozen = false;
+
+// PUBLIC API
+export function configureQueryClient(config: QueryClientConfig): void {
+  if (isFrozen) {
+    throw new Error(
+      "Attempted to configure the QueryClient after initialization"
+    );
+  }
+
+  queryClientConfig = config;
+}
+
+// PRIVATE API (framework code) — only queryClient.ts should call this
+export function freezeAndGetConfig(): QueryClientConfig | undefined {
+  isFrozen = true;
+  return queryClientConfig;
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -1,34 +1,15 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
+import { freezeAndGetConfig } from './queryClient.config'
+
 
 const defaultQueryClientConfig = {};
 
-let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
+const queryClient = new QueryClient(
+  freezeAndGetConfig() ?? defaultQueryClientConfig
 );
 
-// PUBLIC API
-export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
-    throw new Error(
-      "Attempted to configure the QueryClient after initialization"
-    );
-  }
-
-  queryClientConfig = config;
-}
-
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
-}
+export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
+
+// PUBLIC API
+export { configureQueryClient } from './queryClient.config';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -10,6 +10,3 @@ const queryClient = new QueryClient(
 
 // PRIVATE API (framework code)
 export const queryClientInitialized: Promise<QueryClient> = Promise.resolve(queryClient);
-
-// PUBLIC API
-export { configureQueryClient } from './queryClient.config';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,7 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
-
 
 
 
@@ -15,9 +13,6 @@ const routesMapping = {
       ),
   },
 } as const;
-
-
-initializeQueryClient()
 
 const rootElement =
   undefined

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/OperationsGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/OperationsGenerator.hs
@@ -7,8 +7,11 @@ import StrongPath (Dir, File', Path', Rel, reldir, relfile, (</>))
 import Wasp.AppSpec (AppSpec (..))
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.Action as AS.Action
+import qualified Wasp.AppSpec.App as AS.App
+import qualified Wasp.AppSpec.App.Client as AS.App.Client
 import qualified Wasp.AppSpec.Operation as AS.Operation
 import qualified Wasp.AppSpec.Query as AS.Query
+import Wasp.AppSpec.Valid (getApp)
 import Wasp.Generator.Common (makeJsArrayFromHaskellList)
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
@@ -19,6 +22,7 @@ import Wasp.Generator.SdkGenerator.Common
     getOperationTypeName,
     mkTmplFdWithData,
   )
+import Wasp.Generator.SdkGenerator.JsImport (extImportToImportJson)
 import Wasp.Generator.SdkGenerator.Server.OperationsGenerator (getServerOperationsImportPath)
 import qualified Wasp.Generator.ServerGenerator as ServerGenerator
 import qualified Wasp.Generator.ServerGenerator.OperationsRoutesG as ServerOperationsRoutesG
@@ -36,10 +40,24 @@ genOperations spec =
       genFileCopyInClientOps [relfile|rpc.ts|],
       genFileCopyInClientOps [relfile|hooks.ts|],
       genFileCopyInClientOps [relfile|index.ts|],
-      genFileCopyInClientOps [relfile|queryClient.ts|]
+      genFileCopyInClientOps [relfile|queryClient.config.ts|],
+      genQueryClient spec
     ]
     <++> genQueries spec
     <++> genActions spec
+
+genQueryClient :: AppSpec -> Generator FileDraft
+genQueryClient spec =
+  return $
+    mkTmplFdWithData
+      (clientOpsDirInSdkTemplatesDir </> [relfile|queryClient.ts|])
+      tmplData
+  where
+    tmplData =
+      object
+        [ "setupFn" .= extImportToImportJson maybeSetupJsFunction
+        ]
+    maybeSetupJsFunction = AS.App.Client.setupFn =<< AS.App.client (snd $ getApp spec)
 
 genQueries :: AppSpec -> Generator [FileDraft]
 genQueries spec =

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/VitePlugin/VirtualModulesPlugin/VirtualRoutesG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/VitePlugin/VirtualModulesPlugin/VirtualRoutesG.hs
@@ -32,10 +32,8 @@ genVirtualRoutesTsx spec =
       object
         [ "routes" .= map (createRouteTemplateData spec) (AS.getRoutes spec),
           "isAuthEnabled" .= isAuthEnabled spec,
-          "setupFn" .= GJI.jsImportToImportJson (GJI.extImportToRelativeSrcImportFromViteExecution <$> maybeSetupJsFunction),
           "rootComponent" .= GJI.jsImportToImportJson (GJI.extImportToRelativeSrcImportFromViteExecution <$> maybeRootComponent)
         ]
-    maybeSetupJsFunction = AS.App.Client.setupFn =<< AS.App.client (snd $ getApp spec)
     maybeRootComponent = AS.App.Client.rootComponent =<< AS.App.client (snd $ getApp spec)
 
 isRouteLazy :: AS.Route.Route -> Bool


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Closes #3986. `routes.tsx` previously had to `await setupFn()` and then call `initializeQueryClient()` at module top-level — boot orchestration leaking into a routing file. After this change, `queryClient.ts` self-initializes: it top-level-awaits the user's `setupFn` directly (imported via the standard SDK `wasp/src/...` path with `extImportToImportJson`), then synchronously constructs the `QueryClient`. `routes.tsx` is now purely about routes.

To keep the `configureQueryClient` ↔ user `setupFn` import cycle TDZ-safe, the `let` state and the public `configureQueryClient` function were extracted into a new leaf module `queryClient.config.ts`. `WaspApp.tsx`'s `use(queryClientInitialized)` is untouched because `queryClientInitialized` is still exported as `Promise.resolve(queryClient)`. The now-unused `initializeQueryClient` export (marked PRIVATE API) was removed from `operations/index.ts`.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->