### PR TITLE
docs: add raw body parsing guide for Polar webhooks

### DIFF
--- a/polar.md
+++ b/polar.md
@@ -1,0 +1,14 @@
+# Intégration Polar
+
+Pour valider correctement les webhooks Polar en développement local (ngrok), vous devez contourner le parseur JSON par défaut de Wasp qui altère la signature cryptographique.
+
+### Configuration du Middleware (Raw Body)
+
+Dans votre fichier `main.wasp`, déclarez votre route de webhook avec une configuration de middleware personnalisée :
+
+```wasp
+api polarWebhook {
+  fn: import { polarWebhook } from "@src/webhooks/polar.js",
+  httpRoute: (POST, "/webhook/polar"),
+  middlewareConfigFn: import { polarWebhookMiddleware } from "@src/webhooks/middleware.js"
+}

--- a/polar.md
+++ b/polar.md
@@ -1,10 +1,10 @@
-# Intégration Polar
+### Handling Polar Webhook Signatures (Raw Body)
 
-Pour valider correctement les webhooks Polar en développement local (ngrok), vous devez contourner le parseur JSON par défaut de Wasp qui altère la signature cryptographique.
+Polar's `validateEvent` function relies on an HMAC-SHA256 signature. This cryptographic validation requires the exact raw payload (Buffer) sent by Polar's servers. 
 
-### Configuration du Middleware (Raw Body)
+By default, Wasp applies a global `express.json()` middleware that parses the incoming request into a JavaScript object. This alters the payload and causes signature validation to fail (resulting in a 403 Unauthorized error, especially during local testing with ngrok).
 
-Dans votre fichier `main.wasp`, déclarez votre route de webhook avec une configuration de middleware personnalisée :
+To fix this, you must override the middleware for the Polar webhook route in your `main.wasp` file:
 
 ```wasp
 api polarWebhook {
@@ -12,3 +12,25 @@ api polarWebhook {
   httpRoute: (POST, "/webhook/polar"),
   middlewareConfigFn: import { polarWebhookMiddleware } from "@src/webhooks/middleware.js"
 }
+
+```
+Next, create the middleware file to strip the JSON parser and inject the raw
+parser:
+```javascript
+
+// src/webhooks/middleware.js
+import express from 'express'
+
+export const polarWebhookMiddleware = (middlewareConfig) => {
+  // 1. Remove the global JSON parser that destroys the signature
+  middlewareConfig.delete('express.json')
+  
+  // 2. Inject the raw parser required by Polar's SDK
+  middlewareConfig.set('express.raw', express.raw({ type: 'application/json' }))
+  
+  return middlewareConfig
+}
+```
+
+With this configuration, req.body will be passed as a raw Buffer to your
+polarWebhook function, allowing validateEvent to compute the hash correctly.


### PR DESCRIPTION
Closes #4092

This PR adds a dedicated section for Polar webhook integration. It provides the canonical solution using middlewareConfigFn to bypass the global JSON parser and inject express.raw for the webhook route, ensuring cryptographic integrity for validateEvent.