### PR TITLE
Reduce TS Spec fixtures type duplication

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
@@ -9,9 +9,6 @@ import { Branded } from "../../src/branded.js";
 import { action, app, page, query } from "../../src/spec/publicApi/index.js";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
 
-const CONFIG_TYPES = ["minimal", "full"] as const;
-type ConfigType = (typeof CONFIG_TYPES)[number];
-
 export function getMinimalApp(): TsAppSpec.App {
   return app({
     name: "MinimalApp",
@@ -21,24 +18,26 @@ export function getMinimalApp(): TsAppSpec.App {
   });
 }
 
-export function getPage(scope: "minimal"): MinimalConfig<TsAppSpec.Page>;
-export function getPage(scope: "full"): FullConfig<TsAppSpec.Page>;
-export function getPage(scope: ConfigType): Config<TsAppSpec.Page>;
-export function getPage(scope: ConfigType): Config<TsAppSpec.Page> {
+export function getPage<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.Page>;
+export function getPage(scope: ConfigScope): Config<TsAppSpec.Page> {
   switch (scope) {
     case "minimal":
       return page(getExtImport("minimal", "named"));
     case "full":
-      return page(getExtImport("full", "named"), { authRequired: true });
+      return page(getExtImport("full", "named"), {
+        authRequired: true,
+      });
     default:
       assertUnreachable(scope);
   }
 }
 
-export function getQuery(scope: "minimal"): MinimalConfig<TsAppSpec.Query>;
-export function getQuery(scope: "full"): FullConfig<TsAppSpec.Query>;
-export function getQuery(scope: ConfigType): Config<TsAppSpec.Query>;
-export function getQuery(scope: ConfigType): Config<TsAppSpec.Query> {
+export function getQuery<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.Query>;
+export function getQuery(scope: ConfigScope): Config<TsAppSpec.Query> {
   switch (scope) {
     case "minimal":
       return query(getExtImport("minimal", "named"));
@@ -52,10 +51,10 @@ export function getQuery(scope: ConfigType): Config<TsAppSpec.Query> {
   }
 }
 
-export function getAction(scope: "minimal"): MinimalConfig<TsAppSpec.Action>;
-export function getAction(scope: "full"): FullConfig<TsAppSpec.Action>;
-export function getAction(scope: ConfigType): Config<TsAppSpec.Action>;
-export function getAction(scope: ConfigType): Config<TsAppSpec.Action> {
+export function getAction<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.Action>;
+export function getAction(scope: ConfigScope): Config<TsAppSpec.Action> {
   switch (scope) {
     case "minimal":
       return action(getExtImport("minimal", "named"));
@@ -69,7 +68,7 @@ export function getAction(scope: ConfigType): Config<TsAppSpec.Action> {
   }
 }
 
-export function getEntities(scope: ConfigType): string[] {
+export function getEntities(scope: ConfigScope): string[] {
   switch (scope) {
     case "minimal":
       return [];
@@ -80,39 +79,24 @@ export function getEntities(scope: ConfigType): string[] {
   }
 }
 
+export function getExtImport<
+  Scope extends ConfigScope,
+  Kind extends AppSpec.ExtImportKind,
+>(scope: Scope, importKind: Kind): ConfigFor<Scope, ExtImportFor<Kind>>;
 export function getExtImport(
-  scope: "minimal",
-  importKind: AppSpec.ExtImportKind,
-): MinimalConfig<TsAppSpec.ExtImport>;
-export function getExtImport(
-  scope: "full",
-  importKind: AppSpec.ExtImportKind,
-): FullConfig<TsAppSpec.ExtImport>;
-export function getExtImport(
-  scope: ConfigType,
-  importKind: AppSpec.ExtImportKind,
-): Config<TsAppSpec.ExtImport>;
-export function getExtImport(
-  scope: ConfigType,
+  scope: ConfigScope,
   importKind: AppSpec.ExtImportKind,
 ): Config<TsAppSpec.ExtImport> {
   switch (importKind) {
-    case "named": {
-      return {
-        import: "namedExport",
-        ...(scope == "full" && { alias: "namedAlias" }),
-        from: "@src/external",
-      };
-    }
+    case "named":
+      return scope === "full"
+        ? { import: "namedExport", alias: "namedAlias", from: "@src/external" }
+        : { import: "namedExport", from: "@src/external" };
     case "default":
       return { importDefault: "defaultExport", from: "@src/external" };
     default:
       assertUnreachable(importKind);
   }
-}
-
-function assertUnreachable(value: never): never {
-  throw new Error(`Unhandled case: ${value}`);
 }
 
 export type Config<T> = MinimalConfig<T> | FullConfig<T>;
@@ -166,3 +150,18 @@ export type FullConfig<T> =
 type FullConfigObject<T> = {
   [K in keyof T]-?: FullConfig<T[K]>;
 };
+
+type ExtImportFor<Kind extends AppSpec.ExtImportKind> = Kind extends "named"
+  ? TsAppSpec.NamedExtImport
+  : TsAppSpec.DefaultExtImport;
+
+type ConfigFor<Scope extends ConfigScope, Data> = Scope extends "full"
+  ? FullConfig<Data>
+  : MinimalConfig<Data>;
+
+const CONFIG_SCOPES = ["minimal", "full"] as const;
+type ConfigScope = (typeof CONFIG_SCOPES)[number];
+
+function assertUnreachable(value: never): never {
+  throw new Error(`Unhandled case: ${value}`);
+}

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -34,9 +34,16 @@ export type Action = MakePart<
   }
 >;
 
-export type ExtImport =
-  | { import: string; alias?: string; from: `@src/${string}` }
-  | { importDefault: string; from: `@src/${string}` };
+export type ExtImport = NamedExtImport | DefaultExtImport;
+export interface NamedExtImport {
+  import: string;
+  alias?: string;
+  from: `@src/${string}`;
+}
+export interface DefaultExtImport {
+  importDefault: string;
+  from: `@src/${string}`;
+}
 
 /**
  * We need the kind to differentiate between parts with the same structure. One


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Replace this message here, and write a high-level overview with any additional
context (motivation, trade-offs, approaches considered, concerns, ...).

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
