### PR TITLE
wasp-app-runner: Pre-pull Docker images to avoid readiness timeouts

### DIFF
--- a/wasp-app-runner/src/db/postgres.ts
+++ b/wasp-app-runner/src/db/postgres.ts
@@ -2,6 +2,7 @@ import type { DockerImageName, PathToApp } from "../args.js";
 import {
   DbContainerName,
   createAppSpecificDbContainerName,
+  pullDockerImage,
 } from "../docker.js";
 import { createLogger } from "../logging.js";
 import { spawnAndCollectOutput } from "../process.js";
@@ -69,6 +70,8 @@ async function startPostgresContainerAndWaitUntilReady(
 ): Promise<DatabaseConnectionUrl> {
   const port = 5432;
   const password = "devpass";
+
+  await pullDockerImage(dbImage);
 
   logger.info(`Starting the PostgreSQL container with image: ${dbImage}...`);
 

--- a/wasp-app-runner/src/docker.ts
+++ b/wasp-app-runner/src/docker.ts
@@ -1,9 +1,27 @@
 import { createHash } from "crypto";
-import type { PathToApp } from "./args.js";
+import type { DockerImageName, PathToApp } from "./args.js";
+import { createLogger } from "./logging.js";
+import { spawnWithLog } from "./process.js";
 import { Branded } from "./types.js";
 import type { AppName } from "./waspCli.js";
 
 export type DbContainerName = Branded<string, "ContainerName">;
+
+const pullLogger = createLogger("docker-pull");
+
+export async function pullDockerImage(image: DockerImageName): Promise<void> {
+  pullLogger.info(`Pulling Docker image: ${image}...`);
+  try {
+    await spawnWithLog({
+      name: "docker-pull",
+      cmd: "docker",
+      args: ["pull", image],
+    });
+  } catch {
+    pullLogger.error(`Failed to pull Docker image: ${image}`);
+    process.exit(1);
+  }
+}
 
 export function createAppSpecificDbContainerName({
   appName,

--- a/wasp-app-runner/src/smtp.ts
+++ b/wasp-app-runner/src/smtp.ts
@@ -1,8 +1,15 @@
+import type { DockerImageName } from "./args.js";
+import { pullDockerImage } from "./docker.js";
 import { createLogger } from "./logging.js";
 import { spawnWithLog } from "./process.js";
 
+const mailcrabImage = "marlonb/mailcrab:latest" as DockerImageName;
+
 export async function startLocalSmtpServer(): Promise<void> {
   const logger = createLogger("smtp-server");
+
+  await pullDockerImage(mailcrabImage);
+
   spawnWithLog({
     name: "smtp-server",
     cmd: "docker",
@@ -13,7 +20,7 @@ export async function startLocalSmtpServer(): Promise<void> {
       "1080:1080",
       "-p",
       "1025:1025",
-      "marlonb/mailcrab:latest",
+      mailcrabImage,
     ],
   }).then(({ exitCode }) => {
     if (exitCode !== 0) {

--- a/wasp-app-runner/src/smtp.ts
+++ b/wasp-app-runner/src/smtp.ts
@@ -13,15 +13,7 @@ export async function startLocalSmtpServer(): Promise<void> {
   spawnWithLog({
     name: "smtp-server",
     cmd: "docker",
-    args: [
-      "run",
-      "--rm",
-      "-p",
-      "1080:1080",
-      "-p",
-      "1025:1025",
-      mailcrabImage,
-    ],
+    args: ["run", "--rm", "-p", "1080:1080", "-p", "1025:1025", mailcrabImage],
   }).then(({ exitCode }) => {
     if (exitCode !== 0) {
       logger.error(`SMTP server exited with code ${exitCode}`);


### PR DESCRIPTION
## Description

In Wasp App Runner, we sometimes timed out when creating the Docker container for Postgres because it was also implicitly waiting for a pull. Now we do an explicit docker pull before starting the timeout.

## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.