### PR TITLE
Add the remaining app sub-configs to the new spec pipeline

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/spec/appAnalyzer.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/appAnalyzer.unit.test.ts
@@ -2,7 +2,6 @@ import { afterEach } from "node:test";
 import { describe, expect, test, vi } from "vitest";
 import { analyzeApp } from "../../src/spec/appAnalyzer.js";
 import { mapApp } from "../../src/spec/mapApp.js";
-import { app } from "../../src/spec/publicApi/index.js";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
 import * as Fixtures from "./testFixtures.js";
 
@@ -11,36 +10,20 @@ describe("analyzeApp", () => {
 
   test("should parse an app successfully", async () => {
     await testAnalyzeApp({
-      app: Fixtures.getMinimalApp(),
+      app: Fixtures.getApp("minimal"),
       entities: Fixtures.getEntities("minimal"),
     });
   });
 
   test("should parse full app successfully", async () => {
     await testAnalyzeApp({
-      app: app({
-        name: "FullApp",
-        wasp: { version: "^0.16.3" },
-        title: "Mock App",
-        head: ['<link rel="icon" href="/favicon.ico" />'],
-        server: Fixtures.getServerConfig("full"),
-        client: Fixtures.getClientConfig("full"),
-        db: Fixtures.getDbConfig("full"),
-        emailSender: Fixtures.getEmailSenderConfig("full"),
-        webSocket: Fixtures.getWebSocketConfig("full"),
-        parts: [
-          Fixtures.getPage("full"),
-          Fixtures.getRoute("full"),
-          Fixtures.getQuery("full"),
-          Fixtures.getJob("full"),
-        ],
-      }),
+      app: Fixtures.getApp("full"),
       entities: Fixtures.getEntities("full"),
     });
   });
 
   test("should parse app from async default export", async () => {
-    const app = Fixtures.getMinimalApp();
+    const app = Fixtures.getApp("minimal");
     const entities = Fixtures.getEntities("minimal");
     const mockMainWaspTs = "main.wasp.ts";
     vi.doMock(mockMainWaspTs, () => ({ default: Promise.resolve(app) }));

--- a/waspc/data/packages/wasp-config/__tests__/spec/appAnalyzer.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/appAnalyzer.unit.test.ts
@@ -2,6 +2,7 @@ import { afterEach } from "node:test";
 import { describe, expect, test, vi } from "vitest";
 import { analyzeApp } from "../../src/spec/appAnalyzer.js";
 import { mapApp } from "../../src/spec/mapApp.js";
+import { app } from "../../src/spec/publicApi/index.js";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
 import * as Fixtures from "./testFixtures.js";
 
@@ -12,6 +13,28 @@ describe("analyzeApp", () => {
     await testAnalyzeApp({
       app: Fixtures.getMinimalApp(),
       entities: Fixtures.getEntities("minimal"),
+    });
+  });
+
+  test("should parse full app successfully", async () => {
+    await testAnalyzeApp({
+      app: app({
+        name: "FullApp",
+        wasp: { version: "^0.16.3" },
+        title: "Mock App",
+        head: ['<link rel="icon" href="/favicon.ico" />'],
+        server: Fixtures.getServerConfig("full"),
+        client: Fixtures.getClientConfig("full"),
+        db: Fixtures.getDbConfig("full"),
+        emailSender: Fixtures.getEmailSenderConfig("full"),
+        webSocket: Fixtures.getWebSocketConfig("full"),
+        parts: [
+          Fixtures.getPage("full"),
+          Fixtures.getRoute("full"),
+          Fixtures.getQuery("full"),
+        ],
+      }),
+      entities: Fixtures.getEntities("full"),
     });
   });
 

--- a/waspc/data/packages/wasp-config/__tests__/spec/mapApp.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/mapApp.unit.test.ts
@@ -25,7 +25,7 @@ import * as Fixtures from "./testFixtures.js";
 describe("mapApp", () => {
   test("should map minimal app correctly", () => {
     const entityNames = Fixtures.getEntities("minimal");
-    const app = Fixtures.getMinimalApp();
+    const app = Fixtures.getApp("minimal");
 
     const decls = mapApp(app, entityNames);
 
@@ -49,6 +49,8 @@ describe("mapApp", () => {
   });
 
   test("should map full app correctly", () => {
+    // Note: we build the full app inline (instead of using `Fixtures.getApp("full")`)
+    // so the assertions can name each part explicitly when computing expected decls.
     const page = Fixtures.getPage("full");
     const route = Fixtures.getRoute("full");
     const query = Fixtures.getQuery("full");

--- a/waspc/data/packages/wasp-config/__tests__/spec/mapApp.unit.test.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/mapApp.unit.test.ts
@@ -5,10 +5,16 @@ import {
   makeRefParser,
   mapAction,
   mapApp,
+  mapClient,
+  mapDb,
+  mapEmailFromField,
+  mapEmailSender,
   mapExtImport,
   mapPage,
   mapQuery,
   mapRoute,
+  mapServer,
+  mapWebSocket,
 } from "../../src/spec/mapApp.js";
 import { app, page, route } from "../../src/spec/publicApi/index.js";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
@@ -44,6 +50,11 @@ describe("mapApp", () => {
     const page = Fixtures.getPage("full");
     const route = Fixtures.getRoute("full");
     const query = Fixtures.getQuery("full");
+    const server = Fixtures.getServerConfig("full");
+    const client = Fixtures.getClientConfig("full");
+    const db = Fixtures.getDbConfig("full");
+    const emailSender = Fixtures.getEmailSenderConfig("full");
+    const webSocket = Fixtures.getWebSocketConfig("full");
     const entityNames = Fixtures.getEntities("full");
     const entityRefParser = makeRefParser("Entity", entityNames);
 
@@ -52,6 +63,11 @@ describe("mapApp", () => {
       wasp: { version: "^0.16.3" },
       title: "Mock App",
       head: ['<link rel="icon" href="/favicon.ico" />'],
+      server,
+      client,
+      db,
+      emailSender,
+      webSocket,
       parts: [page, route, query],
     });
 
@@ -72,11 +88,11 @@ describe("mapApp", () => {
           title: inputApp.title,
           head: inputApp.head,
           auth: undefined,
-          server: undefined,
-          client: undefined,
-          db: undefined,
-          emailSender: undefined,
-          webSocket: undefined,
+          server: mapServer(server),
+          client: mapClient(client),
+          db: mapDb(db),
+          emailSender: mapEmailSender(emailSender),
+          webSocket: mapWebSocket(webSocket),
         },
       },
       {
@@ -274,6 +290,129 @@ describe("mapAction", () => {
       entities: action.entities?.map(entityRefParser),
       auth: action.auth,
     } satisfies AppSpec.Action);
+  }
+});
+
+describe("mapServer", () => {
+  test("should map minimal config correctly", () => {
+    testMapServer(Fixtures.getServerConfig("minimal"));
+  });
+
+  test("should map full config correctly", () => {
+    testMapServer(Fixtures.getServerConfig("full"));
+  });
+
+  function testMapServer(server: TsAppSpec.Server): void {
+    const result = mapServer(server);
+
+    expect(result).toStrictEqual({
+      setupFn: server.setupFn && mapExtImport(server.setupFn),
+      middlewareConfigFn:
+        server.middlewareConfigFn && mapExtImport(server.middlewareConfigFn),
+      envValidationSchema:
+        server.envValidationSchema && mapExtImport(server.envValidationSchema),
+    } satisfies AppSpec.Server);
+  }
+});
+
+describe("mapClient", () => {
+  test("should map minimal config correctly", () => {
+    testMapClient(Fixtures.getClientConfig("minimal"));
+  });
+
+  test("should map full config correctly", () => {
+    testMapClient(Fixtures.getClientConfig("full"));
+  });
+
+  function testMapClient(client: TsAppSpec.Client): void {
+    const result = mapClient(client);
+
+    expect(result).toStrictEqual({
+      rootComponent: client.rootComponent && mapExtImport(client.rootComponent),
+      setupFn: client.setupFn && mapExtImport(client.setupFn),
+      baseDir: client.baseDir,
+      envValidationSchema:
+        client.envValidationSchema && mapExtImport(client.envValidationSchema),
+    } satisfies AppSpec.Client);
+  }
+});
+
+describe("mapDb", () => {
+  test("should map minimal config correctly", () => {
+    testMapDb(Fixtures.getDbConfig("minimal"));
+  });
+
+  test("should map full config correctly", () => {
+    testMapDb(Fixtures.getDbConfig("full"));
+  });
+
+  function testMapDb(db: TsAppSpec.Db): void {
+    const result = mapDb(db);
+
+    expect(result).toStrictEqual({
+      seeds: db.seeds?.map((seed) => mapExtImport(seed)),
+      prismaSetupFn: db.prismaSetupFn && mapExtImport(db.prismaSetupFn),
+    } satisfies AppSpec.Db);
+  }
+});
+
+describe("mapEmailSender", () => {
+  test("should map minimal config correctly", () => {
+    testMapEmailSender(Fixtures.getEmailSenderConfig("minimal"));
+  });
+
+  test("should map full config correctly", () => {
+    testMapEmailSender(Fixtures.getEmailSenderConfig("full"));
+  });
+
+  function testMapEmailSender(emailSender: TsAppSpec.EmailSender): void {
+    const result = mapEmailSender(emailSender);
+
+    expect(result).toStrictEqual({
+      provider: emailSender.provider,
+      defaultFrom:
+        emailSender.defaultFrom && mapEmailFromField(emailSender.defaultFrom),
+    } satisfies AppSpec.EmailSender);
+  }
+});
+
+describe("mapEmailFromField", () => {
+  test("should map minimal config correctly", () => {
+    testMapEmailFromField(Fixtures.getEmailFromField("minimal"));
+  });
+
+  test("should map full config correctly", () => {
+    testMapEmailFromField(Fixtures.getEmailFromField("full"));
+  });
+
+  function testMapEmailFromField(
+    emailFromField: TsAppSpec.EmailFromField,
+  ): void {
+    const result = mapEmailFromField(emailFromField);
+
+    expect(result).toStrictEqual({
+      name: emailFromField.name,
+      email: emailFromField.email,
+    } satisfies AppSpec.EmailFromField);
+  }
+});
+
+describe("mapWebSocket", () => {
+  test("should map minimal config correctly", () => {
+    testMapWebSocket(Fixtures.getWebSocketConfig("minimal"));
+  });
+
+  test("should map full config correctly", () => {
+    testMapWebSocket(Fixtures.getWebSocketConfig("full"));
+  });
+
+  function testMapWebSocket(webSocket: TsAppSpec.WebSocket): void {
+    const result = mapWebSocket(webSocket);
+
+    expect(result).toStrictEqual({
+      fn: mapExtImport(webSocket.fn),
+      autoConnect: webSocket.autoConnect,
+    } satisfies AppSpec.WebSocket);
   }
 });
 

--- a/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
@@ -109,6 +109,123 @@ export function getEntities(scope: ConfigScope): string[] {
   }
 }
 
+export function getServerConfig<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.Server>;
+export function getServerConfig(scope: ConfigScope): Config<TsAppSpec.Server> {
+  switch (scope) {
+    case "minimal":
+      return {} satisfies MinimalConfig<TsAppSpec.Server>;
+    case "full":
+      return {
+        setupFn: getExtImport("full", "named"),
+        middlewareConfigFn: getExtImport("full", "named"),
+        envValidationSchema: getExtImport("full", "named"),
+      } satisfies FullConfig<TsAppSpec.Server>;
+    default:
+      assertUnreachable(scope);
+  }
+}
+
+export function getClientConfig<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.Client>;
+export function getClientConfig(scope: ConfigScope): Config<TsAppSpec.Client> {
+  switch (scope) {
+    case "minimal":
+      return {} satisfies MinimalConfig<TsAppSpec.Client>;
+    case "full":
+      return {
+        rootComponent: getExtImport("full", "named"),
+        setupFn: getExtImport("full", "named"),
+        baseDir: "/src",
+        envValidationSchema: getExtImport("full", "named"),
+      } satisfies FullConfig<TsAppSpec.Client>;
+    default:
+      assertUnreachable(scope);
+  }
+}
+
+export function getDbConfig<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.Db>;
+export function getDbConfig(scope: ConfigScope): Config<TsAppSpec.Db> {
+  switch (scope) {
+    case "minimal":
+      return {} satisfies MinimalConfig<TsAppSpec.Db>;
+    case "full":
+      return {
+        seeds: [getExtImport("full", "named"), getExtImport("full", "default")],
+        prismaSetupFn: getExtImport("full", "named"),
+      } satisfies FullConfig<TsAppSpec.Db>;
+    default:
+      assertUnreachable(scope);
+  }
+}
+
+export function getEmailSenderConfig<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.EmailSender>;
+export function getEmailSenderConfig(
+  scope: ConfigScope,
+): Config<TsAppSpec.EmailSender> {
+  switch (scope) {
+    case "minimal":
+      return {
+        provider: "SMTP",
+      } satisfies MinimalConfig<TsAppSpec.EmailSender>;
+    case "full":
+      return {
+        provider: "SMTP",
+        defaultFrom: getEmailFromField("full"),
+      } satisfies FullConfig<TsAppSpec.EmailSender>;
+    default:
+      assertUnreachable(scope);
+  }
+}
+
+export function getEmailFromField<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.EmailFromField>;
+export function getEmailFromField(
+  scope: ConfigScope,
+): Config<TsAppSpec.EmailFromField> {
+  switch (scope) {
+    case "minimal":
+      return {
+        email: "noreply@example.com",
+      } satisfies MinimalConfig<TsAppSpec.EmailFromField>;
+    case "full":
+      return {
+        name: "Wasp",
+        email: "noreply@example.com",
+      } satisfies FullConfig<TsAppSpec.EmailFromField>;
+    default:
+      assertUnreachable(scope);
+  }
+}
+
+export function getWebSocketConfig<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, TsAppSpec.WebSocket>;
+export function getWebSocketConfig(
+  scope: ConfigScope,
+): Config<TsAppSpec.WebSocket> {
+  switch (scope) {
+    case "minimal":
+      return {
+        fn: getExtImport("minimal", "named"),
+      } satisfies MinimalConfig<TsAppSpec.WebSocket>;
+    case "full":
+      return {
+        fn: getExtImport("full", "named"),
+        autoConnect: true,
+      } satisfies FullConfig<TsAppSpec.WebSocket>;
+    default:
+      assertUnreachable(scope);
+  }
+}
+
 export function getExtImport<
   Scope extends ConfigScope,
   Kind extends AppSpec.ExtImportKind,

--- a/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/testFixtures.ts
@@ -16,18 +16,41 @@ import {
 } from "../../src/spec/publicApi/index.js";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
 
-export function getMinimalApp(): TsAppSpec.App {
-  return app({
-    name: "MinimalApp",
-    wasp: { version: "^0.16.3" },
-    title: "Mock App",
-    parts: [],
-  });
+export function getApp(scope: ConfigScope): TsAppSpec.App {
+  switch (scope) {
+    case "minimal":
+      return app({
+        name: "MinimalApp",
+        wasp: { version: "^0.16.3" },
+        title: "Mock App",
+        parts: [],
+      });
+    case "full":
+      return app({
+        name: "FullApp",
+        wasp: { version: "^0.16.3" },
+        title: "Mock App",
+        head: ['<link rel="icon" href="/favicon.ico" />'],
+        server: getServerConfig("full"),
+        client: getClientConfig("full"),
+        db: getDbConfig("full"),
+        emailSender: getEmailSenderConfig("full"),
+        webSocket: getWebSocketConfig("full"),
+        parts: [
+          getPage("full"),
+          getRoute("full"),
+          getQuery("full"),
+          getJob("full"),
+        ],
+      });
+    default:
+      assertUnreachable(scope);
+  }
 }
 
 export function getMinimalAppWithParts(parts: TsAppSpec.Part[]): TsAppSpec.App {
   return {
-    ...getMinimalApp(),
+    ...getApp("minimal"),
     parts,
   };
 }

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -10,7 +10,18 @@ export function mapApp(
   app: TsAppSpec.App,
   entityNames: string[],
 ): AppSpec.Decl[] {
-  const { name, wasp, title, head, parts } = app;
+  const {
+    name,
+    wasp,
+    title,
+    head,
+    server,
+    client,
+    db,
+    emailSender,
+    webSocket,
+    parts,
+  } = app;
 
   const entityRefParser = makeRefParser("Entity", entityNames);
 
@@ -64,11 +75,11 @@ export function mapApp(
       head,
       // TODO: add these guys
       auth: undefined,
-      server: undefined,
-      client: undefined,
-      db: undefined,
-      emailSender: undefined,
-      webSocket: undefined,
+      server: server && mapServer(server),
+      client: client && mapClient(client),
+      db: db && mapDb(db),
+      emailSender: emailSender && mapEmailSender(emailSender),
+      webSocket: webSocket && mapWebSocket(webSocket),
     },
   };
 
@@ -166,6 +177,64 @@ export function mapAction(
     fn: mapExtImport(fn),
     entities: entities?.map(entityRefParser),
     auth,
+  };
+}
+
+export function mapServer(server: TsAppSpec.Server): AppSpec.Server {
+  const { setupFn, middlewareConfigFn, envValidationSchema } = server;
+  return {
+    setupFn: setupFn && mapExtImport(setupFn),
+    middlewareConfigFn: middlewareConfigFn && mapExtImport(middlewareConfigFn),
+    envValidationSchema:
+      envValidationSchema && mapExtImport(envValidationSchema),
+  };
+}
+
+export function mapClient(client: TsAppSpec.Client): AppSpec.Client {
+  const { rootComponent, setupFn, baseDir, envValidationSchema } = client;
+  return {
+    rootComponent: rootComponent && mapExtImport(rootComponent),
+    setupFn: setupFn && mapExtImport(setupFn),
+    baseDir,
+    envValidationSchema:
+      envValidationSchema && mapExtImport(envValidationSchema),
+  };
+}
+
+export function mapDb(db: TsAppSpec.Db): AppSpec.Db {
+  const { seeds, prismaSetupFn } = db;
+  return {
+    seeds: seeds?.map(mapExtImport),
+    prismaSetupFn: prismaSetupFn && mapExtImport(prismaSetupFn),
+  };
+}
+
+export function mapEmailSender(
+  emailSender: TsAppSpec.EmailSender,
+): AppSpec.EmailSender {
+  const { provider, defaultFrom } = emailSender;
+  return {
+    provider,
+    defaultFrom: defaultFrom && mapEmailFromField(defaultFrom),
+  };
+}
+
+export function mapEmailFromField(
+  emailFromField: TsAppSpec.EmailFromField,
+): AppSpec.EmailFromField {
+  return {
+    name: emailFromField.name,
+    email: emailFromField.email,
+  };
+}
+
+export function mapWebSocket(
+  webSocket: TsAppSpec.WebSocket,
+): AppSpec.WebSocket {
+  const { fn, autoConnect } = webSocket;
+  return {
+    fn: mapExtImport(fn),
+    autoConnect,
   };
 }
 

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/index.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/index.ts
@@ -2,9 +2,15 @@ export { action, app, page, query, route } from "./constructors.js";
 export type {
   Action,
   App,
+  Client,
+  Db,
+  EmailFromField,
+  EmailSender,
   ExtImport,
   Page,
   Part,
   Query,
   Route,
+  Server,
+  WebSocket,
 } from "./tsAppSpec.js";

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -1,9 +1,49 @@
+import * as AppSpec from "../../appSpec.js";
+
 export type App = {
   name: string;
-  wasp: { version: string };
+  wasp: AppSpec.Wasp;
   title: string;
   head?: string[];
+  server?: Server;
+  client?: Client;
+  db?: Db;
+  emailSender?: EmailSender;
+  webSocket?: WebSocket;
   parts: Part[];
+};
+
+export type Server = {
+  setupFn?: ExtImport;
+  middlewareConfigFn?: ExtImport;
+  envValidationSchema?: ExtImport;
+};
+
+export type Client = {
+  rootComponent?: ExtImport;
+  setupFn?: ExtImport;
+  baseDir?: `/${string}`;
+  envValidationSchema?: ExtImport;
+};
+
+export type Db = {
+  seeds?: ExtImport[];
+  prismaSetupFn?: ExtImport;
+};
+
+export type EmailSender = {
+  provider: AppSpec.EmailProvider;
+  defaultFrom?: EmailFromField;
+};
+
+export type EmailFromField = {
+  name?: string;
+  email: string;
+};
+
+export type WebSocket = {
+  fn: ExtImport;
+  autoConnect?: boolean;
 };
 
 export type Part = Page | Route | Query | Action;


### PR DESCRIPTION
## Description

Adds `server`, `client`, `db`, `emailSender`, and `webSocket` as optional fields on `app({...})`.

`TsAppSpec` now imports `AppSpec.Wasp` and `AppSpec.EmailProvider` where the semantic match is clean. 

## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in \`examples/kitchen-sink/e2e-tests\`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in \`waspc/data/Cli/templates\`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in \`examples/\`, as needed.
    - [ ] _(if you updated \`examples/tutorials\`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in \`web/docs/\`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated \`waspc/ChangeLog.md\` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in \`web/docs/migration-guides/\`.
  - [ ] I **bumped the \`version\`** in \`waspc/waspc.cabal\` to reflect the changes I introduced.