### PR TITLE
Allow Zod object env schemas

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
@@ -136,12 +136,14 @@ describe("ExtImport input types", () => {
 });
 
 describe("Env validation schema input types", () => {
-  test("should accept Zod object schema-shaped values", async () => {
+  test("should accept Zod schema-shaped values", async () => {
     const schema = {
-      shape: {},
-      safeParse: (_data: unknown) => ({ success: true, data: {} }),
-      and: (_schema: unknown) => schema,
-    };
+      _zod: {
+        def: {
+          type: "string",
+        },
+      },
+    } satisfies TsAppSpec.ZodSchema;
 
     const serverConfig = {
       envValidationSchema: schema,
@@ -151,10 +153,10 @@ describe("Env validation schema input types", () => {
     } satisfies TsAppSpec.Client;
 
     expectTypeOf(serverConfig.envValidationSchema).toExtend<
-      TsAppSpec.ExtImport | TsAppSpec.ZodObjectSchema
+      TsAppSpec.ExtImport | TsAppSpec.ZodSchema
     >();
     expectTypeOf(clientConfig.envValidationSchema).toExtend<
-      TsAppSpec.ExtImport | TsAppSpec.ZodObjectSchema
+      TsAppSpec.ExtImport | TsAppSpec.ZodSchema
     >();
   });
 
@@ -172,10 +174,10 @@ describe("Env validation schema input types", () => {
     } satisfies TsAppSpec.Client;
 
     expectTypeOf(serverConfig.envValidationSchema).toExtend<
-      TsAppSpec.ExtImport | TsAppSpec.ZodObjectSchema
+      TsAppSpec.ExtImport | TsAppSpec.ZodSchema
     >();
     expectTypeOf(clientConfig.envValidationSchema).toExtend<
-      TsAppSpec.ExtImport | TsAppSpec.ZodObjectSchema
+      TsAppSpec.ExtImport | TsAppSpec.ZodSchema
     >();
   });
 

--- a/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/extImport.test-d.ts
@@ -134,3 +134,62 @@ describe("ExtImport input types", () => {
     expectTypeOf(pageConfig).toExtend<TsAppSpec.Page>();
   });
 });
+
+describe("Env validation schema input types", () => {
+  test("should accept Zod object schema-shaped values", async () => {
+    const schema = {
+      shape: {},
+      safeParse: (_data: unknown) => ({ success: true, data: {} }),
+      and: (_schema: unknown) => schema,
+    };
+
+    const serverConfig = {
+      envValidationSchema: schema,
+    } satisfies TsAppSpec.Server;
+    const clientConfig = {
+      envValidationSchema: schema,
+    } satisfies TsAppSpec.Client;
+
+    expectTypeOf(serverConfig.envValidationSchema).toExtend<
+      TsAppSpec.ExtImport | TsAppSpec.ZodObjectSchema
+    >();
+    expectTypeOf(clientConfig.envValidationSchema).toExtend<
+      TsAppSpec.ExtImport | TsAppSpec.ZodObjectSchema
+    >();
+  });
+
+  test("should accept ExtImport env validation schemas", async () => {
+    const schemaImport = {
+      importDefault: "schema",
+      from: "@src/env",
+    } satisfies TsAppSpec.ExtImport;
+
+    const serverConfig = {
+      envValidationSchema: schemaImport,
+    } satisfies TsAppSpec.Server;
+    const clientConfig = {
+      envValidationSchema: schemaImport,
+    } satisfies TsAppSpec.Client;
+
+    expectTypeOf(serverConfig.envValidationSchema).toExtend<
+      TsAppSpec.ExtImport | TsAppSpec.ZodObjectSchema
+    >();
+    expectTypeOf(clientConfig.envValidationSchema).toExtend<
+      TsAppSpec.ExtImport | TsAppSpec.ZodObjectSchema
+    >();
+  });
+
+  test("should reject non-schema objects at env validation schema use sites", async () => {
+    const serverConfig: TsAppSpec.Server = {
+      // @ts-expect-error Env validation schema objects must be Zod object schema-shaped.
+      envValidationSchema: {},
+    };
+    const clientConfig: TsAppSpec.Client = {
+      // @ts-expect-error Env validation schema objects must be Zod object schema-shaped.
+      envValidationSchema: [],
+    };
+
+    expectTypeOf(serverConfig).toExtend<TsAppSpec.Server>();
+    expectTypeOf(clientConfig).toExtend<TsAppSpec.Client>();
+  });
+});

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/index.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/index.ts
@@ -32,4 +32,5 @@ export type {
   Server,
   UsernameAndPasswordConfig,
   WebSocket,
+  ZodObjectSchema,
 } from "./tsAppSpec.js";

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/index.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/index.ts
@@ -32,5 +32,5 @@ export type {
   Server,
   UsernameAndPasswordConfig,
   WebSocket,
-  ZodObjectSchema,
+  ZodSchema,
 } from "./tsAppSpec.js";

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -2,12 +2,6 @@ import * as AppSpec from "../../appSpec.js";
 import type { AnyFunction } from "../../typeUtils.js";
 import type { ExtImport } from "../extImport.js";
 
-export type ZodObjectSchema = {
-  readonly shape: object;
-  safeParse: AnyFunction;
-  and: AnyFunction;
-};
-
 export type App = {
   name: string;
   wasp: AppSpec.Wasp;
@@ -78,14 +72,14 @@ export type EmailFlowConfig = {
 export type Server = {
   setupFn?: ExtImport | AnyFunction;
   middlewareConfigFn?: ExtImport | AnyFunction;
-  envValidationSchema?: ExtImport | ZodObjectSchema;
+  envValidationSchema?: ExtImport | ZodSchema;
 };
 
 export type Client = {
   rootComponent?: ExtImport | AnyFunction;
   setupFn?: ExtImport | AnyFunction;
   baseDir?: `/${string}`;
-  envValidationSchema?: ExtImport | ZodObjectSchema;
+  envValidationSchema?: ExtImport | ZodSchema;
 };
 
 export type Db = {
@@ -213,3 +207,17 @@ export type {
 export type MakePart<Kind extends string, PartConfig> = {
   kind: Kind;
 } & PartConfig;
+
+/**
+ * Imported @src env schemas are lowered to ExtImport objects before mapping,
+ * but the user still sees the public API that allows the runtime Zod object
+ * (in `server.envValidationSchema` and `client.envValidationSchema`).
+ * To avoid needing to depend on `zod` package, we structurally recognize Zod 4
+ * schemas via their documented library-author marker.
+ * See https://zod.dev/library-authors.
+ */
+export type ZodSchema = {
+  readonly _zod: {
+    readonly def: object;
+  };
+};

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -2,6 +2,12 @@ import * as AppSpec from "../../appSpec.js";
 import type { AnyFunction } from "../../typeUtils.js";
 import type { ExtImport } from "../extImport.js";
 
+export type ZodObjectSchema = {
+  readonly shape: object;
+  safeParse: AnyFunction;
+  and: AnyFunction;
+};
+
 export type App = {
   name: string;
   wasp: AppSpec.Wasp;
@@ -72,14 +78,14 @@ export type EmailFlowConfig = {
 export type Server = {
   setupFn?: ExtImport | AnyFunction;
   middlewareConfigFn?: ExtImport | AnyFunction;
-  envValidationSchema?: ExtImport;
+  envValidationSchema?: ExtImport | ZodObjectSchema;
 };
 
 export type Client = {
   rootComponent?: ExtImport | AnyFunction;
   setupFn?: ExtImport | AnyFunction;
   baseDir?: `/${string}`;
-  envValidationSchema?: ExtImport;
+  envValidationSchema?: ExtImport | ZodObjectSchema;
 };
 
 export type Db = {


### PR DESCRIPTION
## Description

TS Spec public API accepts `ExtImport`s in two ways:
- as directly written `ExtImport` objects
- as directly imported values

To allow directly imported values e.g. `import { myZodSchema } from "@src/schema"`, the types in the schema need to be written like `ExtImport | SomeObjectTypeThatAllowsZodSchema`.

`SomeObjectTypeThatAllowsZodSchema` can be some generic "accept any object" and let it fail in runtime or it can some Zod specific type. Ideally, it would be `z.ZodType` or similar that we import from `zod`. But that means our `wasp-config` package need to depend on `zod` which I wanted to avoid.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->