### PR TITLE
WIP: Type-safe auth routes (with route objects)

### DIFF
--- a/waspc/data/packages/wasp-config/__tests__/spec/hola.ts
+++ b/waspc/data/packages/wasp-config/__tests__/spec/hola.ts
@@ -1,0 +1,31 @@
+import { app, page, route } from "../../src/spec/publicApi/index.js";
+
+const holaRoute = route(
+  "hola",
+  "/hola",
+  page({ import: "foo", from: "@src/bar" }),
+);
+
+const adiosRoute = route(
+  "adios",
+  "/adios",
+  page({ import: "baz", from: "@src/qux" }),
+);
+
+export default app({
+  name: "hola",
+  wasp: { version: "0.23.0" },
+  title: "My Hola App",
+  auth: {
+    userEntity: "User",
+    methods: {
+      email: {
+        fromField: { email: "my@app.com" },
+        emailVerification: { clientRoute: "/sdafouijnsdu" },
+        passwordReset: { clientRoute: adiosRoute },
+      },
+    },
+    onAuthFailedRedirectTo: holaRoute,
+  },
+  parts: [holaRoute, adiosRoute],
+});

--- a/waspc/data/packages/wasp-config/src/spec/mapApp.ts
+++ b/waspc/data/packages/wasp-config/src/spec/mapApp.ts
@@ -233,8 +233,11 @@ export function mapAuth(
         ? undefined
         : entityRefParser(externalAuthEntity),
     methods: mapAuthMethods(methods, routeRefParser),
-    onAuthFailedRedirectTo,
-    onAuthSucceededRedirectTo,
+    onAuthFailedRedirectTo:
+      onAuthFailedRedirectTo && routeTargetToString(onAuthFailedRedirectTo),
+    onAuthSucceededRedirectTo:
+      onAuthSucceededRedirectTo &&
+      routeTargetToString(onAuthSucceededRedirectTo),
     onBeforeSignup: onBeforeSignup && mapExtImport(onBeforeSignup),
     onAfterSignup: onAfterSignup && mapExtImport(onAfterSignup),
     onAfterEmailVerified:
@@ -311,7 +314,7 @@ export function mapEmailFlow(
   const { getEmailContentFn, clientRoute } = emailFlow;
   return {
     getEmailContentFn: getEmailContentFn && mapExtImport(getEmailContentFn),
-    clientRoute: routeRefParser(clientRoute),
+    clientRoute: routeTargetToRef(clientRoute, routeRefParser),
   };
 }
 
@@ -474,6 +477,19 @@ type GetPartForKind<Kind extends TsAppSpec.Part["kind"]> = Extract<
   TsAppSpec.Part,
   { kind: Kind }
 >;
+
+function routeTargetToString(routeTarget: TsAppSpec.RouteTarget) {
+  return typeof routeTarget === "string" ? routeTarget : routeTarget.path;
+}
+
+export function routeTargetToRef(
+  routeTarget: TsAppSpec.RouteTarget,
+  routeRefParser: RefParser<"Route">,
+) {
+  const routePath =
+    typeof routeTarget === "string" ? routeTarget : routeTarget.path;
+  return routeRefParser(routePath);
+}
 
 function mapToDecls<T, DeclType extends AppSpec.Decl["declType"]>(
   items: T[],

--- a/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/wasp-config/src/spec/publicApi/tsAppSpec.ts
@@ -18,9 +18,11 @@ export type Auth = AuthHooks & {
   userEntity: string;
   externalAuthEntity?: string;
   methods: AuthMethods;
-  onAuthFailedRedirectTo: string;
-  onAuthSucceededRedirectTo?: string;
+  onAuthFailedRedirectTo: RouteTarget;
+  onAuthSucceededRedirectTo?: RouteTarget;
 };
+
+export type RouteTarget = Route | string;
 
 export type AuthHooks = Partial<Record<AuthHookName, ExtImport>>;
 
@@ -64,7 +66,7 @@ export type BaseAuthMethodConfig = {
 
 export type EmailFlowConfig = {
   getEmailContentFn?: ExtImport;
-  clientRoute: string;
+  clientRoute: RouteTarget;
 };
 
 export type Server = {


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Replace this message here, and write a high-level overview with any additional
context (motivation, trade-offs, approaches considered, concerns, ...).

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
