### PR TITLE
Fix Open Vibe post author frontmatter

### DIFF
--- a/web/blog/2026-04-29-introducing-open-vibe.mdx
+++ b/web/blog/2026-04-29-introducing-open-vibe.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introducing Open Vibe: Learn Web Dev While You Build Apps With an AI Tutor"
-author: vinny
+authors: [vinny]
 image: /img/open-vibe/banner.webp
 tags: [wasp, open vibe, vibe coding, ai, education, claude code]
 keywords: ["open vibe course", "vibe coding tutorial", "learn full-stack with AI", "AI coding tutor", "claude code course", "free vibe coding course", "open source coding curriculum", "ship your first app", "vibe coding for beginners", "AI agent tutor", "learn web development with AI", "open saas course"]


### PR DESCRIPTION
## Description

The "Introducing Open Vibe" blog post used the deprecated singular `author: vinny` frontmatter syntax. Docusaurus only resolves author keys against `authors.yml` for the plural `authors:` field, so `author:` was treated as a literal name string (warning: `"key":null`) and the author profile/page never resolved. Switched to `authors: [vinny]`, matching the blog style guide and clearing the build warning.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)