### PR TITLE
Skip lowering @src spec module imports

### DIFF
--- a/waspc/data/packages/spec/__tests__/spec-pipeline/lowerSrcImports.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/lowerSrcImports.unit.test.ts
@@ -117,6 +117,19 @@ describe("lowerSrcImports", () => {
     expect(lowerSrcImports({ sourceText: input, sourcePath })).toBe(input);
   });
 
+  test("leaves @src imports to .wasp.ts spec modules untouched", () => {
+    const input = [
+      `import "@src/features/register.wasp.js";`,
+      `import { homePage } from "@src/features/home.wasp.js";`,
+      `import { tasks } from "@src/features/tasks.wasp";`,
+      `import type { AdminPage } from "@src/features/admin.wasp.ts";`,
+      `export { dashboardPage } from "@src/features/dashboard.wasp.js";`,
+      ``,
+    ].join("\n");
+
+    expect(lowerSrcImports({ sourceText: input, sourcePath })).toBe(input);
+  });
+
   test("lowers only the matching import in a mixed file", () => {
     const input = [
       `import { App } from "@wasp.sh/spec";`,

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/pipeline.integration.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/pipeline.integration.test.ts
@@ -176,7 +176,7 @@ describe("Wasp TS spec pipeline", () => {
       );
     });
 
-    test("loads split .wasp.ts specs and lowers nested @src imports", async () => {
+    test("loads split .wasp.ts specs imported through @src and lowers nested @src imports", async () => {
       const tempDir = makeTempProject("wasp-spec-split-");
       writeUserSourceFiles(tempDir);
       writeNodePackage(tempDir, "spec-helper-package", {
@@ -215,7 +215,7 @@ describe("Wasp TS spec pipeline", () => {
         sourceText: [
           `// @ts-ignore: This test imports the local TS source through Vitest.`,
           `import { app } from ${JSON.stringify(waspSpecEntryUrl)};`,
-          `import { homePage } from "./src/features/home.wasp.js";`,
+          `import { homePage } from "@src/features/home.wasp.js";`,
           `import { archiveAction, splitTitle } from "./features/tasks.wasp.js";`,
           ``,
           `export default app({`,

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/planImportLowering/index.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/planImportLowering/index.unit.test.ts
@@ -70,6 +70,22 @@ describe("planImportLowering", () => {
     ).toEqual({ replacements: [] });
   });
 
+  test("leaves @src imports to .wasp.ts spec modules out of the plan", () => {
+    expect(
+      planImportLowering({
+        sourcePath,
+        sourceText: [
+          `import "@src/features/register.wasp.js";`,
+          `import { homePage } from "@src/features/home.wasp.js";`,
+          `import { tasks } from "@src/features/tasks.wasp";`,
+          `import type { AdminPage } from "@src/features/admin.wasp.ts";`,
+          `export { dashboardPage } from "@src/features/dashboard.wasp.js";`,
+          ``,
+        ].join("\n"),
+      }),
+    ).toEqual({ replacements: [] });
+  });
+
   test.each([
     {
       source: `import "@src/setup";\n`,

--- a/waspc/data/packages/spec/src/spec-pipeline/loadWaspTsSpec.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/loadWaspTsSpec.ts
@@ -1,5 +1,6 @@
 import type { JitiOptions } from "jiti";
 import { createJiti } from "jiti";
+import { dirname, join } from "node:path";
 import { lowerSrcImports } from "./lowerSrcImports.js";
 
 export async function loadWaspTsSpecDefaultExport({
@@ -21,6 +22,9 @@ function createSpecJiti(entryPath: string, tsconfigPath: string) {
     interopDefault: false,
     jsx: true,
     moduleCache: false,
+    alias: {
+      "@src/": join(dirname(tsconfigPath), "src/"),
+    },
     tsconfigPaths: tsconfigPath,
   } satisfies JitiOptions;
 

--- a/waspc/data/packages/spec/src/spec-pipeline/planImportLowering/supportedImportTypes.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/planImportLowering/supportedImportTypes.ts
@@ -103,7 +103,7 @@ export function assertNonSrcImportEqualsDeclaration(
   stmt: ts.ImportEqualsDeclaration,
 ): void {
   const specifier = getImportEqualsSpecifier(stmt);
-  if (!specifier || !isSrcImportSpecifier(specifier)) {
+  if (!isLowerableSrcImportSpecifier(specifier)) {
     return;
   }
 
@@ -122,8 +122,8 @@ export function assertNonSrcReExport(
     return;
   }
 
-  const specifier = getSrcImportSpecifier(stmt.moduleSpecifier);
-  if (!specifier) {
+  const specifier = getStringModuleSpecifier(stmt.moduleSpecifier);
+  if (!isLowerableSrcImportSpecifier(specifier)) {
     return;
   }
 
@@ -151,7 +151,7 @@ export function getSrcImportSpecifier(
   moduleSpecifier: ts.Expression,
 ): string | undefined {
   const specifier = getStringModuleSpecifier(moduleSpecifier);
-  if (!specifier || !isSrcImportSpecifier(specifier)) {
+  if (!isLowerableSrcImportSpecifier(specifier)) {
     return undefined;
   }
 
@@ -166,4 +166,22 @@ function getStringModuleSpecifier(
 
 function isSrcImportSpecifier(specifier: string): boolean {
   return specifier.startsWith(SRC_IMPORT_PREFIX);
+}
+
+function isLowerableSrcImportSpecifier(
+  specifier: string | undefined,
+): specifier is string {
+  return (
+    specifier !== undefined &&
+    isSrcImportSpecifier(specifier) &&
+    !isWaspTsSpecModuleSpecifier(specifier)
+  );
+}
+
+function isWaspTsSpecModuleSpecifier(specifier: string): boolean {
+  return (
+    specifier.endsWith(".wasp") ||
+    specifier.endsWith(".wasp.js") ||
+    specifier.endsWith(".wasp.ts")
+  );
 }


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Stops import lowering from treating `@src/.../*.wasp.ts` spec-module imports as user-source imports. Those imports now stay as imports, while regular `@src` imports in Wasp TS specs still lower to ExtImport descriptors.

Also configures the spec loader's `jiti` instance with the `@src/` alias so unlowered split spec imports can resolve at runtime.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [x] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
