### PR TITLE
Fix broken GuideLink paths in deployment docs and enable broken-link detection

### DIFF
--- a/web/docs/deployment/deployment-methods/paas.md
+++ b/web/docs/deployment/deployment-methods/paas.md
@@ -11,17 +11,17 @@ You can deploy the built Wasp app wherever and however you want, as long as your
 
 We have step-by-step guides for deploying your Wasp app to some of the most popular providers you can follow:
 
-<GuideLink linkToGuide="../../guides/deployment/cloudflare" title="Deploying Wasp to Cloudflare Workers" description="Uses Cloudflare Workers, Wrangler CLI" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/cloudflare" title="Deploying Wasp to Cloudflare Workers" description="Uses Cloudflare Workers, Wrangler CLI" />
 
-<GuideLink linkToGuide="../../guides/deployment/flyio" title="Deploying Wasp to Fly.io" description="Uses Fly.io, fly CLI, Docker" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/flyio" title="Deploying Wasp to Fly.io" description="Uses Fly.io, fly CLI, Docker" />
 
-<GuideLink linkToGuide="../../guides/deployment/heroku" title="Deploying Wasp to Heroku" description="Uses Heroku, heroku CLI, Docker" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/heroku" title="Deploying Wasp to Heroku" description="Uses Heroku, heroku CLI, Docker" />
 
-<GuideLink linkToGuide="../../guides/deployment/netlify" title="Deploying Wasp to Netlify" description="Uses Netlify, Netlify CLI" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/netlify" title="Deploying Wasp to Netlify" description="Uses Netlify, Netlify CLI" />
 
-<GuideLink linkToGuide="../../guides/deployment/railway" title="Deploying Wasp to Railway" description="Uses Railway, Railway CLI" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/railway" title="Deploying Wasp to Railway" description="Uses Railway, Railway CLI" />
 
-<GuideLink linkToGuide="../../guides/deployment/render" title="Deploying Wasp on Render" description="Uses Render, Blueprint (IaC)" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/render" title="Deploying Wasp on Render" description="Uses Render, Blueprint (IaC)" />
 
 If your desired provider isn't on the list, no worries, you can still deploy your app  - it just means we don't yet have a step-by-step guide for you to follow.
 Feel free to [open a PR](https://github.com/wasp-lang/wasp/edit/release/web/docs/deployment/deployment-methods/paas.md) if you'd like to write one yourself :)

--- a/web/docs/deployment/deployment-methods/self-hosted.md
+++ b/web/docs/deployment/deployment-methods/self-hosted.md
@@ -11,11 +11,11 @@ If you have your server or rent out a server, you can self-host your Wasp apps. 
 
 We have step-by-step guides for deploying your Wasp app on your server with different methods. Check out the guides below:
 
-<GuideLink linkToGuide="../../guides/deployment/caprover" title="Deploying Wasp with Caprover on your server" description="Uses Caprover, Github Actions, Github Container Registry" />
+<GuideLink linkToGuide="../../guides/deployment/self-hosted/caprover" title="Deploying Wasp with Caprover on your server" description="Uses Caprover, Github Actions, Github Container Registry" />
 
-<GuideLink linkToGuide="../../guides/deployment/coolify" title="Deploying Wasp with Coolify on your server" description="Uses Coolify, Github Actions, Github Container Registry" />
+<GuideLink linkToGuide="../../guides/deployment/self-hosted/coolify" title="Deploying Wasp with Coolify on your server" description="Uses Coolify, Github Actions, Github Container Registry" />
 
-<GuideLink linkToGuide="../../guides/deployment/vps" title="Deploying Wasp with Docker on your server" description="Uses Ubuntu, Git, Caddy, Docker" />
+<GuideLink linkToGuide="../../guides/deployment/self-hosted/vps" title="Deploying Wasp with Docker on your server" description="Uses Ubuntu, Git, Caddy, Docker" />
 
 ## Manual deployment
 

--- a/web/src/components/GuideLink/index.tsx
+++ b/web/src/components/GuideLink/index.tsx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import "./styles.css";
 
 export function GuideLink({
@@ -10,12 +11,12 @@ export function GuideLink({
   description: string;
 }) {
   return (
-    <a href={linkToGuide} className="guide-link">
+    <Link to={linkToGuide} className="guide-link">
       <div>
         <span className="subtitle">guide</span>
       </div>
       <h3>{title} »</h3>
       <p className="description">{description}</p>
-    </a>
+    </Link>
   );
 }

--- a/web/versioned_docs/version-0.23/deployment/deployment-methods/paas.md
+++ b/web/versioned_docs/version-0.23/deployment/deployment-methods/paas.md
@@ -11,17 +11,17 @@ You can deploy the built Wasp app wherever and however you want, as long as your
 
 We have step-by-step guides for deploying your Wasp app to some of the most popular providers you can follow:
 
-<GuideLink linkToGuide="../../guides/deployment/cloudflare" title="Deploying Wasp to Cloudflare Workers" description="Uses Cloudflare Workers, Wrangler CLI" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/cloudflare" title="Deploying Wasp to Cloudflare Workers" description="Uses Cloudflare Workers, Wrangler CLI" />
 
-<GuideLink linkToGuide="../../guides/deployment/flyio" title="Deploying Wasp to Fly.io" description="Uses Fly.io, fly CLI, Docker" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/flyio" title="Deploying Wasp to Fly.io" description="Uses Fly.io, fly CLI, Docker" />
 
-<GuideLink linkToGuide="../../guides/deployment/heroku" title="Deploying Wasp to Heroku" description="Uses Heroku, heroku CLI, Docker" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/heroku" title="Deploying Wasp to Heroku" description="Uses Heroku, heroku CLI, Docker" />
 
-<GuideLink linkToGuide="../../guides/deployment/netlify" title="Deploying Wasp to Netlify" description="Uses Netlify, Netlify CLI" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/netlify" title="Deploying Wasp to Netlify" description="Uses Netlify, Netlify CLI" />
 
-<GuideLink linkToGuide="../../guides/deployment/railway" title="Deploying Wasp to Railway" description="Uses Railway, Railway CLI" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/railway" title="Deploying Wasp to Railway" description="Uses Railway, Railway CLI" />
 
-<GuideLink linkToGuide="../../guides/deployment/render" title="Deploying Wasp on Render" description="Uses Render, Blueprint (IaC)" />
+<GuideLink linkToGuide="../../guides/deployment/cloud-providers/render" title="Deploying Wasp on Render" description="Uses Render, Blueprint (IaC)" />
 
 If your desired provider isn't on the list, no worries, you can still deploy your app  - it just means we don't yet have a step-by-step guide for you to follow.
 Feel free to [open a PR](https://github.com/wasp-lang/wasp/edit/release/web/docs/deployment/deployment-methods/paas.md) if you'd like to write one yourself :)

--- a/web/versioned_docs/version-0.23/deployment/deployment-methods/self-hosted.md
+++ b/web/versioned_docs/version-0.23/deployment/deployment-methods/self-hosted.md
@@ -11,11 +11,11 @@ If you have your server or rent out a server, you can self-host your Wasp apps. 
 
 We have step-by-step guides for deploying your Wasp app on your server with different methods. Check out the guides below:
 
-<GuideLink linkToGuide="../../guides/deployment/caprover" title="Deploying Wasp with Caprover on your server" description="Uses Caprover, Github Actions, Github Container Registry" />
+<GuideLink linkToGuide="../../guides/deployment/self-hosted/caprover" title="Deploying Wasp with Caprover on your server" description="Uses Caprover, Github Actions, Github Container Registry" />
 
-<GuideLink linkToGuide="../../guides/deployment/coolify" title="Deploying Wasp with Coolify on your server" description="Uses Coolify, Github Actions, Github Container Registry" />
+<GuideLink linkToGuide="../../guides/deployment/self-hosted/coolify" title="Deploying Wasp with Coolify on your server" description="Uses Coolify, Github Actions, Github Container Registry" />
 
-<GuideLink linkToGuide="../../guides/deployment/vps" title="Deploying Wasp with Docker on your server" description="Uses Ubuntu, Git, Caddy, Docker" />
+<GuideLink linkToGuide="../../guides/deployment/self-hosted/vps" title="Deploying Wasp with Docker on your server" description="Uses Ubuntu, Git, Caddy, Docker" />
 
 ## Manual deployment
 


### PR DESCRIPTION
## Description

The deployment guides were moved into `cloud-providers/` and `self-hosted/` subfolders in 0.23, but the `GuideLink` paths in `paas.md` and `self-hosted.md` weren't updated. Fixed both in `web/docs/` and in `versioned_docs/version-0.23/` (where the same broken links are visible on the live site). Also switched `GuideLink` from a plain `<a>` to Docusaurus's `<Link>`, so the build's broken-link checker now catches these going forward (verified: a fresh build with `DOCS_INCLUDE_CURRENT_VERSION=true` first surfaced the existing broken links, then passed after the fixes).

## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.