### PR TITLE
Typecheck only src files in Vite builds

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -2,7 +2,7 @@ import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {
-  tsConfigPath: string
+  srcTsConfigPath: string
 }
 
 export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
@@ -10,16 +10,16 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc(options.tsConfigPath)
+      await runTsc(options.srcTsConfigPath)
     },
   }
 }
 
-function runTsc(tsConfigPath: string): Promise<void> {
+function runTsc(srcTsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--project', tsConfigPath, '--noEmit'],
+      ['--project', srcTsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,21 +1,25 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
-export function typescriptCheck(): Plugin {
+interface TypeScriptCheckOptions {
+  tsConfigPath: string
+}
+
+export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc()
+      await runTsc(options.tsConfigPath)
     },
   }
 }
 
-function runTsc(): Promise<void> {
+function runTsc(tsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--build', '--noEmit'],
+      ['--project', tsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/wasp.ts
@@ -27,7 +27,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck({ tsConfigPath: "{= srcTsConfigPath =}" }),
+    typescriptCheck({ srcTsConfigPath: "{= srcTsConfigPath =}" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/wasp.ts
@@ -27,7 +27,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck(),
+    typescriptCheck({ tsConfigPath: "{= srcTsConfigPath =}" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/e2e-tests/Tests/ViteBuildTest.hs
+++ b/waspc/e2e-tests/Tests/ViteBuildTest.hs
@@ -8,6 +8,7 @@ import ShellCommands
     ShellCommandBuilder,
     TestContext,
     WaspProjectContext (..),
+    appendToFile,
     createTestWaspProject,
     inTestWaspProjectDir,
     setWaspDbToPSQL,
@@ -24,7 +25,7 @@ import Wasp.Project.Env (dotEnvClient)
 viteBuildTest :: Test
 viteBuildTest =
   Test
-    "vite-build-env-vars"
+    "vite-build"
     [ TestCase
         "fail-on-missing-required-env-vars"
         ( createViteBuildTestCase [expectCommandFailure <$> viteBuild]
@@ -65,14 +66,17 @@ viteBuildTest =
             ]
         ),
       TestCase
-        "succeed-with-wasp-ts-project"
-        ( sequence
-            [ createTestWaspProject tsMinimalStarterTemplate,
-              inTestWaspProjectDir
-                [ setWaspDbToPSQL,
-                  waspCliBuild,
-                  appendInlineEnvVars [apiUrlEnvVar] <$> viteBuild
-                ]
+        "fail-on-user-code-type-error"
+        ( createTsMinimalViteBuildTestCase
+            [ addTypeErrorToSrcFile,
+              expectCommandFailure <$> viteBuildWithApiUrl
+            ]
+        ),
+      TestCase
+        "ignore-wasp-ts-type-errors"
+        ( createTsMinimalViteBuildTestCase
+            [ addTypeErrorToWaspTsFile,
+              viteBuildWithApiUrl
             ]
         )
     ]
@@ -84,8 +88,18 @@ viteBuildTest =
           inTestWaspProjectDir $ [setWaspDbToPSQL, writeMainPageTsx, waspCliBuild] ++ commands
         ]
 
+    createTsMinimalViteBuildTestCase :: [ShellCommandBuilder WaspProjectContext ShellCommand] -> ShellCommandBuilder TestContext [ShellCommand]
+    createTsMinimalViteBuildTestCase commands =
+      sequence
+        [ createTestWaspProject tsMinimalStarterTemplate,
+          inTestWaspProjectDir $ [setWaspDbToPSQL, waspCliBuild] ++ commands
+        ]
+
     viteBuild :: ShellCommandBuilder WaspProjectContext ShellCommand
     viteBuild = return "npx vite build"
+
+    viteBuildWithApiUrl :: ShellCommandBuilder WaspProjectContext ShellCommand
+    viteBuildWithApiUrl = appendInlineEnvVars [apiUrlEnvVar] <$> viteBuild
 
     assertBuildOutputContains :: String -> ShellCommandBuilder WaspProjectContext ShellCommand
     assertBuildOutputContains value = return $ "grep -r '" ++ value ++ "' " ++ SP.fromRelDir viteBuildDirPath
@@ -108,6 +122,15 @@ viteBuildTest =
       writeToFile (waspProjectContext.waspProjectDir </> dotEnvClient) $
         T.pack $
           testEnvVarKey ++ "=" ++ value
+
+    addTypeErrorToSrcFile :: ShellCommandBuilder WaspProjectContext ShellCommand
+    addTypeErrorToSrcFile = appendToFile "src/MainPage.tsx" typeError
+
+    addTypeErrorToWaspTsFile :: ShellCommandBuilder WaspProjectContext ShellCommand
+    addTypeErrorToWaspTsFile = appendToFile "main.wasp.ts" typeError
+
+    typeError :: T.Text
+    typeError = "const shouldBeString: string = 123"
 
     appendInlineEnvVars :: [(String, String)] -> ShellCommand -> ShellCommand
     appendInlineEnvVars envVars command = foldr appendInlineEnvVar command envVars

--- a/waspc/e2e-tests/Tests/ViteBuildTest.hs
+++ b/waspc/e2e-tests/Tests/ViteBuildTest.hs
@@ -17,7 +17,7 @@ import ShellCommands
 import StrongPath (relfile, (</>))
 import qualified StrongPath as SP
 import Test (Test (..), TestCase (..))
-import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate, tsMinimalStarterTemplate)
 import Wasp.Generator.WebAppGenerator (viteBuildDirPath)
 import Wasp.Project.Env (dotEnvClient)
 
@@ -62,6 +62,17 @@ viteBuildTest =
             [ writeDotEnvClientFile dotEnvFileValue,
               appendInlineEnvVars [apiUrlEnvVar, (testEnvVarKey, inlineEnvVarValue)] <$> viteBuild,
               assertBuildOutputContains inlineEnvVarValue
+            ]
+        ),
+      TestCase
+        "succeed-with-wasp-ts-project"
+        ( sequence
+            [ createTestWaspProject tsMinimalStarterTemplate,
+              inTestWaspProjectDir
+                [ setWaspDbToPSQL,
+                  waspCliBuild,
+                  appendInlineEnvVars [apiUrlEnvVar] <$> viteBuild
+                ]
             ]
         )
     ]

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -753,7 +753,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "737990d1ed27a0481690366da5a0c8cd7bd795a08e0984d35eac8f6a132fbd3c"
+        "ce47c280695bf45c631306320e25b936782fee5b4cf688130498d298b9140904"
     ],
     [
         [
@@ -774,7 +774,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "7024075a1d16f094219ca1c8bc1dec4e8ed2cccafc4a9f716992a68ed05af2f3"
+        "5309ca5216d526747bef3521e961c98a942ea4b37ed0db3365cac4cab5e61c7a"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -753,7 +753,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "ce47c280695bf45c631306320e25b936782fee5b4cf688130498d298b9140904"
+        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
     ],
     [
         [
@@ -774,7 +774,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "5309ca5216d526747bef3521e961c98a942ea4b37ed0db3365cac4cab5e61c7a"
+        "b2ab09a8b602fb9dad48d30abf1e7fe3aa98e24d6241603c4a70c3f28ac892c5"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -2,7 +2,7 @@ import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {
-  tsConfigPath: string
+  srcTsConfigPath: string
 }
 
 export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
@@ -10,16 +10,16 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc(options.tsConfigPath)
+      await runTsc(options.srcTsConfigPath)
     },
   }
 }
 
-function runTsc(tsConfigPath: string): Promise<void> {
+function runTsc(srcTsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--project', tsConfigPath, '--noEmit'],
+      ['--project', srcTsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,21 +1,25 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
-export function typescriptCheck(): Plugin {
+interface TypeScriptCheckOptions {
+  tsConfigPath: string
+}
+
+export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc()
+      await runTsc(options.tsConfigPath)
     },
   }
 }
 
-function runTsc(): Promise<void> {
+function runTsc(tsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--build', '--noEmit'],
+      ['--project', tsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -26,7 +26,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck(),
+    typescriptCheck({ tsConfigPath: "tsconfig.json" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -26,7 +26,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck({ tsConfigPath: "tsconfig.json" }),
+    typescriptCheck({ srcTsConfigPath: "tsconfig.json" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "ce47c280695bf45c631306320e25b936782fee5b4cf688130498d298b9140904"
+        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "e30a98587561c5904a15947239af393465cc5822cd2f34041aada30db9ccd2d0"
+        "89dcbfc6645d4c53faa393c3a448f5ded31081dc0178197c27df39ff98ca2add"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "737990d1ed27a0481690366da5a0c8cd7bd795a08e0984d35eac8f6a132fbd3c"
+        "ce47c280695bf45c631306320e25b936782fee5b4cf688130498d298b9140904"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "356176e14b791e4d2bf5896dda26d1758cc80500533888990db0ba2b265a1361"
+        "e30a98587561c5904a15947239af393465cc5822cd2f34041aada30db9ccd2d0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -2,7 +2,7 @@ import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {
-  tsConfigPath: string
+  srcTsConfigPath: string
 }
 
 export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
@@ -10,16 +10,16 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc(options.tsConfigPath)
+      await runTsc(options.srcTsConfigPath)
     },
   }
 }
 
-function runTsc(tsConfigPath: string): Promise<void> {
+function runTsc(srcTsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--project', tsConfigPath, '--noEmit'],
+      ['--project', srcTsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,21 +1,25 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
-export function typescriptCheck(): Plugin {
+interface TypeScriptCheckOptions {
+  tsConfigPath: string
+}
+
+export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc()
+      await runTsc(options.tsConfigPath)
     },
   }
 }
 
-function runTsc(): Promise<void> {
+function runTsc(tsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--build', '--noEmit'],
+      ['--project', tsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -26,7 +26,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck(),
+    typescriptCheck({ tsConfigPath: "tsconfig.json" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -26,7 +26,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck({ tsConfigPath: "tsconfig.json" }),
+    typescriptCheck({ srcTsConfigPath: "tsconfig.json" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "ce47c280695bf45c631306320e25b936782fee5b4cf688130498d298b9140904"
+        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "e30a98587561c5904a15947239af393465cc5822cd2f34041aada30db9ccd2d0"
+        "89dcbfc6645d4c53faa393c3a448f5ded31081dc0178197c27df39ff98ca2add"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "737990d1ed27a0481690366da5a0c8cd7bd795a08e0984d35eac8f6a132fbd3c"
+        "ce47c280695bf45c631306320e25b936782fee5b4cf688130498d298b9140904"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "356176e14b791e4d2bf5896dda26d1758cc80500533888990db0ba2b265a1361"
+        "e30a98587561c5904a15947239af393465cc5822cd2f34041aada30db9ccd2d0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -2,7 +2,7 @@ import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {
-  tsConfigPath: string
+  srcTsConfigPath: string
 }
 
 export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
@@ -10,16 +10,16 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc(options.tsConfigPath)
+      await runTsc(options.srcTsConfigPath)
     },
   }
 }
 
-function runTsc(tsConfigPath: string): Promise<void> {
+function runTsc(srcTsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--project', tsConfigPath, '--noEmit'],
+      ['--project', srcTsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,21 +1,25 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
-export function typescriptCheck(): Plugin {
+interface TypeScriptCheckOptions {
+  tsConfigPath: string
+}
+
+export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc()
+      await runTsc(options.tsConfigPath)
     },
   }
 }
 
-function runTsc(): Promise<void> {
+function runTsc(tsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--build', '--noEmit'],
+      ['--project', tsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -26,7 +26,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck(),
+    typescriptCheck({ tsConfigPath: "tsconfig.json" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -26,7 +26,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck({ tsConfigPath: "tsconfig.json" }),
+    typescriptCheck({ srcTsConfigPath: "tsconfig.json" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "ce47c280695bf45c631306320e25b936782fee5b4cf688130498d298b9140904"
+        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "e30a98587561c5904a15947239af393465cc5822cd2f34041aada30db9ccd2d0"
+        "89dcbfc6645d4c53faa393c3a448f5ded31081dc0178197c27df39ff98ca2add"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "737990d1ed27a0481690366da5a0c8cd7bd795a08e0984d35eac8f6a132fbd3c"
+        "ce47c280695bf45c631306320e25b936782fee5b4cf688130498d298b9140904"
     ],
     [
         [
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "356176e14b791e4d2bf5896dda26d1758cc80500533888990db0ba2b265a1361"
+        "e30a98587561c5904a15947239af393465cc5822cd2f34041aada30db9ccd2d0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -2,7 +2,7 @@ import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {
-  tsConfigPath: string
+  srcTsConfigPath: string
 }
 
 export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
@@ -10,16 +10,16 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc(options.tsConfigPath)
+      await runTsc(options.srcTsConfigPath)
     },
   }
 }
 
-function runTsc(tsConfigPath: string): Promise<void> {
+function runTsc(srcTsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--project', tsConfigPath, '--noEmit'],
+      ['--project', srcTsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,21 +1,25 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
-export function typescriptCheck(): Plugin {
+interface TypeScriptCheckOptions {
+  tsConfigPath: string
+}
+
+export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
     async buildStart() {
-      await runTsc()
+      await runTsc(options.tsConfigPath)
     },
   }
 }
 
-function runTsc(): Promise<void> {
+function runTsc(tsConfigPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       'tsc',
-      ['--build', '--noEmit'],
+      ['--project', tsConfigPath, '--noEmit'],
       {
         stdio: 'inherit',
         shell: process.platform === 'win32',

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -26,7 +26,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck(),
+    typescriptCheck({ tsConfigPath: "tsconfig.json" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -26,7 +26,7 @@ export function wasp(options?: WaspPluginOptions): PluginOption {
     /**
      * Plugins running after core Vite plugins.
      */
-    typescriptCheck({ tsConfigPath: "tsconfig.json" }),
+    typescriptCheck({ srcTsConfigPath: "tsconfig.json" }),
     validateEnv(),
     react(options?.reactOptions),
     ssr({

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/VitePluginG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/VitePluginG.hs
@@ -54,6 +54,7 @@ genWaspPlugin spec = return $ C.mkTmplFdWithData tmplPath tmplData
     tmplData =
       object
         [ "clientEntryPointPath" .= clientEntryPointPath,
+          "srcTsConfigPath" .= SP.fromRelFile (AS.srcTsConfigPath spec),
           "ssrEntryPointPath" .= ssrEntryPointPath,
           "spaFallbackFile" .= spaFallbackFile,
           "ssrPaths" .= makeJsArrayFromHaskellList prerenderPaths


### PR DESCRIPTION
## Description

Changes the `wasp:typescript-check` Vite plugin to run TypeScript only against the source tsconfig passed from Haskell. This avoids checking `.wasp.ts` files during Vite builds, since those files need Wasp import lowering before they are valid TypeScript.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [x] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
