### PR TITLE
Throw SpecUserError from spec analyzer

### DIFF
--- a/waspc/data/packages/spec/__tests__/spec-pipeline/pipeline.integration.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/pipeline.integration.test.ts
@@ -495,15 +495,11 @@ async function analyzeSpec({
   writeFileSync(sourcePath, sourceText, "utf8");
   writeTsConfig(tsconfigPath, specFileName);
 
-  const result = await analyzeApp({
+  return analyzeApp({
     waspTsSpecPath: sourcePath,
     tsconfigPath,
     entityNames: [],
   });
-
-  if (result.status === "error") throw new Error(result.error);
-
-  return result.value;
 }
 
 function writeTsConfig(tsconfigPath: string, include: string): void {

--- a/waspc/data/packages/spec/__tests__/spec/appAnalyzer.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec/appAnalyzer.unit.test.ts
@@ -3,6 +3,7 @@ import { loadWaspTsSpecDefaultExport } from "../../src/spec-pipeline/loadWaspTsS
 import { analyzeApp } from "../../src/spec/appAnalyzer.js";
 import { mapApp } from "../../src/spec/mapApp.js";
 import * as TsAppSpec from "../../src/spec/publicApi/tsAppSpec.js";
+import { SpecUserError } from "../../src/spec/specUserError.js";
 import * as Fixtures from "./testFixtures.js";
 
 vi.mock("../../src/spec-pipeline/loadWaspTsSpec.js", () => ({
@@ -62,28 +63,25 @@ describe("analyzeApp", () => {
     } = input;
     mockLoadWaspTsSpecDefaultExport.mockResolvedValue(app);
 
-    const result = await analyzeApp({
-      waspTsSpecPath: "main.wasp.ts",
-      tsconfigPath: "tsconfig.wasp.json",
-      entityNames: entities,
-    });
+    const analyze = () =>
+      analyzeApp({
+        waspTsSpecPath: "main.wasp.ts",
+        tsconfigPath: "tsconfig.wasp.json",
+        entityNames: entities,
+      });
+
+    if (shouldReturnError) {
+      await expect(analyze()).rejects.toThrowError(SpecUserError);
+    } else {
+      const result = await analyze();
+      const expected = mapApp(app, entities);
+
+      expect(result).toEqual(expected);
+    }
 
     expect(mockLoadWaspTsSpecDefaultExport).toHaveBeenCalledWith({
       specPath: "main.wasp.ts",
       tsconfigPath: "tsconfig.wasp.json",
     });
-
-    if (shouldReturnError) {
-      expect(result).toMatchObject({
-        status: "error",
-        error: expect.anything(),
-      });
-    } else {
-      const expected = mapApp(app, entities);
-      expect(result).toMatchObject({
-        status: "ok",
-        value: expected,
-      });
-    }
   }
 });

--- a/waspc/data/packages/spec/src/result.ts
+++ b/waspc/data/packages/spec/src/result.ts
@@ -1,7 +1,0 @@
-/**
- * Use Result instead of exceptions when expected failures should be reported
- * without stack traces and kept visible in the type system.
- */
-export type Result<Value, Error> =
-  | { status: "ok"; value: Value }
-  | { status: "error"; error: Error };

--- a/waspc/data/packages/spec/src/run.ts
+++ b/waspc/data/packages/spec/src/run.ts
@@ -24,15 +24,11 @@ async function main(args: string[]): Promise<void> {
   const { waspTsSpecPath, tsconfigPath, declsJsonPath, entityNames } =
     parseProcessArgsOrThrow(args);
 
-  const declsResult = await analyzeApp({
+  const decls = await analyzeApp({
     waspTsSpecPath,
     tsconfigPath,
     entityNames,
   });
 
-  if (declsResult.status === "error") {
-    throw new Error(declsResult.error);
-  }
-
-  writeFileSync(declsJsonPath, JSON.stringify(declsResult.value));
+  writeFileSync(declsJsonPath, JSON.stringify(decls));
 }

--- a/waspc/data/packages/spec/src/spec/appAnalyzer.ts
+++ b/waspc/data/packages/spec/src/spec/appAnalyzer.ts
@@ -1,8 +1,8 @@
 import * as AppSpec from "../appSpec.js";
-import type { Result } from "../result.js";
 import { loadWaspTsSpecDefaultExport } from "../spec-pipeline/loadWaspTsSpec.js";
 import { mapApp } from "./mapApp.js";
 import * as TsAppSpec from "./publicApi/tsAppSpec.js";
+import { SpecUserError } from "./specUserError.js";
 
 export async function analyzeApp({
   waspTsSpecPath,
@@ -12,47 +12,33 @@ export async function analyzeApp({
   waspTsSpecPath: string;
   tsconfigPath: string;
   entityNames: string[];
-}): Promise<Result<AppSpec.Decl[], string>> {
+}): Promise<AppSpec.Decl[]> {
   const waspTsDefaultExport = await loadWaspTsSpecDefaultExport({
     specPath: waspTsSpecPath,
     tsconfigPath,
   });
 
-  const appResult = getApp(waspTsDefaultExport);
+  const app = getApp(waspTsDefaultExport);
 
-  if (appResult.status === "error") {
-    return appResult;
-  }
-
-  const app = appResult.value;
-  const appSpecDecls = mapApp(app, entityNames);
-
-  return {
-    status: "ok",
-    value: appSpecDecls,
-  };
+  return mapApp(app, entityNames);
 }
 
-function getApp(waspTsDefaultExport: unknown): Result<TsAppSpec.App, string> {
+function getApp(waspTsDefaultExport: unknown): TsAppSpec.App {
   if (!waspTsDefaultExport) {
-    return {
-      status: "error",
-      error:
-        "Could not load your app config. " +
+    throw new SpecUserError(
+      "Could not load your app config. " +
         "Make sure your *.wasp.ts file includes a default export of the app.",
-    };
+    );
   }
 
   if (!isApp(waspTsDefaultExport)) {
-    return {
-      status: "error",
-      error:
-        "The default export of your *.wasp.ts file must be the result of " +
+    throw new SpecUserError(
+      "The default export of your *.wasp.ts file must be the result of " +
         "calling `app({ ... })`. Make sure you export that value.",
-    };
+    );
   }
 
-  return { status: "ok", value: waspTsDefaultExport };
+  return waspTsDefaultExport;
 }
 
 // TODO: This should probably live elsewhere.


### PR DESCRIPTION
## Description

Replaces the active Wasp TS spec analyzer `Result` return path with direct `SpecUserError` throws. The CLI now writes declarations directly and keeps user-facing `SpecUserError` handling at the top-level boundary.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you are unsure about any of them, do not hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.