### PR TITLE
Add Slack auth to TS spec API

### DIFF
--- a/waspc/data/packages/spec/__tests__/legacy/mapTsAppSpecToAppSpecDecls.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/legacy/mapTsAppSpecToAppSpecDecls.unit.test.ts
@@ -255,6 +255,7 @@ describe("mapAuthMethods", () => {
       usernameAndPassword:
         authMethods.usernameAndPassword &&
         mapUsernameAndPassword(authMethods.usernameAndPassword),
+      slack: authMethods.slack && mapExternalAuth(authMethods.slack),
       discord: authMethods.discord && mapExternalAuth(authMethods.discord),
       google: authMethods.google && mapExternalAuth(authMethods.google),
       gitHub: authMethods.gitHub && mapExternalAuth(authMethods.gitHub),

--- a/waspc/data/packages/spec/__tests__/legacy/testFixtures.ts
+++ b/waspc/data/packages/spec/__tests__/legacy/testFixtures.ts
@@ -175,6 +175,7 @@ export function getAuthMethods(
       return {
         email: getEmailAuthConfig(scope),
         usernameAndPassword: getUsernameAndPasswordConfig(scope),
+        slack: getExternalAuthConfig(scope),
         discord: getExternalAuthConfig(scope),
         google: getExternalAuthConfig(scope),
         gitHub: getExternalAuthConfig(scope),

--- a/waspc/data/packages/spec/__tests__/spec/mapApp.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec/mapApp.unit.test.ts
@@ -541,6 +541,7 @@ describe("mapAuthMethods", () => {
       usernameAndPassword:
         authMethods.usernameAndPassword &&
         mapUsernameAndPassword(authMethods.usernameAndPassword),
+      slack: authMethods.slack && mapExternalAuth(authMethods.slack),
       discord: authMethods.discord && mapExternalAuth(authMethods.discord),
       google: authMethods.google && mapExternalAuth(authMethods.google),
       gitHub: authMethods.gitHub && mapExternalAuth(authMethods.gitHub),

--- a/waspc/data/packages/spec/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/spec/__tests__/spec/testFixtures.ts
@@ -427,6 +427,7 @@ export function getAuthMethods(
       return {} satisfies MinimalConfig<TsAppSpec.AuthMethods>;
     case "full":
       return {
+        slack: getExternalAuthConfig("full"),
         discord: getExternalAuthConfig("full"),
         google: getExternalAuthConfig("full"),
         gitHub: getExternalAuthConfig("full"),

--- a/waspc/data/packages/spec/__tests__/spec/tsAppSpec.test-d.ts
+++ b/waspc/data/packages/spec/__tests__/spec/tsAppSpec.test-d.ts
@@ -24,6 +24,10 @@ describe("AuthMethods", () => {
     google: {},
   };
 
+  const slack: Required<Pick<TsAppSpec.AuthMethods, "slack">> = {
+    slack: {},
+  };
+
   test("allows only usernameAndPassword", () => {
     expectTypeOf<
       typeof usernameAndPassword
@@ -36,6 +40,7 @@ describe("AuthMethods", () => {
 
   test("allows no local auth method (e.g. only a social method)", () => {
     expectTypeOf<typeof google>().toExtend<TsAppSpec.AuthMethods>();
+    expectTypeOf<typeof slack>().toExtend<TsAppSpec.AuthMethods>();
     // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     expectTypeOf<{}>().toExtend<TsAppSpec.AuthMethods>();
   });

--- a/waspc/data/packages/spec/src/appSpec.ts
+++ b/waspc/data/packages/spec/src/appSpec.ts
@@ -161,6 +161,7 @@ export type Auth = {
 
 export type AuthMethods = {
   usernameAndPassword: Optional<UsernameAndPasswordConfig>;
+  slack: Optional<ExternalAuthConfig>;
   discord: Optional<ExternalAuthConfig>;
   google: Optional<ExternalAuthConfig>;
   gitHub: Optional<ExternalAuthConfig>;

--- a/waspc/data/packages/spec/src/legacy/mapTsAppSpecToAppSpecDecls.ts
+++ b/waspc/data/packages/spec/src/legacy/mapTsAppSpecToAppSpecDecls.ts
@@ -253,6 +253,7 @@ export function mapAuthMethods(
   // TODO: check keyof danger, effective ts
   const {
     usernameAndPassword,
+    slack,
     discord,
     google,
     gitHub,
@@ -263,6 +264,7 @@ export function mapAuthMethods(
   return {
     usernameAndPassword:
       usernameAndPassword && mapUsernameAndPassword(usernameAndPassword),
+    slack: slack && mapExternalAuth(slack),
     discord: discord && mapExternalAuth(discord),
     google: google && mapExternalAuth(google),
     gitHub: gitHub && mapExternalAuth(gitHub),

--- a/waspc/data/packages/spec/src/legacy/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/spec/src/legacy/publicApi/tsAppSpec.ts
@@ -65,6 +65,7 @@ export type AuthConfig = {
 
 export type AuthMethods = {
   usernameAndPassword?: UsernameAndPasswordConfig;
+  slack?: ExternalAuthConfig;
   discord?: ExternalAuthConfig;
   google?: ExternalAuthConfig;
   gitHub?: ExternalAuthConfig;

--- a/waspc/data/packages/spec/src/spec/mapApp.ts
+++ b/waspc/data/packages/spec/src/spec/mapApp.ts
@@ -263,6 +263,7 @@ export function mapAuthMethods(
 ): AppSpec.AuthMethods {
   const {
     usernameAndPassword,
+    slack,
     discord,
     google,
     gitHub,
@@ -273,6 +274,7 @@ export function mapAuthMethods(
   return {
     usernameAndPassword:
       usernameAndPassword && mapUsernameAndPassword(usernameAndPassword),
+    slack: slack && mapExternalAuth(slack),
     discord: discord && mapExternalAuth(discord),
     google: google && mapExternalAuth(google),
     gitHub: gitHub && mapExternalAuth(gitHub),

--- a/waspc/data/packages/spec/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/tsAppSpec.ts
@@ -48,7 +48,8 @@ export type SocialAuthMethodName =
   | "google"
   | "gitHub"
   | "keycloak"
-  | "microsoft";
+  | "microsoft"
+  | "slack";
 
 export type UsernameAndPasswordConfig = BaseAuthMethodConfig;
 


### PR DESCRIPTION
## Summary

Adds Slack as a supported social auth method in the TypeScript spec API and AppSpec mirror. Wires the Slack auth config through both the current and legacy TS spec mappers.

## Validation

- npm run build
- npm run test:unit
- npm run test:type
