### PR TITLE
Improve API reference organization

### DIFF
--- a/waspc/data/packages/spec/src/spec/publicApi/constructors.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/constructors.ts
@@ -42,9 +42,9 @@ import type {
  * })
  * ```
  *
- * @param input The app configuration.
+ * @param config The app configuration.
  *
- * @category Constructors
+ * @category Spec
  */
 export function app(config: AppConfig): App {
   return config;

--- a/waspc/data/packages/spec/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/tsAppSpec.ts
@@ -10,7 +10,7 @@ import { FromRegister } from "./register.js";
  * Pass an `App` to the {@link app} constructor and `export default` the
  * result from `main.wasp.ts`.
  *
- * @category Parts
+ * @category Spec
  *
  * @example
  * ```ts
@@ -190,8 +190,9 @@ export interface LocalAuthMethods {
  * [Social Auth overview](https://wasp.sh/docs/auth/social-auth/overview) for
  * details on each provider.
  */
-export interface ExternalAuthMethods
-  extends Partial<Record<SocialAuthMethodName, SocialAuthConfig>> {}
+export interface ExternalAuthMethods extends Partial<
+  Record<SocialAuthMethodName, SocialAuthConfig>
+> {}
 
 /**
  * Supported social auth providers.
@@ -744,8 +745,9 @@ export interface Crud extends BasePart<"crud"> {
  * Wasp's defaults. Default `get`, `update`, and `delete` implementations use
  * the field marked with `@id` in the Prisma schema as the entity ID.
  */
-export interface CrudOperations
-  extends Partial<Record<CrudOperation, CrudOperationOptions>> {}
+export interface CrudOperations extends Partial<
+  Record<CrudOperation, CrudOperationOptions>
+> {}
 
 /**
  * Operations a {@link Crud} can generate.

--- a/waspc/data/packages/spec/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/tsAppSpec.ts
@@ -190,9 +190,8 @@ export interface LocalAuthMethods {
  * [Social Auth overview](https://wasp.sh/docs/auth/social-auth/overview) for
  * details on each provider.
  */
-export interface ExternalAuthMethods extends Partial<
-  Record<SocialAuthMethodName, SocialAuthConfig>
-> {}
+export interface ExternalAuthMethods
+  extends Partial<Record<SocialAuthMethodName, SocialAuthConfig>> {}
 
 /**
  * Supported social auth providers.
@@ -745,9 +744,8 @@ export interface Crud extends BasePart<"crud"> {
  * Wasp's defaults. Default `get`, `update`, and `delete` implementations use
  * the field marked with `@id` in the Prisma schema as the entity ID.
  */
-export interface CrudOperations extends Partial<
-  Record<CrudOperation, CrudOperationOptions>
-> {}
+export interface CrudOperations
+  extends Partial<Record<CrudOperation, CrudOperationOptions>> {}
 
 /**
  * Operations a {@link Crud} can generate.

--- a/waspc/data/packages/spec/typedoc.jsonc
+++ b/waspc/data/packages/spec/typedoc.jsonc
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+
+  // We don't want to show a readme for this package, the current one is the
+  // contributing guide; and there's nothing more relevant we want to show
+  // instead.
+  "readme": "none",
+
+  // Linking to the source code is not useful for this package, and might be
+  // confusing about the package's location.
+  "disableSources": true,
+
+  // For exports with no category
+  "defaultCategory": "Fields",
+
+  "categoryOrder": ["Spec", "Constructors", "Parts", "*"],
+}

--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -299,13 +299,9 @@ const config: Config = {
         // docusaurus-plugin-typedoc options
         sidebar: { typescript: true },
 
-        // typedoc-plugin-mardkown options
+        // typedoc-plugin-markdown options
         readme: "none",
         alwaysCreateEntryPointModule: true,
-
-        // typedoc options
-        disableSources: true,
-        packageOptions: { readme: "none" },
 
         // input packages
         entryPointStrategy: "packages",

--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -300,12 +300,17 @@ const config: Config = {
         sidebar: { typescript: true },
 
         // typedoc-plugin-markdown options
-        readme: "none",
-        alwaysCreateEntryPointModule: true,
+        readme: "none", // Otherwise it will copy the `<repo>/README.md` file to the docs, which we don't want.
+        alwaysCreateEntryPointModule: true, // Otherwise it will put all of the exports of the packages into a single pool instead of per-package.
 
         // input packages
         entryPointStrategy: "packages",
         entryPoints: ["../waspc/data/packages/spec"],
+
+        // If you want to set an option to a specific package, you can create a
+        // `typedoc.jsonc` file in that package's folder with the desired
+        // options from
+        // https://typedoc.org/documents/Options.Package_Options.html.
       },
     ],
   ],


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
