### PR TITLE
Add BeforeAfter component for migration docs

### DIFF
--- a/web/docs/guides/legacy/wasp-dsl.md
+++ b/web/docs/guides/legacy/wasp-dsl.md
@@ -5,6 +5,8 @@ last_checked_with_versions:
   Wasp: 0.24
 ---
 
+import BeforeAfter, { Before, After } from '@site/src/components/BeforeAfter';
+
 # Migrating from the Wasp DSL
 
 Wasp used to have its own configuration language, the **Wasp DSL**, which you wrote in a `main.wasp` file. Start with Wasp 0.24, the Wasp DSL is now retired in favor of the [Wasp Spec](../../general/spec.md): a `main.wasp.ts` file written in TypeScript.
@@ -46,8 +48,8 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
 
 In the DSL, a `route` points to a `page` by name. In the Wasp Spec, `route` takes the `page` object directly.
 
-<Tabs>
-  <TabItem value="before" label="Wasp DSL">
+<BeforeAfter>
+  <Before>
     ```wasp title="main.wasp"
     app todoApp {
       title: "ToDo App",
@@ -60,8 +62,8 @@ In the DSL, a `route` points to a `page` by name. In the Wasp Spec, `route` take
       authRequired: true
     }
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { app, page, route } from '@wasp.sh/spec'
     import { MainPage } from './src/MainPage' with { type: "ref" }
@@ -75,15 +77,15 @@ In the DSL, a `route` points to a `page` by name. In the Wasp Spec, `route` take
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 Note that `route` no longer references a page by name (`to: MainPage`); it takes the `page(...)` object directly.
 
 ### Queries and actions
 
-<Tabs>
-  <TabItem value="before" label="Wasp DSL">
+<BeforeAfter>
+  <Before>
     ```wasp title="main.wasp"
     query getTasks {
       fn: import { getTasks } from "@src/queries",
@@ -95,8 +97,8 @@ Note that `route` no longer references a page by name (`to: MainPage`); it takes
       entities: [Task]
     }
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { action, app, query } from '@wasp.sh/spec'
     import { getTasks } from './src/queries' with { type: "ref" }
@@ -110,15 +112,15 @@ Note that `route` no longer references a page by name (`to: MainPage`); it takes
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ### APIs: `httpRoute` becomes positional arguments
 
 The DSL's `httpRoute: (GET, "/path")` becomes the first two arguments of `api`.
 
-<Tabs>
-  <TabItem value="before" label="Wasp DSL">
+<BeforeAfter>
+  <Before>
     ```wasp title="main.wasp"
     apiNamespace bar {
       middlewareConfigFn: import { barNamespaceMiddlewareFn } from "@src/apis",
@@ -132,8 +134,8 @@ The DSL's `httpRoute: (GET, "/path")` becomes the first two arguments of `api`.
       httpRoute: (GET, "/bar/baz")
     }
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { api, apiNamespace, app } from '@wasp.sh/spec'
     import { barBaz, barNamespaceMiddlewareFn } from './src/apis' with { type: "ref" }
@@ -148,15 +150,15 @@ The DSL's `httpRoute: (GET, "/path")` becomes the first two arguments of `api`.
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ### Jobs: `perform` is flattened
 
 The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the first argument and `executorOptions` becomes `performExecutorOptions`.
 
-<Tabs>
-  <TabItem value="before" label="Wasp DSL">
+<BeforeAfter>
+  <Before>
     ```wasp title="main.wasp"
     job mySpecialJob {
       executor: PgBoss,
@@ -167,8 +169,8 @@ The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the firs
       entities: [Task]
     }
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { app, job } from '@wasp.sh/spec'
     import { foo } from './src/jobs/bar' with { type: "ref" }
@@ -184,13 +186,13 @@ The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the firs
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ### CRUD
 
-<Tabs>
-  <TabItem value="before" label="Wasp DSL">
+<BeforeAfter>
+  <Before>
     ```wasp title="main.wasp"
     crud tasks {
       entity: Task,
@@ -200,8 +202,8 @@ The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the firs
       }
     }
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { app, crud } from '@wasp.sh/spec'
     import { createTask } from './src/actions' with { type: "ref" }
@@ -216,15 +218,15 @@ The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the firs
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ### Top-level config: `auth`, `server`, `client`, `db`, `emailSender`, `webSocket`
 
 These were top-level fields of the `app` declaration's dictionary in the DSL. In the Wasp Spec they are keys of the `app({ ... })` object.
 
-<Tabs>
-  <TabItem value="before" label="Wasp DSL">
+<BeforeAfter>
+  <Before>
     ```wasp title="main.wasp"
     app todoApp {
       title: "ToDo App",
@@ -243,8 +245,8 @@ These were top-level fields of the `app` declaration's dictionary in the DSL. In
       }
     }
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { app } from '@wasp.sh/spec'
     import App from './src/App' with { type: "ref" }
@@ -268,8 +270,8 @@ These were top-level fields of the `app` declaration's dictionary in the DSL. In
       parts: [],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ## How to migrate
 

--- a/web/docs/guides/legacy/wasp-ts-config.md
+++ b/web/docs/guides/legacy/wasp-ts-config.md
@@ -5,6 +5,8 @@ last_checked_with_versions:
   Wasp: 0.24
 ---
 
+import BeforeAfter, { Before, After } from '@site/src/components/BeforeAfter';
+
 # Migrating from the Wasp TS Config
 
 The first version of configuring Wasp in TypeScript used a **class-based API**: you created an `App` instance with `new App(...)` and registered parts with mutating method calls like `app.page(...)` and `app.query(...)`. We called this the **TS Config**.
@@ -21,8 +23,8 @@ The mapping below is mechanical. You can give the [Wasp Spec reference](../../ge
 
 In the TS Config you could only reference your code with import objects (`{ import, from }`). The Wasp Spec also supports **reference imports**: import the value with the regular `import` syntax and pass it directly to a constructor.
 
-<Tabs>
-  <TabItem value="before" label="TS Config">
+<BeforeAfter>
+  <Before>
     ```ts title="main.wasp.ts"
     const mainPage = app.page('MainPage', {
       component: { importDefault: 'MainPage', from: '@src/MainPage' },
@@ -32,8 +34,8 @@ In the TS Config you could only reference your code with import objects (`{ impo
       fn: { import: 'getTasks', from: '@src/queries' },
     })
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import MainPage from './src/MainPage' with { type: "ref" }
     import { getTasks } from './src/queries' with { type: "ref" }
@@ -46,8 +48,8 @@ In the TS Config you could only reference your code with import objects (`{ impo
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 Import objects still work, so you can migrate gradually. See the [Wasp Spec documentation](../../general/spec.md#referencing-your-apps-code) for the supported patterns and their limitations.
 
@@ -71,8 +73,8 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
 
 ### App and parts
 
-<Tabs>
-  <TabItem value="before" label="TS Config">
+<BeforeAfter>
+  <Before>
     ```ts title="main.wasp.ts"
     import { App } from 'wasp-config'
 
@@ -93,8 +95,8 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
 
     export default app
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { app, page, query, route } from '@wasp.sh/spec'
     import MainPage from './src/MainPage' with { type: "ref" }
@@ -110,13 +112,13 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ### API: `httpRoute` becomes positional arguments
 
-<Tabs>
-  <TabItem value="before" label="TS Config">
+<BeforeAfter>
+  <Before>
     ```ts title="main.wasp.ts"
     app.apiNamespace('bar', {
       middlewareConfigFn: { import: 'barNamespaceMiddlewareFn', from: '@src/apis' },
@@ -130,8 +132,8 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
       httpRoute: { method: 'GET', route: '/bar/baz' },
     })
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { api, apiNamespace, app } from '@wasp.sh/spec'
     import { barBaz, barNamespaceMiddlewareFn } from './src/apis' with { type: "ref" }
@@ -146,13 +148,13 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ### Jobs: `perform` is flattened
 
-<Tabs>
-  <TabItem value="before" label="TS Config">
+<BeforeAfter>
+  <Before>
     ```ts title="main.wasp.ts"
     app.job('mySpecialJob', {
       executor: 'PgBoss',
@@ -163,8 +165,8 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
       entities: ['Task'],
     })
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { app, job } from '@wasp.sh/spec'
     import { foo } from './src/jobs/bar' with { type: "ref" }
@@ -180,13 +182,13 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ### CRUD
 
-<Tabs>
-  <TabItem value="before" label="TS Config">
+<BeforeAfter>
+  <Before>
     ```ts title="main.wasp.ts"
     app.crud('tasks', {
       entity: 'Task',
@@ -196,8 +198,8 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
       },
     })
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { app, crud } from '@wasp.sh/spec'
     import { createTask } from './src/actions' with { type: "ref" }
@@ -212,15 +214,15 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
       ],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ### Top-level config: `auth`, `server`, `client`, `db`, `emailSender`, `webSocket`
 
 These were configured with mutating method calls. They are now keys of the `app({ ... })` object.
 
-<Tabs>
-  <TabItem value="before" label="TS Config">
+<BeforeAfter>
+  <Before>
     ```ts title="main.wasp.ts"
     const app = new App('todoApp', {
       title: 'ToDo App',
@@ -244,8 +246,8 @@ These were configured with mutating method calls. They are now keys of the `app(
 
     export default app
     ```
-  </TabItem>
-  <TabItem value="after" label="Wasp Spec">
+  </Before>
+  <After>
     ```ts title="main.wasp.ts"
     import { app } from '@wasp.sh/spec'
     import App from './src/App' with { type: "ref" }
@@ -269,8 +271,8 @@ These were configured with mutating method calls. They are now keys of the `app(
       parts: [],
     })
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 ## How to migrate
 
@@ -280,8 +282,8 @@ Wasp validates the Wasp Spec support files during migration, including the requi
 
 1. Update your `package.json` with the new dependencies:
 
-    <Tabs>
-      <TabItem value="before" label="Before">
+    <BeforeAfter>
+      <Before>
         ```json title="package.json"
         {
           "devDependencies": {
@@ -289,8 +291,8 @@ Wasp validates the Wasp Spec support files during migration, including the requi
           }
         }
         ```
-      </TabItem>
-      <TabItem value="after" label="After">
+      </Before>
+      <After>
         ```json title="package.json"
         {
           "devDependencies": {
@@ -299,8 +301,8 @@ Wasp validates the Wasp Spec support files during migration, including the requi
           }
         }
         ```
-      </TabItem>
-    </Tabs>
+      </After>
+    </BeforeAfter>
 
     Keep your existing dependencies, replace `wasp-config` with `@wasp.sh/spec`, and add `@types/node`. `@types/node` is required because the Wasp Spec runs in a Node.js environment.
 
@@ -341,8 +343,8 @@ Wasp validates the Wasp Spec support files during migration, including the requi
 
     Replace `new App(...)` and the `app.*(...)` method calls with a single `app({ ... })` call whose `parts` array holds the constructors (see the [mapping above](#changes)), and update the import:
 
-    <Tabs>
-      <TabItem value="before" label="Before">
+    <BeforeAfter>
+      <Before>
         ```ts title="main.wasp.ts"
         import { App } from 'wasp-config'
 
@@ -351,8 +353,8 @@ Wasp validates the Wasp Spec support files during migration, including the requi
           wasp: { version: '^0.24.0' },
         })
         ```
-      </TabItem>
-      <TabItem value="after" label="After">
+      </Before>
+      <After>
         ```ts title="main.wasp.ts"
         import { app, page, route, query, action } from '@wasp.sh/spec'
 
@@ -363,8 +365,8 @@ Wasp validates the Wasp Spec support files during migration, including the requi
           parts: [],
         })
         ```
-      </TabItem>
-    </Tabs>
+      </After>
+    </BeforeAfter>
 
 6. Run your app with `wasp start`. If everything is correct, your app should behave exactly as before.
 

--- a/web/docs/migration-guide.md
+++ b/web/docs/migration-guide.md
@@ -4,6 +4,7 @@ title: Migration from 0.23.X to 0.24.X
 
 import InstallInstructions from './_install-instructions.md'
 import LegacyInstallerMigration from './_legacy_installer_migration.md'
+import BeforeAfter, { Before, After } from '@site/src/components/BeforeAfter';
 
 <LegacyInstallerMigration />
 <InstallInstructions version="0.24" />
@@ -74,8 +75,8 @@ Add `vitest` to `devDependencies` because `wasp test client` now runs the Vitest
 
 The `api` object was previously an Axios instance. It is now a [ky](https://github.com/sindresorhus/ky) instance with a pre-configured base URL and authentication. Update your code as follows:
 
-<Tabs>
-  <TabItem value="before" label="Before">
+<BeforeAfter>
+  <Before>
     ```ts
     import { api } from 'wasp/client/api'
 
@@ -95,9 +96,9 @@ The `api` object was previously an Axios instance. It is now a [ky](https://gith
       console.log(error.response?.status)
     }
     ```
-  </TabItem>
+  </Before>
 
-  <TabItem value="after" label="After">
+  <After>
     ```ts
     import { api } from 'wasp/client/api'
     import { isHTTPError } from 'ky'
@@ -117,8 +118,8 @@ The `api` object was previously an Axios instance. It is now a [ky](https://gith
       }
     }
     ```
-  </TabItem>
-</Tabs>
+  </After>
+</BeforeAfter>
 
 You can also remove `axios` from your project's dependencies if you added it only for use with the Wasp `api` wrapper.
 

--- a/web/src/components/BeforeAfter/Context.tsx
+++ b/web/src/components/BeforeAfter/Context.tsx
@@ -1,0 +1,23 @@
+import { ComponentType, createContext, ReactNode, useContext } from "react";
+
+export interface BeforeAfterValue {
+  sideBySide: boolean;
+}
+
+const BeforeAfterContext = createContext<BeforeAfterValue | null>(null);
+BeforeAfterContext.displayName = "BeforeAfterContext";
+
+export const BeforeAfterProvider: ComponentType<{
+  value: BeforeAfterValue;
+  children?: ReactNode;
+}> = BeforeAfterContext.Provider;
+
+export const useBeforeAfterContext = () => {
+  const context = useContext(BeforeAfterContext);
+  if (!context) {
+    throw new Error(
+      "useBeforeAfterContext must be used within a BeforeAfterProvider",
+    );
+  }
+  return context;
+};

--- a/web/src/components/BeforeAfter/index.tsx
+++ b/web/src/components/BeforeAfter/index.tsx
@@ -1,0 +1,74 @@
+import { useWindowSize } from "@docusaurus/theme-common";
+import TabItem from "@theme/TabItem";
+import Tabs from "@theme/Tabs";
+import * as React from "react";
+import { BeforeAfterProvider, useBeforeAfterContext } from "./Context";
+
+export default function BeforeAfter({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const windowSize = useWindowSize();
+  const sideBySide = windowSize === "desktop";
+
+  const ctxValue = React.useMemo(() => ({ sideBySide }), [sideBySide]);
+
+  return (
+    <BeforeAfterProvider value={ctxValue}>
+      {sideBySide ? (
+        <div className="grid grid-cols-2 gap-4">{children}</div>
+      ) : (
+        <Tabs
+          values={[
+            { value: "before", label: "Before" },
+            { value: "after", label: "After" },
+          ]}
+        >
+          {children}
+        </Tabs>
+      )}
+    </BeforeAfterProvider>
+  );
+}
+
+export function Before({ children }: { children?: React.ReactNode }) {
+  const { sideBySide } = useBeforeAfterContext();
+
+  return sideBySide ? (
+    <Column label="Before">{children}</Column>
+  ) : (
+    <TabItem value="before" label="Before">
+      {children}
+    </TabItem>
+  );
+}
+
+export function After({ children }: { children?: React.ReactNode }) {
+  const { sideBySide } = useBeforeAfterContext();
+
+  return sideBySide ? (
+    <Column label="After">{children}</Column>
+  ) : (
+    <TabItem value="after" label="After">
+      {children}
+    </TabItem>
+  );
+}
+
+function Column({
+  label,
+  children,
+}: {
+  label: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-2 text-sm font-semibold uppercase tracking-wider text-wasp-g5">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds a new `BeforeAfter` component (`web/src/components/BeforeAfter/`) that renders code comparisons as a side-by-side two-column grid on desktop and as Docusaurus tabs on smaller viewports.

Migrates `web/docs/guides/legacy/wasp-dsl.md`, `web/docs/guides/legacy/wasp-ts-config.md`, and `web/docs/migration-guide.md` to use it.

### Limitations

- We use JS detection instead of CSS media queries because we do need to remove the `Tabs` component when the window is big enough.

- I tried to do our own size detection (with ResizeObserver), but it fights with some internal Docusaurus mechanism for code blocks and throws errors; so I had to piggyback off Docusaurus' exposed `useWindowSize` function.
  - This function doesn't return a `number`, but `"desktop" | "mobile" | "ssr"`, so we are stuck with their breakpoint and can't customize it. It's internally hardcoded to 996px window size. It does look a bit too compact in the sizes close to the threshold.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.