### PR TITLE
Enable typedoc watch mode in docs dev server

### DIFF
--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -21,6 +21,7 @@ const darkCodeTheme = {
 const includeCurrentVersion =
   process.env.DOCS_INCLUDE_CURRENT_VERSION === "true";
 const isProduction = process.env.NODE_ENV === "production";
+const isTypedocWatchMode = process.env.TYPEDOC_WATCH === "true";
 
 const config: Config = {
   title: "Wasp",
@@ -297,6 +298,7 @@ const config: Config = {
       {
         // docusaurus-plugin-typedoc options
         sidebar: { typescript: true },
+        watch: isTypedocWatchMode,
 
         // typedoc-plugin-markdown options
         readme: "none", // Otherwise it will copy the `<repo>/README.md` file to the docs, which we don't want.

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "remark:once": "npm run remark -- --quiet --frail --use remark-validate-links docs/",
     "remove-version": "node ./scripts/remove-version.mjs",
     "serve": "docusaurus serve",
-    "start": "npm run install-spec-package && DOCS_INCLUDE_CURRENT_VERSION=true docusaurus start --port 3002",
+    "start": "npm run install-spec-package && DOCS_INCLUDE_CURRENT_VERSION=true TYPEDOC_WATCH=true docusaurus start --port 3002",
     "swizzle": "docusaurus swizzle",
     "write-heading-ids": "docusaurus write-heading-ids",
     "write-translations": "docusaurus write-translations"


### PR DESCRIPTION
## Description

Enables [typedoc-plugin-markdown's watch mode](https://typedoc-plugin-markdown.org/plugins/docusaurus/guides/watch-mode) in the docs dev server so the TS spec API reference regenerates when source files change. Gated behind a `TYPEDOC_WATCH=true` env var that's only set by `npm start`, keeping production builds unaffected.

## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.