### PR TITLE
Add Fix API links plugin

### DIFF
--- a/waspc/data/packages/spec/README.md
+++ b/waspc/data/packages/spec/README.md
@@ -6,6 +6,8 @@ Wasp Spec is a library for defining a Wasp application specification in Typescri
 
 The `appSpec.ts` type definitions in this package are meant to mirror the AppSpec declarations defined in the `waspc` Haskell codebase. When making changes to this package, ensure that they align with the corresponding Haskell implementation.
 
+When linking to other Wasp docs from TSDoc comments in this package, write the full `https://wasp.sh/docs/...` URL rather than a relative path. The website build rewrites those URLs to relative links via the `fix-api-links` remark plugin (see [Writing Docs](../../../../web/WRITING-DOCS.md)), so they resolve correctly both on the rendered website and in the raw markdown that consumers of this package read.
+
 ## Testing
 
 ```bash

--- a/web/WRITING-DOCS.md
+++ b/web/WRITING-DOCS.md
@@ -167,3 +167,13 @@ export const validatePassword = (password: string) => password.length > 8 && /* 
 ````
 
 This Docusaurus plugin is implemented in [./src/remark/code-with-hole.ts](./src/remark/code-with-hole.ts).
+
+## Links
+
+### `fix-api-links`: rewrite absolute `wasp.sh` URLs to relative links in API docs
+
+The API reference at `docs/api/` is generated from TSDoc comments in the `@wasp.sh/spec` package (see [its README](../waspc/data/packages/spec/README.md)). Those comments are also consumed outside of the website as raw markdown (as IDE annotations), so links in them need to work in both contexts.
+
+To make that possible, authors write links to other Wasp docs as full `https://wasp.sh/docs/...` URLs in the TSDoc comments. The `fix-api-links` plugin then strips the `https://wasp.sh` prefix from any link inside `docs/api/`, leaving a relative path that resolves on the website and can be checked for broken links.
+
+This Docusaurus plugin is implemented in [./src/remark/fix-api-links.ts](./src/remark/fix-api-links.ts).

--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -6,6 +6,7 @@ import autoImportTabs from "./src/remark/auto-import-tabs";
 import autoJSCode from "./src/remark/auto-js-code";
 import codeWithHole from "./src/remark/code-with-hole";
 import fileExtSwitcher from "./src/remark/file-ext-switcher";
+import fixAPILinks from "./src/remark/fix-api-links";
 import searchAndReplace from "./src/remark/search-and-replace";
 
 const lightCodeTheme = {
@@ -194,6 +195,7 @@ const config: Config = {
             fileExtSwitcher,
             searchAndReplace,
             codeWithHole,
+            fixAPILinks,
           ],
 
           // ------ Configuration for multiple docs versions ------ //

--- a/web/src/remark/fix-api-links.ts
+++ b/web/src/remark/fix-api-links.ts
@@ -1,0 +1,25 @@
+import type * as md from "mdast";
+import * as path from "node:path";
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+const API_FOLDER = "docs/api/";
+const URL_PREFIX = "https://wasp.sh";
+
+/*
+  This plugin turns absolute URLs to the Wasp website itself (inside the API
+  docs) into relative links, so that they work both on the website and in the
+  generated markdown files; and can be checked for broken links.
+*/
+const fixAPILinks: Plugin<[], md.Root> = () => (tree, file) => {
+  const relativePath = path.relative(file.cwd, file.path);
+  if (!relativePath.startsWith(API_FOLDER)) return;
+
+  visit(tree, "link", (node) => {
+    if (node.url.startsWith(URL_PREFIX)) {
+      node.url = node.url.slice(URL_PREFIX.length);
+    }
+  });
+};
+
+export default fixAPILinks;


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

- Resolves #4176

Adds a plugin to Docusaurus that converts full URLs to wasp.sh into `/`-prefixed URLs that Docusaurus can understand. We'll continue to author the TS Spec with full URLs, so that they are clickable in the IDE.

I tested with a broken link to see if it found it at https://github.com/wasp-lang/wasp/pull/4214 (and it works)

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
