### PR TITLE
Check something

### DIFF
--- a/waspc/data/packages/spec/src/spec/publicApi/tsAppSpec.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/tsAppSpec.ts
@@ -8,7 +8,7 @@ import { FromRegister } from "./register.js";
  * Root shape of a Wasp app specification.
  *
  * Pass an `App` to the {@link app} constructor and `export default` the
- * result from `main.wasp.ts`.
+ * result from `main.wasp.ts`. [Check something](https://wasp.sh/docs/general/speasasdc#creating-the-app-specification)
  *
  * @category Spec
  *
@@ -198,8 +198,9 @@ export interface LocalAuthMethods {
  * [Social Auth overview](https://wasp.sh/docs/auth/social-auth/overview) for
  * details on each provider.
  */
-export interface ExternalAuthMethods
-  extends Partial<Record<SocialAuthMethodName, SocialAuthConfig>> {}
+export interface ExternalAuthMethods extends Partial<
+  Record<SocialAuthMethodName, SocialAuthConfig>
+> {}
 
 /**
  * Supported social auth providers.
@@ -779,8 +780,9 @@ export interface Crud extends BasePart<"crud"> {
  * CRUD operations are implemented with Wasp queries and actions. See
  * [Operations](https://wasp.sh/docs/data-model/operations/overview).
  */
-export interface CrudOperations
-  extends Partial<Record<CrudOperation, CrudOperationOptions>> {}
+export interface CrudOperations extends Partial<
+  Record<CrudOperation, CrudOperationOptions>
+> {}
 
 /**
  * Operations a {@link Crud} can generate.

--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -6,6 +6,7 @@ import autoImportTabs from "./src/remark/auto-import-tabs";
 import autoJSCode from "./src/remark/auto-js-code";
 import codeWithHole from "./src/remark/code-with-hole";
 import fileExtSwitcher from "./src/remark/file-ext-switcher";
+import fixAPILinks from "./src/remark/fix-api-links";
 import searchAndReplace from "./src/remark/search-and-replace";
 
 const lightCodeTheme = {
@@ -194,6 +195,7 @@ const config: Config = {
             fileExtSwitcher,
             searchAndReplace,
             codeWithHole,
+            fixAPILinks,
           ],
 
           // ------ Configuration for multiple docs versions ------ //

--- a/web/src/remark/fix-api-links.ts
+++ b/web/src/remark/fix-api-links.ts
@@ -1,0 +1,25 @@
+import type * as md from "mdast";
+import * as path from "node:path";
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+const API_FOLDER = "docs/api/";
+const URL_PREFIX = "https://wasp.sh";
+
+/*
+  This plugin turns absolute URLs to the Wasp website itself (inside the API
+  docs) into relative links, so that they work both on the website and in the
+  generated markdown files; and can be checked for broken links.
+*/
+const fixAPILinks: Plugin<[], md.Root> = () => (tree, file) => {
+  const relativePath = path.relative(file.cwd, file.path);
+  if (!relativePath.startsWith(API_FOLDER)) return;
+
+  visit(tree, "link", (node) => {
+    if (node.url.startsWith(URL_PREFIX)) {
+      node.url = node.url.slice(URL_PREFIX.length);
+    }
+  });
+};
+
+export default fixAPILinks;


### PR DESCRIPTION
Testing broken link detection from #4213 . It works:

```
2026-05-27T15:19:22.177347Z	  Exhaustive list of all broken links found:
2026-05-27T15:19:22.177403Z	  - Broken link on source page path = /docs/api/@wasp.sh/spec/interfaces/App:
2026-05-27T15:19:22.177461Z	     -> linking to /docs/general/speasasdc#creating-the-app-specification
```
