### PR TITLE
Add security considerations warnings upfront

### DIFF
--- a/web/docs/guides/configuration/cors-multiple-domains.md
+++ b/web/docs/guides/configuration/cors-multiple-domains.md
@@ -9,6 +9,10 @@ last_checked_with_versions:
 
 This guide shows you how to configure CORS (Cross-Origin Resource Sharing) to support multiple domains in your Wasp application using custom global middleware.
 
+:::warning Security matters here
+A loose CORS config can expose your API to any client on the internet. Make sure to understand the [Security Considerations](#security-considerations) before proceeding.
+:::
+
 ## Prerequisites
 
 Make sure you have a Wasp project set up. If you haven't, follow the [Getting Started](../../introduction/quick-start.md) guide first.

--- a/web/docs/guides/configuration/cors-multiple-domains.md
+++ b/web/docs/guides/configuration/cors-multiple-domains.md
@@ -9,7 +9,7 @@ last_checked_with_versions:
 
 This guide shows you how to configure CORS (Cross-Origin Resource Sharing) to support multiple domains in your Wasp application using custom global middleware.
 
-:::warning Security matters here
+:::warning Potentially exposing your API
 A loose CORS config can expose your API to any client on the internet. Make sure to understand the [Security Considerations](#security-considerations) before proceeding.
 :::
 

--- a/web/docs/guides/debugging/db-studio-fly-io.md
+++ b/web/docs/guides/debugging/db-studio-fly-io.md
@@ -8,6 +8,10 @@ comments: true
 
 This guide shows you how to connect to your production database on Fly.io and run `wasp db studio` to inspect or modify your data.
 
+:::warning Working with production data
+You are about to point your local tooling at the live production database. Make sure to understand the [Security Considerations](#security-considerations) before proceeding.
+:::
+
 ## Prerequisites
 
 - A Wasp app deployed to [Fly.io](https://fly.io/)
@@ -64,7 +68,7 @@ Before opening the tunnel, make sure nothing else is running on port 5432:
 - Stop any local database started with `wasp db start`
 - Check for Docker containers that might be using the port
 
-:::caution
+:::warning Background processes
 Even if you close the terminal that was running `wasp db start`, the Docker container may still be running in the background. Make sure to stop it before proceeding.
 :::
 
@@ -108,6 +112,7 @@ This will open a web interface where you can view and modify your database recor
 Be careful when modifying production data. Always back up your database before making changes, and consider using a read-only user for routine inspections.
 :::
 
+- **Any changes you make to production data is immediate** and may be hard to undo
 - Remember to restore your `.env.server` to point to your local database when you're done
 - Close the tunnel when finished by terminating the `fly proxy` command
 - Never commit production credentials to version control

--- a/web/docs/guides/debugging/db-studio-fly-io.md
+++ b/web/docs/guides/debugging/db-studio-fly-io.md
@@ -112,7 +112,7 @@ This will open a web interface where you can view and modify your database recor
 Be careful when modifying production data. Always back up your database before making changes, and consider using a read-only user for routine inspections.
 :::
 
-- **Any changes you make to production data is immediate** and may be hard to undo
+- **Any changes you make to production data is immediate** and may be hard or impossible to undo
 - Remember to restore your `.env.server` to point to your local database when you're done
 - Close the tunnel when finished by terminating the `fly proxy` command
 - Never commit production credentials to version control

--- a/web/docs/guides/debugging/db-studio-fly-io.md
+++ b/web/docs/guides/debugging/db-studio-fly-io.md
@@ -108,11 +108,9 @@ This will open a web interface where you can view and modify your database recor
 
 ## Security Considerations
 
-:::warning
-Be careful when modifying production data. Always back up your database before making changes, and consider using a read-only user for routine inspections.
-:::
-
-- **Any changes you make to production data is immediate** and may be hard or impossible to undo
+- **Any changes you make to production data are immediate** and may be hard or impossible to undo
+- **Back up your database** before making changes
+- Consider using a **read-only user** for routine inspections
 - Remember to restore your `.env.server` to point to your local database when you're done
 - Close the tunnel when finished by terminating the `fly proxy` command
 - Never commit production credentials to version control


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Adds a callout block at the start of a guide as a reminder for security considerations.
The idea is that the user:
- can still jump directly into the practical part
- while having the security mindset through the process (in contrast to consider it at the end of everything)


<img width="1304" height="461" alt="image" src="https://github.com/user-attachments/assets/68e1604f-1574-44d9-9359-b0bddd6f4c72" />

<img width="1404" height="406" alt="image" src="https://github.com/user-attachments/assets/fab165a7-d26e-472c-b869-f176cd1f5a31" />

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
