### PR TITLE
Remove redundant root tsconfig exclude

### DIFF
--- a/waspc/data/Cli/starters/skeleton/tsconfig.json
+++ b/waspc/data/Cli/starters/skeleton/tsconfig.json
@@ -3,6 +3,5 @@
   "references": [
     { "path": "./tsconfig.src.json" },
     { "path": "./tsconfig.wasp.json" }
-  ],
-  "exclude": ["**/*.wasp.ts"]
+  ]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/tsconfig.json
@@ -3,6 +3,5 @@
   "references": [
     { "path": "./tsconfig.src.json" },
     { "path": "./tsconfig.wasp.json" }
-  ],
-  "exclude": ["**/*.wasp.ts"]
+  ]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/tsconfig.json
@@ -3,6 +3,5 @@
   "references": [
     { "path": "./tsconfig.src.json" },
     { "path": "./tsconfig.wasp.json" }
-  ],
-  "exclude": ["**/*.wasp.ts"]
+  ]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/tsconfig.json
@@ -3,6 +3,5 @@
   "references": [
     { "path": "./tsconfig.src.json" },
     { "path": "./tsconfig.wasp.json" }
-  ],
-  "exclude": ["**/*.wasp.ts"]
+  ]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-new-golden/wasp-app/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-new-golden/wasp-app/tsconfig.json
@@ -3,6 +3,5 @@
   "references": [
     { "path": "./tsconfig.src.json" },
     { "path": "./tsconfig.wasp.json" }
-  ],
-  "exclude": ["**/*.wasp.ts"]
+  ]
 }


### PR DESCRIPTION
## Description

Removes the redundant root-level `exclude` from the skeleton root `tsconfig.json`. This was likely a merge mistake.

Note: I'll merge this once the CI passes.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, do not hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  No unit tests added; generated CLI snapshots cover this template output.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

## Verification

- `./run build`
- `WASP_E2E_TESTS_SKIP_DOCKER=1 ./run test:waspc:e2e:accept-all`
- `./run test:waspc:e2e`
- `npx prettier --ignore-unknown --check --config prettier.config.mjs <changed-json-files>`

`./run check:prettier` currently reports an unrelated formatting issue in `waspc/data/packages/studio/public/index.html`.