### PR TITLE
Reject auto-js on Wasp Spec files

### DIFF
--- a/web/src/remark/auto-js-code.ts
+++ b/web/src/remark/auto-js-code.ts
@@ -163,6 +163,12 @@ async function makeFormattedJsCodeBlock(
   // Find the `title=` meta param and change the extension.
   const originalTitle = meta.get("title");
   if (originalTitle) {
+    if (/\.wasp\.tsx?$/.test(originalTitle)) {
+      throw new Error(
+        `The \`${META_FLAG}\` flag cannot be used on Wasp Spec files (${originalTitle}): Wasp Spec files should always be TypeScript.`,
+      );
+    }
+
     const newTitle = transformExt(originalTitle, EXTENSION_TRANSFORMATIONS);
     meta.set("title", newTitle);
   }


### PR DESCRIPTION
## Description

The `auto-js` remark plugin now throws when applied to a code block whose `title` ends in `.wasp.ts` or `.wasp.tsx`. Wasp Spec files must always be TypeScript, so generating a JS counterpart is incorrect; the error is reported as a file error with the code block's position.

## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.