### PR TITLE
Remove JS tabs from Wasp Spec examples

### DIFF
--- a/web/docs/advanced/middleware-config.md
+++ b/web/docs/advanced/middleware-config.md
@@ -83,22 +83,22 @@ Below is the actual definitions of default middleware which you can override.
 
 If you would like to modify the middleware for _all_ operations and APIs, you can do something like:
 
+```ts {7} title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { serverMiddlewareFn } from "./src/serverSetup" with { type: "ref" }
+
+export default app({
+  name: "todoApp",
+  server: {
+    middlewareConfigFn: serverMiddlewareFn,
+  },
+  // ...
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts {7} title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { serverMiddlewareFn } from "./src/serverSetup" with { type: "ref" }
-
-    export default app({
-      name: "todoApp",
-      server: {
-        middlewareConfigFn: serverMiddlewareFn,
-      },
-      // ...
-    })
-    ```
-
-    ```ts title="src/serverSetup.js"
+    ```js title="src/serverSetup.js"
     import cors from "cors"
     import { config } from "wasp/server"
 
@@ -111,19 +111,6 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts {7} title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { serverMiddlewareFn } from "./src/serverSetup" with { type: "ref" }
-
-    export default app({
-      name: "todoApp",
-      server: {
-        middlewareConfigFn: serverMiddlewareFn,
-      },
-      // ...
-    })
-    ```
-
     ```ts title="src/serverSetup.ts"
     import cors from "cors"
     import { config, type MiddlewareConfigFn } from "wasp/server"
@@ -141,24 +128,24 @@ If you would like to modify the middleware for _all_ operations and APIs, you ca
 
 If you would like to modify the middleware for a single API, you can do something like:
 
+```ts title="main.wasp.ts"
+import { api, app } from "@wasp.sh/spec"
+import { webhookCallback, webhookCallbackMiddlewareFn } from "./src/apis" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    api("POST", "/webhook/callback", webhookCallback, {
+      middlewareConfigFn: webhookCallbackMiddlewareFn,
+      auth: false,
+    }),
+  ],
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { api, app } from "@wasp.sh/spec"
-    import { webhookCallback, webhookCallbackMiddlewareFn } from "./src/apis" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        api("POST", "/webhook/callback", webhookCallback, {
-          middlewareConfigFn: webhookCallbackMiddlewareFn,
-          auth: false,
-        }),
-      ],
-    })
-    ```
-
-    ```ts title="src/apis.js"
+    ```js title="src/apis.js"
     import express from "express"
 
     export const webhookCallback = (req, res, _context) => {
@@ -178,21 +165,6 @@ If you would like to modify the middleware for a single API, you can do somethin
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { api, app } from "@wasp.sh/spec"
-    import { webhookCallback, webhookCallbackMiddlewareFn } from "./src/apis" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        api("POST", "/webhook/callback", webhookCallback, {
-          middlewareConfigFn: webhookCallbackMiddlewareFn,
-          auth: false,
-        }),
-      ],
-    })
-    ```
-
     ```ts title="src/apis.ts"
     import express from "express"
     import { type WebhookCallback } from "wasp/server/api"
@@ -228,23 +200,23 @@ router.post("/webhook/callback", webhookCallbackMiddleware, ...)
 
 If you would like to modify the middleware for all API routes under some common path, you can define a `middlewareConfigFn` on an `apiNamespace`:
 
+```ts title="main.wasp.ts"
+import { apiNamespace, app } from "@wasp.sh/spec"
+import { fooBarNamespaceMiddlewareFn } from "./src/apis" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    apiNamespace("/foo/bar", {
+      middlewareConfigFn: fooBarNamespaceMiddlewareFn,
+    }),
+  ],
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { apiNamespace, app } from "@wasp.sh/spec"
-    import { fooBarNamespaceMiddlewareFn } from "./src/apis" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        apiNamespace("/foo/bar", {
-          middlewareConfigFn: fooBarNamespaceMiddlewareFn,
-        }),
-      ],
-    })
-    ```
-
-    ```ts title="src/apis.js"
+    ```js title="src/apis.js"
     export const fooBarNamespaceMiddlewareFn = (middlewareConfig) => {
       const customMiddleware = (_req, _res, next) => {
         console.log("fooBarNamespaceMiddlewareFn: custom middleware")
@@ -259,20 +231,6 @@ If you would like to modify the middleware for all API routes under some common 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { apiNamespace, app } from "@wasp.sh/spec"
-    import { fooBarNamespaceMiddlewareFn } from "./src/apis" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        apiNamespace("/foo/bar", {
-          middlewareConfigFn: fooBarNamespaceMiddlewareFn,
-        }),
-      ],
-    })
-    ```
-
     ```ts title="src/apis.ts"
     import express from "express"
     import { type MiddlewareConfigFn } from "wasp/server"

--- a/web/docs/advanced/web-sockets.md
+++ b/web/docs/advanced/web-sockets.md
@@ -23,39 +23,19 @@ Let's go through setting up WebSockets step by step, starting with enabling WebS
 
 We specify that we are using WebSockets by adding `webSocket` to our `app` and providing the required `fn`. You can optionally change the auto-connect behavior.
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { webSocketFn } from "./src/webSocket" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { webSocketFn } from "./src/webSocket" with { type: "ref" }
 
-    export default app({
-      name: "todoApp",
-      webSocket: {
-        fn: webSocketFn,
-        autoConnect: true, // optional, default: true
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { webSocketFn } from "./src/webSocket" with { type: "ref" }
-
-    export default app({
-      name: "todoApp",
-      webSocket: {
-        fn: webSocketFn,
-        autoConnect: true, // optional, default: true
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "todoApp",
+  webSocket: {
+    fn: webSocketFn,
+    autoConnect: true, // optional, default: true
+  },
+  // ...
+})
+```
 
 ## Defining the Events Handler
 
@@ -77,7 +57,7 @@ This is how we can define our `webSocketFn` function:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="src/webSocket.js"
+    ```js title="src/webSocket.js"
     import { v4 as uuidv4 } from "uuid"
 
     export const webSocketFn = (io, context) => {
@@ -168,7 +148,7 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title="src/ChatPage.jsx"
+    ```jsx title="src/ChatPage.jsx"
     import React, { useState } from "react"
     import {
       useSocket,
@@ -301,39 +281,19 @@ Additionally, there is a `useSocketListener: (event, callback) => void` hook whi
 
 ## API Reference
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { webSocketFn } from "./src/webSocket" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { webSocketFn } from "./src/webSocket" with { type: "ref" }
 
-    export default app({
-      name: "todoApp",
-      webSocket: {
-        fn: webSocketFn,
-        autoConnect: true, // optional, default: true
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { webSocketFn } from "./src/webSocket" with { type: "ref" }
-
-    export default app({
-      name: "todoApp",
-      webSocket: {
-        fn: webSocketFn,
-        autoConnect: true, // optional, default: true
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "todoApp",
+  webSocket: {
+    fn: webSocketFn,
+    autoConnect: true, // optional, default: true
+  },
+  // ...
+})
+```
 
 The `webSocket` object has the following fields:
 

--- a/web/docs/auth/auth-hooks.md
+++ b/web/docs/auth/auth-hooks.md
@@ -45,71 +45,35 @@ Users signing in with [OAuth](./social-auth/overview.md) must authorize access b
 
 To use auth hooks, you must first declare them in the Wasp file:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import {
-      onBeforeSignup,
-      onAfterSignup,
-      onAfterEmailVerified,
-      onBeforeOAuthRedirect,
-      onBeforeLogin,
-      onAfterLogin,
-    } from "./src/auth/hooks" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import {
+  onBeforeSignup,
+  onAfterSignup,
+  onAfterEmailVerified,
+  onBeforeOAuthRedirect,
+  onBeforeLogin,
+  onAfterLogin,
+} from "./src/auth/hooks" with { type: "ref" }
 
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      auth: {
-        userEntity: "User",
-        methods: {
-          // ...
-        },
-        onBeforeSignup,
-        onAfterSignup,
-        onAfterEmailVerified,
-        onBeforeOAuthRedirect,
-        onBeforeLogin,
-        onAfterLogin,
-      },
+export default app({
+  name: "myApp",
+  wasp: { version: "{latestWaspVersion}" },
+  auth: {
+    userEntity: "User",
+    methods: {
       // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import {
-      onBeforeSignup,
-      onAfterSignup,
-      onAfterEmailVerified,
-      onBeforeOAuthRedirect,
-      onBeforeLogin,
-      onAfterLogin,
-    } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      auth: {
-        userEntity: "User",
-        methods: {
-          // ...
-        },
-        onBeforeSignup,
-        onAfterSignup,
-        onAfterEmailVerified,
-        onBeforeOAuthRedirect,
-        onBeforeLogin,
-        onAfterLogin,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+    },
+    onBeforeSignup,
+    onAfterSignup,
+    onAfterEmailVerified,
+    onBeforeOAuthRedirect,
+    onBeforeLogin,
+    onAfterLogin,
+  },
+  // ...
+})
+```
 
 If the hooks are defined as async functions, Wasp _awaits_ them. This means the auth process waits for the hooks to finish before continuing.
 
@@ -125,22 +89,22 @@ The `onBeforeSignup` hook can be useful if you want to reject a user based on so
 
 Works with <EmailPill /> <UsernameAndPasswordPill /> <SlackPill /> <DiscordPill /> <GithubPill /> <GooglePill /> <KeycloakPill />
 
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { onBeforeSignup } from "./src/auth/hooks" with { type: "ref" }
+
+export default app({
+  // ...
+  auth: {
+    // ...
+    onBeforeSignup,
+  },
+  // ...
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onBeforeSignup } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onBeforeSignup,
-      },
-      // ...
-    })
-    ```
-
     ```js title="src/auth/hooks.js"
     import { HttpError } from "wasp/server"
 
@@ -165,20 +129,6 @@ Works with <EmailPill /> <UsernameAndPasswordPill /> <SlackPill /> <DiscordPill 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onBeforeSignup } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onBeforeSignup,
-      },
-      // ...
-    })
-    ```
-
     ```ts title="src/auth/hooks.ts"
     import { HttpError } from "wasp/server"
     import type { OnBeforeSignupHook } from "wasp/server/auth"
@@ -220,22 +170,22 @@ Since the `onAfterSignup` hook receives the OAuth tokens, you can use this hook 
 
 Works with <EmailPill /> <UsernameAndPasswordPill /> <SlackPill /> <DiscordPill /> <GithubPill /> <GooglePill /> <KeycloakPill />
 
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { onAfterSignup } from "./src/auth/hooks" with { type: "ref" }
+
+export default app({
+  // ...
+  auth: {
+    // ...
+    onAfterSignup,
+  },
+  // ...
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onAfterSignup } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onAfterSignup,
-      },
-      // ...
-    })
-    ```
-
     ```js title="src/auth/hooks.js"
     export const onAfterSignup = async ({
       providerId,
@@ -265,20 +215,6 @@ Works with <EmailPill /> <UsernameAndPasswordPill /> <SlackPill /> <DiscordPill 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onAfterSignup } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onAfterSignup,
-      },
-      // ...
-    })
-    ```
-
     ```ts title="src/auth/hooks.ts"
     import type { OnAfterSignupHook } from "wasp/server/auth"
 
@@ -322,9 +258,6 @@ The `onAfterEmailVerified` hook receives an `email` string and `user` object, th
 
 Works with <EmailPill />
 
-<Tabs groupId="js-ts">
-<TabItem value="js" label="JavaScript">
-
 ```ts title="main.wasp.ts"
 import { app } from "@wasp.sh/spec"
 import { onAfterEmailVerified } from "./src/auth/hooks" with { type: "ref" }
@@ -338,6 +271,9 @@ export default app({
   // ...
 })
 ```
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
 
 ```js title="src/auth/hooks.js"
 import { emailSender } from "wasp/server/email"
@@ -358,20 +294,6 @@ export const onAfterEmailVerified = async ({ email }) => {
 
 </TabItem>
 <TabItem value="ts" label="TypeScript">
-
-```ts title="main.wasp.ts"
-import { app } from "@wasp.sh/spec"
-import { onAfterEmailVerified } from "./src/auth/hooks" with { type: "ref" }
-
-export default app({
-  // ...
-  auth: {
-    // ...
-    onAfterEmailVerified,
-  },
-  // ...
-})
-```
 
 ```ts title="src/auth/hooks.ts"
 import type { OnAfterEmailVerifiedHook } from "wasp/server/auth"
@@ -406,22 +328,22 @@ The `onBeforeOAuthRedirect` hook can be useful if you want to save some data (e.
 
 Works with <DiscordPill /> <GithubPill /> <GooglePill /> <KeycloakPill />
 
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { onBeforeOAuthRedirect } from "./src/auth/hooks" with { type: "ref" }
+
+export default app({
+  // ...
+  auth: {
+    // ...
+    onBeforeOAuthRedirect,
+  },
+  // ...
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onBeforeOAuthRedirect } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onBeforeOAuthRedirect,
-      },
-      // ...
-    })
-    ```
-
     ```js title="src/auth/hooks.js"
     export const onBeforeOAuthRedirect = async ({ url, oauth, prisma, req }) => {
       console.log("query params before oAuth redirect", req.query)
@@ -436,20 +358,6 @@ Works with <DiscordPill /> <GithubPill /> <GooglePill /> <KeycloakPill />
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onBeforeOAuthRedirect } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onBeforeOAuthRedirect,
-      },
-      // ...
-    })
-    ```
-
     ```ts title="src/auth/hooks.ts"
     import type { OnBeforeOAuthRedirectHook } from "wasp/server/auth"
 
@@ -483,22 +391,22 @@ The `onBeforeLogin` hook can be useful if you want to reject a user based on som
 
 Works with <EmailPill /> <UsernameAndPasswordPill /> <SlackPill /> <DiscordPill /> <GithubPill /> <GooglePill /> <KeycloakPill />
 
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { onBeforeLogin } from "./src/auth/hooks" with { type: "ref" }
+
+export default app({
+  // ...
+  auth: {
+    // ...
+    onBeforeLogin,
+  },
+  // ...
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onBeforeLogin } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onBeforeLogin,
-      },
-      // ...
-    })
-    ```
-
     ```js title="src/auth/hooks.js"
     import { HttpError } from "wasp/server"
 
@@ -514,20 +422,6 @@ Works with <EmailPill /> <UsernameAndPasswordPill /> <SlackPill /> <DiscordPill 
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onBeforeLogin } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onBeforeLogin,
-      },
-      // ...
-    })
-    ```
-
     ```ts title="src/auth/hooks.ts"
     import { HttpError } from "wasp/server"
     import type { OnBeforeLoginHook } from "wasp/server/auth"
@@ -561,22 +455,22 @@ Since the `onAfterLogin` hook receives the OAuth tokens, you can use it to updat
 
 Works with <EmailPill /> <UsernameAndPasswordPill /> <DiscordPill /> <GithubPill /> <GooglePill /> <KeycloakPill />
 
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { onAfterLogin } from "./src/auth/hooks" with { type: "ref" }
+
+export default app({
+  // ...
+  auth: {
+    // ...
+    onAfterLogin,
+  },
+  // ...
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onAfterLogin } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onAfterLogin,
-      },
-      // ...
-    })
-    ```
-
     ```js title="src/auth/hooks.js"
     export const onAfterLogin = async ({
       providerId,
@@ -604,20 +498,6 @@ Works with <EmailPill /> <UsernameAndPasswordPill /> <DiscordPill /> <GithubPill
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { onAfterLogin } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      // ...
-      auth: {
-        // ...
-        onAfterLogin,
-      },
-      // ...
-    })
-    ```
-
     ```ts title="src/auth/hooks.ts"
     import type { OnAfterLoginHook } from "wasp/server/auth"
 
@@ -698,71 +578,35 @@ If you want to refresh the token periodically, use a [Wasp Job](../advanced/jobs
 
 ## API Reference
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import {
-      onBeforeSignup,
-      onAfterSignup,
-      onAfterEmailVerified,
-      onBeforeOAuthRedirect,
-      onBeforeLogin,
-      onAfterLogin,
-    } from "./src/auth/hooks" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import {
+  onBeforeSignup,
+  onAfterSignup,
+  onAfterEmailVerified,
+  onBeforeOAuthRedirect,
+  onBeforeLogin,
+  onAfterLogin,
+} from "./src/auth/hooks" with { type: "ref" }
 
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      auth: {
-        userEntity: "User",
-        methods: {
-          // ...
-        },
-        onBeforeSignup,
-        onAfterSignup,
-        onAfterEmailVerified,
-        onBeforeOAuthRedirect,
-        onBeforeLogin,
-        onAfterLogin,
-      },
+export default app({
+  name: "myApp",
+  wasp: { version: "{latestWaspVersion}" },
+  auth: {
+    userEntity: "User",
+    methods: {
       // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import {
-      onBeforeSignup,
-      onAfterSignup,
-      onAfterEmailVerified,
-      onBeforeOAuthRedirect,
-      onBeforeLogin,
-      onAfterLogin,
-    } from "./src/auth/hooks" with { type: "ref" }
-
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      auth: {
-        userEntity: "User",
-        methods: {
-          // ...
-        },
-        onBeforeSignup,
-        onAfterSignup,
-        onAfterEmailVerified,
-        onBeforeOAuthRedirect,
-        onBeforeLogin,
-        onAfterLogin,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+    },
+    onBeforeSignup,
+    onAfterSignup,
+    onAfterEmailVerified,
+    onBeforeOAuthRedirect,
+    onBeforeLogin,
+    onAfterLogin,
+  },
+  // ...
+})
+```
 
 ### Common hook input
 

--- a/web/docs/auth/email.md
+++ b/web/docs/auth/email.md
@@ -57,79 +57,39 @@ export default app({
 
 Let's start with adding the following to our `main.wasp.ts` file:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
 
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My App",
-      auth: {
-        // 1. Specify the user entity (we'll define it next)
-        userEntity: "User",
-        methods: {
-          // 2. Enable email authentication
-          email: {
-            // 3. Specify the email from field
-            fromField: {
-              name: "My App Postman",
-              email: "hello@itsme.com"
-            },
-            // 4. Specify the email verification and password reset options (we'll talk about them later)
-            emailVerification: {
-              clientRoute: "EmailVerificationRoute",
-            },
-            passwordReset: {
-              clientRoute: "PasswordResetRoute",
-            },
-          },
+export default app({
+  name: "myApp",
+  wasp: { version: "{latestWaspVersion}" },
+  title: "My App",
+  auth: {
+    // 1. Specify the user entity (we'll define it next)
+    userEntity: "User",
+    methods: {
+      // 2. Enable email authentication
+      email: {
+        // 3. Specify the email from field
+        fromField: {
+          name: "My App Postman",
+          email: "hello@itsme.com"
         },
-        onAuthFailedRedirectTo: "/login",
-        onAuthSucceededRedirectTo: "/"
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My App",
-      auth: {
-        // 1. Specify the user entity (we'll define it next)
-        userEntity: "User",
-        methods: {
-          // 2. Enable email authentication
-          email: {
-            // 3. Specify the email from field
-            fromField: {
-              name: "My App Postman",
-              email: "hello@itsme.com"
-            },
-            // 4. Specify the email verification and password reset options (we'll talk about them later)
-            emailVerification: {
-              clientRoute: "EmailVerificationRoute",
-            },
-            passwordReset: {
-              clientRoute: "PasswordResetRoute",
-            },
-          },
+        // 4. Specify the email verification and password reset options (we'll talk about them later)
+        emailVerification: {
+          clientRoute: "EmailVerificationRoute",
         },
-        onAuthFailedRedirectTo: "/login",
-        onAuthSucceededRedirectTo: "/"
+        passwordReset: {
+          clientRoute: "PasswordResetRoute",
+        },
       },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+    },
+    onAuthFailedRedirectTo: "/login",
+    onAuthSucceededRedirectTo: "/"
+  },
+  // ...
+})
+```
 
 Read more about the `email` auth method options [here](#fields-in-the-email-object).
 
@@ -171,63 +131,31 @@ Next, we need to define the routes and pages for the authentication pages.
 
 Add the following to the `main.wasp.ts` file:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import {
-      LoginPage,
-      SignupPage,
-      RequestPasswordResetPage,
-      PasswordResetPage,
-      EmailVerificationPage,
-    } from "./src/pages/auth" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app, page, route } from "@wasp.sh/spec"
+import {
+  LoginPage,
+  SignupPage,
+  RequestPasswordResetPage,
+  PasswordResetPage,
+  EmailVerificationPage,
+} from "./src/pages/auth" with { type: "ref" }
 
-    export default app({
-      // ...
-      parts: [
-        route("LoginRoute", "/login", page(LoginPage)),
-        route("SignupRoute", "/signup", page(SignupPage)),
-        route(
-          "RequestPasswordResetRoute",
-          "/request-password-reset",
-          page(RequestPasswordResetPage)
-        ),
-        route("PasswordResetRoute", "/password-reset", page(PasswordResetPage)),
-        route("EmailVerificationRoute", "/email-verification", page(EmailVerificationPage)),
-      ],
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import {
-      LoginPage,
-      SignupPage,
-      RequestPasswordResetPage,
-      PasswordResetPage,
-      EmailVerificationPage,
-    } from "./src/pages/auth" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("LoginRoute", "/login", page(LoginPage)),
-        route("SignupRoute", "/signup", page(SignupPage)),
-        route(
-          "RequestPasswordResetRoute",
-          "/request-password-reset",
-          page(RequestPasswordResetPage)
-        ),
-        route("PasswordResetRoute", "/password-reset", page(PasswordResetPage)),
-        route("EmailVerificationRoute", "/email-verification", page(EmailVerificationPage)),
-      ],
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  // ...
+  parts: [
+    route("LoginRoute", "/login", page(LoginPage)),
+    route("SignupRoute", "/signup", page(SignupPage)),
+    route(
+      "RequestPasswordResetRoute",
+      "/request-password-reset",
+      page(RequestPasswordResetPage)
+    ),
+    route("PasswordResetRoute", "/password-reset", page(PasswordResetPage)),
+    route("EmailVerificationRoute", "/email-verification", page(EmailVerificationPage)),
+  ],
+})
+```
 
 We'll define the React components for these pages in the `src/pages/auth.{jsx,tsx}` file below.
 
@@ -239,7 +167,7 @@ Let's create a `auth.{jsx,tsx}` file in the `src/pages` folder and add the follo
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title="src/pages/auth.jsx"
+    ```jsx title="src/pages/auth.jsx"
     import {
       LoginForm,
       SignupForm,
@@ -421,31 +349,15 @@ We'll use the `Dummy` provider to speed up the setup. It just logs the emails to
 
 To set up the `Dummy` provider to send emails, add the following to the `main.wasp.ts` file:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    export default app({
-      // ...
-      // 7. Set up the email sender
-      emailSender: {
-        provider: "Dummy",
-      },
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    export default app({
-      // ...
-      // 7. Set up the email sender
-      emailSender: {
-        provider: "Dummy",
-      },
-    })
-    ```
-  </TabItem>
-</Tabs>
+```ts title="main.wasp.ts"
+export default app({
+  // ...
+  // 7. Set up the email sender
+  emailSender: {
+    provider: "Dummy",
+  },
+})
+```
 
 ### Conclusion
 
@@ -498,27 +410,13 @@ By default, Wasp requires the e-mail to be verified before allowing the user to 
 
 Our setup looks like this:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    // ...
+```ts title="main.wasp.ts"
+// ...
 
-    emailVerification: {
-      clientRoute: "EmailVerificationRoute",
-    }
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    // ...
-
-    emailVerification: {
-      clientRoute: "EmailVerificationRoute",
-    }
-    ```
-  </TabItem>
-</Tabs>
+emailVerification: {
+  clientRoute: "EmailVerificationRoute",
+}
+```
 
 When the user receives an e-mail, they receive a link that goes to the client route specified in the `clientRoute` field. In our case, this is the `EmailVerificationRoute` route we defined in the `main.wasp.ts` file.
 
@@ -546,27 +444,13 @@ If somebody requests a password reset with an unknown email address, we'll give 
 
 Our setup in `main.wasp.ts` looks like this:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    // ...
+```ts title="main.wasp.ts"
+// ...
 
-    passwordReset: {
-      clientRoute: "PasswordResetRoute",
-    }
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    // ...
-
-    passwordReset: {
-      clientRoute: "PasswordResetRoute",
-    }
-    ```
-  </TabItem>
-</Tabs>
+passwordReset: {
+  clientRoute: "PasswordResetRoute",
+}
+```
 
 ### Request Password Reset Page
 
@@ -610,155 +494,76 @@ Let's go over the options we can specify when using email authentication.
 
 ### `userEntity` fields
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
 
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My app",
-      // ...
+export default app({
+  name: "myApp",
+  wasp: { version: "{latestWaspVersion}" },
+  title: "My app",
+  // ...
 
-      auth: {
-        userEntity: "User",
-        methods: {
-          email: {
-            // We'll explain these options below
-          },
-        },
-        onAuthFailedRedirectTo: "/someRoute"
+  auth: {
+    userEntity: "User",
+    methods: {
+      email: {
+        // We'll explain these options below
       },
-      // ...
-    })
-    ```
+    },
+    onAuthFailedRedirectTo: "/someRoute"
+  },
+  // ...
+})
+```
 
-    ```prisma title="schema.prisma"
-    model User {
-      id Int @id @default(autoincrement())
-    }
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My app",
-      // ...
-
-      auth: {
-        userEntity: "User",
-        methods: {
-          email: {
-            // We'll explain these options below
-          },
-        },
-        onAuthFailedRedirectTo: "/someRoute"
-      },
-      // ...
-    })
-    ```
-
-    ```prisma title="schema.prisma"
-    model User {
-      id Int @id @default(autoincrement())
-    }
-    ```
-  </TabItem>
-</Tabs>
+```prisma title="schema.prisma"
+model User {
+  id Int @id @default(autoincrement())
+}
+```
 
 <UserFields />
 
 ### Fields in the `email` object
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { userSignupFields } from "./src/auth" with { type: "ref" }
-    import {
-      getVerificationEmailContent,
-      getPasswordResetEmailContent,
-    } from "./src/auth/email" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { userSignupFields } from "./src/auth" with { type: "ref" }
+import {
+  getVerificationEmailContent,
+  getPasswordResetEmailContent,
+} from "./src/auth/email" with { type: "ref" }
 
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My app",
-      // ...
+export default app({
+  name: "myApp",
+  wasp: { version: "{latestWaspVersion}" },
+  title: "My app",
+  // ...
 
-      auth: {
-        userEntity: "User",
-        methods: {
-          email: {
-            userSignupFields,
-            fromField: {
-              name: "My App",
-              email: "hello@itsme.com"
-            },
-            emailVerification: {
-              clientRoute: "EmailVerificationRoute",
-              getEmailContentFn: getVerificationEmailContent,
-            },
-            passwordReset: {
-              clientRoute: "PasswordResetRoute",
-              getEmailContentFn: getPasswordResetEmailContent,
-            },
-          },
+  auth: {
+    userEntity: "User",
+    methods: {
+      email: {
+        userSignupFields,
+        fromField: {
+          name: "My App",
+          email: "hello@itsme.com"
         },
-        onAuthFailedRedirectTo: "/someRoute"
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { userSignupFields } from "./src/auth" with { type: "ref" }
-    import {
-      getVerificationEmailContent,
-      getPasswordResetEmailContent,
-    } from "./src/auth/email" with { type: "ref" }
-
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My app",
-      // ...
-
-      auth: {
-        userEntity: "User",
-        methods: {
-          email: {
-            userSignupFields,
-            fromField: {
-              name: "My App",
-              email: "hello@itsme.com"
-            },
-            emailVerification: {
-              clientRoute: "EmailVerificationRoute",
-              getEmailContentFn: getVerificationEmailContent,
-            },
-            passwordReset: {
-              clientRoute: "PasswordResetRoute",
-              getEmailContentFn: getPasswordResetEmailContent,
-            },
-          },
+        emailVerification: {
+          clientRoute: "EmailVerificationRoute",
+          getEmailContentFn: getVerificationEmailContent,
         },
-        onAuthFailedRedirectTo: "/someRoute"
+        passwordReset: {
+          clientRoute: "PasswordResetRoute",
+          getEmailContentFn: getPasswordResetEmailContent,
+        },
       },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+    },
+    onAuthFailedRedirectTo: "/someRoute"
+  },
+  // ...
+})
+```
 
 #### `userSignupFields`: [`Reference`](../general/spec.md#reference-imports)
 
@@ -787,7 +592,7 @@ It has the following fields:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title="src/pages/EmailVerificationPage.jsx"
+      ```jsx title="src/pages/EmailVerificationPage.jsx"
       import { verifyEmail } from "wasp/client/auth"
       ...
       await verifyEmail({ token });
@@ -795,7 +600,7 @@ It has the following fields:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title="src/pages/EmailVerificationPage.tsx"
+      ```tsx title="src/pages/EmailVerificationPage.tsx"
       import { verifyEmail } from "wasp/client/auth"
       ...
       await verifyEmail({ token });
@@ -813,7 +618,7 @@ It has the following fields:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```ts title="src/email.js"
+      ```js title="src/email.js"
       export const getVerificationEmailContent = ({ verificationLink }) => ({
         subject: "Verify your email",
         text: `Click the link below to verify your email: ${verificationLink}`,
@@ -857,13 +662,13 @@ It has the following fields:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```js title="src/pages/ForgotPasswordPage.jsx"
+      ```jsx title="src/pages/ForgotPasswordPage.jsx"
       import { requestPasswordReset } from "wasp/client/auth"
       ...
       await requestPasswordReset({ email });
       ```
 
-      ```js title="src/pages/PasswordResetPage.jsx"
+      ```jsx title="src/pages/PasswordResetPage.jsx"
       import { resetPassword } from "wasp/client/auth"
       ...
       await resetPassword({ password, token })
@@ -871,13 +676,13 @@ It has the following fields:
     </TabItem>
 
     <TabItem value="ts" label="TypeScript">
-      ```ts title="src/pages/ForgotPasswordPage.tsx"
+      ```tsx title="src/pages/ForgotPasswordPage.tsx"
       import { requestPasswordReset } from "wasp/client/auth"
       ...
       await requestPasswordReset({ email });
       ```
 
-      ```ts title="src/pages/PasswordResetPage.tsx"
+      ```tsx title="src/pages/PasswordResetPage.tsx"
       import { resetPassword } from "wasp/client/auth"
       ...
       await resetPassword({ password, token })
@@ -895,7 +700,7 @@ It has the following fields:
 
   <Tabs groupId="js-ts">
     <TabItem value="js" label="JavaScript">
-      ```ts title="src/email.js"
+      ```js title="src/email.js"
       export const getPasswordResetEmailContent = ({ passwordResetLink }) => ({
         subject: "Password reset",
         text: `Click the link below to reset your password: ${passwordResetLink}`,

--- a/web/docs/auth/entities/entities.md
+++ b/web/docs/auth/entities/entities.md
@@ -594,20 +594,20 @@ In the Advanced section you can see an example for [Email](../advanced/custom-au
 
 Below is a simplified version of a custom signup action which you probably wouldn't use in your app but it shows you how you can use the `Auth` and `AuthIdentity` entities to create a custom signup action.
 
+```ts title="main.wasp.ts"
+import { action, app } from "@wasp.sh/spec"
+import { customSignup } from "./src/auth/signup" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    action(customSignup, { entities: ["User"] }),
+  ],
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { action, app } from "@wasp.sh/spec"
-    import { customSignup } from "./src/auth/signup" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        action(customSignup, { entities: ["User"] }),
-      ],
-    })
-    ```
-
     ```js title="src/auth/signup.js"
     import {
       createProviderId,
@@ -667,18 +667,6 @@ Below is a simplified version of a custom signup action which you probably would
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { action, app } from "@wasp.sh/spec"
-    import { customSignup } from "./src/auth/signup" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        action(customSignup, { entities: ["User"] }),
-      ],
-    })
-    ```
-
     ```ts title="src/auth/signup.ts"
     import {
       createProviderId,

--- a/web/docs/auth/ui.md
+++ b/web/docs/auth/ui.md
@@ -22,7 +22,7 @@ After Wasp generates the UI components for your auth, you can use it as is, or c
 
 Based on the authentication providers you enabled in your `main.wasp.ts` file, the Auth UI will show the corresponding UI (form and buttons). For example, if you enabled e-mail authentication:
 
-```ts title="main.wasp.ts" {7}
+```ts title="main.wasp.ts"
 import { app } from "@wasp.sh/spec"
 
 export default app({
@@ -30,6 +30,7 @@ export default app({
   //...
   auth: {
     methods: {
+      // highlight-next-line
       email: {},
     },
     // ...
@@ -44,7 +45,7 @@ You'll get the following UI:
 
 And then if you enable Google and Github:
 
-```ts title="main.wasp.ts" {8-9}
+```ts title="main.wasp.ts"
 import { app } from "@wasp.sh/spec"
 
 export default app({
@@ -53,8 +54,10 @@ export default app({
   auth: {
     methods: {
       email: {},
+      // highlight-start
       google: {},
       gitHub: {},
+      // highlight-end
     },
     // ...
   },

--- a/web/docs/auth/ui.md
+++ b/web/docs/auth/ui.md
@@ -22,43 +22,21 @@ After Wasp generates the UI components for your auth, you can use it as is, or c
 
 Based on the authentication providers you enabled in your `main.wasp.ts` file, the Auth UI will show the corresponding UI (form and buttons). For example, if you enabled e-mail authentication:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts" {7}
-    import { app } from "@wasp.sh/spec"
+```ts title="main.wasp.ts" {7}
+import { app } from "@wasp.sh/spec"
 
-    export default app({
-      name: "MyApp",
-      //...
-      auth: {
-        methods: {
-          email: {},
-        },
-        // ...
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts" {7}
-    import { app } from "@wasp.sh/spec"
-
-    export default app({
-      name: "MyApp",
-      //...
-      auth: {
-        methods: {
-          email: {},
-        },
-        // ...
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "MyApp",
+  //...
+  auth: {
+    methods: {
+      email: {},
+    },
+    // ...
+  },
+  // ...
+})
+```
 
 You'll get the following UI:
 
@@ -66,47 +44,23 @@ You'll get the following UI:
 
 And then if you enable Google and Github:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts" {8-9}
-    import { app } from "@wasp.sh/spec"
+```ts title="main.wasp.ts" {8-9}
+import { app } from "@wasp.sh/spec"
 
-    export default app({
-      name: "MyApp",
-      //...
-      auth: {
-        methods: {
-          email: {},
-          google: {},
-          gitHub: {},
-        },
-        // ...
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts" {8-9}
-    import { app } from "@wasp.sh/spec"
-
-    export default app({
-      name: "MyApp",
-      //...
-      auth: {
-        methods: {
-          email: {},
-          google: {},
-          gitHub: {},
-        },
-        // ...
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "MyApp",
+  //...
+  auth: {
+    methods: {
+      email: {},
+      google: {},
+      gitHub: {},
+    },
+    // ...
+  },
+  // ...
+})
+```
 
 The form will automatically update to look like this:
 
@@ -132,21 +86,21 @@ Used with <UsernameAndPasswordPill />, <EmailPill />, <GithubPill />, <GooglePil
 
 You can use the `LoginForm` component to build your login page:
 
+```ts title="main.wasp.ts"
+import { app, page, route } from "@wasp.sh/spec"
+import { LoginPage } from "./src/LoginPage" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    route("LoginRoute", "/login", page(LoginPage)),
+  ],
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { LoginPage } from "./src/LoginPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("LoginRoute", "/login", page(LoginPage)),
-      ],
-    })
-    ```
-
-    ```tsx title="src/LoginPage.jsx"
+    ```jsx title="src/LoginPage.jsx"
     import { LoginForm } from "wasp/client/auth"
 
     // Use it like this
@@ -157,18 +111,6 @@ You can use the `LoginForm` component to build your login page:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { LoginPage } from "./src/LoginPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("LoginRoute", "/login", page(LoginPage)),
-      ],
-    })
-    ```
-
     ```tsx title="src/LoginPage.tsx"
     import { LoginForm } from "wasp/client/auth"
 
@@ -190,21 +132,21 @@ Used with <UsernameAndPasswordPill />, <EmailPill />, <GithubPill />, <GooglePil
 
 You can use the `SignupForm` component to build your signup page:
 
+```ts title="main.wasp.ts"
+import { app, page, route } from "@wasp.sh/spec"
+import { SignupPage } from "./src/SignupPage" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    route("SignupRoute", "/signup", page(SignupPage)),
+  ],
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { SignupPage } from "./src/SignupPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("SignupRoute", "/signup", page(SignupPage)),
-      ],
-    })
-    ```
-
-    ```tsx title="src/SignupPage.jsx"
+    ```jsx title="src/SignupPage.jsx"
     import { SignupForm } from "wasp/client/auth"
 
     // Use it like this
@@ -215,18 +157,6 @@ You can use the `SignupForm` component to build your signup page:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { SignupPage } from "./src/SignupPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("SignupRoute", "/signup", page(SignupPage)),
-      ],
-    })
-    ```
-
     ```tsx title="src/SignupPage.tsx"
     import { SignupForm } from "wasp/client/auth"
 
@@ -252,25 +182,25 @@ If users forget their password, they can use this form to reset it.
 
 You can use the `ForgotPasswordForm` component to build your own forgot password page:
 
+```ts title="main.wasp.ts"
+import { app, page, route } from "@wasp.sh/spec"
+import { ForgotPasswordPage } from "./src/ForgotPasswordPage" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    route(
+      "RequestPasswordResetRoute",
+      "/request-password-reset",
+      page(ForgotPasswordPage)
+    ),
+  ],
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { ForgotPasswordPage } from "./src/ForgotPasswordPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route(
-          "RequestPasswordResetRoute",
-          "/request-password-reset",
-          page(ForgotPasswordPage)
-        ),
-      ],
-    })
-    ```
-
-    ```tsx title="src/ForgotPasswordPage.jsx"
+    ```jsx title="src/ForgotPasswordPage.jsx"
     import { ForgotPasswordForm } from "wasp/client/auth"
 
     // Use it like this
@@ -281,22 +211,6 @@ You can use the `ForgotPasswordForm` component to build your own forgot password
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { ForgotPasswordPage } from "./src/ForgotPasswordPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route(
-          "RequestPasswordResetRoute",
-          "/request-password-reset",
-          page(ForgotPasswordPage)
-        ),
-      ],
-    })
-    ```
-
     ```tsx title="src/ForgotPasswordPage.tsx"
     import { ForgotPasswordForm } from "wasp/client/auth"
 
@@ -318,21 +232,21 @@ After users click on the link in the email they receive after submitting the for
 
 You can use the `ResetPasswordForm` component to build your reset password page:
 
+```ts title="main.wasp.ts"
+import { app, page, route } from "@wasp.sh/spec"
+import { ResetPasswordPage } from "./src/ResetPasswordPage" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    route("PasswordResetRoute", "/password-reset", page(ResetPasswordPage)),
+  ],
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { ResetPasswordPage } from "./src/ResetPasswordPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("PasswordResetRoute", "/password-reset", page(ResetPasswordPage)),
-      ],
-    })
-    ```
-
-    ```tsx title="src/ResetPasswordPage.jsx"
+    ```jsx title="src/ResetPasswordPage.jsx"
     import { ResetPasswordForm } from "wasp/client/auth"
 
     // Use it like this
@@ -343,18 +257,6 @@ You can use the `ResetPasswordForm` component to build your reset password page:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { ResetPasswordPage } from "./src/ResetPasswordPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("PasswordResetRoute", "/password-reset", page(ResetPasswordPage)),
-      ],
-    })
-    ```
-
     ```tsx title="src/ResetPasswordPage.tsx"
     import { ResetPasswordForm } from "wasp/client/auth"
 
@@ -376,21 +278,21 @@ After users sign up, they will receive an email with a link to this form where t
 
 You can use the `VerifyEmailForm` component to build your email verification page:
 
+```ts title="main.wasp.ts"
+import { app, page, route } from "@wasp.sh/spec"
+import { VerifyEmailPage } from "./src/VerifyEmailPage" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    route("EmailVerificationRoute", "/email-verification", page(VerifyEmailPage)),
+  ],
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { VerifyEmailPage } from "./src/VerifyEmailPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("EmailVerificationRoute", "/email-verification", page(VerifyEmailPage)),
-      ],
-    })
-    ```
-
-    ```tsx title="src/VerifyEmailPage.jsx"
+    ```jsx title="src/VerifyEmailPage.jsx"
     import { VerifyEmailForm } from "wasp/client/auth"
 
     // Use it like this
@@ -401,18 +303,6 @@ You can use the `VerifyEmailForm` component to build your email verification pag
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { VerifyEmailPage } from "./src/VerifyEmailPage" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("EmailVerificationRoute", "/email-verification", page(VerifyEmailPage)),
-      ],
-    })
-    ```
-
     ```tsx title="src/VerifyEmailPage.tsx"
     import { VerifyEmailForm } from "wasp/client/auth"
 
@@ -508,7 +398,7 @@ You can add your logo to the Auth UI by passing the `logo` prop to any of the co
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title="src/LoginPage.jsx"
+    ```jsx title="src/LoginPage.jsx"
     import { LoginForm } from "wasp/client/auth"
     import Logo from "./logo.png"
 
@@ -548,7 +438,7 @@ If we pass in `vertical`:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title="src/LoginPage.jsx"
+    ```jsx title="src/LoginPage.jsx"
     import { LoginForm } from "wasp/client/auth"
 
     export function LoginPage() {
@@ -588,7 +478,7 @@ If we provide the logo and custom colors:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="src/appearance.js"
+    ```js title="src/appearance.js"
     export const appearance = {
       colors: {
         brand: "#5969b8", // blue
@@ -598,7 +488,7 @@ If we provide the logo and custom colors:
     }
     ```
 
-    ```tsx title="src/LoginPage.jsx"
+    ```jsx title="src/LoginPage.jsx"
     import { LoginForm } from "wasp/client/auth"
 
     import { authAppearance } from "./appearance"

--- a/web/docs/auth/username-and-pass.md
+++ b/web/docs/auth/username-and-pass.md
@@ -49,51 +49,25 @@ export default app({
 
 Let's start with adding the following to our `main.wasp.ts` file:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts" {12}
-    import { app } from "@wasp.sh/spec"
+```ts title="main.wasp.ts" {12}
+import { app } from "@wasp.sh/spec"
 
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My App",
-      auth: {
-        // 1. Specify the user entity (we'll define it next)
-        userEntity: "User",
-        methods: {
-          // 2. Enable username authentication
-          usernameAndPassword: {},
-        },
-        onAuthFailedRedirectTo: "/login"
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts" {12}
-    import { app } from "@wasp.sh/spec"
-
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My App",
-      auth: {
-        // 1. Specify the user entity (we'll define it next)
-        userEntity: "User",
-        methods: {
-          // 2. Enable username authentication
-          usernameAndPassword: {},
-        },
-        onAuthFailedRedirectTo: "/login"
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "myApp",
+  wasp: { version: "{latestWaspVersion}" },
+  title: "My App",
+  auth: {
+    // 1. Specify the user entity (we'll define it next)
+    userEntity: "User",
+    methods: {
+      // 2. Enable username authentication
+      usernameAndPassword: {},
+    },
+    onAuthFailedRedirectTo: "/login"
+  },
+  // ...
+})
+```
 
 Read more about the `usernameAndPassword` auth method options [here](#fields-in-the-usernameandpassword-object).
 
@@ -135,37 +109,18 @@ Next, we need to define the routes and pages for the authentication pages.
 
 Add the following to the `main.wasp.ts` file:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { LoginPage, SignupPage } from "./src/pages/auth" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app, page, route } from "@wasp.sh/spec"
+import { LoginPage, SignupPage } from "./src/pages/auth" with { type: "ref" }
 
-    export default app({
-      // ...
-      parts: [
-        route("LoginRoute", "/login", page(LoginPage)),
-        route("SignupRoute", "/signup", page(SignupPage)),
-      ],
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { LoginPage, SignupPage } from "./src/pages/auth" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        route("LoginRoute", "/login", page(LoginPage)),
-        route("SignupRoute", "/signup", page(SignupPage)),
-      ],
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  // ...
+  parts: [
+    route("LoginRoute", "/login", page(LoginPage)),
+    route("SignupRoute", "/signup", page(SignupPage)),
+  ],
+})
+```
 
 We'll define the React components for these pages in the `src/pages/auth.{jsx,tsx}` file below.
 
@@ -177,7 +132,7 @@ Let's create a `auth.{jsx,tsx}` file in the `src/pages` folder and add the follo
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```tsx title="src/pages/auth.jsx"
+    ```jsx title="src/pages/auth.jsx"
     import { LoginForm, SignupForm } from "wasp/client/auth"
     import { Link } from "react-router"
 
@@ -289,111 +244,54 @@ When you receive the `user` object [on the client or the server](./overview.md#a
 
 ### `userEntity` fields
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
 
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My App",
-      auth: {
-        userEntity: "User",
-        methods: {
-          usernameAndPassword: {},
-        },
-        onAuthFailedRedirectTo: "/login"
-      },
-      // ...
-    })
-    ```
+export default app({
+  name: "myApp",
+  wasp: { version: "{latestWaspVersion}" },
+  title: "My App",
+  auth: {
+    userEntity: "User",
+    methods: {
+      usernameAndPassword: {},
+    },
+    onAuthFailedRedirectTo: "/login"
+  },
+  // ...
+})
+```
 
-    ```prisma title="schema.prisma"
-    model User {
-      id Int @id @default(autoincrement())
-    }
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My App",
-      auth: {
-        userEntity: "User",
-        methods: {
-          usernameAndPassword: {},
-        },
-        onAuthFailedRedirectTo: "/login"
-      },
-      // ...
-    })
-    ```
-
-    ```prisma title="schema.prisma"
-    model User {
-      id Int @id @default(autoincrement())
-    }
-    ```
-  </TabItem>
-</Tabs>
+```prisma title="schema.prisma"
+model User {
+  id Int @id @default(autoincrement())
+}
+```
 
 <UserFieldsExplainer />
 
 ### Fields in the `usernameAndPassword` object
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { userSignupFields } from "./src/auth/email" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { userSignupFields } from "./src/auth/email" with { type: "ref" }
 
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My App",
-      auth: {
-        userEntity: "User",
-        methods: {
-          usernameAndPassword: {
-            userSignupFields,
-          },
-        },
-        onAuthFailedRedirectTo: "/login"
+export default app({
+  name: "myApp",
+  wasp: { version: "{latestWaspVersion}" },
+  title: "My App",
+  auth: {
+    userEntity: "User",
+    methods: {
+      usernameAndPassword: {
+        userSignupFields,
       },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { userSignupFields } from "./src/auth/email" with { type: "ref" }
-
-    export default app({
-      name: "myApp",
-      wasp: { version: "{latestWaspVersion}" },
-      title: "My App",
-      auth: {
-        userEntity: "User",
-        methods: {
-          usernameAndPassword: {
-            userSignupFields,
-          },
-        },
-        onAuthFailedRedirectTo: "/login"
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+    },
+    onAuthFailedRedirectTo: "/login"
+  },
+  // ...
+})
+```
 
 #### `userSignupFields`: [`Reference`](../general/spec.md#reference-imports)
 

--- a/web/docs/data-model/crud.md
+++ b/web/docs/data-model/crud.md
@@ -456,133 +456,66 @@ CRUD declaration works on top of an existing entity declaration. We'll fully exp
 
 If we create CRUD operations for an entity named `Task`, like this:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, crud } from "@wasp.sh/spec"
+```ts title="main.wasp.ts"
+import { app, crud } from "@wasp.sh/spec"
 
-    export default app({
-      // ...
-      parts: [
-        crud("Tasks", "Task", { // crud name here is "Tasks"
-          get: {},
-          getAll: {},
-          create: {},
-          update: {},
-          delete: {},
-        }),
-      ],
-    })
-    ```
+export default app({
+  // ...
+  parts: [
+    crud("Tasks", "Task", { // crud name here is "Tasks"
+      get: {},
+      getAll: {},
+      create: {},
+      update: {},
+      delete: {},
+    }),
+  ],
+})
+```
 
-    Wasp will give you the following default implementations:
+Wasp will give you the following default implementations:
 
-    **get** - returns one entity based on the `id` field
+**get** - returns one entity based on the `id` field
 
-    ```js
-    // ...
-    // Wasp uses the field marked with `@id` in Prisma schema as the id field.
-    return Task.findUnique({ where: { id: args.id } })
-    ```
+```ts
+// ...
+// Wasp uses the field marked with `@id` in Prisma schema as the id field.
+return Task.findUnique({ where: { id: args.id } })
+```
 
-    **getAll** - returns all entities
+**getAll** - returns all entities
 
-    ```js
-    // ...
+```ts
+// ...
 
-    // If the operation is not public, Wasp checks if an authenticated user
-    // is making the request.
+// If the operation is not public, Wasp checks if an authenticated user
+// is making the request.
 
-    return Task.findMany()
-    ```
+return Task.findMany()
+```
 
-    **create** - creates a new entity
+**create** - creates a new entity
 
-    ```js
-    // ...
-    return Task.create({ data: args.data })
-    ```
+```ts
+// ...
+return Task.create({ data: args.data })
+```
 
-    **update** - updates an existing entity
+**update** - updates an existing entity
 
-    ```js
-    // ...
-    // Wasp uses the field marked with `@id` in Prisma schema as the id field.
-    return Task.update({ where: { id: args.id }, data: args.data })
-    ```
+```ts
+// ...
+// Wasp uses the field marked with `@id` in Prisma schema as the id field.
+return Task.update({ where: { id: args.id }, data: args.data })
+```
 
-    **delete** - deletes an existing entity
+**delete** - deletes an existing entity
 
-    ```js
-    // ...
-    // Wasp uses the field marked with `@id` in Prisma schema as the id field.
-    return Task.delete({ where: { id: args.id } })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, crud } from "@wasp.sh/spec"
-
-    export default app({
-      // ...
-      parts: [
-        crud("Tasks", "Task", { // crud name here is "Tasks"
-          get: {},
-          getAll: {},
-          create: {},
-          update: {},
-          delete: {},
-        }),
-      ],
-    })
-    ```
-
-    Wasp will give you the following default implementations:
-
-    **get** - returns one entity based on the `id` field
-
-    ```ts
-    // ...
-    // Wasp uses the field marked with `@id` in Prisma schema as the id field.
-    return Task.findUnique({ where: { id: args.id } })
-    ```
-
-    **getAll** - returns all entities
-
-    ```ts
-    // ...
-
-    // If the operation is not public, Wasp checks if an authenticated user
-    // is making the request.
-
-    return Task.findMany()
-    ```
-
-    **create** - creates a new entity
-
-    ```ts
-    // ...
-    return Task.create({ data: args.data })
-    ```
-
-    **update** - updates an existing entity
-
-    ```ts
-    // ...
-    // Wasp uses the field marked with `@id` in Prisma schema as the id field.
-    return Task.update({ where: { id: args.id }, data: args.data })
-    ```
-
-    **delete** - deletes an existing entity
-
-    ```ts
-    // ...
-    // Wasp uses the field marked with `@id` in Prisma schema as the id field.
-    return Task.delete({ where: { id: args.id } })
-    ```
-  </TabItem>
-</Tabs>
+```ts
+// ...
+// Wasp uses the field marked with `@id` in Prisma schema as the id field.
+return Task.delete({ where: { id: args.id } })
+```
 
 :::info Current Limitations
 In the default `create` and `update` implementations, we are saving all of the data that the client sends to the server. This is not always desirable, i.e. in the case when the client should not be able to modify all of the data in the entity.
@@ -597,53 +530,26 @@ For now, the solution is to provide an override function. You can override the d
 
 Here's an example of a more complex CRUD declaration:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, crud } from "@wasp.sh/spec"
-    import { createTask } from "./src/tasks" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app, crud } from "@wasp.sh/spec"
+import { createTask } from "./src/tasks" with { type: "ref" }
 
-    export default app({
-      // ...
-      parts: [
-        crud("Tasks", "Task", { // crud name here is "Tasks"
-          getAll: {
-            isPublic: true, // optional, defaults to false
-          },
-          get: {},
-          create: {
-            overrideFn: createTask, // optional
-          },
-          update: {},
-        }),
-      ],
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, crud } from "@wasp.sh/spec"
-    import { createTask } from "./src/tasks" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        crud("Tasks", "Task", { // crud name here is "Tasks"
-          getAll: {
-            isPublic: true, // optional, defaults to false
-          },
-          get: {},
-          create: {
-            overrideFn: createTask, // optional
-          },
-          update: {},
-        }),
-      ],
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  // ...
+  parts: [
+    crud("Tasks", "Task", { // crud name here is "Tasks"
+      getAll: {
+        isPublic: true, // optional, defaults to false
+      },
+      get: {},
+      create: {
+        overrideFn: createTask, // optional
+      },
+      update: {},
+    }),
+  ],
+})
+```
 
 The `crud` function accepts the following arguments:
 

--- a/web/docs/data-model/databases.md
+++ b/web/docs/data-model/databases.md
@@ -195,37 +195,18 @@ Seeding is most commonly used for:
 
 You can define as many **seed functions** as you want in an array under the `db.seeds` field:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { devSeedSimple, prodSeed } from "./src/dbSeeds" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { devSeedSimple, prodSeed } from "./src/dbSeeds" with { type: "ref" }
 
-    export default app({
-      name: "MyApp",
-      // ...
-      db: {
-        seeds: [devSeedSimple, prodSeed],
-      },
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { devSeedSimple, prodSeed } from "./src/dbSeeds" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      // ...
-      db: {
-        seeds: [devSeedSimple, prodSeed],
-      },
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "MyApp",
+  // ...
+  db: {
+    seeds: [devSeedSimple, prodSeed],
+  },
+})
+```
 
 Each seed function must be an async function that takes one argument, `prisma`, which is a [Prisma Client](https://www.prisma.io/docs/concepts/components/prisma-client/crud) instance used to interact with the database.
 This is the same Prisma Client instance that Wasp uses internally.
@@ -360,22 +341,22 @@ Wasp interacts with the database using the [Prisma Client](https://www.prisma.io
 To customize the client, define a function in the `db.prismaSetupFn` field that returns a Prisma Client instance.
 This allows you to configure features like [logging](https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/logging) or [client extensions](https://www.prisma.io/docs/orm/prisma-client/client-extensions):
 
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { setUpPrisma } from "./src/prisma" with { type: "ref" }
+
+export default app({
+  name: "MyApp",
+  title: "My app",
+  // ...
+  db: {
+    prismaSetupFn: setUpPrisma,
+  },
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { setUpPrisma } from "./src/prisma" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      // ...
-      db: {
-        prismaSetupFn: setUpPrisma,
-      },
-    })
-    ```
-
     ```js title="src/prisma.js"
     import { PrismaClient } from "@prisma/client"
 
@@ -403,20 +384,6 @@ This allows you to configure features like [logging](https://www.prisma.io/docs/
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { setUpPrisma } from "./src/prisma" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      // ...
-      db: {
-        prismaSetupFn: setUpPrisma,
-      },
-    })
-    ```
-
     ```ts title="src/prisma.ts"
     import { PrismaClient } from "@prisma/client"
 
@@ -446,43 +413,21 @@ This allows you to configure features like [logging](https://www.prisma.io/docs/
 
 ## API Reference
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import devSeed from "./src/dbSeeds" with { type: "ref" }
-    import { setUpPrisma } from "./src/prisma" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import devSeed from "./src/dbSeeds" with { type: "ref" }
+import { setUpPrisma } from "./src/prisma" with { type: "ref" }
 
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      // ...
-      db: {
-        seeds: [devSeed],
-        prismaSetupFn: setUpPrisma,
-      },
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import devSeed from "./src/dbSeeds" with { type: "ref" }
-    import { setUpPrisma } from "./src/prisma" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      // ...
-      db: {
-        seeds: [devSeed],
-        prismaSetupFn: setUpPrisma,
-      },
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "MyApp",
+  title: "My app",
+  // ...
+  db: {
+    seeds: [devSeed],
+    prismaSetupFn: setUpPrisma,
+  },
+})
+```
 
 `db` is an object with the following fields (all fields are optional):
 
@@ -521,43 +466,21 @@ Use one of the following commands to run the seed functions:
   This command runs the seed function with the specified name. Wasp derives this name from the imported function name you list in `db.seeds`.
   For example, to run the seed function `devSeedSimple` which was defined like this:
 
-  <Tabs groupId="js-ts">
-    <TabItem value="js" label="JavaScript">
-      ```ts title="main.wasp.ts"
-      import { app } from "@wasp.sh/spec"
-      import { devSeedSimple } from "./src/dbSeeds" with { type: "ref" }
+  ```ts title="main.wasp.ts"
+  import { app } from "@wasp.sh/spec"
+  import { devSeedSimple } from "./src/dbSeeds" with { type: "ref" }
 
-      export default app({
-        name: "MyApp",
+  export default app({
+    name: "MyApp",
+    // ...
+    db: {
+      seeds: [
         // ...
-        db: {
-          seeds: [
-            // ...
-            devSeedSimple,
-          ],
-        },
-      })
-      ```
-    </TabItem>
-
-    <TabItem value="ts" label="TypeScript">
-      ```ts title="main.wasp.ts"
-      import { app } from "@wasp.sh/spec"
-      import { devSeedSimple } from "./src/dbSeeds" with { type: "ref" }
-
-      export default app({
-        name: "MyApp",
-        // ...
-        db: {
-          seeds: [
-            // ...
-            devSeedSimple,
-          ],
-        },
-      })
-      ```
-    </TabItem>
-  </Tabs>
+        devSeedSimple,
+      ],
+    },
+  })
+  ```
 
   Use the following command:
 

--- a/web/docs/project/client-config.md
+++ b/web/docs/project/client-config.md
@@ -8,43 +8,21 @@ import { ShowForTs, ShowForJs } from '@site/src/components/TsJsHelpers'
 
 You can configure the client using the `client` field inside the `app` declaration:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import Root from "./src/Root" with { type: "ref" }
-    import mySetupFunction from "./src/myClientSetupCode" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import Root from "./src/Root" with { type: "ref" }
+import mySetupFunction from "./src/myClientSetupCode" with { type: "ref" }
 
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      client: {
-        rootComponent: Root,
-        setupFn: mySetupFunction,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import Root from "./src/Root" with { type: "ref" }
-    import mySetupFunction from "./src/myClientSetupCode" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      client: {
-        rootComponent: Root,
-        setupFn: mySetupFunction,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "MyApp",
+  title: "My app",
+  client: {
+    rootComponent: Root,
+    setupFn: mySetupFunction,
+  },
+  // ...
+})
+```
 
 ## Root Component
 
@@ -59,22 +37,22 @@ It can be used for a variety of purposes, but the most common ones are:
 
 Let's define a common layout for your application:
 
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import Root from "./src/Root" with { type: "ref" }
+
+export default app({
+  name: "MyApp",
+  title: "My app",
+  client: {
+    rootComponent: Root,
+  },
+  // ...
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import Root from "./src/Root" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      client: {
-        rootComponent: Root,
-      },
-      // ...
-    })
-    ```
-
     ```jsx title="src/Root.jsx"
     import { Outlet } from "react-router"
 
@@ -96,20 +74,6 @@ Let's define a common layout for your application:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import Root from "./src/Root" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      client: {
-        rootComponent: Root,
-      },
-      // ...
-    })
-    ```
-
     ```tsx title="src/Root.tsx"
     import { Outlet } from "react-router"
 
@@ -137,22 +101,22 @@ You need to import the [`Outlet`](https://reactrouter.com/7.12.0/api/components/
 
 This is how to set up various providers that your application needs:
 
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import Root from "./src/Root" with { type: "ref" }
+
+export default app({
+  name: "MyApp",
+  title: "My app",
+  client: {
+    rootComponent: Root,
+  },
+  // ...
+})
+```
+
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import Root from "./src/Root" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      client: {
-        rootComponent: Root,
-      },
-      // ...
-    })
-    ```
-
     ```jsx title="src/Root.jsx"
     import { Outlet } from "react-router"
     import store from "./store"
@@ -169,20 +133,6 @@ This is how to set up various providers that your application needs:
   </TabItem>
 
   <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import Root from "./src/Root" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      client: {
-        rootComponent: Root,
-      },
-      // ...
-    })
-    ```
-
     ```tsx title="src/Root.tsx"
     import { Outlet } from "react-router"
     import store from "./store"
@@ -320,44 +270,22 @@ router will work correctly, and all the assets will be served from
 
 ## API Reference
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import Root from "./src/Root" with { type: "ref" }
-    import mySetupFunction from "./src/myClientSetupCode" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import Root from "./src/Root" with { type: "ref" }
+import mySetupFunction from "./src/myClientSetupCode" with { type: "ref" }
 
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      client: {
-        rootComponent: Root,
-        setupFn: mySetupFunction,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import Root from "./src/Root" with { type: "ref" }
-    import mySetupFunction from "./src/myClientSetupCode" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      client: {
-        rootComponent: Root,
-        setupFn: mySetupFunction,
-        baseDir: "/my-app",
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "MyApp",
+  title: "My app",
+  client: {
+    rootComponent: Root,
+    setupFn: mySetupFunction,
+    baseDir: "/my-app",
+  },
+  // ...
+})
+```
 
 Client has the following options:
 

--- a/web/docs/project/server-config.md
+++ b/web/docs/project/server-config.md
@@ -6,41 +6,20 @@ import { ShowForTs, ShowForJs } from "@site/src/components/TsJsHelpers";
 
 You can configure the behavior of the server via the `server` field of `app` declaration:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { myMiddlewareConfigFn, mySetupFunction } from "./src/myServerSetupCode" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { myMiddlewareConfigFn, mySetupFunction } from "./src/myServerSetupCode" with { type: "ref" }
 
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      server: {
-        setupFn: mySetupFunction,
-        middlewareConfigFn: myMiddlewareConfigFn,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { myMiddlewareConfigFn, mySetupFunction } from "./src/myServerSetupCode" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      server: {
-        setupFn: mySetupFunction,
-        middlewareConfigFn: myMiddlewareConfigFn,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "MyApp",
+  title: "My app",
+  server: {
+    setupFn: mySetupFunction,
+    middlewareConfigFn: myMiddlewareConfigFn,
+  },
+  // ...
+})
+```
 
 ## Setup Function
 
@@ -58,7 +37,7 @@ As an example, adding a custom route would look something like:
 
 <Tabs groupId="js-ts">
   <TabItem value="js" label="JavaScript">
-    ```js title="src/myServerSetupCode.ts"
+    ```js title="src/myServerSetupCode.js"
     export const mySetupFunction = async ({ app }) => {
       addCustomRoute(app)
     }
@@ -168,41 +147,20 @@ Read more about [middleware config function](#middlewareconfigfn-reference) belo
 
 ## API Reference
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { myMiddlewareConfigFn, mySetupFunction } from "./src/myServerSetupCode" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app } from "@wasp.sh/spec"
+import { myMiddlewareConfigFn, mySetupFunction } from "./src/myServerSetupCode" with { type: "ref" }
 
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      server: {
-        setupFn: mySetupFunction,
-        middlewareConfigFn: myMiddlewareConfigFn,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import { myMiddlewareConfigFn, mySetupFunction } from "./src/myServerSetupCode" with { type: "ref" }
-
-    export default app({
-      name: "MyApp",
-      title: "My app",
-      server: {
-        setupFn: mySetupFunction,
-        middlewareConfigFn: myMiddlewareConfigFn,
-      },
-      // ...
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "MyApp",
+  title: "My app",
+  server: {
+    setupFn: mySetupFunction,
+    middlewareConfigFn: myMiddlewareConfigFn,
+  },
+  // ...
+})
+```
 
 `server` is an object with the following fields:
 

--- a/web/docs/tutorial/02-project-structure.md
+++ b/web/docs/tutorial/02-project-structure.md
@@ -87,55 +87,27 @@ The file exports your app's top-level configuration and a `parts` array. Each en
 
 The default `main.wasp.ts` file generated with `wasp new` on the previous page looks like this:
 
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { MainPage } from "./src/MainPage" with { type: "ref" }
+```ts title="main.wasp.ts"
+import { app, page, route } from "@wasp.sh/spec"
+// This is a reference to your MainPage component.
+// Read more about how Wasp references your code in the section below.
+import { MainPage } from "./src/MainPage" with { type: "ref" }
 
-    export default app({
-      name: "TodoApp",
-      wasp: {
-        version: "{latestWaspVersion}", // Pins the version of Wasp to use.
-      },
-      title: "TodoApp", // Used as the browser tab title.
-      head: [
-        "<link rel='icon' href='/favicon.ico' />",
-      ],
-      // Add your app declarations here so Wasp knows to register them.
-      parts: [
-        // We specify that the React implementation of the page is exported from
-        // `src/MainPage.jsx`. Reference imports must point to files inside `src`.
-        route("RootRoute", "/", page(MainPage)),
-      ],
-    })
-    ```
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { MainPage } from "./src/MainPage" with { type: "ref" }
-
-    export default app({
-      name: "TodoApp",
-      wasp: {
-        version: "{latestWaspVersion}", // Pins the version of Wasp to use.
-      },
-      title: "TodoApp", // Used as the browser tab title.
-      head: [
-        "<link rel='icon' href='/favicon.ico' />",
-      ],
-      // Add your app declarations here so Wasp knows to register them.
-      parts: [
-        // We specify that the React implementation of the page is exported from
-        // `src/MainPage.tsx`. Reference imports must point to files inside `src`.
-        route("RootRoute", "/", page(MainPage)),
-      ],
-    })
-    ```
-  </TabItem>
-</Tabs>
+export default app({
+  name: "TodoApp",
+  wasp: {
+    version: "{latestWaspVersion}", // Pins the version of Wasp to use.
+  },
+  title: "TodoApp", // Used as the browser tab title.
+  head: [
+    "<link rel='icon' href='/favicon.ico' />",
+  ],
+  // Add your app declarations here so Wasp knows to register them.
+  parts: [
+    route("RootRoute", "/", page(MainPage)),
+  ],
+})
+```
 
 ### Referencing code from `src`
 

--- a/web/docs/tutorial/05-queries.md
+++ b/web/docs/tutorial/05-queries.md
@@ -26,49 +26,27 @@ We'll create a new Query called `getTasks`. We'll need to declare the Query in t
 We need to add a **query** declaration to `main.wasp.ts` so that Wasp knows it exists:
 
 <TutorialAction id="query-get-tasks" action="APPLY_PATCH">
-<Tabs groupId="js-ts">
-  <TabItem value="js" label="JavaScript">
-    ```ts title="main.wasp.ts"
-    import { app, query } from "@wasp.sh/spec"
+```ts title="main.wasp.ts"
+import { app, query } from "@wasp.sh/spec"
+// highlight-next-line
+import { getTasks } from "./src/queries" with { type: "ref" }
+
+export default app({
+  // ...
+  parts: [
+    // Tell Wasp that this query reads from the `Task` entity. Wasp will
+    // automatically update the results of this query when tasks are modified.
     // highlight-next-line
-    import { getTasks } from "./src/queries" with { type: "ref" }
+    query(getTasks, { entities: ["Task"] }),
+  ],
+})
+```
 
-    export default app({
-      // ...
-      parts: [
-        // Tell Wasp that this query reads from the `Task` entity. Wasp will
-        // automatically update the results of this query when tasks are modified.
-        // highlight-next-line
-        query(getTasks, { entities: ["Task"] }),
-      ],
-    })
-    ```
-
-  </TabItem>
-
-  <TabItem value="ts" label="TypeScript">
-    ```ts title="main.wasp.ts"
-    import { app, query } from "@wasp.sh/spec"
-    // highlight-next-line
-    import { getTasks } from "./src/queries" with { type: "ref" }
-
-    export default app({
-      // ...
-      parts: [
-        // Tell Wasp that this query reads from the `Task` entity. Wasp will
-        // automatically update the results of this query when tasks are modified.
-        // highlight-next-line
-        query(getTasks, { entities: ["Task"] }),
-      ],
-    })
-    ```
-
-    :::note
-    To generate the types used in the next section, make sure that `wasp start` is still running.
-    :::
-
-  </TabItem>
-</Tabs>
+<ShowForTs>
+  :::note
+  To generate the types used in the next section, make sure that `wasp start` is still running.
+  :::
+</ShowForTs>
 </TutorialAction>
 
 ### Implementing a Query


### PR DESCRIPTION
## Description

Removes JavaScript/TypeScript tabs around `main.wasp.ts` examples where the Wasp Spec is identical for both app languages. Keeps JS/TS tabs only for actual implementation files, and fixes related code fence language/title mismatches in the touched docs.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
