### PR TITLE
Expose wasp start on local network by default

### DIFF
--- a/wasp-app-runner/src/waspCli.ts
+++ b/wasp-app-runner/src/waspCli.ts
@@ -47,7 +47,10 @@ export function waspStart({
   return spawnWithLog({
     name: "wasp-start",
     cmd: waspCliCmd.cmd,
-    args: [...waspCliCmd.args, "start"],
+    // `--no-lan` keeps the app on localhost. e2e tests run against
+    // `http://localhost`, but `wasp start` exposes the app on the local network
+    // by default, which rebinds the client/server URLs to a LAN hostname.
+    args: [...waspCliCmd.args, "start", "--no-lan"],
     cwd: pathToApp,
     extraEnv,
   });

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -53,8 +53,8 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
   let commandCall = case args of
         ("new" : newArgs) -> Command.Call.New newArgs
         ("new:ai" : newAiArgs) -> Command.Call.NewAi newAiArgs
-        ["start"] -> Command.Call.Start
         ("start" : "db" : startDbArgs) -> Command.Call.StartDb startDbArgs
+        ("start" : startArgs) -> Command.Call.Start startArgs
         ["clean"] -> Command.Call.Clean
         ["install"] -> Command.Call.Install
         ["compile"] -> Command.Call.Compile
@@ -106,7 +106,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
             appDescription
             projectConfigJson
       _unknownCommand -> printWaspNewAiUsage >> exitFailure
-    Command.Call.Start -> runCommand start
+    Command.Call.Start startArgs -> runCommand $ start startArgs
     Command.Call.StartDb startDbArgs -> runCommand $ Command.Start.Db.start startDbArgs
     Command.Call.Clean -> runCommand clean
     Command.Call.Install -> runCommand install
@@ -179,7 +179,11 @@ printUsage =
         cmd   "    completion            Prints help on bash completion.",
         cmd   "    uninstall             Removes Wasp from your system.",
         title "  IN PROJECT",
-        cmd   "    start                 Runs Wasp app in development mode, watching for file changes.",
+        cmd   "    start [--no-lan] [--host <hostname>]",
+              "                          Runs Wasp app in development mode, watching for file changes.",
+              "                          By default, the app is exposed on the local network so other",
+              "                          devices on the same Wi-Fi can connect. Use --no-lan to disable,",
+              "                          or --host to override the auto-detected hostname.",
         cmd   "    start db [--db-image <image>] [--db-volume-mount-path <path>]",
               "                          Starts managed development database for you.",
               "                          Optionally specify a custom Docker image or Docker volume mount path.",

--- a/waspc/cli/src/Wasp/Cli/Command/Call.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Call.hs
@@ -3,7 +3,7 @@ module Wasp.Cli.Command.Call where
 data Call
   = New Arguments
   | NewAi Arguments
-  | Start
+  | Start Arguments
   | StartDb Arguments
   | Clean
   | Install

--- a/waspc/cli/src/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start.hs
@@ -5,24 +5,39 @@ where
 
 import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar (MVar, newMVar, tryTakeMVar)
+import Control.Monad (forM_)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
-import StrongPath ((</>))
+import qualified Data.Set as Set
+import StrongPath (Abs, Dir, Path', (</>))
 import Wasp.Cli.Command (Command, CommandError (..))
+import Wasp.Cli.Command.Call (Arguments)
 import Wasp.Cli.Command.Compile (compile, printWarningsAndErrorsIfAny)
 import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.News (fetchAndListMustSeeNewsIfDue)
 import Wasp.Cli.Command.Require (DbConnectionEstablished (DbConnectionEstablished), InWaspProject (InWaspProject), require)
+import Wasp.Cli.Command.Start.ArgumentsParser (StartArgs (..), startArgsParser)
 import Wasp.Cli.Command.Watch (watch)
+import Wasp.Cli.Util.Parser (withArguments)
+import Wasp.Env (EnvVar)
 import qualified Wasp.Generator
+import qualified Wasp.Generator.ServerGenerator.Common as Server
+import qualified Wasp.Generator.WebAppGenerator.Common as WebApp
 import qualified Wasp.Message as Msg
 import Wasp.Project (CompileError, CompileWarning)
-import Wasp.Project.Common (generatedAppDirInWaspProjectDir)
+import Wasp.Project.Common (WaspProjectDir, generatedAppDirInWaspProjectDir)
+import Wasp.Project.Env (readDotEnvClient, readDotEnvServer)
+import qualified Wasp.Util.Network.LocalAddress as LocalAddress
+
+-- | Env var name read by the Vite plugin template to extend `server.allowedHosts`.
+-- Keep in sync with the generated waspConfig.ts plugin.
+lanAllowedHostEnvVarName :: String
+lanAllowedHostEnvVarName = "WASP_LAN_ALLOWED_HOST"
 
 -- | Does initial compile of wasp code and then runs the generated project.
 -- It also listens for any file changes and recompiles and restarts generated project accordingly.
-start :: Command ()
-start = do
+start :: Arguments -> Command ()
+start = withArguments "wasp start" startArgsParser $ \args -> do
   -- We check for the news only in `wasp start`, and only periodically,
   -- to avoid being too aggressive. Specifically:
   --   - We don't run it in other `wasp` commands because we don't want to
@@ -43,6 +58,8 @@ start = do
 
   DbConnectionEstablished <- require
 
+  startOptions <- resolveStartOptions args waspProjectDir
+
   cliSendMessageC $ Msg.Start "Listening for file changes..."
   cliSendMessageC $ Msg.Start "Starting up generated project..."
 
@@ -54,7 +71,7 @@ start = do
     -- 'watch') once jobs from 'start' quiet down a bit.
     ongoingCompilationResultMVar <- newMVar (warnings, [])
     let watchWaspProjectSource = watch waspProjectDir outDir ongoingCompilationResultMVar
-    let startGeneratedWebApp = Wasp.Generator.start waspProjectDir outDir (onJobsQuietDown ongoingCompilationResultMVar)
+    let startGeneratedWebApp = Wasp.Generator.start startOptions waspProjectDir outDir (onJobsQuietDown ongoingCompilationResultMVar)
     -- In parallel:
     -- 1. watch for any changes in the Wasp project, be it users wasp code or users JS/HTML/...
     --    code. On any change, Wasp is recompiled (and generated app is re-generated).
@@ -84,3 +101,80 @@ start = do
           putStrLn ""
           printWarningsAndErrorsIfAny (warnings, errors)
           putStrLn ""
+
+resolveStartOptions :: StartArgs -> Path' Abs (Dir WaspProjectDir) -> Command Wasp.Generator.StartOptions
+resolveStartOptions args waspProjectDir
+  | disableLanExposure args = do
+      cliSendMessageC $ Msg.Info "Local network exposure disabled (--no-lan)."
+      return Wasp.Generator.defaultStartOptions
+  | otherwise = do
+      maybeHost <- liftIO $ resolveLanHost (hostOverride args)
+      case maybeHost of
+        Nothing -> do
+          cliSendMessageC $
+            Msg.Info "Could not detect a local network address; the app will only be reachable at http://localhost."
+          return Wasp.Generator.defaultStartOptions
+        Just host -> buildLanStartOptions host waspProjectDir
+
+resolveLanHost :: Maybe String -> IO (Maybe String)
+resolveLanHost (Just userHost) = return $ Just $ LocalAddress.toNipIoHostname userHost
+resolveLanHost Nothing = do
+  maybeIp <- LocalAddress.getLocalNetworkIPv4
+  return $ LocalAddress.toNipIoHostname <$> maybeIp
+
+buildLanStartOptions :: String -> Path' Abs (Dir WaspProjectDir) -> Command Wasp.Generator.StartOptions
+buildLanStartOptions host waspProjectDir = do
+  serverDotEnvVars <- liftIO $ readDotEnvServer waspProjectDir
+  clientDotEnvVars <- liftIO $ readDotEnvClient waspProjectDir
+
+  let candidateServerEnv =
+        [ (Server.clientUrlEnvVarName, clientUrl),
+          (Server.serverUrlEnvVarName, serverUrl)
+        ]
+      candidateClientEnv =
+        [ (WebApp.serverUrlEnvVarName, serverUrl),
+          (lanAllowedHostEnvVarName, host)
+        ]
+
+      (serverEnv, skippedServerVars) = skipExistingVars candidateServerEnv serverDotEnvVars
+      (clientEnv, skippedClientVars) = skipExistingVars candidateClientEnv clientDotEnvVars
+
+  warnAboutSkippedVars ".env.server" skippedServerVars
+  warnAboutSkippedVars ".env.client" skippedClientVars
+
+  cliSendMessageC $
+    Msg.Info $
+      unlines
+        [ "Local network access enabled. Open this URL on another device on the same network:",
+          "  " ++ clientUrl,
+          "Use `wasp start --no-lan` to disable, or `wasp start --host <hostname>` to override the auto-detected hostname."
+        ]
+
+  return $
+    Wasp.Generator.StartOptions
+      { Wasp.Generator.extraServerEnv = serverEnv,
+        Wasp.Generator.extraClientEnv = clientEnv
+      }
+  where
+    clientUrl = "http://" ++ host ++ ":" ++ show WebApp.defaultClientPort
+    serverUrl = "http://" ++ host ++ ":" ++ show Server.defaultServerPort
+
+skipExistingVars :: [EnvVar] -> [EnvVar] -> ([EnvVar], [String])
+skipExistingVars candidates existing = (kept, dropped)
+  where
+    existingNames = Set.fromList (map fst existing)
+    (dropped, kept) = foldr partition ([], []) candidates
+    partition var@(name, _) (skip, keep)
+      | name `Set.member` existingNames = (name : skip, keep)
+      | otherwise = (skip, var : keep)
+
+warnAboutSkippedVars :: String -> [String] -> Command ()
+warnAboutSkippedVars sourceLabel names =
+  forM_ names $ \name ->
+    cliSendMessageC $
+      Msg.Warning "LAN env var skipped" $
+        "Not injecting `"
+          ++ name
+          ++ "` because it is already set in `"
+          ++ sourceLabel
+          ++ "`. The app may not be reachable on the local network unless you update its value."

--- a/waspc/cli/src/Wasp/Cli/Command/Start/ArgumentsParser.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start/ArgumentsParser.hs
@@ -1,0 +1,30 @@
+module Wasp.Cli.Command.Start.ArgumentsParser
+  ( startArgsParser,
+    StartArgs (..),
+  )
+where
+
+import qualified Options.Applicative as Opt
+
+data StartArgs = StartArgs
+  { disableLanExposure :: Bool,
+    hostOverride :: Maybe String
+  }
+
+startArgsParser :: Opt.Parser StartArgs
+startArgsParser =
+  StartArgs
+    <$> Opt.switch
+      ( Opt.long "no-lan"
+          <> Opt.help "Do not expose the app on the local network. URLs default to localhost."
+      )
+    <*> Opt.optional
+      ( Opt.strOption $
+          Opt.long "host"
+            <> Opt.metavar "HOSTNAME"
+            <> Opt.help
+              ( "Hostname (or IP address) used to compute the URLs the dev app is reachable at. "
+                  <> "A bare IP gets a `.nip.io` suffix appended so OAuth-style integrations keep working. "
+                  <> "Defaults to the local network IP."
+              )
+      )

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -37,6 +37,10 @@ export function waspConfig(): PluginOption {
         server: {
           port: useUserValue(config.server?.port, {= defaultClientPort =}),
           host: useUserValue(config.server?.host, "0.0.0.0"),
+          // `wasp start` sets this to the LAN hostname it auto-detects (or the
+          // user override from `--host`). It's `undefined` in any other case so
+          // Vite keeps its default `allowedHosts` policy.
+          allowedHosts: process.env.WASP_LAN_ALLOWED_HOST ? [process.env.WASP_LAN_ALLOWED_HOST] : undefined,
         },
         envPrefix: forcedOptions['envPrefix'],
         build: {

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -781,7 +781,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "b5db741e0d7b953cd7f6f70ace2172c35c8123bd4ff60c9d43a14bbb7a5bd03c"
+        "54106e7c920d7d79c615e3b1cbcba344d3694d403e1619fb2a99dd3bae0725c5"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -36,6 +36,10 @@ export function waspConfig(): PluginOption {
         server: {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
+          // `wasp start` sets this to the LAN hostname it auto-detects (or the
+          // user override from `--host`). It's `undefined` in any other case so
+          // Vite keeps its default `allowedHosts` policy.
+          allowedHosts: process.env.WASP_LAN_ALLOWED_HOST ? [process.env.WASP_LAN_ALLOWED_HOST] : undefined,
         },
         envPrefix: forcedOptions['envPrefix'],
         build: {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -340,7 +340,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "b5db741e0d7b953cd7f6f70ace2172c35c8123bd4ff60c9d43a14bbb7a5bd03c"
+        "54106e7c920d7d79c615e3b1cbcba344d3694d403e1619fb2a99dd3bae0725c5"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -36,6 +36,10 @@ export function waspConfig(): PluginOption {
         server: {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
+          // `wasp start` sets this to the LAN hostname it auto-detects (or the
+          // user override from `--host`). It's `undefined` in any other case so
+          // Vite keeps its default `allowedHosts` policy.
+          allowedHosts: process.env.WASP_LAN_ALLOWED_HOST ? [process.env.WASP_LAN_ALLOWED_HOST] : undefined,
         },
         envPrefix: forcedOptions['envPrefix'],
         build: {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -340,7 +340,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "b5db741e0d7b953cd7f6f70ace2172c35c8123bd4ff60c9d43a14bbb7a5bd03c"
+        "54106e7c920d7d79c615e3b1cbcba344d3694d403e1619fb2a99dd3bae0725c5"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -36,6 +36,10 @@ export function waspConfig(): PluginOption {
         server: {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
+          // `wasp start` sets this to the LAN hostname it auto-detects (or the
+          // user override from `--host`). It's `undefined` in any other case so
+          // Vite keeps its default `allowedHosts` policy.
+          allowedHosts: process.env.WASP_LAN_ALLOWED_HOST ? [process.env.WASP_LAN_ALLOWED_HOST] : undefined,
         },
         envPrefix: forcedOptions['envPrefix'],
         build: {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -340,7 +340,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "b5db741e0d7b953cd7f6f70ace2172c35c8123bd4ff60c9d43a14bbb7a5bd03c"
+        "54106e7c920d7d79c615e3b1cbcba344d3694d403e1619fb2a99dd3bae0725c5"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -36,6 +36,10 @@ export function waspConfig(): PluginOption {
         server: {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
+          // `wasp start` sets this to the LAN hostname it auto-detects (or the
+          // user override from `--host`). It's `undefined` in any other case so
+          // Vite keeps its default `allowedHosts` policy.
+          allowedHosts: process.env.WASP_LAN_ALLOWED_HOST ? [process.env.WASP_LAN_ALLOWED_HOST] : undefined,
         },
         envPrefix: forcedOptions['envPrefix'],
         build: {

--- a/waspc/src/Wasp/Generator.hs
+++ b/waspc/src/Wasp/Generator.hs
@@ -1,6 +1,8 @@
 module Wasp.Generator
   ( writeWebAppCode,
     Wasp.Generator.Start.start,
+    Wasp.Generator.Start.StartOptions (..),
+    Wasp.Generator.Start.defaultStartOptions,
     Wasp.Generator.Test.testWebApp,
     GeneratedAppDir,
   )

--- a/waspc/src/Wasp/Generator/ServerGenerator/Start.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Start.hs
@@ -4,12 +4,13 @@ module Wasp.Generator.ServerGenerator.Start
 where
 
 import StrongPath (Abs, Dir, Path', (</>))
+import Wasp.Env (EnvVar)
 import Wasp.Generator.Common (GeneratedAppDir)
 import qualified Wasp.Generator.ServerGenerator.Common as Common
 import qualified Wasp.Job as J
-import Wasp.Job.Process (runNodeCommandAsJob)
+import Wasp.Job.Process (runNodeCommandAsJobWithExtraEnv)
 
-startServer :: Path' Abs (Dir GeneratedAppDir) -> J.Job
-startServer generatedAppDir = do
+startServer :: [EnvVar] -> Path' Abs (Dir GeneratedAppDir) -> J.Job
+startServer extraEnvVars generatedAppDir = do
   let serverDir = generatedAppDir </> Common.serverRootDirInGeneratedAppDir
-  runNodeCommandAsJob serverDir "npm" ["run", "watch"] J.Server
+  runNodeCommandAsJobWithExtraEnv extraEnvVars serverDir "npm" ["run", "watch"] J.Server

--- a/waspc/src/Wasp/Generator/Start.hs
+++ b/waspc/src/Wasp/Generator/Start.hs
@@ -1,5 +1,7 @@
 module Wasp.Generator.Start
   ( start,
+    StartOptions (..),
+    defaultStartOptions,
   )
 where
 
@@ -8,6 +10,7 @@ import Control.Concurrent.Async (concurrently, race)
 import Control.Concurrent.Extra (threadDelay)
 import Control.Monad (void)
 import StrongPath (Abs, Dir, Path')
+import Wasp.Env (EnvVar)
 import Wasp.Generator.Common (GeneratedAppDir)
 import Wasp.Generator.ServerGenerator.Start (startServer)
 import Wasp.Generator.WebAppGenerator.Start (startWebApp)
@@ -15,15 +18,29 @@ import qualified Wasp.Job as J
 import Wasp.Job.IO (readJobMessagesAndPrintThemPrefixed)
 import Wasp.Project.Common (WaspProjectDir)
 
+-- | Extra options influencing how the generated app is started.
+-- 'extraServerEnv' and 'extraClientEnv' are forwarded as environment variables
+-- to the spawned server and client dev processes respectively, on top of the
+-- inherited shell environment.
+data StartOptions = StartOptions
+  { extraServerEnv :: [EnvVar],
+    extraClientEnv :: [EnvVar]
+  }
+
+defaultStartOptions :: StartOptions
+defaultStartOptions = StartOptions {extraServerEnv = [], extraClientEnv = []}
+
 -- | This is a blocking action, that will start the processes that run web app and server.
 --   It will run as long as one of those processes does not fail.
 --   It alo receives 'onJobsQuietDown' IO action, which it executes every time all the processes
 --   go quiet (don't produce any stdout/err) for some time (5s), after they have previously
 --   produced some output.
-start :: Path' Abs (Dir WaspProjectDir) -> Path' Abs (Dir GeneratedAppDir) -> IO () -> IO (Either String ())
-start waspProjectDir outDir onJobsQuietDown = do
+start :: StartOptions -> Path' Abs (Dir WaspProjectDir) -> Path' Abs (Dir GeneratedAppDir) -> IO () -> IO (Either String ())
+start opts waspProjectDir outDir onJobsQuietDown = do
   chan <- newChan
-  let runStartJobs = startServer outDir chan `race` startWebApp waspProjectDir chan
+  let runStartJobs =
+        startServer (extraServerEnv opts) outDir chan
+          `race` startWebApp (extraClientEnv opts) waspProjectDir chan
   ((serverOrWebExitCode, _), _) <-
     runStartJobs
       `concurrently` readJobMessagesAndPrintThemPrefixed chan

--- a/waspc/src/Wasp/Generator/WebAppGenerator/Start.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/Start.hs
@@ -4,10 +4,11 @@ module Wasp.Generator.WebAppGenerator.Start
 where
 
 import StrongPath (Abs, Dir, Path')
+import Wasp.Env (EnvVar)
 import qualified Wasp.Job as J
-import Wasp.Job.Process (runNodeCommandAsJob)
+import Wasp.Job.Process (runNodeCommandAsJobWithExtraEnv)
 import Wasp.Project.Common (WaspProjectDir)
 
-startWebApp :: Path' Abs (Dir WaspProjectDir) -> J.Job
-startWebApp waspProjectDir = do
-  runNodeCommandAsJob waspProjectDir "npx" ["vite"] J.WebApp
+startWebApp :: [EnvVar] -> Path' Abs (Dir WaspProjectDir) -> J.Job
+startWebApp extraEnvVars waspProjectDir = do
+  runNodeCommandAsJobWithExtraEnv extraEnvVars waspProjectDir "npx" ["vite"] J.WebApp

--- a/waspc/src/Wasp/Util/Network/LocalAddress.hs
+++ b/waspc/src/Wasp/Util/Network/LocalAddress.hs
@@ -1,0 +1,64 @@
+module Wasp.Util.Network.LocalAddress
+  ( getLocalNetworkIPv4,
+    toNipIoHostname,
+    isIPv4Address,
+  )
+where
+
+import Control.Exception (SomeException, try)
+import Data.Char (isDigit)
+import Data.List.Split (splitOn)
+import qualified Network.Socket as S
+import UnliftIO.Exception (bracket)
+
+-- | Returns the local IPv4 address the operating system would use to reach an
+-- external host, formatted as a dotted-decimal string. This is usually the LAN
+-- address of the machine on its primary interface.
+--
+-- The implementation uses a UDP socket trick that does not send any packets:
+-- creating and connecting a datagram socket only sets the kernel's routing
+-- entry, after which we read back the socket's local address.
+--
+-- Returns Nothing when no usable IPv4 address can be determined (e.g. when the
+-- machine has no network interfaces or DNS lookup fails).
+getLocalNetworkIPv4 :: IO (Maybe String)
+getLocalNetworkIPv4 = do
+  result <- try $ bracket createUdpSocket S.close $ \sock -> do
+    S.connect sock arbitraryPublicAddress
+    sockName <- S.getSocketName sock
+    return $ case sockName of
+      S.SockAddrInet _ hostAddr ->
+        let (a, b, c, d) = S.hostAddressToTuple hostAddr
+         in Just $ show a ++ "." ++ show b ++ "." ++ show c ++ "." ++ show d
+      _ -> Nothing
+  case (result :: Either SomeException (Maybe String)) of
+    Left _ -> return Nothing
+    Right mIp -> return mIp
+  where
+    createUdpSocket = S.socket S.AF_INET S.Datagram S.defaultProtocol
+    -- Cloudflare's public DNS resolver. Any routable public IPv4 works here;
+    -- nothing is actually sent because we never write to the socket.
+    arbitraryPublicAddress = S.SockAddrInet 80 (S.tupleToHostAddress (1, 1, 1, 1))
+
+-- | If the input parses as an IPv4 dotted-decimal address, returns the
+-- equivalent @<ip>.nip.io@ hostname. Otherwise returns the input unchanged.
+--
+-- nip.io is a public wildcard DNS service that resolves @a.b.c.d.nip.io@ back
+-- to @a.b.c.d@, giving us a real hostname for an IP. This matters because
+-- several integrations (OAuth providers, cookie policies, Vite's allowedHosts)
+-- treat hostnames and raw IPs differently.
+toNipIoHostname :: String -> String
+toNipIoHostname host
+  | isIPv4Address host = host ++ ".nip.io"
+  | otherwise = host
+
+isIPv4Address :: String -> Bool
+isIPv4Address s = case splitOn "." s of
+  [a, b, c, d] -> all isOctet [a, b, c, d]
+  _ -> False
+  where
+    isOctet octet =
+      not (null octet)
+        && length octet <= 3
+        && all isDigit octet
+        && (read octet :: Int) <= 255

--- a/waspc/tests/Util/Network/LocalAddressTest.hs
+++ b/waspc/tests/Util/Network/LocalAddressTest.hs
@@ -1,0 +1,43 @@
+module Util.Network.LocalAddressTest where
+
+import Test.Hspec
+import Wasp.Util.Network.LocalAddress (isIPv4Address, toNipIoHostname)
+
+spec_isIPv4Address :: Spec
+spec_isIPv4Address =
+  describe "isIPv4Address" $ do
+    it "accepts a standard private IPv4 address" $
+      isIPv4Address "192.168.1.39" `shouldBe` True
+
+    it "accepts the boundary values 0.0.0.0 and 255.255.255.255" $ do
+      isIPv4Address "0.0.0.0" `shouldBe` True
+      isIPv4Address "255.255.255.255" `shouldBe` True
+
+    it "rejects octets above 255" $
+      isIPv4Address "256.0.0.1" `shouldBe` False
+
+    it "rejects non-numeric octets" $
+      isIPv4Address "192.168.1.abc" `shouldBe` False
+
+    it "rejects addresses with the wrong number of octets" $ do
+      isIPv4Address "192.168.1" `shouldBe` False
+      isIPv4Address "192.168.1.1.1" `shouldBe` False
+
+    it "rejects empty octets" $
+      isIPv4Address "192..1.1" `shouldBe` False
+
+    it "rejects hostnames" $
+      isIPv4Address "my-machine.local" `shouldBe` False
+
+spec_toNipIoHostname :: Spec
+spec_toNipIoHostname =
+  describe "toNipIoHostname" $ do
+    it "appends .nip.io to a bare IPv4 address" $
+      toNipIoHostname "192.168.1.39" `shouldBe` "192.168.1.39.nip.io"
+
+    it "leaves non-IPv4 hostnames unchanged" $ do
+      toNipIoHostname "my-machine.local" `shouldBe` "my-machine.local"
+      toNipIoHostname "example.com" `shouldBe` "example.com"
+
+    it "leaves an already-suffixed nip.io hostname unchanged" $
+      toNipIoHostname "192.168.1.39.nip.io" `shouldBe` "192.168.1.39.nip.io"

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -470,6 +470,7 @@ library
     Wasp.Util.InstallMethod
     Wasp.Util.Json
     Wasp.Util.Network.HTTP
+    Wasp.Util.Network.LocalAddress
     Wasp.Util.Network.Socket
     Wasp.Util.StrongPath
     Wasp.Util.TH
@@ -622,6 +623,7 @@ library cli-lib
     Wasp.Cli.Command.News.LocalNewsState
     Wasp.Cli.Command.Require
     Wasp.Cli.Command.Start
+    Wasp.Cli.Command.Start.ArgumentsParser
     Wasp.Cli.Command.Start.Db
     Wasp.Cli.Command.Studio
     Wasp.Cli.Command.Telemetry
@@ -761,6 +763,7 @@ test-suite waspc-tests
     Util.FibTest
     Util.FilePathTest
     Util.IO.RetryTest
+    Util.Network.LocalAddressTest
     Util.Prisma
     Util.StrongPathTest
     UtilTest

--- a/web/docs/guides/debugging/local-network-testing.md
+++ b/web/docs/guides/debugging/local-network-testing.md
@@ -20,96 +20,61 @@ Run your application normally:
 wasp start
 ```
 
-## Step 2: Find Your Network URL
-
-Look for the network URLs in Wasp's terminal output:
+`wasp start` auto-detects the LAN address of your machine and configures the dev server so other devices on the same network can connect to it. You'll see a message like:
 
 ```
-[ Client ]   VITE v7.3.1  ready in 536 ms
-[ Client ]
-[ Client ]   ->  Local:   http://localhost:3000/
-[ Client ]   ->  Network: http://192.168.1.39:3000/
-[ Client ]   ->  Network: http://198.19.249.3:3000/
-[ Client ]   ->  Network: http://192.168.215.0:3000/
-[ Client ]   ->  press h + enter to show help
+Local network access enabled. Open this URL on another device on the same network:
+  http://192.168.1.39.nip.io:3000
+Use `wasp start --no-lan` to disable, or `wasp start --host <hostname>` to override the auto-detected hostname.
 ```
 
-If you have multiple network interfaces, you'll see multiple Network URLs. Note one of these IPs (you may need to try a few to find the one that works).
+## Step 2: Open the URL on Your Device
 
-## Step 3: Configure Environment Variables
-
-The app won't be fully functional until you configure the environment variables. Edit your environment files:
-
-### .env.server
-
-```bash title=".env.server"
-WASP_WEB_CLIENT_URL=http://192.168.1.39.nip.io:3000
-WASP_SERVER_URL=http://192.168.1.39.nip.io:3001
-```
-
-### .env.client
-
-```bash title=".env.client"
-REACT_APP_API_URL=http://192.168.1.39.nip.io:3001
-```
-
-Replace `192.168.1.39` with your actual IP address from Step 2.
-
-:::note Why these variables?
-
-- **WASP_WEB_CLIENT_URL**: Ensures CORS works correctly
-- **WASP_SERVER_URL**: Makes OAuth redirects work properly
-- **REACT_APP_API_URL**: Tells the client where to find the server on the local network
-  :::
-
-## Step 4: Allow the Host in Vite Config
-
-By default, Vite blocks requests from hostnames other than `localhost`. Since we're using a `.nip.io` hostname, you need to explicitly allow it.
-
-Add `allowedHosts` to the `server` section in your `vite.config.ts`:
-
-```ts title="vite.config.ts"
-import { defineConfig } from "vitest/config";
-import { wasp } from "wasp/client/vite";
-
-export default defineConfig({
-  server: {
-    // highlight-next-line
-    allowedHosts: ["192.168.1.39.nip.io"],
-  },
-  plugins: [wasp()],
-});
-```
-
-Replace `192.168.1.39.nip.io` with the hostname matching your IP from Step 2.
-
-## Step 5: Restart and Test
-
-After saving the environment files, restart your app:
-
-```bash
-wasp start
-```
-
-On your phone or tablet, open the URL with the `.nip.io` suffix:
+On your phone or tablet, open the URL printed by `wasp start`:
 
 ```
 http://192.168.1.39.nip.io:3000
 ```
 
+That's it. Both the client and the API call work over the network without any manual configuration.
+
+## Overriding the Hostname
+
+If `wasp start` picks the wrong network interface (this can happen on machines with multiple network adapters, VPNs, or Docker bridges), pass `--host` to specify which hostname or IP to use:
+
+```bash
+# Force a specific LAN IP
+wasp start --host 192.168.1.50
+
+# Or use a custom hostname (e.g. a mDNS name)
+wasp start --host my-laptop.local
+```
+
+A bare IP gets a `.nip.io` suffix appended automatically, so OAuth-style integrations keep working. Custom hostnames are used as-is.
+
+## Disabling Local Network Access
+
+If you don't want your dev server exposed on the network, pass `--no-lan`:
+
+```bash
+wasp start --no-lan
+```
+
+The app will only be reachable at `http://localhost:3000`, just like in earlier versions of Wasp.
+
 ## Why Use nip.io?
 
 [nip.io](https://nip.io) is a free DNS service that maps any IP address to a hostname. For example, `192.168.1.39.nip.io` resolves to `192.168.1.39`.
 
-This is necessary because some Wasp features (like Google OAuth) don't allow plain IP addresses. Using nip.io provides a proper hostname without any configuration.
+This matters because some Wasp features (like Google OAuth) don't allow plain IP addresses as redirect URLs. Using nip.io gives you a real hostname for your LAN IP without any DNS setup on your side.
 
-:::tip
-You can skip nip.io if you're not using features that require proper hostnames, but using it has no downside and ensures everything works correctly.
-:::
+## Respecting Your `.env` Files
+
+If you've already set `WASP_WEB_CLIENT_URL`, `WASP_SERVER_URL`, or `REACT_APP_API_URL` in your `.env.server` / `.env.client` files, Wasp won't override them and will print a warning telling you which variable it skipped. If that's not what you want, remove the value from the `.env` file and let `wasp start` populate it.
 
 ## OAuth Configuration
 
-If you're using OAuth providers (Google, GitHub, etc.), remember to add your local network URLs to the allowed redirect URIs in each provider's configuration:
+If you're using OAuth providers (Google, GitHub, etc.), add your local network URL to the allowed redirect URIs in each provider's configuration:
 
 ```
 http://192.168.1.39.nip.io:3001/auth/google/callback
@@ -121,16 +86,15 @@ http://192.168.1.39.nip.io:3001/auth/google/callback
 
 1. Make sure both devices are on the same network
 2. Check if your firewall is blocking incoming connections on ports 3000 and 3001
-3. Try different Network URLs if you have multiple
+3. If you have multiple network interfaces, try overriding with `wasp start --host <ip>`
 
 ### API calls failing
 
-1. Verify `REACT_APP_API_URL` is set correctly in `.env.client`
-2. Make sure the server is accessible on port 3001
-3. Check browser console for CORS errors
+1. Confirm the URL in your browser uses the `.nip.io` hostname Wasp printed, not `localhost`
+2. Make sure the server is reachable on port 3001 from the same device
+3. Check the browser console for CORS errors
 
 ### OAuth not working
 
-1. Update redirect URIs in your OAuth provider's settings
-2. Make sure `WASP_SERVER_URL` uses the nip.io hostname
-3. Restart the server after changing environment variables
+1. Update redirect URIs in your OAuth provider's settings to match the `.nip.io` URL
+2. Make sure you haven't overridden `WASP_SERVER_URL` in `.env.server` with a `localhost` value


### PR DESCRIPTION
## Description

`wasp start` now auto-detects the machine's LAN IP and configures the dev server so other devices on the same network (phones, tablets) can connect, using a `nip.io` hostname so OAuth-style integrations keep working. It auto-injects `WASP_WEB_CLIENT_URL`, `WASP_SERVER_URL`, `REACT_APP_API_URL`, and `WASP_LAN_ALLOWED_HOST` (respecting and warning about values you already set in `.env.server` / `.env.client`), and the generated Vite plugin now adds the LAN host to `server.allowedHosts`. Use `--no-lan` to opt out or `--host <hostname>` to override the detected hostname. This removes the manual `.env` and `vite.config.ts` editing that the local network testing guide previously required, which has been rewritten accordingly.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)