### PR TITLE
Require the TypeScript Wasp file to be named main.wasp.ts

### DIFF
--- a/waspc/src/Wasp/Project/Common.hs
+++ b/waspc/src/Wasp/Project/Common.hs
@@ -9,6 +9,7 @@ module Wasp.Project.Common
     WaspFilePath (..),
     WaspLangFile,
     WaspTsFile,
+    mainWaspTsFileInWaspProjectDir,
     findFileInWaspProjectDir,
     dotWaspDirInWaspProjectDir,
     generatedAppDirInDotWaspDir,
@@ -63,6 +64,9 @@ data WaspFilePath
 data WaspLangFile
 
 data WaspTsFile
+
+mainWaspTsFileInWaspProjectDir :: Path' (Rel WaspProjectDir) (File WaspTsFile)
+mainWaspTsFileInWaspProjectDir = [relfile|main.wasp.ts|]
 
 data SrcTsConfigFile
 

--- a/waspc/src/Wasp/Project/WaspFile.hs
+++ b/waspc/src/Wasp/Project/WaspFile.hs
@@ -5,6 +5,7 @@ module Wasp.Project.WaspFile
   )
 where
 
+import Data.Functor ((<&>))
 import StrongPath
   ( Abs,
     Dir,
@@ -20,6 +21,7 @@ import Wasp.Project.Common
   ( CompileError,
     WaspFilePath (..),
     WaspProjectDir,
+    mainWaspTsFileInWaspProjectDir,
   )
 import Wasp.Project.WaspFile.TypeScript (analyzeWaspTsFile)
 import Wasp.Project.WaspFile.WaspLang (analyzeWaspLangFile)
@@ -28,30 +30,41 @@ import qualified Wasp.Util.IO as IOUtil
 import Wasp.Util.StrongPath (findAllFilesWithSuffix)
 
 findWaspFile :: Path' Abs (Dir WaspProjectDir) -> IO (Either String WaspFilePath)
-findWaspFile projectDir = do
-  filesInProjectDir <- fst <$> IOUtil.listDirectory projectDir
-  let filesEndingWithWasp = findAllFilesWithSuffix ".wasp" filesInProjectDir
-      filesEndingWithWaspTs = findAllFilesWithSuffix ".wasp.ts" filesInProjectDir
-  return $ case (filesEndingWithWasp, filesEndingWithWaspTs) of
-    ([], []) -> Left fileNotFoundMessage
-    (_ : _, _ : _) -> Left bothFilesFoundMessage
-    ([], waspTsFiles) -> case waspTsFiles of
-      [singleWaspTsFile]
-        | fromRelFile singleWaspTsFile == ".wasp.ts" -> Left (makeInvalidFileNameMessage ".wasp.ts")
-        | otherwise -> Right . WaspTs $ castFile (projectDir </> singleWaspTsFile)
-      multipleWaspTsFiles -> Left (makeMultipleFilesMessage "*.wasp.ts" (map fromRelFile multipleWaspTsFiles))
-    (waspLangFiles, []) -> case waspLangFiles of
-      [singleWaspLangFile]
-        | fromRelFile singleWaspLangFile == ".wasp" -> Left (makeInvalidFileNameMessage ".wasp")
-        | otherwise -> Right . WaspLang $ castFile (projectDir </> singleWaspLangFile)
-      multipleWaspFiles -> Left (makeMultipleFilesMessage "*.wasp" (map fromRelFile multipleWaspFiles))
+findWaspFile projectDir =
+  liftA2 (,) (findWaspLangFile projectDir) (findWaspTsFile projectDir)
+    <&> \case
+      (Left err, _) -> Left err
+      (Right Nothing, Nothing) -> Left fileNotFoundMessage
+      (Right (Just _), Just _) -> Left bothFilesFoundMessage
+      (Right (Just waspLangFile), _) -> Right waspLangFile
+      (_, Just waspTsFile) -> Right waspTsFile
   where
     fileNotFoundMessage = "Couldn't find the *.wasp or a *.wasp.ts file in the project directory."
     bothFilesFoundMessage =
       "Found both *.wasp and *.wasp.ts files in the project directory. "
         ++ "You must choose how you want to define your app (using Wasp or TypeScript) and only keep one of them."
-    makeMultipleFilesMessage suffix files = "Found multiple " ++ suffix ++ " files in the project directory: " ++ show files ++ ". Please keep only one."
-    makeInvalidFileNameMessage suffix = "Your Wasp file can't be called '" ++ suffix ++ "'. Please rename it to something like [name]" ++ suffix ++ "."
+
+findWaspLangFile :: Path' Abs (Dir WaspProjectDir) -> IO (Either String (Maybe WaspFilePath))
+findWaspLangFile projectDir = do
+  (filesInProjectDir, _) <- IOUtil.listDirectory projectDir
+  let waspLangFiles = findAllFilesWithSuffix ".wasp" filesInProjectDir
+  return $ case waspLangFiles of
+    [] -> Right Nothing
+    [waspFile] ->
+      if fromRelFile waspFile == ".wasp"
+        then Left invalidFileNameMessage
+        else Right $ Just $ WaspLang $ castFile (projectDir </> waspFile)
+    _ -> Left $ makeMultipleFilesMessage $ map fromRelFile waspLangFiles
+  where
+    invalidFileNameMessage = "Your Wasp file can't be called '.wasp'. Please rename it to something like '[name].wasp'."
+    makeMultipleFilesMessage files = "Found multiple *.wasp files in the project directory: " ++ show files ++ ". Please keep only one."
+
+findWaspTsFile :: Path' Abs (Dir WaspProjectDir) -> IO (Maybe WaspFilePath)
+findWaspTsFile projectDir = do
+  let fullPath = projectDir </> mainWaspTsFileInWaspProjectDir
+  IOUtil.doesFileExist fullPath <&> \case
+    True -> Just $ WaspTs $ castFile fullPath
+    False -> Nothing
 
 isWaspTsProject :: Path' Abs (Dir WaspProjectDir) -> IO Bool
 isWaspTsProject projectDir =

--- a/web/docs/guides/legacy/wasp-dsl.md
+++ b/web/docs/guides/legacy/wasp-dsl.md
@@ -353,7 +353,7 @@ Wasp validates the Wasp Spec support files during migration, including the requi
     ```
 
     :::note
-    While previously we accepted any `*.wasp` file name, with the Wasp Spec the file must be named `main.wasp.ts`. You can still split the rest of your config across other `*.wasp.ts` files.
+    While previously we accepted any `*.wasp` file name, with the Wasp Spec the entry file must be named `main.wasp.ts`. You can still split the rest of your config across other `*.wasp.ts` files.
     :::
 
 8. Rewrite your config:

--- a/web/docs/guides/legacy/wasp-dsl.md
+++ b/web/docs/guides/legacy/wasp-dsl.md
@@ -352,6 +352,10 @@ Wasp validates the Wasp Spec support files during migration, including the requi
     })
     ```
 
+    :::note
+    While previously we accepted any `*.wasp` file name, with the Wasp Spec the file must be named `main.wasp.ts`. You can still split the rest of your config across other `*.wasp.ts` files.
+    :::
+
 8. Rewrite your config:
 
     You can use the mapping above. Top-level concerns (e.g. `auth`, `server`, `client`, `db`, `emailSender`, `webSocket`) become keys of the `app({ ... })` object; pages, routes, queries, actions, APIs, jobs, and CRUDs go into the `decls` array.

--- a/web/docs/guides/legacy/wasp-ts-config.md
+++ b/web/docs/guides/legacy/wasp-ts-config.md
@@ -368,6 +368,10 @@ Wasp validates the Wasp Spec support files during migration, including the requi
       </TabItem>
     </Tabs>
 
+    :::note
+    While previously we accepted any `*.wasp.ts` file name, with the Wasp Spec the file must be named `main.wasp.ts`. You can still split the rest of your config across other `*.wasp.ts` files.
+    :::
+
 6. Run your app with `wasp start`. If everything is correct, your app should behave exactly as before.
 
   :::note

--- a/web/docs/guides/legacy/wasp-ts-config.md
+++ b/web/docs/guides/legacy/wasp-ts-config.md
@@ -369,7 +369,7 @@ Wasp validates the Wasp Spec support files during migration, including the requi
     </Tabs>
 
     :::note
-    While previously we accepted any `*.wasp.ts` file name, with the Wasp Spec the file must be named `main.wasp.ts`. You can still split the rest of your config across other `*.wasp.ts` files.
+    While previously we accepted any `*.wasp.ts` file name, with the Wasp Spec the entry file must be named `main.wasp.ts`. You can still split the rest of your config across other `*.wasp.ts` files.
     :::
 
 6. Run your app with `wasp start`. If everything is correct, your app should behave exactly as before.


### PR DESCRIPTION
- Resolves #2411

## Description

Refactors `findWaspFile` by splitting it into `findWaspLangFile` and `findWaspTsFile`. The TypeScript config lookup now checks for an exact `main.wasp.ts` file instead of accepting any `*.wasp.ts` file, matching the standard name already used by the starter templates and the spec package.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.