### PR TITLE
Improve Wasp Spec typecheck errors

### DIFF
--- a/waspc/data/packages/spec/__tests__/spec-pipeline/typechecking.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/typechecking.unit.test.ts
@@ -1,4 +1,3 @@
-import { stripVTControlCharacters } from "node:util";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { typecheck } from "../../src/spec-pipeline/typecheck.js";
 import { SpecUserError } from "../../src/spec/specUserError.js";
@@ -24,21 +23,17 @@ describe("typecheck", () => {
   });
 
   test("throws SpecUserError with formatted diagnostics when an added source file has a type error", async () => {
-    const error = await getRejectedError(
-      runTypecheck(async ({ addSourceFile }) => {
-        addSourceFile("./bad.ts", `export const x: string = 123;\n`);
-        return "should not reach";
-      }),
+    const result = runTypecheck(async ({ addSourceFile }) => {
+      addSourceFile("./bad.ts", `export const x: string = 123;\n`);
+      return "should not reach";
+    });
+
+    await expect(result).rejects.toThrowError(SpecUserError);
+    await expect(result).rejects.toThrowError("bad.ts");
+    await expect(result).rejects.toThrowError("TS2322");
+    await expect(result).rejects.toThrowError(
+      "export const x: string = 123;",
     );
-
-    expect(error).toBeInstanceOf(SpecUserError);
-    expect(stripVTControlCharacters((error as Error).message))
-      .toMatchInlineSnapshot(`
-        "bad.ts:1:14 - error TS2322: Type 'number' is not assignable to type 'string'.
-
-        1 export const x: string = 123;
-                       ~"
-      `);
   });
 
   test("re-throws a ParseError from the callback without typechecking", async () => {
@@ -69,30 +64,26 @@ describe("typecheck", () => {
   });
 
   test("type errors take precedence over a runtime error from the callback", async () => {
-    const error = await getRejectedSpecUserError(
-      runTypecheck(async ({ addSourceFile }) => {
-        addSourceFile("./bad.ts", `export const x: string = 123;\n`);
-        throw new Error("runtime boom");
-      }),
-    );
+    const result = runTypecheck(async ({ addSourceFile }) => {
+      addSourceFile("./bad.ts", `export const x: string = 123;\n`);
+      throw new Error("runtime boom");
+    });
 
-    const message = stripVTControlCharacters(error.message);
-    expect(message).toContain("bad.ts:1:14 - error TS2322");
-    expect(message).not.toContain("runtime boom");
+    await expect(result).rejects.toThrowError(SpecUserError);
+    await expect(result).rejects.toThrowError("TS2322");
+    await expect(result).rejects.not.toThrowError("runtime boom");
   });
 
   test("reports type errors from any added source file", async () => {
-    const error = await getRejectedSpecUserError(
-      runTypecheck(async ({ addSourceFile }) => {
-        addSourceFile("./main.ts", `export const x: number = 1;\n`);
-        addSourceFile("./helper.ts", `export const broken: string = 123;\n`);
-        return "unused";
-      }),
-    );
+    const result = runTypecheck(async ({ addSourceFile }) => {
+      addSourceFile("./main.ts", `export const x: number = 1;\n`);
+      addSourceFile("./helper.ts", `export const broken: string = 123;\n`);
+      return "unused";
+    });
 
-    expect(stripVTControlCharacters(error.message)).toContain(
-      "helper.ts:1:14 - error TS2322",
-    );
+    await expect(result).rejects.toThrowError(SpecUserError);
+    await expect(result).rejects.toThrowError("helper.ts");
+    await expect(result).rejects.toThrowError("TS2322");
   });
 
   test("addSourceFile called twice with the same path uses the latest contents", async () => {
@@ -125,21 +116,4 @@ function runTypecheck<T>(
   }) => Promise<T>,
 ): Promise<T> {
   return typecheck({ tsconfigPath: null }, fn);
-}
-
-async function getRejectedError(promise: Promise<unknown>): Promise<unknown> {
-  try {
-    await promise;
-  } catch (error) {
-    return error;
-  }
-  throw new Error("Expected promise to reject");
-}
-
-async function getRejectedSpecUserError(
-  promise: Promise<unknown>,
-): Promise<SpecUserError> {
-  const error = await getRejectedError(promise);
-  expect(error).toBeInstanceOf(SpecUserError);
-  return error as SpecUserError;
 }

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/typechecking.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/typechecking.unit.test.ts
@@ -23,13 +23,22 @@ describe("typecheck", () => {
     expect(result).toBe("ok");
   });
 
-  test("throws SpecUserError when an added source file has a type error", async () => {
-    await expect(
+  test("throws SpecUserError with formatted diagnostics when an added source file has a type error", async () => {
+    const error = await getRejectedError(
       runTypecheck(async ({ addSourceFile }) => {
         addSourceFile("./bad.ts", `export const x: string = 123;\n`);
         return "should not reach";
       }),
-    ).rejects.toThrow(new SpecUserError("Type errors found"));
+    );
+
+    expect(error).toBeInstanceOf(SpecUserError);
+    expect(stripVTControlCharacters((error as Error).message))
+      .toMatchInlineSnapshot(`
+        "bad.ts:1:14 - error TS2322: Type 'number' is not assignable to type 'string'.
+
+        1 export const x: string = 123;
+                       ~"
+      `);
   });
 
   test("re-throws a ParseError from the callback without typechecking", async () => {
@@ -60,22 +69,30 @@ describe("typecheck", () => {
   });
 
   test("type errors take precedence over a runtime error from the callback", async () => {
-    await expect(
+    const error = await getRejectedSpecUserError(
       runTypecheck(async ({ addSourceFile }) => {
         addSourceFile("./bad.ts", `export const x: string = 123;\n`);
         throw new Error("runtime boom");
       }),
-    ).rejects.toThrow(new SpecUserError("Type errors found"));
+    );
+
+    const message = stripVTControlCharacters(error.message);
+    expect(message).toContain("bad.ts:1:14 - error TS2322");
+    expect(message).not.toContain("runtime boom");
   });
 
   test("reports type errors from any added source file", async () => {
-    await expect(
+    const error = await getRejectedSpecUserError(
       runTypecheck(async ({ addSourceFile }) => {
         addSourceFile("./main.ts", `export const x: number = 1;\n`);
         addSourceFile("./helper.ts", `export const broken: string = 123;\n`);
         return "unused";
       }),
-    ).rejects.toThrow(new SpecUserError("Type errors found"));
+    );
+
+    expect(stripVTControlCharacters(error.message)).toContain(
+      "helper.ts:1:14 - error TS2322",
+    );
   });
 
   test("addSourceFile called twice with the same path uses the latest contents", async () => {
@@ -88,7 +105,7 @@ describe("typecheck", () => {
     expect(result).toBe("ok");
   });
 
-  test("prints formatted diagnostics to stderr when type errors exist", async () => {
+  test("does not print formatted diagnostics to stderr when type errors exist", async () => {
     const consoleError = vi.spyOn(console, "error");
 
     await expect(
@@ -98,21 +115,7 @@ describe("typecheck", () => {
       }),
     ).rejects.toThrow(SpecUserError);
 
-    expect(consoleError).toHaveBeenCalledTimes(1);
-
-    const rawOutput = consoleError.mock.calls[0]?.[0] as string;
-
-    // `ts-morph` prints with colors (terminal control characters), so we strip
-    // those out for the snapshot test, otherwise it would be unreadable.
-    const output = stripVTControlCharacters(rawOutput);
-
-    expect(output).toMatchInlineSnapshot(`
-      "bad.ts:1:14 - error TS2322: Type 'number' is not assignable to type 'string'.
-
-      1 export const x: string = 123;
-                     ~
-      "
-    `);
+    expect(consoleError).not.toHaveBeenCalled();
   });
 });
 
@@ -122,4 +125,21 @@ function runTypecheck<T>(
   }) => Promise<T>,
 ): Promise<T> {
   return typecheck({ tsconfigPath: null }, fn);
+}
+
+async function getRejectedError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected promise to reject");
+}
+
+async function getRejectedSpecUserError(
+  promise: Promise<unknown>,
+): Promise<SpecUserError> {
+  const error = await getRejectedError(promise);
+  expect(error).toBeInstanceOf(SpecUserError);
+  return error as SpecUserError;
 }

--- a/waspc/data/packages/spec/src/spec-pipeline/typecheck.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/typecheck.ts
@@ -50,13 +50,14 @@ export async function typecheck<T>(
   project.resolveSourceFileDependencies();
 
   const diagnostics = project.getPreEmitDiagnostics();
+  const errorDiagnostics = diagnostics.filter(
+    (d) => d.getCategory() === DiagnosticCategory.Error,
+  );
 
-  if (diagnostics.length > 0) {
-    console.error(project.formatDiagnosticsWithColorAndContext(diagnostics));
-  }
-
-  if (diagnostics.some((d) => d.getCategory() === DiagnosticCategory.Error)) {
-    throw new SpecUserError("Type errors found");
+  if (errorDiagnostics.length > 0) {
+    throw new SpecUserError(
+      project.formatDiagnosticsWithColorAndContext(errorDiagnostics).trimEnd(),
+    );
   }
 
   if (result.type === "error") {

--- a/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
+++ b/waspc/src/Wasp/Project/WaspFile/TypeScript.hs
@@ -69,7 +69,7 @@ analyzeWaspTsFile compileOptions prismaSchemaAst waspFilePath = do
           Analyzer.getEntityDecls prismaSchemaAst
 
     formatSpecAnalysisError specErrorMessage =
-      "Error while analyzing spec (*.wasp.ts) files: " ++ specErrorMessage
+      "Error while analyzing spec (*.wasp.ts) files:\n\n" ++ specErrorMessage
 
 runWaspSpecAnalyzer ::
   CompileOptions ->


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Like in #4174, where we started returning Wasp Spec analyzer errors through `spec-result.json` so `waspc` can render them as Wasp compiler errors, this extends the same behavior to type-checking error reporting.

Before:

```text
[ Wasp ] main.wasp.ts:1:14 - error TS2322: Type 'number' is not assignable to type 'string'.
[ Wasp ]
[ Wasp ] 1 export const x: string = 123;
[ Wasp ]                ~

Your wasp project failed to compile:
- Error while analyzing spec (*.wasp.ts) files: Type errors found
```

After:

```text
Your wasp project failed to compile:
- Error while analyzing spec (*.wasp.ts) files:

main.wasp.ts:1:14 - error TS2322: Type 'number' is not assignable to type 'string'.

1 export const x: string = 123;
               ~
```

Expected type-checking diagnostics no longer get printed directly to stderr by the Node subprocess. Instead, `typecheck` throws a `SpecUserError` with the formatted TypeScript diagnostics, `run.ts` writes it to `spec-result.json`, and `waspc` renders it in the final compiler error.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [x] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

Tests run:

- `npm run test:unit -- typechecking.unit.test.ts`
- `npm run test:unit`
- `npm run build`
- `./run check:ormolu`
- `./run check:prettier`
- `./run test:waspc:e2e`

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
