### PR TITLE
Reuse mainWaspTsFileInWaspProjectDir in e2e tests

### DIFF
--- a/waspc/e2e-tests/FileSystem.hs
+++ b/waspc/e2e-tests/FileSystem.hs
@@ -5,7 +5,6 @@ module FileSystem
     SeedsFile,
     seedsDirInWaspProjectDir,
     mainWaspFileInWaspProjectDir,
-    mainWaspTsFileInWaspProjectDir,
     seedsFileInSeedsDir,
     TestOutputsDir,
     TestLogFile,
@@ -36,7 +35,6 @@ import qualified StrongPath as SP
 import System.Directory (getCurrentDirectory)
 import System.FilePath (joinPath, takeFileName)
 import Wasp.Project (WaspProjectDir)
-import qualified Wasp.Project.Common as Project.Common
 
 data GitRootDir
 
@@ -76,9 +74,6 @@ seedsFileInSeedsDir = fromJust . parseRelFile
 
 mainWaspFileInWaspProjectDir :: Path' (Rel WaspProjectDir) File'
 mainWaspFileInWaspProjectDir = [relfile|main.wasp|]
-
-mainWaspTsFileInWaspProjectDir :: Path' (Rel WaspProjectDir) File'
-mainWaspTsFileInWaspProjectDir = SP.castFile Project.Common.mainWaspTsFileInWaspProjectDir
 
 data TestLogFile
 

--- a/waspc/e2e-tests/FileSystem.hs
+++ b/waspc/e2e-tests/FileSystem.hs
@@ -36,6 +36,7 @@ import qualified StrongPath as SP
 import System.Directory (getCurrentDirectory)
 import System.FilePath (joinPath, takeFileName)
 import Wasp.Project (WaspProjectDir)
+import qualified Wasp.Project.Common as Project.Common
 
 data GitRootDir
 
@@ -77,7 +78,7 @@ mainWaspFileInWaspProjectDir :: Path' (Rel WaspProjectDir) File'
 mainWaspFileInWaspProjectDir = [relfile|main.wasp|]
 
 mainWaspTsFileInWaspProjectDir :: Path' (Rel WaspProjectDir) File'
-mainWaspTsFileInWaspProjectDir = [relfile|main.wasp.ts|]
+mainWaspTsFileInWaspProjectDir = SP.castFile Project.Common.mainWaspTsFileInWaspProjectDir
 
 data TestLogFile
 

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -57,14 +57,14 @@ import Control.Monad.Reader (MonadReader (ask), Reader, runReader)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.Text as T
-import FileSystem (GitRootDir, SnapshotDir, TestCaseDir, gitRootFromSnapshotDir, mainWaspFileInWaspProjectDir, mainWaspTsFileInWaspProjectDir, seedsDirInWaspProjectDir, seedsFileInSeedsDir)
-import StrongPath (Abs, Dir, File', Path', Rel, fromAbsDir, fromAbsFile, fromRelDir, parent, (</>))
+import FileSystem (GitRootDir, SnapshotDir, TestCaseDir, gitRootFromSnapshotDir, seedsDirInWaspProjectDir, seedsFileInSeedsDir)
+import StrongPath (Abs, Dir, File, Path', Rel, fromAbsDir, fromAbsFile, fromRelDir, parent, (</>))
 import System.FilePath (joinPath)
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates (StarterTemplate)
 import Wasp.Generator.DbGenerator.Common (dbMigrationsDirInDbRootDir, dbRootDirInGeneratedAppDir)
 import Wasp.Project (WaspProjectDir)
-import Wasp.Project.Common (dotWaspDirInWaspProjectDir, generatedAppDirInDotWaspDir)
+import Wasp.Project.Common (dotWaspDirInWaspProjectDir, generatedAppDirInDotWaspDir, mainWaspTsFileInWaspProjectDir)
 import Wasp.Project.Db.Migrations (dbMigrationsDirInWaspProjectDir)
 
 -- NOTE: Using `wasp-cli` herein so we can assume using latest `cabal install` in CI and locally.
@@ -111,7 +111,7 @@ infixl 4 ~?
 
 -- General commands
 
-writeToFile :: Path' Abs File' -> T.Text -> ShellCommandBuilder context ShellCommand
+writeToFile :: Path' Abs (File a) -> T.Text -> ShellCommandBuilder context ShellCommand
 writeToFile file fileContent = return $ createParentDir ~&& writeContentsToFile
   where
     createParentDir :: ShellCommand


### PR DESCRIPTION
## Description

Uses `Wasp.Project.Common.mainWaspTsFileInWaspProjectDir` in `waspc/e2e-tests`. No functional change.

Based on a suggestion by @FranjoMindek in https://github.com/wasp-lang/wasp/pull/4241#discussion_r3334537686

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
