### PR TITLE
Remove redundant main.wasp.ts from tsconfig.wasp.json include

### DIFF
--- a/examples/ask-the-documents/tsconfig.wasp.json
+++ b/examples/ask-the-documents/tsconfig.wasp.json
@@ -17,5 +17,5 @@
 
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/examples/kitchen-sink/tsconfig.wasp.json
+++ b/examples/kitchen-sink/tsconfig.wasp.json
@@ -17,5 +17,5 @@
 
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/examples/tutorials/TodoApp/tsconfig.wasp.json
+++ b/examples/tutorials/TodoApp/tsconfig.wasp.json
@@ -17,5 +17,5 @@
 
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/examples/tutorials/TodoAppTs/tsconfig.wasp.json
+++ b/examples/tutorials/TodoAppTs/tsconfig.wasp.json
@@ -17,5 +17,5 @@
 
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/examples/waspello/tsconfig.wasp.json
+++ b/examples/waspello/tsconfig.wasp.json
@@ -17,5 +17,5 @@
 
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/examples/waspleau/tsconfig.wasp.json
+++ b/examples/waspleau/tsconfig.wasp.json
@@ -17,5 +17,5 @@
 
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/examples/websockets-realtime-voting/tsconfig.wasp.json
+++ b/examples/websockets-realtime-voting/tsconfig.wasp.json
@@ -17,5 +17,5 @@
 
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/waspc/data/Cli/starters/skeleton/tsconfig.wasp.json
+++ b/waspc/data/Cli/starters/skeleton/tsconfig.wasp.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/tsconfig.wasp.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/tsconfig.wasp.json
@@ -17,5 +17,5 @@
 
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/tsconfig.wasp.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/tsconfig.wasp.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/tsconfig.wasp.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/tsconfig.wasp.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/tsconfig.wasp.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/tsconfig.wasp.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-new-golden/wasp-app/tsconfig.wasp.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-new-golden/wasp-app/tsconfig.wasp.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "lib": ["ES2023"]
   },
-  "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+  "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
 }

--- a/waspc/src/Wasp/Project/ExternalConfig/WaspTsConfig.hs
+++ b/waspc/src/Wasp/Project/ExternalConfig/WaspTsConfig.hs
@@ -22,7 +22,7 @@ parseAndValidateWaspTsConfig = parseAndValidateTsConfigFile waspTsConfigValidato
 waspTsConfigValidator :: V.Validator T.TsConfig
 waspTsConfigValidator =
   V.all
-    [ V.inField ("include", T.include) $ V.eqJust ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"],
+    [ V.inField ("include", T.include) $ V.eqJust ["**/*.wasp.ts", ".wasp/out/types/spec"],
       V.inField ("compilerOptions", T.compilerOptions) $ V.required compilerOptionsValidator
     ]
   where

--- a/waspc/tests/Project/ExternalConfig/WaspTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/WaspTsConfigTest.hs
@@ -47,7 +47,7 @@ validTsConfig :: T.TsConfig
 validTsConfig =
   T.TsConfig
     { T.compilerOptions = Just validCompilerOptions,
-      T.include = Just ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"],
+      T.include = Just ["**/*.wasp.ts", ".wasp/out/types/spec"],
       T.exclude = Nothing,
       T.files = Nothing,
       T.references = Nothing

--- a/web/docs/guides/legacy/wasp-dsl.md
+++ b/web/docs/guides/legacy/wasp-dsl.md
@@ -316,7 +316,7 @@ Wasp validates the Wasp Spec support files during migration, including the requi
         "noEmit": true,
         "lib": ["ES2023"]
       },
-      "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+      "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
     }
     ```
 

--- a/web/docs/guides/legacy/wasp-ts-config.md
+++ b/web/docs/guides/legacy/wasp-ts-config.md
@@ -321,7 +321,7 @@ Wasp validates the Wasp Spec support files during migration, including the requi
         "noEmit": true,
         "lib": ["ES2023"]
       },
-      "include": ["main.wasp.ts", "**/*.wasp.ts", ".wasp/out/types/spec"]
+      "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
     }
     ```
 


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

The `"**/*.wasp.ts"` glob in `tsconfig.wasp.json`'s `include` already matches `main.wasp.ts`, so the explicit `"main.wasp.ts"` entry was redundant. This removes it from the validator (and its test), the skeleton starter template, the example apps, and the legacy migration guides, then regenerates the affected e2e golden snapshots.

Based on a suggestion by @FranjoMindek in https://github.com/wasp-lang/wasp/pull/4241#pullrequestreview-4401550483

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
