### PR TITLE
Landing page: Open SaaS section

### DIFF
--- a/web/src/components/AI.tsx
+++ b/web/src/components/AI.tsx
@@ -3,9 +3,9 @@ import { ReactNode } from "react";
 import { Zap } from "react-feather";
 
 import useBrokenLinks from "@docusaurus/useBrokenLinks";
+import CtaLink from "./CtaLink";
 import SectionContainer from "./Layouts/SectionContainer";
 import SectionLabel from "./Layouts/SectionLabel";
-import TextLink from "./TextLink";
 
 const AI_SECTION_ID = "ai";
 
@@ -84,13 +84,9 @@ const AI = () => {
       </div>
 
       <div className="mt-8 text-center">
-        <TextLink
-          to="/vibe-coding"
-          variant="purple"
-          className="inline-flex items-center gap-2 font-mono text-sm font-bold"
-        >
-          See how Wasp supercharges vibe coding <Zap size={14} />
-        </TextLink>
+        <CtaLink to="/vibe-coding" variant="purple">
+          See how Wasp supercharges vibe coding <Zap size={16} />
+        </CtaLink>
       </div>
     </SectionContainer>
   );

--- a/web/src/components/CtaLink.tsx
+++ b/web/src/components/CtaLink.tsx
@@ -1,0 +1,17 @@
+import { ComponentProps } from "react";
+import { twMerge } from "tailwind-merge";
+
+import TextLink from "./TextLink";
+
+const CtaLink = ({ className, ...props }: ComponentProps<typeof TextLink>) => (
+  <TextLink
+    {...props}
+    className={twMerge(
+      "inline-flex items-center gap-2 font-mono text-base font-bold",
+      "underline-offset-4",
+      className,
+    )}
+  />
+);
+
+export default CtaLink;

--- a/web/src/components/Hero.jsx
+++ b/web/src/components/Hero.jsx
@@ -210,11 +210,7 @@ const Hero = () => {
               deployment built in. Ship in a day and own every line.
               <span className="mt-1 block font-bold">
                 Designed for humans,{" "}
-                <TextLink
-                  to="#ai"
-                  variant="purple"
-                  className="text-wasp-g6 underline-offset-4"
-                >
+                <TextLink to="#ai" variant="purple" className="text-wasp-g6">
                   works beautifully with AI.
                 </TextLink>
               </span>

--- a/web/src/components/OpenSaas.tsx
+++ b/web/src/components/OpenSaas.tsx
@@ -58,10 +58,10 @@ const OpenSaas = () => (
             <Strong>Admin</Strong> dashboard
           </Feature>
           <Feature>
-            <Strong>Blog</Strong> with markdown
+            Markdown-based <Strong>blog</Strong> (powered by Astro)
           </Feature>
           <Feature>
-            <Strong>Email</Strong> sending (SendGrid, Mailgun)
+            <Strong>Email</Strong> sending (SendGrid, Mailgun, Resend)
           </Feature>
           <Feature>
             <Strong>File upload</Strong> (AWS S3)
@@ -70,7 +70,7 @@ const OpenSaas = () => (
             <Strong>SEO</Strong> optimized
           </Feature>
           <Feature>
-            <Strong>Analytics</Strong> integration
+            <Strong>Analytics</Strong> integration (GA, Plausible)
           </Feature>
           <Feature>
             <Strong>Landing page</Strong> template

--- a/web/src/components/OpenSaas.tsx
+++ b/web/src/components/OpenSaas.tsx
@@ -1,0 +1,129 @@
+import Link from "@docusaurus/Link";
+import { ReactNode } from "react";
+import { Search } from "react-feather";
+
+import CtaLink from "./CtaLink";
+import SectionContainer from "./Layouts/SectionContainer";
+import SectionLabel from "./Layouts/SectionLabel";
+
+const OpenSaas = () => (
+  <SectionContainer>
+    <SectionLabel
+      text="starter template"
+      bgColorClassName="bg-wasp-purple"
+      textColorClassName="text-wasp-white"
+    />
+
+    <div className="border-2 border-wasp-purple p-6 lg:p-10">
+      <div className="grid grid-cols-1 items-center gap-8 lg:grid-cols-2 lg:gap-12">
+        <div>
+          <h2 className="mb-3 font-mono text-2xl font-extrabold tracking-tight text-wasp-black lg:text-3xl">
+            Start even faster with{" "}
+            <span className="inline-block bg-wasp-purple px-1.5 text-wasp-white">
+              Open SaaS
+            </span>
+          </h2>
+          <p className="mb-6 max-w-prose text-pretty font-mono text-sm leading-relaxed text-wasp-g6">
+            What batteries we couldn't fit into Wasp, we put into Open SaaS! The
+            most popular free, open-source SaaS starter on the internet, built
+            on top of Wasp. Everything you need to launch a SaaS product: wired
+            up, tested, and ready to go.
+          </p>
+
+          <div className="flex gap-8">
+            <Stat number="14k+" label="GitHub stars" />
+            <Stat number="1k+" label="apps launched" />
+            <Stat number="#2" label="on Product Hunt"
+              to="https://www.producthunt.com/products/open-saas"
+            />
+          </div>
+
+          <div className="mt-12">
+            <CtaLink to="https://opensaas.sh" variant="purple">
+              Explore Open SaaS <Search size={18} />
+            </CtaLink>
+          </div>
+        </div>
+
+        <ul>
+          <Feature>
+            <Strong>Authentication</Strong> (email, Google, GitHub)
+          </Feature>
+          <Feature>
+            <Strong>Stripe</Strong> payments & subscriptions
+          </Feature>
+          <Feature>
+            <Strong>Admin</Strong> dashboard
+          </Feature>
+          <Feature>
+            <Strong>Blog</Strong> with markdown
+          </Feature>
+          <Feature>
+            <Strong>Email</Strong> sending (SendGrid, Mailgun)
+          </Feature>
+          <Feature>
+            <Strong>File upload</Strong> (AWS S3)
+          </Feature>
+          <Feature>
+            <Strong>SEO</Strong> optimized
+          </Feature>
+          <Feature>
+            <Strong>Analytics</Strong> integration
+          </Feature>
+          <Feature>
+            <Strong>Landing page</Strong> template
+          </Feature>
+          <Feature>
+            <Strong>OpenAI API</Strong> integration
+          </Feature>
+          <Feature>
+            Full <Strong>test</Strong> suite
+          </Feature>
+        </ul>
+      </div>
+    </div>
+  </SectionContainer>
+);
+
+const Stat = ({
+  number,
+  label,
+  to,
+}: {
+  number: string;
+  label: string;
+  to?: string;
+}) => {
+  const inner = (
+    <>
+      <div className="font-mono text-2xl font-extrabold text-wasp-purple">
+        {number}
+      </div>
+      <div className="mt-0.5 font-mono text-[0.65rem] uppercase tracking-wider text-wasp-g5">
+        {label}
+      </div>
+    </>
+  );
+  return to ? (
+    <Link to={to} className="transition duration-200 ease-out hover:opacity-70">
+      {inner}
+    </Link>
+  ) : (
+    <div>{inner}</div>
+  );
+};
+
+const Feature = ({ children }: { children: ReactNode }) => (
+  <li className="flex items-center gap-2.5 border-b-2 border-wasp-black/15 py-2 font-mono text-sm text-wasp-g6 last:border-b-0">
+    <span aria-hidden="true" className="font-bold text-wasp-purple">
+      ✓
+    </span>
+    <span>{children}</span>
+  </li>
+);
+
+const Strong = ({ children }: { children: ReactNode }) => (
+  <strong className="font-bold text-wasp-purple">{children}</strong>
+);
+
+export default OpenSaas;

--- a/web/src/components/OpenSaas.tsx
+++ b/web/src/components/OpenSaas.tsx
@@ -33,7 +33,9 @@ const OpenSaas = () => (
           <div className="flex gap-8">
             <Stat number="14k+" label="GitHub stars" />
             <Stat number="1k+" label="apps launched" />
-            <Stat number="#2" label="on Product Hunt"
+            <Stat
+              number="#2"
+              label="on Product Hunt"
               to="https://www.producthunt.com/products/open-saas"
             />
           </div>

--- a/web/src/components/WaspOutThere.tsx
+++ b/web/src/components/WaspOutThere.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import { ReactNode } from "react";
 import { ArrowUpRight, GitHub, Monitor } from "react-feather";
 
+import CtaLink from "./CtaLink";
 import SectionContainer from "./Layouts/SectionContainer";
 import SectionLabel from "./Layouts/SectionLabel";
 import TextLink from "./TextLink";
@@ -67,13 +68,10 @@ const WaspOutThere = () => {
           ))}
         </div>
         <div className="mt-8">
-          <TextLink
-            to="https://github.com/wasp-lang/wasp/tree/release/examples"
-            className="inline-flex items-center gap-1 font-mono text-sm font-semibold"
-          >
+          <CtaLink to="https://github.com/wasp-lang/wasp/tree/release/examples">
             <span>See all examples</span>
-            <ArrowUpRight size={14} />
-          </TextLink>
+            <ArrowUpRight size={16} />
+          </CtaLink>
         </div>
       </SectionContainer>
 

--- a/web/src/pages/index.jsx
+++ b/web/src/pages/index.jsx
@@ -10,6 +10,7 @@ import HowItWorks from "../components/HowItWorks";
 import Nav from "../components/Nav/index";
 import Newsletter from "../components/Newsletter";
 import NoLockIn from "../components/NoLockIn";
+import OpenSaas from "../components/OpenSaas";
 import Philosophy from "../components/Philosophy";
 import Properties from "../components/Properties";
 import Roadmap from "../components/Roadmap";
@@ -57,6 +58,7 @@ const Index = () => {
             <NoLockIn />
             <WaspOutThere />
             <Philosophy />
+            <OpenSaas />
             <Newsletter />
             <Roadmap />
             <Faq />


### PR DESCRIPTION
I went with purple, same as with AI section, both to break the yellow/black domination a bit, and also to inform that this is a section that is somehow not core Wasp but related to Wasp.

<img width="1841" height="1061" alt="image" src="https://github.com/user-attachments/assets/cea92f50-ea28-4434-9142-8dd29c7fb8c9" />

