### PR TITLE
Move client-entry script to head and drop `async`

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -16,6 +16,10 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 - Added a type-safe `NavLink` component, mirroring `react-router`'s `NavLink` API (with `isActive`, `isPending`, `isTransitioning` render-prop helpers). ([#4104](https://github.com/wasp-lang/wasp/pull/4104))
 - Wasp TS spec now supports real JS imports, letting you import values in `main.wasp.ts` and pass them directly instead of using import objects like `{ import, from }`. ([#4143](https://github.com/wasp-lang/wasp/pull/4143))
 
+### 🐞 Bug fixes
+
+- Fixed a race condition in development mode that could potentially load the app's JS bundle before the Vite runtime, causing the app to fail the load with a "Can't detect preamble" error. ([#4258](https://github.com/wasp-lang/wasp/issues/4258))
+
 ### 🔧 Small improvements
 
 - Wasp now also validates `tsconfig.wasp.json` and the root `tsconfig.json` in TS spec projects, and tsconfig validation errors now mention which `tsconfig.*.json` file caused them. ([#3911](https://github.com/wasp-lang/wasp/pull/3911))

--- a/waspc/data/Generator/templates/sdk/wasp/client/app/layout.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/app/layout.tsx
@@ -50,18 +50,6 @@ export function Layout({
           {=& head =}
 
           <title>{= title =}</title>
-        </head>
-        <body>
-          <noscript>You need to enable JavaScript to run this app.</noscript>
-
-          {
-            // We don't really need to wrap the app in a div nor name it "root",
-            // but we keep it for backwards compatibility with older Wasp
-            // versions.
-          }
-          <div id="root">
-              {shouldRenderChildren ? children : null}
-          </div>
 
           {
             // We pass that argument in SSR builds and not in client builds.
@@ -75,16 +63,21 @@ export function Layout({
               // we just add the script ourselves in the regular way.
               //
               // https://react.dev/reference/react-dom/static/prerenderToNodeStream
-              <script
-                type="module"
-                src={clientEntrySrc}
-                // We make it `async` to decouple the tag's position from its
-                // execution phase. This way Vite can move it anywhere in the
-                // document to optimize loading performance.
-                async
-              />
+              <script type="module" src={clientEntrySrc} />
             ) : null
           }
+        </head>
+        <body>
+          <noscript>You need to enable JavaScript to run this app.</noscript>
+
+          {
+            // We don't really need to wrap the app in a div nor name it "root",
+            // but we keep it for backwards compatibility with older Wasp
+            // versions.
+          }
+          <div id="root">
+              {shouldRenderChildren ? children : null}
+          </div>
         </body>
       </html>
     </StrictMode>

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -459,7 +459,7 @@
             "file",
             "sdk/wasp/client/app/layout.tsx"
         ],
-        "2e0183cc2604a05991c483f21a3ef74377d21e410f734949cce23e3bdcd5277f"
+        "9beef4e9bd21b93ce3e5246e55f0ff9db2557e7144bcb1fc7784897c91a2e90f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
@@ -50,18 +50,6 @@ export function Layout({
 <link rel='icon' href='/favicon.ico' />
 
           <title>Wasp Kitchen Sink</title>
-        </head>
-        <body>
-          <noscript>You need to enable JavaScript to run this app.</noscript>
-
-          {
-            // We don't really need to wrap the app in a div nor name it "root",
-            // but we keep it for backwards compatibility with older Wasp
-            // versions.
-          }
-          <div id="root">
-              {shouldRenderChildren ? children : null}
-          </div>
 
           {
             // We pass that argument in SSR builds and not in client builds.
@@ -75,16 +63,21 @@ export function Layout({
               // we just add the script ourselves in the regular way.
               //
               // https://react.dev/reference/react-dom/static/prerenderToNodeStream
-              <script
-                type="module"
-                src={clientEntrySrc}
-                // We make it `async` to decouple the tag's position from its
-                // execution phase. This way Vite can move it anywhere in the
-                // document to optimize loading performance.
-                async
-              />
+              <script type="module" src={clientEntrySrc} />
             ) : null
           }
+        </head>
+        <body>
+          <noscript>You need to enable JavaScript to run this app.</noscript>
+
+          {
+            // We don't really need to wrap the app in a div nor name it "root",
+            // but we keep it for backwards compatibility with older Wasp
+            // versions.
+          }
+          <div id="root">
+              {shouldRenderChildren ? children : null}
+          </div>
         </body>
       </html>
     </StrictMode>

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -109,7 +109,7 @@
             "file",
             "sdk/wasp/client/app/layout.tsx"
         ],
-        "41d376823d51bcbc38267f1f6050ccafc0c5a0bd1cfb76125bf1456f4655e796"
+        "e2e453d10b129803681e6cec3dccead055cfde26a20a1a81b374a0a1ed43001c"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
@@ -49,18 +49,6 @@ export function Layout({
           <link rel='icon' href='/favicon.ico' />
 
           <title>wasp-app</title>
-        </head>
-        <body>
-          <noscript>You need to enable JavaScript to run this app.</noscript>
-
-          {
-            // We don't really need to wrap the app in a div nor name it "root",
-            // but we keep it for backwards compatibility with older Wasp
-            // versions.
-          }
-          <div id="root">
-              {shouldRenderChildren ? children : null}
-          </div>
 
           {
             // We pass that argument in SSR builds and not in client builds.
@@ -74,16 +62,21 @@ export function Layout({
               // we just add the script ourselves in the regular way.
               //
               // https://react.dev/reference/react-dom/static/prerenderToNodeStream
-              <script
-                type="module"
-                src={clientEntrySrc}
-                // We make it `async` to decouple the tag's position from its
-                // execution phase. This way Vite can move it anywhere in the
-                // document to optimize loading performance.
-                async
-              />
+              <script type="module" src={clientEntrySrc} />
             ) : null
           }
+        </head>
+        <body>
+          <noscript>You need to enable JavaScript to run this app.</noscript>
+
+          {
+            // We don't really need to wrap the app in a div nor name it "root",
+            // but we keep it for backwards compatibility with older Wasp
+            // versions.
+          }
+          <div id="root">
+              {shouldRenderChildren ? children : null}
+          </div>
         </body>
       </html>
     </StrictMode>

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/200.html
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/200.html
@@ -1,2 +1,2 @@
-<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"/><link rel="icon" href="/favicon.ico"/><title>wasp-app</title>  <script async type="module" crossorigin src="/assets/200.js"></script>
+<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"/><link rel="icon" href="/favicon.ico"/><title>wasp-app</title>  <script type="module" crossorigin src="/assets/200.js"></script>
 </head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div><script id="_R_">window.__WASP_SSR_DATA__={"isFallbackPage":true};</script></body></html>

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -53,11 +53,7 @@ function Layout({ children, isFallbackPage: isFallbackPage2 = false, clientEntry
       /* @__PURE__ */ jsx("meta", { charSet: "utf-8" }),
       /* @__PURE__ */ jsx("meta", { name: "viewport", content: "minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no" }),
       /* @__PURE__ */ jsx("link", { rel: "icon", href: "/favicon.ico" }),
-      /* @__PURE__ */ jsx("title", { children: "wasp-app" })
-    ] }),
-    /* @__PURE__ */ jsxs("body", { children: [
-      /* @__PURE__ */ jsx("noscript", { children: "You need to enable JavaScript to run this app." }),
-      /* @__PURE__ */ jsx("div", { id: "root", children: shouldRenderChildren ? children : null }),
+      /* @__PURE__ */ jsx("title", { children: "wasp-app" }),
       // We pass that argument in SSR builds and not in client builds.
       // This would usually cause a hydration mismatch, but React has an
       // exception for `<script>` tags, for this specific usecase, so it
@@ -69,15 +65,12 @@ function Layout({ children, isFallbackPage: isFallbackPage2 = false, clientEntry
         // we just add the script ourselves in the regular way.
         //
         // https://react.dev/reference/react-dom/static/prerenderToNodeStream
-        /* @__PURE__ */ jsx(
-          "script",
-          {
-            type: "module",
-            src: clientEntrySrc,
-            async: true
-          }
-        )
+        /* @__PURE__ */ jsx("script", { type: "module", src: clientEntrySrc })
       ) : null
+    ] }),
+    /* @__PURE__ */ jsxs("body", { children: [
+      /* @__PURE__ */ jsx("noscript", { children: "You need to enable JavaScript to run this app." }),
+      /* @__PURE__ */ jsx("div", { id: "root", children: shouldRenderChildren ? children : null })
     ] })
   ] }) });
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -109,7 +109,7 @@
             "file",
             "sdk/wasp/client/app/layout.tsx"
         ],
-        "41d376823d51bcbc38267f1f6050ccafc0c5a0bd1cfb76125bf1456f4655e796"
+        "e2e453d10b129803681e6cec3dccead055cfde26a20a1a81b374a0a1ed43001c"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
@@ -49,18 +49,6 @@ export function Layout({
           <link rel='icon' href='/favicon.ico' />
 
           <title>wasp-app</title>
-        </head>
-        <body>
-          <noscript>You need to enable JavaScript to run this app.</noscript>
-
-          {
-            // We don't really need to wrap the app in a div nor name it "root",
-            // but we keep it for backwards compatibility with older Wasp
-            // versions.
-          }
-          <div id="root">
-              {shouldRenderChildren ? children : null}
-          </div>
 
           {
             // We pass that argument in SSR builds and not in client builds.
@@ -74,16 +62,21 @@ export function Layout({
               // we just add the script ourselves in the regular way.
               //
               // https://react.dev/reference/react-dom/static/prerenderToNodeStream
-              <script
-                type="module"
-                src={clientEntrySrc}
-                // We make it `async` to decouple the tag's position from its
-                // execution phase. This way Vite can move it anywhere in the
-                // document to optimize loading performance.
-                async
-              />
+              <script type="module" src={clientEntrySrc} />
             ) : null
           }
+        </head>
+        <body>
+          <noscript>You need to enable JavaScript to run this app.</noscript>
+
+          {
+            // We don't really need to wrap the app in a div nor name it "root",
+            // but we keep it for backwards compatibility with older Wasp
+            // versions.
+          }
+          <div id="root">
+              {shouldRenderChildren ? children : null}
+          </div>
         </body>
       </html>
     </StrictMode>

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -109,7 +109,7 @@
             "file",
             "sdk/wasp/client/app/layout.tsx"
         ],
-        "41d376823d51bcbc38267f1f6050ccafc0c5a0bd1cfb76125bf1456f4655e796"
+        "e2e453d10b129803681e6cec3dccead055cfde26a20a1a81b374a0a1ed43001c"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
@@ -49,18 +49,6 @@ export function Layout({
           <link rel='icon' href='/favicon.ico' />
 
           <title>wasp-app</title>
-        </head>
-        <body>
-          <noscript>You need to enable JavaScript to run this app.</noscript>
-
-          {
-            // We don't really need to wrap the app in a div nor name it "root",
-            // but we keep it for backwards compatibility with older Wasp
-            // versions.
-          }
-          <div id="root">
-              {shouldRenderChildren ? children : null}
-          </div>
 
           {
             // We pass that argument in SSR builds and not in client builds.
@@ -74,16 +62,21 @@ export function Layout({
               // we just add the script ourselves in the regular way.
               //
               // https://react.dev/reference/react-dom/static/prerenderToNodeStream
-              <script
-                type="module"
-                src={clientEntrySrc}
-                // We make it `async` to decouple the tag's position from its
-                // execution phase. This way Vite can move it anywhere in the
-                // document to optimize loading performance.
-                async
-              />
+              <script type="module" src={clientEntrySrc} />
             ) : null
           }
+        </head>
+        <body>
+          <noscript>You need to enable JavaScript to run this app.</noscript>
+
+          {
+            // We don't really need to wrap the app in a div nor name it "root",
+            // but we keep it for backwards compatibility with older Wasp
+            // versions.
+          }
+          <div id="root">
+              {shouldRenderChildren ? children : null}
+          </div>
         </body>
       </html>
     </StrictMode>


### PR DESCRIPTION
## Description

`<script type="module">` tags have two ways of working, timing-wise:
- **By default**, they wait until HTML is parsed and run just before HTML hits `DOMContentLoaded`.
- **With the `async` attribute**, they're considered fully parallel and run as soon as they are ready, without waiting for HTML parsing.

We previously marked them as `async`, but given that we're hydrating the existing HTML (instead of working independently of it), we should ensure it is parsed, so we should _not_ mark it as `async`.

It was previously at the bottom of the body, but because React automatically moves `<script async>` to the `<head>`, it didn't have any effect. Now that it's not `async`, we move it to the `<head>` ourselves.

This has the side-effect (which prompted the investigation) of: Fixes #4258. `<script type="module">`s that are non-`async` load in parallel but run in the order they appear in the document (instead of fully parallel), so the race condition describe in the issue is fixed.

## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The behavior is template/ordering-based and not reachable by the existing unit test setup; covered by the regenerated e2e snapshots instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- The race is timing-dependent and not deterministically reproducible in CI; the snapshot update locks in the corrected script ordering. -->
  - [x] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
