### PR TITLE
Reject re-exporting refs in spec files

### DIFF
--- a/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/imports.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/imports.unit.test.ts
@@ -186,6 +186,11 @@ describe("transformRefImports", () => {
     });
   });
 
+  test("leaves re-exports without the ref attribute untouched", () => {
+    const source = `export { helper } from "./helpers";\n`;
+    expect(transformImports(source)).toBe(source);
+  });
+
   test("throws when transforming re-exports with ref imports", () => {
     expect(() =>
       transformImports(

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/imports.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/imports.unit.test.ts
@@ -1,8 +1,8 @@
 import { RolldownMagicString } from "rolldown";
 import { parseAst } from "rolldown/parseAst";
 import { describe, expect, test } from "vitest";
-import { applyTransformImportsPlan_mutate } from "../../../src/spec-pipeline/transformWaspTsSpecFilesPlugin/imports/apply.js";
-import { planTransformImports } from "../../../src/spec-pipeline/transformWaspTsSpecFilesPlugin/imports/plan.js";
+import { transformRefImports_mutate } from "../../../src/spec-pipeline/transformWaspTsSpecFilesPlugin/imports/index.js";
+import { SpecUserError } from "../../../src/spec/specUserError.js";
 
 describe("transformRefImports", () => {
   test("leaves files without ref imports untouched", () => {
@@ -158,17 +158,21 @@ describe("transformRefImports", () => {
       ].join("\n"),
     );
   });
+
+  test("throws when transforming re-exports with ref imports", () => {
+    expect(() =>
+      transformImports(
+        `export { MainPage } from "./src/MainPage" with { type: "ref" };`,
+      ),
+    ).toThrow(SpecUserError);
+  });
 });
 
 function transformImports(sourceText: string): string {
   const ast = parseAst(sourceText, { lang: "ts" });
   const source = new RolldownMagicString(sourceText);
 
-  const plan = planTransformImports(ast);
-
-  if (plan) {
-    applyTransformImportsPlan_mutate(source, plan);
-  }
+  transformRefImports_mutate(ast, source);
 
   return source.toString();
 }

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/imports.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/imports.unit.test.ts
@@ -191,6 +191,26 @@ describe("transformRefImports", () => {
     expect(transformImports(source)).toBe(source);
   });
 
+  test("transforms a ref import that is then re-exported", () => {
+    expect(
+      transformImports(
+        [
+          `import MainPage from "./src/MainPage" with { type: "ref" };`,
+          `export { MainPage };`,
+          ``,
+        ].join("\n"),
+      ),
+    ).toBe(
+      [
+        `import { ref } from "@wasp.sh/spec";`,
+        `const MainPage = ref({"importDefault":"MainPage","from":"./src/MainPage"});`,
+        ``,
+        `export { MainPage };`,
+        ``,
+      ].join("\n"),
+    );
+  });
+
   test("throws when transforming re-exports with ref imports", () => {
     expect(() =>
       transformImports(

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
@@ -140,6 +140,11 @@ describe("transformRefHelper", () => {
     );
   });
 
+  test("leaves re-exports from other modules untouched", () => {
+    const source = `export { ref } from "./helpers";\n`;
+    expect(transformRefHelper(source)).toBe(source);
+  });
+
   test("throws when transforming re-exports of the ref helper", () => {
     expect(() =>
       transformRefHelper(`export { ref } from "@wasp.sh/spec";`),

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
@@ -145,6 +145,26 @@ describe("transformRefHelper", () => {
     expect(transformRefHelper(source)).toBe(source);
   });
 
+  test("rewrites a ref import that is then re-exported", () => {
+    expect(
+      transformRefHelper(
+        [
+          `import { ref } from "@wasp.sh/spec";`,
+          `export { ref };`,
+          ``,
+        ].join("\n"),
+      ),
+    ).toBe(
+      [
+        `import { _waspMakeRef } from "@wasp.sh/spec/internal";`,
+        `const ref = _waspMakeRef("/path/main.wasp.ts");`,
+        ``,
+        `export { ref };`,
+        ``,
+      ].join("\n"),
+    );
+  });
+
   test("throws when transforming re-exports of the ref helper", () => {
     expect(() =>
       transformRefHelper(`export { ref } from "@wasp.sh/spec";`),

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
@@ -1,8 +1,8 @@
 import { RolldownMagicString } from "rolldown";
 import { parseAst } from "rolldown/parseAst";
 import { describe, expect, test } from "vitest";
-import { applyTransformRefHelperPlan_mutate } from "../../../src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/apply.js";
-import { planTransformRefHelper } from "../../../src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/plan.js";
+import { transformRefHelper_mutate } from "../../../src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/index.js";
+import { SpecUserError } from "../../../src/spec/specUserError.js";
 
 describe("transformRefHelper", () => {
   test("leaves files without a public ref import untouched", () => {
@@ -139,16 +139,19 @@ describe("transformRefHelper", () => {
       ].join("\n"),
     );
   });
+
+  test("throws when transforming re-exports of the ref helper", () => {
+    expect(() =>
+      transformRefHelper(`export { ref } from "@wasp.sh/spec";`),
+    ).toThrow(SpecUserError);
+  });
 });
 
 function transformRefHelper(sourceText: string): string {
   const ast = parseAst(sourceText, { lang: "ts" });
   const source = new RolldownMagicString(sourceText);
 
-  const plan = planTransformRefHelper(ast);
-  if (plan) {
-    applyTransformRefHelperPlan_mutate("/path/main.wasp.ts", source, plan);
-  }
+  transformRefHelper_mutate("/path/main.wasp.ts", ast, source);
 
   return source.toString();
 }

--- a/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
@@ -148,11 +148,9 @@ describe("transformRefHelper", () => {
   test("rewrites a ref import that is then re-exported", () => {
     expect(
       transformRefHelper(
-        [
-          `import { ref } from "@wasp.sh/spec";`,
-          `export { ref };`,
-          ``,
-        ].join("\n"),
+        [`import { ref } from "@wasp.sh/spec";`, `export { ref };`, ``].join(
+          "\n",
+        ),
       ),
     ).toBe(
       [

--- a/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/imports/check.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/imports/check.ts
@@ -1,0 +1,24 @@
+import type { ESTree as t } from "rolldown/utils";
+import { SpecUserError } from "../../../spec/specUserError.js";
+import { getStringValue } from "../util.js";
+
+export function assertCanTransformImports(ast: t.Program): void {
+  const hasRefExports = ast.body.some(isRefExportDeclaration);
+  if (hasRefExports) {
+    throw new SpecUserError(
+      "Re-exporting refs is not supported. First import the reference and then re-export it if needed.",
+    );
+  }
+}
+
+function isRefExportDeclaration(node: t.Statement): boolean {
+  return (
+    (node.type === "ExportNamedDeclaration" ||
+      node.type === "ExportAllDeclaration") &&
+    node.attributes.some(
+      (attr) =>
+        getStringValue(attr.key) === "type" &&
+        getStringValue(attr.value) === "ref",
+    )
+  );
+}

--- a/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/imports/index.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/imports/index.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
-import type { Plugin } from "rolldown";
+import type { Plugin, RolldownMagicString } from "rolldown";
+import type { ESTree as t } from "rolldown/utils";
 import { WASP_SPEC_FILE_REGEX } from "../../common.js";
 import { applyTransformImportsPlan_mutate } from "./apply.js";
+import { assertCanTransformImports } from "./check.js";
 import { planTransformImports } from "./plan.js";
 
 export function transformRefImportsPlugin(): Plugin {
@@ -29,16 +31,25 @@ export function transformRefImportsPlugin(): Plugin {
         // parse it.
         const ast = meta.ast || this.parse(code, { lang: "ts" });
 
-        const importsPlan = planTransformImports(ast);
-
-        if (!importsPlan) {
-          return null;
-        }
-
-        applyTransformImportsPlan_mutate(meta.magicString, importsPlan);
+        transformRefImports_mutate(ast, meta.magicString);
 
         return { code: meta.magicString };
       },
     },
   };
+}
+
+export function transformRefImports_mutate(
+  ast: t.Program,
+  magicString: RolldownMagicString,
+): void {
+  assertCanTransformImports(ast);
+
+  const importsPlan = planTransformImports(ast);
+
+  if (!importsPlan) {
+    return;
+  }
+
+  applyTransformImportsPlan_mutate(magicString, importsPlan);
 }

--- a/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/check.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/check.ts
@@ -1,0 +1,20 @@
+import type { ESTree as t } from "rolldown/utils";
+import { SpecUserError } from "../../../spec/specUserError.js";
+import { PUBLIC_REF_HELPER_IMPORT_SOURCE } from "../util.js";
+
+export function assertCanTransformRefHelper(ast: t.Program): void {
+  const hasRefHelperExports = ast.body.some(isRefHelperExportDeclaration);
+  if (hasRefHelperExports) {
+    throw new SpecUserError(
+      `Re-exporting from the ${PUBLIC_REF_HELPER_IMPORT_SOURCE} package is not supported. First import it and then re-export it if needed.`,
+    );
+  }
+}
+
+function isRefHelperExportDeclaration(node: t.Statement): boolean {
+  return (
+    (node.type === "ExportNamedDeclaration" ||
+      node.type === "ExportAllDeclaration") &&
+    node.source?.value === PUBLIC_REF_HELPER_IMPORT_SOURCE
+  );
+}

--- a/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/index.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/index.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
-import type { Plugin } from "rolldown";
+import type { Plugin, RolldownMagicString } from "rolldown";
+import type { ESTree as t } from "rolldown/utils";
 import { WASP_SPEC_FILE_REGEX } from "../../common.js";
 import { applyTransformRefHelperPlan_mutate } from "./apply.js";
+import { assertCanTransformRefHelper } from "./check.js";
 import { planTransformRefHelper } from "./plan.js";
 
 export function transformRefHelperPlugin(): Plugin {
@@ -29,15 +31,25 @@ export function transformRefHelperPlugin(): Plugin {
         // parse it.
         const ast = meta.ast || this.parse(code, { lang: "ts" });
 
-        const refHelperPlan = planTransformRefHelper(ast);
-        if (!refHelperPlan) {
-          return null;
-        }
-
-        applyTransformRefHelperPlan_mutate(id, meta.magicString, refHelperPlan);
+        transformRefHelper_mutate(id, ast, meta.magicString);
 
         return { code: meta.magicString };
       },
     },
   };
+}
+
+export function transformRefHelper_mutate(
+  id: string,
+  ast: t.Program,
+  magicString: RolldownMagicString,
+): void {
+  assertCanTransformRefHelper(ast);
+
+  const refHelperPlan = planTransformRefHelper(ast);
+  if (!refHelperPlan) {
+    return;
+  }
+
+  applyTransformRefHelperPlan_mutate(id, magicString, refHelperPlan);
 }

--- a/web/docs/general/spec.md
+++ b/web/docs/general/spec.md
@@ -86,6 +86,7 @@ Reference imports have some limitations:
 
 - They only work from `*.wasp.ts` files.
 - The referenced files must be inside the `src` directory.
+- You can't re-export something as a reference import (`export { X } from "./X" with { type: "ref" }`). Import it first, then re-export it if needed.
 
 The vast majority of Wasp apps won't run into these limitations, so we recommend using reference imports by default.
 
@@ -109,6 +110,12 @@ export default app({
 ```
 
 The `from` path is relative to the `*.wasp.ts` file where you call `ref(...)` and must resolve inside your project's `src` directory.
+
+:::note Limitation
+
+You can't re-export `ref` from `@wasp.sh/spec` (`export { ref } from "@wasp.sh/spec"`). Import it first, then re-export it if needed.
+
+:::
 
 ## Useful patterns
 


### PR DESCRIPTION
## Description

Re-exporting refs from `*.wasp.ts` files was silently ignored during transformation. This now throws a `SpecUserError` for both re-exported reference imports (`export { X } from "./X" with { type: "ref" }`) and re-exports from `@wasp.sh/spec` (`export { ref } from "@wasp.sh/spec"`), pointing users to import first and re-export afterwards. The transform entrypoints are consolidated into single `transform*_mutate` functions, and the limitation is documented in the Spec docs.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
