### PR TITLE
(Blocked) Resolve spec ref helper paths from import.meta.url

### DIFF
--- a/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec-pipeline/transformWaspTsSpecFile/refHelper.unit.test.ts
@@ -23,7 +23,7 @@ describe("transformRefHelper", () => {
     ).toBe(
       [
         `import { _waspMakeRef } from "@wasp.sh/spec/internal";`,
-        `const ref = _waspMakeRef("/path/main.wasp.ts");`,
+        `const ref = _waspMakeRef(import.meta.url);`,
         ``,
         `const MainPage = ref({ importDefault: "MainPage", from: "./src/MainPage" });`,
         ``,
@@ -43,7 +43,7 @@ describe("transformRefHelper", () => {
     ).toBe(
       [
         `import { _waspMakeRef } from "@wasp.sh/spec/internal";`,
-        `const appRef = _waspMakeRef("/path/main.wasp.ts");`,
+        `const appRef = _waspMakeRef(import.meta.url);`,
         ``,
         `const MainPage = appRef({ importDefault: "MainPage", from: "./src/MainPage" });`,
         ``,
@@ -64,7 +64,7 @@ describe("transformRefHelper", () => {
     ).toBe(
       [
         `import { _waspMakeRef as _waspMakeRef_0 } from "@wasp.sh/spec/internal";`,
-        `const appRef = _waspMakeRef_0("/path/main.wasp.ts");`,
+        `const appRef = _waspMakeRef_0(import.meta.url);`,
         `const ref = "taken";`,
         `const _waspMakeRef = "taken";`,
         ``,
@@ -85,7 +85,7 @@ describe("transformRefHelper", () => {
     ).toBe(
       [
         `import { _waspMakeRef as _waspMakeRef_0 } from "@wasp.sh/spec/internal";`,
-        `const appRef = _waspMakeRef_0("/path/main.wasp.ts");`,
+        `const appRef = _waspMakeRef_0(import.meta.url);`,
         `class _waspMakeRef {}`,
         ``,
         ``,
@@ -106,7 +106,7 @@ describe("transformRefHelper", () => {
     ).toBe(
       [
         `import { _waspMakeRef } from "@wasp.sh/spec/internal";`,
-        `const refA = _waspMakeRef("/path/main.wasp.ts");`,
+        `const refA = _waspMakeRef(import.meta.url);`,
         `const refB = refA;`,
         `const refC = refA;`,
         `const ref = refA;`,
@@ -132,7 +132,7 @@ describe("transformRefHelper", () => {
     ).toBe(
       [
         `import { _waspMakeRef } from "@wasp.sh/spec/internal";`,
-        `const appRef = _waspMakeRef("/path/main.wasp.ts");`,
+        `const appRef = _waspMakeRef(import.meta.url);`,
         `import { type RefObject, page } from "@wasp.sh/spec";`,
         `const MainPage = appRef({ importDefault: "MainPage", from: "./src/MainPage" });`,
         ``,
@@ -147,7 +147,7 @@ function transformRefHelper(sourceText: string): string {
 
   const plan = planTransformRefHelper(ast);
   if (plan) {
-    applyTransformRefHelperPlan_mutate("/path/main.wasp.ts", source, plan);
+    applyTransformRefHelperPlan_mutate(source, plan);
   }
 
   return source.toString();

--- a/waspc/data/packages/spec/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/spec/__tests__/spec/testFixtures.ts
@@ -4,6 +4,7 @@
  * surface currently supports (`page`, `query`).
  */
 
+import * as url from "node:url";
 import * as AppSpec from "../../src/appSpec.js";
 import { Branded } from "../../src/branded.js";
 import { _waspMakeRef } from "../../src/internal.js";
@@ -629,7 +630,10 @@ export function getRefObject(
   }
 }
 
-const getRefObjectForMockProject = _waspMakeRef(MOCK_MAIN_WASP_TS_PATH);
+const MOCK_MAIN_WASP_TS_FILE_URL = url.pathToFileURL(
+  MOCK_MAIN_WASP_TS_PATH,
+).href;
+const getRefObjectForMockProject = _waspMakeRef(MOCK_MAIN_WASP_TS_FILE_URL);
 
 export type Config<T> = MinimalConfig<T> | FullConfig<T>;
 

--- a/waspc/data/packages/spec/package-lock.json
+++ b/waspc/data/packages/spec/package-lock.json
@@ -14,7 +14,7 @@
         "ts-morph": "^28.0.0",
         "type-fest": "^5.6.0",
         "typescript": "^5.8.3",
-        "unrun": "^0.3.0"
+        "unrun": "^0.3.1"
       },
       "bin": {
         "__internal_wasp_spec__": "dist/src/run.js"
@@ -3216,9 +3216,9 @@
       "license": "MIT"
     },
     "node_modules/unrun": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.3.0.tgz",
-      "integrity": "sha512-5xw2AIVS2WR9Lqhz76qDIQLxipKRidf7Nq+Iz5SZ8shk1OmRlxnc6FyI/1Q2m99WLj6cbqaKFdESfWE99KPzlA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.3.1.tgz",
+      "integrity": "sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==",
       "license": "MIT",
       "dependencies": {
         "rolldown": "^1.0.0"

--- a/waspc/data/packages/spec/package.json
+++ b/waspc/data/packages/spec/package.json
@@ -34,7 +34,7 @@
     "ts-morph": "^28.0.0",
     "type-fest": "^5.6.0",
     "typescript": "^5.8.3",
-    "unrun": "^0.3.0"
+    "unrun": "^0.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/apply.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/apply.ts
@@ -7,7 +7,6 @@ import {
 import { Plan } from "./plan.js";
 
 export function applyTransformRefHelperPlan_mutate(
-  importingFilePath: string,
   magicString: RolldownMagicString,
   {
     refHelperLocalNames,
@@ -35,7 +34,7 @@ export function applyTransformRefHelperPlan_mutate(
         [[INTERNAL_MAKE_REF_HELPER_IMPORT_NAME, safeMakeRefHelperName]],
         INTERNAL_MAKE_REF_HELPER_IMPORT_SOURCE,
       ),
-      `const ${firstRefHelperLocalName} = ${safeMakeRefHelperName}(${JSON.stringify(importingFilePath)});\n`,
+      `const ${firstRefHelperLocalName} = ${safeMakeRefHelperName}(import.meta.url);\n`,
       ...extraRefHelperAliases.map(
         (localName) => `const ${localName} = ${firstRefHelperLocalName};\n`,
       ),

--- a/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/index.ts
+++ b/waspc/data/packages/spec/src/spec-pipeline/transformWaspTsSpecFilesPlugin/refHelper/index.ts
@@ -34,7 +34,7 @@ export function transformRefHelperPlugin(): Plugin {
           return null;
         }
 
-        applyTransformRefHelperPlan_mutate(id, meta.magicString, refHelperPlan);
+        applyTransformRefHelperPlan_mutate(meta.magicString, refHelperPlan);
 
         return { code: meta.magicString };
       },

--- a/waspc/data/packages/spec/src/spec/refObject.ts
+++ b/waspc/data/packages/spec/src/spec/refObject.ts
@@ -1,3 +1,4 @@
+import * as url from "node:url";
 import type * as AppSpec from "../appSpec.js";
 import type { Branded } from "../branded.js";
 import { normalizeRefObjectPath } from "./refObjectPath.js";
@@ -92,14 +93,16 @@ export function ref(_descriptor: RefObjectDescriptor): RefObject {
  *
  * Ref objects need the current spec file location to resolve relative paths,
  * but `ref` itself can't use `import.meta.url` because it would point to this
- * helper module. `_waspMakeRef(sourceFilePath)` lets each `.wasp.ts` file
+ * helper module. `_waspMakeRef(import.meta.url)` lets each `.wasp.ts` file
  * create a local `ref` that carries its own source file path.
  *
  * @internal
  */
 export function _waspMakeRef(
-  sourceFilePath: string,
+  sourceFileUrl: string,
 ): (descriptor: RefObjectDescriptor) => SourceAwareRefObject {
+  const sourceFilePath = url.fileURLToPath(sourceFileUrl);
+
   return (descriptor: RefObjectDescriptor) => {
     const refObject = {
       ...descriptor,


### PR DESCRIPTION
## Description

Converts the spec pipeline's ref helper to resolve source paths from `import.meta.url` instead of an embedded rolldown module ID. `_waspMakeRef` now takes a file URL (resolved via `node:url`) rather than a raw path, restoring the intended import-resolution behaviour. This also bumps `unrun` to `^0.3.1`.

**Note:** This is prep work and is blocked on [unrun#23](https://github.com/Gugustinette/unrun/issues/23), which breaks `import.meta.url` in transitively imported files. Keeping this as a draft until that bug is fixed upstream.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
