### PR TITLE
Generate LLM files from Docusaurus build plugin

### DIFF
--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -1,6 +1,7 @@
 import type * as Preset from "@docusaurus/preset-classic";
 import type { Config, DocusaurusConfig } from "@docusaurus/types";
 import { themes } from "prism-react-renderer";
+import { llmFilesPlugin } from "./plugins/llm-files";
 import { SCRIPT_WITH_CONSENT_TYPE } from "./src/lib/cookie-consent";
 import autoImportTabs from "./src/remark/auto-import-tabs";
 import autoJSCode from "./src/remark/auto-js-code";
@@ -314,6 +315,7 @@ const config: Config = {
         // https://typedoc.org/documents/Options.Package_Options.html.
       },
     ],
+    llmFilesPlugin,
   ],
   themes: ["@docusaurus/theme-mermaid"],
   markdown: {

--- a/web/package.json
+++ b/web/package.json
@@ -7,11 +7,10 @@
   },
   "scripts": {
     "//": "Remark scripts based on https://github.com/facebook/docusaurus/issues/3321#issuecomment-1477543749",
-    "build": "npm run install-spec-package && npm run generate-llm-files && docusaurus build",
+    "build": "npm run install-spec-package && docusaurus build",
     "clear": "docusaurus clear",
     "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus",
-    "generate-llm-files": "tsx ./scripts/generate-llm-files.ts",
     "install-spec-package": "npm install --prefix ../waspc/data/packages/spec",
     "remark": "remark",
     "remark:once": "npm run remark -- --quiet --frail --use remark-validate-links docs/",

--- a/web/plugins/llm-files/common.ts
+++ b/web/plugins/llm-files/common.ts
@@ -1,0 +1,4 @@
+export type LlmFile = {
+  fileName: string;
+  content: string;
+};

--- a/web/plugins/llm-files/docs.ts
+++ b/web/plugins/llm-files/docs.ts
@@ -71,7 +71,12 @@ type DocsLlmFilesContext = {
   versionedDocsDir: string;
   versionedSidebarsDir: string;
   blogDir: string;
+  // versioned_docs/version-<version> doc-id -> relative-path maps, built lazily
+  // and cached because a single version's sidebar can reference migration
+  // guides that live in many other versions' folders.
   docIdToPathMapCache: Map<string, Map<string, string>>;
+  // Resolved docs cached by absolute path: the same migration guide is
+  // referenced by every later version's sidebar, so we only read it once.
   sourceDocCache: Map<string, SourceDoc | null>;
 };
 
@@ -563,6 +568,7 @@ function cleanDocContent(content: string): string {
   if (!content) return "";
 
   const componentsToReplace = new Set<string>();
+  // NOTE: Not sure if this is needed, as LLMs can probably parse the component's meaning from context.
   // Regex to capture imports from '@site/src/components/Tag'
   // e.g. import MyTag from '...' -> MyTag
   // e.g. import {Tag1, Tag2 as MyTag2} from '...' -> {Tag1, Tag2 as MyTag2}

--- a/web/plugins/llm-files/docs.ts
+++ b/web/plugins/llm-files/docs.ts
@@ -7,13 +7,10 @@ import fs from "fs/promises";
 import { globSync } from "glob";
 import path from "path";
 
-import waspVersionsJson from "../versions.json";
+import waspVersionsJson from "../../versions.json";
 
-const SITE_ROOT = process.cwd();
-const STATIC_DIR = path.join(SITE_ROOT, "static/");
-const VERSIONED_DOCS_DIR = path.join(SITE_ROOT, "versioned_docs/");
-const VERSIONED_SIDEBARS_DIR = path.join(SITE_ROOT, "versioned_sidebars/");
-const BLOG_DIR = path.join(SITE_ROOT, "blog/");
+import type { LlmFile } from "./common";
+
 const GITHUB_RAW_BASE_URL =
   "https://raw.githubusercontent.com/wasp-lang/wasp/refs/heads/release/web/"; // Use the release branch
 const WASP_BASE_URL = "https://wasp.sh/";
@@ -69,47 +66,55 @@ type BlogPost = {
   linkPath: string;
 };
 
-generateFiles().catch((err) => {
-  console.error("Failed to generate LLM files:", err);
-  process.exit(1);
-});
+type DocsLlmFilesContext = {
+  siteDir: string;
+  versionedDocsDir: string;
+  versionedSidebarsDir: string;
+  blogDir: string;
+  docIdToPathMapCache: Map<string, Map<string, string>>;
+  sourceDocCache: Map<string, SourceDoc | null>;
+};
 
-async function generateFiles() {
+export async function buildDocsLlmFiles(siteDir: string): Promise<LlmFile[]> {
   console.log("Starting LLM file generation...");
 
   if (!waspVersionsJson || waspVersionsJson.length === 0) {
     throw new Error("No versions found in versions.json");
   }
+
+  const context = createDocsLlmFilesContext(siteDir);
+  const files: LlmFile[] = [];
   // Our llms.txt URL is the entry point for the LLM.
   // It contains a section with links to llms-{version}.txt files
   // which are versioned documentation maps that link
   // to the individual raw markdown files on GitHub.
   const latestWaspVersion = waspVersionsJson[0];
-  const blogPostsSection = await buildBlogPostsSection();
+  const blogPostsSection = await buildBlogPostsSection(context);
   const docsMapsByVersionSection =
     buildDocsMapsByVersionSection(waspVersionsJson);
   const llmsTxtContent = buildLlmsTxtContent(
     docsMapsByVersionSection,
     blogPostsSection,
   );
-  await fs.writeFile(path.join(STATIC_DIR, "llms.txt"), llmsTxtContent, "utf8");
-  console.log("Generated: llms.txt");
+  files.push({ fileName: "llms.txt", content: llmsTxtContent });
 
   for (const version of waspVersionsJson) {
     console.log(`Processing version ${version}...`);
     const isLatest = version === latestWaspVersion;
-    const sidebarItems = await loadVersionedSidebar(version);
-    const categorizedDocs = await loadCategorizedDocs(sidebarItems, version);
+    const sidebarItems = await loadVersionedSidebar(context, version);
+    const categorizedDocs = await loadCategorizedDocs(
+      context,
+      sidebarItems,
+      version,
+    );
     const versionedLlmsTxtContent = buildVersionedLlmsTxtContent(
       version,
       categorizedDocs,
     );
-    await fs.writeFile(
-      path.join(STATIC_DIR, `llms-${version}.txt`),
-      versionedLlmsTxtContent,
-      "utf8",
-    );
-    console.log(`  Generated: llms-${version}.txt`);
+    files.push({
+      fileName: `llms-${version}.txt`,
+      content: versionedLlmsTxtContent,
+    });
 
     // We also generate a full concatenated documentation file, llms-full.txt,
     // for the latest version only with a section containing links
@@ -117,26 +122,30 @@ async function generateFiles() {
     const fullDocsBody = buildFullDocsBody(categorizedDocs);
     const llmsFullVersionedContent =
       buildFullDocsHeader(version) + fullDocsBody;
-    await fs.writeFile(
-      path.join(STATIC_DIR, `llms-full-${version}.txt`),
-      llmsFullVersionedContent.trim(),
-      "utf8",
-    );
-    console.log(`  Generated: llms-full-${version}.txt`);
+    files.push({
+      fileName: `llms-full-${version}.txt`,
+      content: llmsFullVersionedContent,
+    });
 
     if (isLatest) {
       const llmsFullWithIndex =
         buildFullDocsHeaderWithIndex(version, waspVersionsJson) + fullDocsBody;
-      await fs.writeFile(
-        path.join(STATIC_DIR, "llms-full.txt"),
-        llmsFullWithIndex.trim(),
-        "utf8",
-      );
-      console.log(`  Generated: llms-full.txt`);
+      files.push({ fileName: "llms-full.txt", content: llmsFullWithIndex });
     }
   }
 
-  console.log("LLM files generation completed successfully.");
+  return files;
+}
+
+function createDocsLlmFilesContext(siteDir: string): DocsLlmFilesContext {
+  return {
+    siteDir,
+    versionedDocsDir: path.join(siteDir, "versioned_docs"),
+    versionedSidebarsDir: path.join(siteDir, "versioned_sidebars"),
+    blogDir: path.join(siteDir, "blog"),
+    docIdToPathMapCache: new Map(),
+    sourceDocCache: new Map(),
+  };
 }
 
 function buildDocsMapsByVersionSection(versions: string[]): string {
@@ -174,10 +183,13 @@ Use the same URL pattern as the versioned documentation maps: ${WASP_BASE_URL}ll
     fullDocsSection,
     blogPostsSection,
     LLMS_TXT_RESOURCES,
-  ].join("\n\n");
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 }
 
 async function loadCategorizedDocs(
+  context: DocsLlmFilesContext,
   sidebarItems: SidebarItemConfig[],
   version: string,
 ): Promise<CategorizedDocs> {
@@ -187,12 +199,12 @@ async function loadCategorizedDocs(
   for (const category of sidebarCategories) {
     const docs: DocMapEntry[] = [];
     for (const ref of category.docRefs) {
-      const info = await resolveDocRef(ref);
+      const info = await resolveDocRef(context, ref);
       if (!info) {
         continue;
       }
       const relativeToSite = path
-        .relative(SITE_ROOT, info.absolutePath)
+        .relative(context.siteDir, info.absolutePath)
         .replace(/\\/g, "/");
       docs.push({
         title: info.title,
@@ -271,27 +283,25 @@ function buildDocIdToPathMap(directory: string): Map<string, string> {
   return docIdToPath;
 }
 
-// versioned_docs/version-<version> doc-id -> relative-path maps, built lazily
-// and cached because a single version's sidebar can reference migration
-// guides that live in many other versions' folders.
-const docIdToPathMapCache = new Map<string, Map<string, string>>();
-// Resolved docs cached by absolute path: the same migration guide is
-// referenced by every later version's sidebar, so we only read it once.
-const sourceDocCache = new Map<string, SourceDoc | null>();
-
-function getDocIdToPathMap(version: string): Map<string, string> {
-  let docIdToPath = docIdToPathMapCache.get(version);
+function getDocIdToPathMap(
+  context: DocsLlmFilesContext,
+  version: string,
+): Map<string, string> {
+  let docIdToPath = context.docIdToPathMapCache.get(version);
   if (!docIdToPath) {
     docIdToPath = buildDocIdToPathMap(
-      path.join(VERSIONED_DOCS_DIR, `version-${version}`),
+      path.join(context.versionedDocsDir, `version-${version}`),
     );
-    docIdToPathMapCache.set(version, docIdToPath);
+    context.docIdToPathMapCache.set(version, docIdToPath);
   }
   return docIdToPath;
 }
 
-async function resolveDocRef(ref: DocRef): Promise<SourceDoc | null> {
-  const relativePath = getDocIdToPathMap(ref.version).get(ref.docId);
+async function resolveDocRef(
+  context: DocsLlmFilesContext,
+  ref: DocRef,
+): Promise<SourceDoc | null> {
+  const relativePath = getDocIdToPathMap(context, ref.version).get(ref.docId);
   if (!relativePath) {
     console.warn(
       `Document ID "${ref.docId}" was not found in version ${ref.version} (or it is ignored).`,
@@ -300,12 +310,12 @@ async function resolveDocRef(ref: DocRef): Promise<SourceDoc | null> {
   }
 
   const absolutePath = path.join(
-    VERSIONED_DOCS_DIR,
+    context.versionedDocsDir,
     `version-${ref.version}`,
     relativePath,
   );
-  if (sourceDocCache.has(absolutePath)) {
-    return sourceDocCache.get(absolutePath)!;
+  if (context.sourceDocCache.has(absolutePath)) {
+    return context.sourceDocCache.get(absolutePath)!;
   }
 
   try {
@@ -321,7 +331,7 @@ async function resolveDocRef(ref: DocRef): Promise<SourceDoc | null> {
       absolutePath,
       relativePath,
     };
-    sourceDocCache.set(absolutePath, sourceDoc);
+    context.sourceDocCache.set(absolutePath, sourceDoc);
     return sourceDoc;
   } catch (fileReadError) {
     // This is intentionally not re-thrown to allow the script to continue
@@ -330,7 +340,7 @@ async function resolveDocRef(ref: DocRef): Promise<SourceDoc | null> {
       `Error reading or processing file for docId '${ref.docId}' (version ${ref.version}) at ${absolutePath}:`,
       fileReadError,
     );
-    sourceDocCache.set(absolutePath, null);
+    context.sourceDocCache.set(absolutePath, null);
     return null;
   }
 }
@@ -426,9 +436,11 @@ function parseInternalDocHref(href: string): DocRef | null {
   return { docId, version };
 }
 
-async function buildBlogPostsSection(): Promise<string> {
+async function buildBlogPostsSection(
+  context: DocsLlmFilesContext,
+): Promise<string> {
   const blogPostFiles = globSync("*.{md,mdx}", {
-    cwd: BLOG_DIR,
+    cwd: context.blogDir,
     nodir: true,
     ignore: ["_*.md", "_*.mdx", "authors.yml", "components/**"],
   });
@@ -440,7 +452,7 @@ async function buildBlogPostsSection(): Promise<string> {
     if (!fileDate) {
       continue;
     }
-    const absoluteFilePath = path.join(BLOG_DIR, file);
+    const absoluteFilePath = path.join(context.blogDir, file);
     try {
       const rawContent = await fs.readFile(absoluteFilePath, "utf8");
       const { attributes } = fm(rawContent);
@@ -518,10 +530,11 @@ function constructBlogUrl(filename: string): string {
 }
 
 async function loadVersionedSidebar(
+  context: DocsLlmFilesContext,
   version: string,
 ): Promise<SidebarItemConfig[]> {
   const sidebarPath = path.join(
-    VERSIONED_SIDEBARS_DIR,
+    context.versionedSidebarsDir,
     `version-${version}-sidebars.json`,
   );
   const sidebarContent = await fs.readFile(sidebarPath, "utf8");
@@ -550,7 +563,6 @@ function cleanDocContent(content: string): string {
   if (!content) return "";
 
   const componentsToReplace = new Set<string>();
-  // NOTE: Not sure if this is needed, as LLMs can probably parse the component's meaning from context.
   // Regex to capture imports from '@site/src/components/Tag'
   // e.g. import MyTag from '...' -> MyTag
   // e.g. import {Tag1, Tag2 as MyTag2} from '...' -> {Tag1, Tag2 as MyTag2}

--- a/web/plugins/llm-files/index.ts
+++ b/web/plugins/llm-files/index.ts
@@ -1,0 +1,33 @@
+import type { LoadContext, Plugin } from "@docusaurus/types";
+import fs from "fs/promises";
+import path from "path";
+
+import type { LlmFile } from "./common";
+import { buildDocsLlmFiles } from "./docs";
+import { buildSpecApiFile } from "./specApi";
+
+export function llmFilesPlugin(context: LoadContext): Plugin<void> {
+  return {
+    name: "llm-files",
+    async postBuild({ outDir }) {
+      await writeLlmFiles(outDir, [
+        ...(await buildDocsLlmFiles(context.siteDir)),
+        await buildSpecApiFile(context.siteDir),
+      ]);
+      console.log("LLM files generation completed successfully.");
+    },
+  };
+}
+
+async function writeLlmFiles(outDir: string, files: LlmFile[]): Promise<void> {
+  await fs.mkdir(outDir, { recursive: true });
+
+  for (const file of files) {
+    await fs.writeFile(
+      path.join(outDir, file.fileName),
+      file.content.trim(),
+      "utf8",
+    );
+    console.log(`Generated: ${file.fileName}`);
+  }
+}

--- a/web/plugins/llm-files/index.ts
+++ b/web/plugins/llm-files/index.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 import type { LlmFile } from "./common";
 import { buildDocsLlmFiles } from "./docs";
-import { buildSpecApiFile } from "./specApi";
+import { buildSpecApiFiles } from "./specApi";
 
 export function llmFilesPlugin(context: LoadContext): Plugin<void> {
   return {
@@ -12,7 +12,7 @@ export function llmFilesPlugin(context: LoadContext): Plugin<void> {
     async postBuild({ outDir }) {
       await writeLlmFiles(outDir, [
         ...(await buildDocsLlmFiles(context.siteDir)),
-        await buildSpecApiFile(context.siteDir),
+        ...(await buildSpecApiFiles(context.siteDir)),
       ]);
       console.log("LLM files generation completed successfully.");
     },

--- a/web/plugins/llm-files/specApi.ts
+++ b/web/plugins/llm-files/specApi.ts
@@ -1,0 +1,183 @@
+import fs from "fs/promises";
+import { globSync } from "glob";
+import path from "path";
+
+import type { LlmFile } from "./common";
+
+const SPEC_API_DOCS_PATH = "docs/api/@wasp.sh/spec";
+const SPEC_API_FILE_NAME = "spec-api.txt";
+const WASP_SPEC_API_BASE_URL = "https://wasp.sh/docs/api/@wasp.sh/spec";
+
+type SpecApiPage = {
+  title: string;
+  url: string;
+  content: string;
+};
+
+export async function buildSpecApiFile(siteDir: string): Promise<LlmFile> {
+  const apiPages = await loadSpecApiPages(
+    path.join(siteDir, SPEC_API_DOCS_PATH),
+  );
+
+  return {
+    fileName: SPEC_API_FILE_NAME,
+    content: buildSpecApiFileContent(apiPages),
+  };
+}
+
+async function loadSpecApiPages(
+  specApiDocsDir: string,
+): Promise<SpecApiPage[]> {
+  const markdownFiles = await getOrderedMarkdownFiles(specApiDocsDir);
+  if (markdownFiles.length === 0) {
+    throw new Error(
+      `No generated Spec API Markdown files found in ${specApiDocsDir}`,
+    );
+  }
+
+  const pages: SpecApiPage[] = [];
+  for (const relativePath of markdownFiles) {
+    const rawContent = await fs.readFile(
+      path.join(specApiDocsDir, relativePath),
+      "utf8",
+    );
+    const content = rewriteMarkdownLinks(rawContent, relativePath);
+
+    pages.push({
+      title: extractTitle(content, relativePath),
+      url: getSpecApiPageUrl(relativePath),
+      content,
+    });
+  }
+
+  return pages;
+}
+
+async function getOrderedMarkdownFiles(
+  specApiDocsDir: string,
+): Promise<string[]> {
+  const allMarkdownFiles = globSync("**/*.md", {
+    cwd: specApiDocsDir,
+    nodir: true,
+  }).sort(compareMarkdownPaths);
+
+  if (!allMarkdownFiles.includes("index.md")) {
+    return allMarkdownFiles;
+  }
+
+  const orderedFiles = new Set<string>(["index.md"]);
+  const indexContent = await fs.readFile(
+    path.join(specApiDocsDir, "index.md"),
+    "utf8",
+  );
+
+  for (const linkedFile of extractMarkdownFileLinks(indexContent, "index.md")) {
+    if (allMarkdownFiles.includes(linkedFile)) {
+      orderedFiles.add(linkedFile);
+    }
+  }
+
+  for (const file of allMarkdownFiles) {
+    orderedFiles.add(file);
+  }
+
+  return [...orderedFiles];
+}
+
+function buildSpecApiFileContent(apiPages: SpecApiPage[]): string {
+  const apiMap = [
+    "## API Pages",
+    ...apiPages.map((page) => `- [${page.title}](${page.url})`),
+  ].join("\n");
+
+  const apiContent = apiPages
+    .map((page) => [`Source: ${page.url}`, "", page.content].join("\n"))
+    .join("\n\n---\n\n");
+
+  return [
+    "# Wasp Spec API",
+    "> API reference for @wasp.sh/spec, the TypeScript package used to define Wasp apps in main.wasp.ts.",
+    apiMap,
+    "---",
+    apiContent,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function extractMarkdownFileLinks(
+  content: string,
+  sourcePath: string,
+): string[] {
+  const links: string[] = [];
+  const linkRegex = /\[[^\]]*\]\(([^)]+\.md(?:#[^)]+)?)\)/g;
+  for (const match of content.matchAll(linkRegex)) {
+    const target = match[1];
+    if (!isExternalUrl(target)) {
+      links.push(resolveMarkdownTarget(sourcePath, target).filePath);
+    }
+  }
+  return links;
+}
+
+function rewriteMarkdownLinks(content: string, sourcePath: string): string {
+  return content.replace(
+    /\[([^\]]+)\]\(([^)]+\.md(?:#[^)]+)?)\)/g,
+    (match, label, target) => {
+      if (isExternalUrl(target)) {
+        return match;
+      }
+
+      const resolvedTarget = resolveMarkdownTarget(sourcePath, target);
+      const url = getSpecApiPageUrl(
+        resolvedTarget.filePath,
+        resolvedTarget.hash,
+      );
+      return `[${label}](${url})`;
+    },
+  );
+}
+
+function resolveMarkdownTarget(
+  sourcePath: string,
+  target: string,
+): { filePath: string; hash: string } {
+  const [targetPath, rawHash = ""] = target.split("#");
+  const resolvedPath = path
+    .normalize(path.join(path.dirname(sourcePath), targetPath))
+    .replace(/\\/g, "/");
+
+  return {
+    filePath: resolvedPath,
+    hash: rawHash ? `#${rawHash}` : "",
+  };
+}
+
+function getSpecApiPageUrl(relativePath: string, hash = ""): string {
+  const routePath = relativePath
+    .replace(/\.md$/, "")
+    .replace(/(^|\/)index$/, "");
+  return routePath
+    ? `${WASP_SPEC_API_BASE_URL}/${routePath}${hash}`
+    : `${WASP_SPEC_API_BASE_URL}${hash}`;
+}
+
+function extractTitle(content: string, relativePath: string): string {
+  const titleMatch = content.match(/^#\s+(.+)$/m);
+  if (titleMatch) {
+    return titleMatch[1];
+  }
+
+  return path.basename(relativePath, ".md");
+}
+
+function compareMarkdownPaths(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a === "index.md") return -1;
+  if (b === "index.md") return 1;
+  return a.localeCompare(b);
+}
+
+function isExternalUrl(url: string): boolean {
+  return url.startsWith("http://") || url.startsWith("https://");
+}

--- a/web/plugins/llm-files/specApi.ts
+++ b/web/plugins/llm-files/specApi.ts
@@ -8,132 +8,59 @@ const SPEC_API_DOCS_PATH = "docs/api/@wasp.sh/spec";
 const SPEC_API_FILE_NAME = "spec-api.txt";
 const WASP_SPEC_API_BASE_URL = "https://wasp.sh/docs/api/@wasp.sh/spec";
 
-type SpecApiPage = {
-  title: string;
-  url: string;
-  content: string;
-};
-
 export async function buildSpecApiFile(siteDir: string): Promise<LlmFile> {
-  const apiPages = await loadSpecApiPages(
-    path.join(siteDir, SPEC_API_DOCS_PATH),
-  );
+  const specApiDocsDir = path.join(siteDir, SPEC_API_DOCS_PATH);
+  const markdownFiles = globSync("**/*.md", {
+    cwd: specApiDocsDir,
+    nodir: true,
+  }).sort(sortMarkdownFiles);
 
-  return {
-    fileName: SPEC_API_FILE_NAME,
-    content: buildSpecApiFileContent(apiPages),
-  };
-}
-
-async function loadSpecApiPages(
-  specApiDocsDir: string,
-): Promise<SpecApiPage[]> {
-  const markdownFiles = await getOrderedMarkdownFiles(specApiDocsDir);
   if (markdownFiles.length === 0) {
     throw new Error(
       `No generated Spec API Markdown files found in ${specApiDocsDir}`,
     );
   }
 
-  const pages: SpecApiPage[] = [];
-  for (const relativePath of markdownFiles) {
-    const rawContent = await fs.readFile(
-      path.join(specApiDocsDir, relativePath),
-      "utf8",
-    );
-    const content = rewriteMarkdownLinks(rawContent, relativePath);
+  const sections = await Promise.all(
+    markdownFiles.map(async (relativePath) => {
+      const rawContent = await fs.readFile(
+        path.join(specApiDocsDir, relativePath),
+        "utf8",
+      );
 
-    pages.push({
-      title: extractTitle(content, relativePath),
-      url: getSpecApiPageUrl(relativePath),
-      content,
-    });
-  }
-
-  return pages;
-}
-
-async function getOrderedMarkdownFiles(
-  specApiDocsDir: string,
-): Promise<string[]> {
-  const allMarkdownFiles = globSync("**/*.md", {
-    cwd: specApiDocsDir,
-    nodir: true,
-  }).sort(compareMarkdownPaths);
-
-  if (!allMarkdownFiles.includes("index.md")) {
-    return allMarkdownFiles;
-  }
-
-  const orderedFiles = new Set<string>(["index.md"]);
-  const indexContent = await fs.readFile(
-    path.join(specApiDocsDir, "index.md"),
-    "utf8",
+      return [
+        `Source: ${getSpecApiPageUrl(relativePath)}`,
+        "",
+        rewriteLocalMarkdownLinks(rawContent, relativePath),
+      ].join("\n");
+    }),
   );
 
-  for (const linkedFile of extractMarkdownFileLinks(indexContent, "index.md")) {
-    if (allMarkdownFiles.includes(linkedFile)) {
-      orderedFiles.add(linkedFile);
-    }
-  }
-
-  for (const file of allMarkdownFiles) {
-    orderedFiles.add(file);
-  }
-
-  return [...orderedFiles];
-}
-
-function buildSpecApiFileContent(apiPages: SpecApiPage[]): string {
-  const apiMap = [
-    "## API Pages",
-    ...apiPages.map((page) => `- [${page.title}](${page.url})`),
+  const header = [
+    "# Wasp Spec API",
+    "",
+    "> API reference for @wasp.sh/spec, the TypeScript package used to define Wasp apps in main.wasp.ts.",
   ].join("\n");
 
-  const apiContent = apiPages
-    .map((page) => [`Source: ${page.url}`, "", page.content].join("\n"))
-    .join("\n\n---\n\n");
-
-  return [
-    "# Wasp Spec API",
-    "> API reference for @wasp.sh/spec, the TypeScript package used to define Wasp apps in main.wasp.ts.",
-    apiMap,
-    "---",
-    apiContent,
-  ]
-    .filter(Boolean)
-    .join("\n\n");
+  return {
+    fileName: SPEC_API_FILE_NAME,
+    content: [header, ...sections].join("\n\n---\n\n"),
+  };
 }
 
-function extractMarkdownFileLinks(
+function rewriteLocalMarkdownLinks(
   content: string,
   sourcePath: string,
-): string[] {
-  const links: string[] = [];
-  const linkRegex = /\[[^\]]*\]\(([^)]+\.md(?:#[^)]+)?)\)/g;
-  for (const match of content.matchAll(linkRegex)) {
-    const target = match[1];
-    if (!isExternalUrl(target)) {
-      links.push(resolveMarkdownTarget(sourcePath, target).filePath);
-    }
-  }
-  return links;
-}
-
-function rewriteMarkdownLinks(content: string, sourcePath: string): string {
+): string {
   return content.replace(
     /\[([^\]]+)\]\(([^)]+\.md(?:#[^)]+)?)\)/g,
     (match, label, target) => {
-      if (isExternalUrl(target)) {
+      if (target.startsWith("http://") || target.startsWith("https://")) {
         return match;
       }
 
-      const resolvedTarget = resolveMarkdownTarget(sourcePath, target);
-      const url = getSpecApiPageUrl(
-        resolvedTarget.filePath,
-        resolvedTarget.hash,
-      );
-      return `[${label}](${url})`;
+      const { filePath, hash } = resolveMarkdownTarget(sourcePath, target);
+      return `[${label}](${getSpecApiPageUrl(filePath, hash)})`;
     },
   );
 }
@@ -143,12 +70,10 @@ function resolveMarkdownTarget(
   target: string,
 ): { filePath: string; hash: string } {
   const [targetPath, rawHash = ""] = target.split("#");
-  const resolvedPath = path
-    .normalize(path.join(path.dirname(sourcePath), targetPath))
-    .replace(/\\/g, "/");
-
   return {
-    filePath: resolvedPath,
+    filePath: path
+      .normalize(path.join(path.dirname(sourcePath), targetPath))
+      .replace(/\\/g, "/"),
     hash: rawHash ? `#${rawHash}` : "",
   };
 }
@@ -162,22 +87,9 @@ function getSpecApiPageUrl(relativePath: string, hash = ""): string {
     : `${WASP_SPEC_API_BASE_URL}${hash}`;
 }
 
-function extractTitle(content: string, relativePath: string): string {
-  const titleMatch = content.match(/^#\s+(.+)$/m);
-  if (titleMatch) {
-    return titleMatch[1];
-  }
-
-  return path.basename(relativePath, ".md");
-}
-
-function compareMarkdownPaths(a: string, b: string): number {
+function sortMarkdownFiles(a: string, b: string): number {
   if (a === b) return 0;
   if (a === "index.md") return -1;
   if (b === "index.md") return 1;
   return a.localeCompare(b);
-}
-
-function isExternalUrl(url: string): boolean {
-  return url.startsWith("http://") || url.startsWith("https://");
 }

--- a/web/plugins/llm-files/specApi.ts
+++ b/web/plugins/llm-files/specApi.ts
@@ -6,9 +6,11 @@ import type { LlmFile } from "./common";
 
 const SPEC_API_DOCS_PATH = "docs/api/@wasp.sh/spec";
 const SPEC_API_FILE_NAME = "spec-api.txt";
+const SPEC_API_FULL_FILE_NAME = "spec-api-full.txt";
 const WASP_SPEC_API_BASE_URL = "https://wasp.sh/docs/api/@wasp.sh/spec";
+const WASP_BASE_URL = "https://wasp.sh/";
 
-export async function buildSpecApiFile(siteDir: string): Promise<LlmFile> {
+export async function buildSpecApiFiles(siteDir: string): Promise<LlmFile[]> {
   const specApiDocsDir = path.join(siteDir, SPEC_API_DOCS_PATH);
   const markdownFiles = globSync("**/*.md", {
     cwd: specApiDocsDir,
@@ -21,6 +23,37 @@ export async function buildSpecApiFile(siteDir: string): Promise<LlmFile> {
     );
   }
 
+  return [
+    {
+      fileName: SPEC_API_FILE_NAME,
+      content: await buildSpecApiMap(specApiDocsDir),
+    },
+    {
+      fileName: SPEC_API_FULL_FILE_NAME,
+      content: await buildFullSpecApiFile(specApiDocsDir, markdownFiles),
+    },
+  ];
+}
+
+async function buildSpecApiMap(specApiDocsDir: string): Promise<string> {
+  const indexContent = await fs.readFile(
+    path.join(specApiDocsDir, "index.md"),
+    "utf8",
+  );
+
+  return [
+    "# Wasp Spec API",
+    "> API reference map for @wasp.sh/spec, the TypeScript package used to define Wasp apps in main.wasp.ts.",
+    "Load this map first. Load the full file only when you need the complete generated TypeDoc reference.",
+    `- [Full Spec API](${WASP_BASE_URL}${SPEC_API_FULL_FILE_NAME})`,
+    rewriteLocalMarkdownLinks(indexContent, "index.md"),
+  ].join("\n\n");
+}
+
+async function buildFullSpecApiFile(
+  specApiDocsDir: string,
+  markdownFiles: string[],
+): Promise<string> {
   const sections = await Promise.all(
     markdownFiles.map(async (relativePath) => {
       const rawContent = await fs.readFile(
@@ -42,10 +75,7 @@ export async function buildSpecApiFile(siteDir: string): Promise<LlmFile> {
     "> API reference for @wasp.sh/spec, the TypeScript package used to define Wasp apps in main.wasp.ts.",
   ].join("\n");
 
-  return {
-    fileName: SPEC_API_FILE_NAME,
-    content: [header, ...sections].join("\n\n---\n\n"),
-  };
+  return [header, ...sections].join("\n\n---\n\n");
 }
 
 function rewriteLocalMarkdownLinks(


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Unifies generation of `llms*.txt`, `spec-api.txt`, and `spec-api-full.txt` behind a Docusaurus build plugin.

- Moves the LLM file generation code from `scripts/` into `plugins/llm-files/`.
- Runs generation from Docusaurus `postBuild`, so generated files are written to the final `build/` output.
- Removes the standalone `generate-llm-files` npm script and legacy `static/` output path.
- Adds `spec-api.txt` as a compact map for the generated Wasp Spec TypeDoc pages.
- Adds `spec-api-full.txt` as the full concatenated generated TypeDoc Markdown reference.

Verification: `npm run build` loads the plugin and generates `llms*.txt`, `spec-api.txt`, and `spec-api-full.txt`. The build still fails afterward on existing unrelated broken Docusaurus links.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
