### PR TITLE
Clear stale generated workspaces before install

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Install.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Install.hs
@@ -5,14 +5,19 @@ module Wasp.Cli.Command.Install
 where
 
 import Control.Concurrent (newChan)
+import Control.Monad (unless, when)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
-import StrongPath (Abs, Dir, Path')
+import StrongPath (Abs, Dir, Path', (</>))
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Require (InWaspProject (InWaspProject), require)
+import Wasp.Cli.Message (cliSendMessage)
 import Wasp.Generator.NpmInstall (installProjectNpmDependencies)
+import qualified Wasp.Generator.WaspInfo as WaspInfo
+import qualified Wasp.Message as Msg
 import Wasp.NodePackageFFI (InstallablePackage (WaspSpecPackage), ensurePackageIsAtInstallationPathInProject)
-import Wasp.Project.Common (WaspProjectDir)
+import Wasp.Project.Common (WaspProjectDir, generatedAppDirInWaspProjectDir)
+import qualified Wasp.Util.IO as IOUtil
 
 -- | Standalone `wasp install` command: copies @wasp.sh/spec and runs npm install.
 install :: Command ()
@@ -25,6 +30,18 @@ install = do
 
 installIO :: Path' Abs (Dir WaspProjectDir) -> IO (Either String ())
 installIO waspProjectDir = do
+  removeStaleGeneratedAppDir waspProjectDir
   ensurePackageIsAtInstallationPathInProject waspProjectDir WaspSpecPackage
   messageChan <- newChan
   installProjectNpmDependencies messageChan waspProjectDir
+
+removeStaleGeneratedAppDir :: Path' Abs (Dir WaspProjectDir) -> IO ()
+removeStaleGeneratedAppDir waspProjectDir = do
+  let generatedAppDir = waspProjectDir </> generatedAppDirInWaspProjectDir
+  generatedAppDirExists <- IOUtil.doesDirectoryExist generatedAppDir
+  when generatedAppDirExists $ do
+    wasGeneratedByCurrentVersion <- either (const False) WaspInfo.isGeneratedByCurrentVersion <$> WaspInfo.safeRead generatedAppDir
+    unless wasGeneratedByCurrentVersion $ do
+      cliSendMessage $ Msg.Start "Removing stale .wasp/out before npm install..."
+      IOUtil.deleteDirectoryIfExists generatedAppDir
+      cliSendMessage $ Msg.Success "Removed stale .wasp/out."

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -9,6 +9,8 @@ module ShellCommands
     (~&&),
     (~?),
     (~||),
+    assertDirectoryDoesNotExist,
+    assertDirectoryExists,
     writeToFile,
     appendToFile,
     replaceLineInFile,
@@ -110,6 +112,12 @@ infixl 6 ~||
 infixl 4 ~?
 
 -- General commands
+
+assertDirectoryExists :: FilePath -> ShellCommand
+assertDirectoryExists dirFilePath = "[ -d '" ++ dirFilePath ++ "' ]"
+
+assertDirectoryDoesNotExist :: FilePath -> ShellCommand
+assertDirectoryDoesNotExist = ("! " ++) . assertDirectoryExists
 
 writeToFile :: Path' Abs (File a) -> T.Text -> ShellCommandBuilder context ShellCommand
 writeToFile file fileContent = return $ createParentDir ~&& writeContentsToFile

--- a/waspc/e2e-tests/Tests/WaspBuildTest.hs
+++ b/waspc/e2e-tests/Tests/WaspBuildTest.hs
@@ -1,6 +1,6 @@
 module Tests.WaspBuildTest (waspBuildTest) where
 
-import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliBuild)
+import ShellCommands (ShellCommand, assertDirectoryExists, createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliBuild)
 import Test (Test (..), TestCase (..))
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
@@ -34,6 +34,3 @@ waspBuildTest =
   where
     waspCliBuildFails :: ShellCommand
     waspCliBuildFails = "! wasp-cli build"
-
-    assertDirectoryExists :: FilePath -> ShellCommand
-    assertDirectoryExists dirFilePath = "[ -d '" ++ dirFilePath ++ "' ]"

--- a/waspc/e2e-tests/Tests/WaspCleanTest.hs
+++ b/waspc/e2e-tests/Tests/WaspCleanTest.hs
@@ -1,6 +1,6 @@
 module Tests.WaspCleanTest (waspCleanTest) where
 
-import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliClean, waspCliCompile)
+import ShellCommands (ShellCommand, assertDirectoryDoesNotExist, createTestWaspProject, inTestWaspProjectDir, waspCliClean, waspCliCompile)
 import Test (Test (..), TestCase (..))
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
@@ -38,6 +38,3 @@ waspCleanTest =
   where
     waspCliCleanFails :: ShellCommand
     waspCliCleanFails = "! wasp-cli clean"
-
-    assertDirectoryDoesNotExist :: FilePath -> ShellCommand
-    assertDirectoryDoesNotExist dirFilePath = "[ ! -d '" ++ dirFilePath ++ "' ]"

--- a/waspc/e2e-tests/Tests/WaspCompileTest.hs
+++ b/waspc/e2e-tests/Tests/WaspCompileTest.hs
@@ -1,6 +1,6 @@
 module Tests.WaspCompileTest (waspCompileTest) where
 
-import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliCompile)
+import ShellCommands (ShellCommand, assertDirectoryExists, createTestWaspProject, inTestWaspProjectDir, waspCliCompile)
 import Test (Test (..), TestCase (..))
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
@@ -38,6 +38,3 @@ waspCompileTest =
   where
     waspCliCompileFails :: ShellCommand
     waspCliCompileFails = "! wasp-cli compile"
-
-    assertDirectoryExists :: FilePath -> ShellCommand
-    assertDirectoryExists dirFilePath = "[ -d '" ++ dirFilePath ++ "' ]"

--- a/waspc/e2e-tests/Tests/WaspInstallTest.hs
+++ b/waspc/e2e-tests/Tests/WaspInstallTest.hs
@@ -1,15 +1,23 @@
 module Tests.WaspInstallTest (waspInstallTest) where
 
+import Control.Monad.Reader (ask)
+import qualified Data.Text as T
 import ShellCommands
   ( ShellCommand,
+    ShellCommandBuilder,
+    WaspProjectContext (..),
     createTestWaspProject,
     inTestWaspProjectDir,
     waspCliClean,
     waspCliCompile,
     waspCliInstall,
+    writeToFile,
+    (~&&),
   )
+import StrongPath (relfile, (</>))
 import Test (Test (..), TestCase (..))
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
+import Wasp.Project.Common (generatedAppDirInWaspProjectDir)
 
 waspInstallTest :: Test
 waspInstallTest =
@@ -30,6 +38,31 @@ waspInstallTest =
                   waspCliCompile
                 ]
             ]
+        ),
+      TestCase
+        "install-removes-stale-generated-workspaces"
+        ( sequence
+            [ createTestWaspProject minimalStarterTemplate,
+              inTestWaspProjectDir
+                [ waspCliClean,
+                  createStaleGeneratedAppDir,
+                  waspCliInstall,
+                  return $ assertDirectoryDoesNotExist ".wasp/out",
+                  return $ assertSymlinkExists "node_modules/@wasp.sh/spec"
+                ]
+            ]
+        ),
+      TestCase
+        "install-keeps-current-generated-workspaces"
+        ( sequence
+            [ createTestWaspProject minimalStarterTemplate,
+              inTestWaspProjectDir
+                [ waspCliCompile,
+                  return $ assertDirectoryExists ".wasp/out",
+                  waspCliInstall,
+                  return $ assertDirectoryExists ".wasp/out"
+                ]
+            ]
         )
     ]
   where
@@ -39,5 +72,38 @@ waspInstallTest =
     assertDirectoryDoesNotExist :: FilePath -> ShellCommand
     assertDirectoryDoesNotExist dirFilePath = "[ ! -d '" ++ dirFilePath ++ "' ]"
 
+    assertDirectoryExists :: FilePath -> ShellCommand
+    assertDirectoryExists dirFilePath = "[ -d '" ++ dirFilePath ++ "' ]"
+
     assertSymlinkExists :: FilePath -> ShellCommand
     assertSymlinkExists path = "[ -L '" ++ path ++ "' ]"
+
+    createStaleGeneratedAppDir :: ShellCommandBuilder WaspProjectContext ShellCommand
+    createStaleGeneratedAppDir = do
+      context <- ask
+      let generatedAppDir = context.waspProjectDir </> generatedAppDirInWaspProjectDir
+      writeWaspInfo <- writeToFile (generatedAppDir </> [relfile|.waspinfo|]) staleWaspInfo
+      writeServerPackageJson <- writeToFile (generatedAppDir </> [relfile|server/package.json|]) staleServerPackageJson
+      return $ writeWaspInfo ~&& writeServerPackageJson
+
+    staleWaspInfo :: T.Text
+    staleWaspInfo =
+      T.unlines
+        [ "{",
+          "  \"waspVersion\": \"0.23.0\",",
+          "  \"generatedAt\": \"2025-01-01T00:00:00Z\",",
+          "  \"buildType\": \"Development\"",
+          "}"
+        ]
+
+    staleServerPackageJson :: T.Text
+    staleServerPackageJson =
+      T.unlines
+        [ "{",
+          "  \"name\": \"stale-generated-server\",",
+          "  \"version\": \"0.23.0\",",
+          "  \"dependencies\": {",
+          "    \"@wasp.sh/lib-auth\": \"file:../libs/@wasp_sh_lib-auth-0.23.0.tgz\"",
+          "  }",
+          "}"
+        ]

--- a/waspc/e2e-tests/Tests/WaspInstallTest.hs
+++ b/waspc/e2e-tests/Tests/WaspInstallTest.hs
@@ -6,6 +6,8 @@ import ShellCommands
   ( ShellCommand,
     ShellCommandBuilder,
     WaspProjectContext (..),
+    assertDirectoryDoesNotExist,
+    assertDirectoryExists,
     createTestWaspProject,
     inTestWaspProjectDir,
     waspCliClean,
@@ -68,12 +70,6 @@ waspInstallTest =
   where
     waspCliInstallFails :: ShellCommand
     waspCliInstallFails = "! wasp-cli install"
-
-    assertDirectoryDoesNotExist :: FilePath -> ShellCommand
-    assertDirectoryDoesNotExist dirFilePath = "[ ! -d '" ++ dirFilePath ++ "' ]"
-
-    assertDirectoryExists :: FilePath -> ShellCommand
-    assertDirectoryExists dirFilePath = "[ -d '" ++ dirFilePath ++ "' ]"
 
     assertSymlinkExists :: FilePath -> ShellCommand
     assertSymlinkExists path = "[ -L '" ++ path ++ "' ]"

--- a/waspc/e2e-tests/Tests/WaspStartTest.hs
+++ b/waspc/e2e-tests/Tests/WaspStartTest.hs
@@ -1,6 +1,6 @@
 module Tests.WaspStartTest (waspStartTest) where
 
-import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliCompile, waspCliStart)
+import ShellCommands (ShellCommand, assertDirectoryExists, createTestWaspProject, inTestWaspProjectDir, waspCliCompile, waspCliStart)
 import Test (Test (..), TestCase (..))
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 
@@ -37,6 +37,3 @@ waspStartTest =
   where
     waspCliStartFails :: ShellCommand
     waspCliStartFails = "! wasp-cli start"
-
-    assertDirectoryExists :: FilePath -> ShellCommand
-    assertDirectoryExists dirFilePath = "[ -d '" ++ dirFilePath ++ "' ]"

--- a/waspc/src/Wasp/Generator/WaspInfo.hs
+++ b/waspc/src/Wasp/Generator/WaspInfo.hs
@@ -3,6 +3,7 @@
 module Wasp.Generator.WaspInfo
   ( persist,
     isCompatibleWithExistingBuildAt,
+    isGeneratedByCurrentVersion,
     WaspInfo (..),
     safeRead,
     ReadResult,
@@ -49,16 +50,19 @@ persist generatedAppDir currentBuildType = do
         }
 
     waspInfoFile = generatedAppDir </> waspInfoInGeneratedAppDir
-    currentVersion = showVersion Paths_waspc.version
 
 isCompatibleWithExistingBuildAt :: BuildType -> Path' Abs (Dir GeneratedAppDir) -> IO Bool
 currentBuildType `isCompatibleWithExistingBuildAt` outDir =
   either (const False) isCompatible <$> safeRead outDir
   where
-    isCompatible (WaspInfo {waspVersion = storedVersion, buildType = storedBuildType}) =
-      (storedVersion == currentVersion) && (storedBuildType == currentBuildType)
+    isCompatible waspInfo@(WaspInfo {buildType = storedBuildType}) =
+      isGeneratedByCurrentVersion waspInfo && (storedBuildType == currentBuildType)
 
-    currentVersion = showVersion Paths_waspc.version
+isGeneratedByCurrentVersion :: WaspInfo -> Bool
+isGeneratedByCurrentVersion (WaspInfo {waspVersion = storedVersion}) = storedVersion == currentVersion
+
+currentVersion :: String
+currentVersion = showVersion Paths_waspc.version
 
 type ReadResult = Either ReadError WaspInfo
 


### PR DESCRIPTION
## Description

Wasp projects use npm workspaces, and the root `package.json` includes generated workspaces under `.wasp/out/*` and `.wasp/out/sdk/wasp`. During a Wasp version migration, `.wasp/out` can still contain package manifests generated by the previous Wasp version.

`wasp install` runs `npm install` before regenerating `.wasp/out`, so npm can read those stale workspace manifests and try to install old local Wasp lib tarballs, e.g. `@wasp.sh/lib-auth@file:../libs/...0.23.0.tgz`.

If those old generated tarballs are missing or stale, npm reports warnings like:

`npm warn tarball tarball data for @wasp.sh/lib-auth@file:../libs/auth/wasp.sh-lib-auth-0.23.0.tgz (null) seems to be corrupted`

This PR makes `wasp install` remove `.wasp/out` before running `npm install` when `.wasp/out/.waspinfo` is missing, corrupt, or generated by a different Wasp version. Current-version `.wasp/out` is preserved.

This prevents npm from seeing stale generated workspace manifests during install. The next compile regenerates `.wasp/out` normally.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [x] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
