### PR TITLE
Add --full flag to wasp version

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -24,7 +24,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 
 - Wasp now also validates `tsconfig.wasp.json` and the root `tsconfig.json` in TS spec projects, and tsconfig validation errors now mention which `tsconfig.*.json` file caused them. ([#3911](https://github.com/wasp-lang/wasp/pull/3911))
 - The npm package now shows a clear error when installed on an unsupported Node.js version. ([#4268](https://github.com/wasp-lang/wasp/pull/4268))
-- `wasp version` now accepts a `--full` flag that additionally prints the git commit the binary was built from, the OS and architecture, and the user's Node.js and npm versions.
+- `wasp version` now accepts a `--full` flag that additionally prints the git commit the binary was built from, the OS and architecture, and the user's Node.js and npm versions. ([#4279](https://github.com/wasp-lang/wasp/pull/4279))
 
 ## 0.23.0
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -24,6 +24,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 
 - Wasp now also validates `tsconfig.wasp.json` and the root `tsconfig.json` in TS spec projects, and tsconfig validation errors now mention which `tsconfig.*.json` file caused them. ([#3911](https://github.com/wasp-lang/wasp/pull/3911))
 - The npm package now shows a clear error when installed on an unsupported Node.js version. ([#4268](https://github.com/wasp-lang/wasp/pull/4268))
+- `wasp version` now accepts a `--full` flag that additionally prints the git commit the binary was built from, the OS and architecture, and the user's Node.js and npm versions.
 
 ## 0.23.0
 

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -40,12 +40,11 @@ import Wasp.Cli.Command.Uninstall (uninstall)
 import Wasp.Cli.Command.WaspLS (runWaspLS)
 import Wasp.Cli.Message (cliSendMessage)
 import Wasp.Cli.Terminal (title)
+import Wasp.Cli.Version (printVersion)
 import qualified Wasp.Message as Message
 import qualified Wasp.Node.Version as NodeVersion
 import Wasp.Util (indent)
-import Wasp.Util.InstallMethod (getInstallationCommand)
 import qualified Wasp.Util.Terminal as Term
-import Wasp.Version (waspVersion)
 
 main :: IO ()
 main = withUtf8 . (`E.catch` handleInternalErrors) $ do
@@ -60,7 +59,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
         ["compile"] -> Command.Call.Compile
         ("db" : dbArgs) -> Command.Call.Db dbArgs
         ["uninstall"] -> Command.Call.Uninstall
-        ["version"] -> Command.Call.Version
+        ("version" : versionArgs) -> Command.Call.Version versionArgs
         ["build"] -> Command.Call.Build
         ("build" : "start" : buildStartArgs) -> Command.Call.BuildStart buildStartArgs
         ["telemetry"] -> Command.Call.Telemetry
@@ -112,7 +111,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
     Command.Call.Install -> runCommand install
     Command.Call.Compile -> runCommand compile
     Command.Call.Db dbArgs -> dbCli dbArgs
-    Command.Call.Version -> printVersion
+    Command.Call.Version versionArgs -> printVersion versionArgs
     Command.Call.Studio -> runCommand studio
     Command.Call.Uninstall -> runCommand uninstall
     Command.Call.Build -> runCommand build
@@ -174,7 +173,7 @@ printUsage =
               "      You can do the same thing with `wasp new` interactively.",
               "      Run `wasp new:ai` for more info.",
               "",
-        cmd   "    version               Prints current version of CLI.",
+        cmd   "    version [--full]      Prints current version of CLI.",
         cmd   "    waspls                Run Wasp Language Server. Add --help to get more info.",
         cmd   "    completion            Prints help on bash completion.",
         cmd   "    uninstall             Removes Wasp from your system.",
@@ -208,21 +207,6 @@ printUsage =
         Term.applyStyles [Term.Cyan]    "Newsletter:" ++ " https://wasp.sh/#signup"
       ]
 {- ORMOLU_ENABLE -}
-
-printVersion :: IO ()
-printVersion =
-  putStrLn $
-    unlines
-      [ show waspVersion,
-        "",
-        "If you wish to install/switch to the latest version of Wasp, do:",
-        indent 2 $ getInstallationCommand Nothing,
-        "",
-        "If you want a specific x.y.z version of Wasp, do:",
-        indent 2 $ getInstallationCommand $ Just "x.y.z",
-        "",
-        "Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one."
-      ]
 
 -- TODO: maybe extract to a separate module, e.g. DbCli.hs?
 dbCli :: [String] -> IO ()

--- a/waspc/cli/src/Wasp/Cli/Command/Call.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Call.hs
@@ -12,7 +12,7 @@ data Call
   | Db Arguments -- db args
   | Build
   | BuildStart Arguments
-  | Version
+  | Version Arguments
   | Telemetry
   | Deps
   | Dockerfile

--- a/waspc/cli/src/Wasp/Cli/Version.hs
+++ b/waspc/cli/src/Wasp/Cli/Version.hs
@@ -1,0 +1,66 @@
+module Wasp.Cli.Version
+  ( printVersion,
+  )
+where
+
+import Control.Monad (guard)
+import Data.Char (isSpace)
+import Data.Functor (($>))
+import Data.List (dropWhileEnd, intersperse)
+import Data.Maybe (catMaybes, fromMaybe)
+import System.IO.Error (catchIOError)
+import qualified System.Info
+import System.Process (readProcessWithExitCode)
+import qualified Wasp.Node.Version as NodeVersion
+import Wasp.Util (eitherToMaybe)
+import Wasp.Util.GitRev (gitRevDescription)
+import Wasp.Util.InstallMethod (installInstructions)
+import Wasp.Version (waspVersion)
+
+-- | Prints the Wasp CLI version. With the `--full` flag it also prints
+-- diagnostic information useful for bug reports: the git commit the binary was
+-- built from, the operating system, and the user's Node.js and npm versions.
+printVersion :: [String] -> IO ()
+printVersion versionArgs = do
+  (putStr . unlines . intersperse "") =<< sequence (catMaybes versionInfoParts)
+  where
+    versionInfoParts =
+      [ Just $ return $ show waspVersion,
+        guard ("--full" `elem` versionArgs)
+          $> getFullVersionInfo,
+        Just $ return installInstructions
+      ]
+
+getFullVersionInfo :: IO String
+getFullVersionInfo =
+  makeFullVersionInfo
+    <$> getOsInfo
+    <*> (eitherToMaybe <$> NodeVersion.getUserNodeVersion)
+    <*> (eitherToMaybe <$> NodeVersion.getUserNpmVersion)
+  where
+    makeFullVersionInfo osInfo nodeVersion npmVersion =
+      unlines
+        [ "Git commit: " ++ ifKnown gitRevDescription,
+          "OS:         " ++ osInfo,
+          "Node:       " ++ ifKnown (show <$> nodeVersion),
+          "npm:        " ++ ifKnown (show <$> npmVersion)
+        ]
+
+    ifKnown = fromMaybe "unknown"
+
+-- | Returns a string like "darwin 24.5.0 aarch64" combining the operating
+-- system name, its release/version, and the architecture.
+getOsInfo :: IO String
+getOsInfo = do
+  osVersion <- getOsVersion
+  return $ unwords $ filter (not . null) [System.Info.os, osVersion, System.Info.arch]
+
+-- | Returns the OS release/version via `uname -r`, or an empty string if it
+-- can't be determined (e.g. on systems without `uname`).
+getOsVersion :: IO String
+getOsVersion = getVersionFromUname `catchIOError` const (return "")
+  where
+    getVersionFromUname = do
+      (_exitCode, stdout, _stderr) <- readProcessWithExitCode "uname" ["-r"] ""
+      return $ trim stdout
+    trim = dropWhileEnd isSpace . dropWhile isSpace

--- a/waspc/src/Wasp/Node/Version.hs
+++ b/waspc/src/Wasp/Node/Version.hs
@@ -5,6 +5,8 @@ module Wasp.Node.Version
     nodeTypesVersionRangeMatchingNodeMajor,
     isRangeInWaspSupportedRange,
     checkUserNodeAndNpmMeetWaspRequirements,
+    getUserNodeVersion,
+    getUserNpmVersion,
   )
 where
 
@@ -68,6 +70,12 @@ checkUserToolVersion commandName commandArgs oldestSupportedToolVersion = do
           "You are running " ++ commandName ++ " " ++ show version ++ ".",
           "Wasp requires " ++ commandName ++ " version " ++ show oldestSupportedToolVersion ++ " or higher."
         ]
+
+getUserNodeVersion :: IO (Either ErrorMessage SV.Version)
+getUserNodeVersion = getToolVersionFromCommandOutput "node" ["--version"]
+
+getUserNpmVersion :: IO (Either ErrorMessage SV.Version)
+getUserNpmVersion = getToolVersionFromCommandOutput "npm" ["--version"]
 
 getToolVersionFromCommandOutput :: String -> [String] -> IO (Either ErrorMessage SV.Version)
 getToolVersionFromCommandOutput commandName commandArgs = do

--- a/waspc/src/Wasp/Util/GitRev.hs
+++ b/waspc/src/Wasp/Util/GitRev.hs
@@ -1,0 +1,18 @@
+module Wasp.Util.GitRev
+  ( gitRevDescription,
+  )
+where
+
+import qualified GitHash as GH
+import Wasp.Util (eitherToMaybe)
+
+-- | The `git describe` of the Wasp source tree this binary was built from, or
+-- `Nothing` if it couldn't be determined (e.g. building outside of a git
+-- repository or without `git` installed). This is embedded at build time.
+gitRevDescription :: Maybe String
+gitRevDescription =
+  eitherToMaybe $ getGitDescription <$> $$GH.tGitInfoCwdTry
+  where
+    getGitDescription gitInfo
+      | GH.giDirty gitInfo = GH.giTag gitInfo ++ "-dirty"
+      | otherwise = GH.giTag gitInfo

--- a/waspc/src/Wasp/Util/InstallMethod.hs
+++ b/waspc/src/Wasp/Util/InstallMethod.hs
@@ -1,10 +1,12 @@
 module Wasp.Util.InstallMethod
   ( getInstallationCommand,
     uninstallationCommand,
+    installInstructions,
   )
 where
 
 import Data.Maybe (fromMaybe)
+import Wasp.Util (indent)
 
 getInstallationCommand :: Maybe String -> String
 getInstallationCommand version =
@@ -18,3 +20,15 @@ uninstallationCommand =
 
 npmPackageName :: String
 npmPackageName = "@wasp.sh/wasp-cli"
+
+installInstructions :: String
+installInstructions =
+  unlines
+    [ "If you wish to install/switch to the latest version of Wasp, do:",
+      indent 2 $ getInstallationCommand Nothing,
+      "",
+      "If you want a specific x.y.z version of Wasp, do:",
+      indent 2 $ getInstallationCommand $ Just "x.y.z",
+      "",
+      "Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one."
+    ]

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -144,6 +144,7 @@ library
     exceptions ^>=0.10.7,
     extra ^>=1.7.16,
     filepath ^>=1.4.301,
+    githash ^>=0.1.7,
     http-conduit ^>=2.3.9,
     http-types ^>=0.12.4,
     megaparsec ^>=9.5.0,
@@ -464,6 +465,7 @@ library
     Wasp.Util.Docker
     Wasp.Util.Fib
     Wasp.Util.FilePath
+    Wasp.Util.GitRev
     Wasp.Util.HashMap
     Wasp.Util.IO
     Wasp.Util.IO.Retry
@@ -641,6 +643,7 @@ library cli-lib
     Wasp.Cli.Util.EnvVarArgument
     Wasp.Cli.Util.Parser
     Wasp.Cli.Util.PathArgument
+    Wasp.Cli.Version
 
 executable wasp-cli
   import: common-all, common-exe

--- a/web/docs/general/cli.md
+++ b/web/docs/general/cli.md
@@ -26,7 +26,8 @@ COMMANDS
       You can do the same thing with `wasp new` interactively.
       Run `wasp new:ai` for more info.
 
-    version               Prints current version of CLI.
+    version [--full]      Prints current version of CLI.
+                          With --full, also prints the git commit, OS, and Node.js/npm versions.
     waspls                Run Wasp Language Server. Add --help to get more info.
     completion            Prints help on bash completion.
     uninstall             Removes Wasp from your system.
@@ -179,6 +180,29 @@ To set up Bash completion, run the `wasp completion` command and follow the inst
 $ wasp version
 
 0.14.0
+
+If you wish to install/switch to the latest version of Wasp, do:
+npm i -g @wasp.sh/wasp-cli@latest
+
+If you want specific x.y.z version of Wasp, do:
+npm i -g @wasp.sh/wasp-cli@x.y.z
+
+Check https://github.com/wasp-lang/wasp/releases for the list of valid versions, including the latest one.
+
+```
+
+  Add the `--full` flag to also print diagnostic information useful for bug reports: the git commit the binary was built from, your operating system and architecture, and your Node.js and npm versions.
+
+```
+
+$ wasp version --full
+
+0.14.0
+
+Git commit: v0.23.0-136-g874e208c13
+OS:         darwin 25.5.0 aarch64
+Node:       24.14.1
+npm:        11.16.0
 
 If you wish to install/switch to the latest version of Wasp, do:
 npm i -g @wasp.sh/wasp-cli@latest


### PR DESCRIPTION
## Description

Adds a `--full` flag to `wasp version`. On top of the CLI version, `wasp version --full` prints the git revision the binary was built from (via `git describe`, embedded at build time with the `githash` package), the OS name/version/architecture, and the user's Node.js and npm versions, to make bug reports easier to triage. The install-instructions text was extracted into a reusable `installInstructions` helper, and the docs and changelog are updated.

<img width="748" height="370" alt="file-c2c377f7b808eeb65ced79256c7f2d70" src="https://github.com/user-attachments/assets/ad33c1bc-b1c0-4774-875e-2675cfee0902" />


## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
