### PR TITLE
Fix Mage external script loading

### DIFF
--- a/mage/main.wasp
+++ b/mage/main.wasp
@@ -13,7 +13,6 @@ app waspAi {
     "<meta name=\"twitter:image:width\" content=\"800\" />",
     "<meta name=\"twitter:image:height\" content=\"400\" />",
     "<meta name=\"twitter:card\" content=\"summary_large_image\" />",
-    "<script defer data-domain=\"usemage.ai\" data-api=\"/waspara/wasp/event\" src=\"/waspara/wasp/script.js\"></script>",
     "<script src=\"/piggy.js\"></script>",
   ],
   client: {

--- a/mage/src/client/RootComponent.jsx
+++ b/mage/src/client/RootComponent.jsx
@@ -34,14 +34,26 @@ export function RootComponent() {
 
   useEffect(() => {
     recordAndDeleteReferrer();
-    const script = document.createElement("script");
-    script.src = "https://buttons.github.io/buttons.js"; // <----- add your script url
-    script.async = true;
+    const scripts = [];
 
-    document.body.appendChild(script);
+    if (import.meta.env.PROD) {
+      const plausibleScript = document.createElement("script");
+      plausibleScript.defer = true;
+      plausibleScript.dataset.domain = "usemage.ai";
+      plausibleScript.dataset.api = "/waspara/wasp/event";
+      plausibleScript.src = "/waspara/wasp/script.js";
+
+      const githubButtonsScript = document.createElement("script");
+      githubButtonsScript.src = "https://buttons.github.io/buttons.js";
+      githubButtonsScript.async = true;
+
+      scripts.push(plausibleScript, githubButtonsScript);
+    }
+
+    scripts.forEach((script) => document.body.appendChild(script));
 
     return () => {
-      document.body.removeChild(script);
+      scripts.forEach((script) => script.parentNode?.removeChild(script));
     };
   }, []);
 


### PR DESCRIPTION
## Description

Follow-up to [#4280](https://github.com/wasp-lang/wasp/pull/4280).

Fixes Mage hydration errors by moving Plausible out of `app.head` and loading external scripts from `RootComponent` only in production.

This keeps local Mage development from trying to load the proxied Plausible script and keeps GitHub buttons script loading in the same client-side path.

## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. --> Not practical for this Mage browser script-loading fix.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. --> Not practical for this Mage browser script-loading fix.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. Not applicable.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. Not applicable.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. Not applicable.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa). Not applicable.

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. Not applicable.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. Mage-only fix, no Wasp CLI changelog entry.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`. Not applicable.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. Not applicable.