### PR TITLE
Fix Railpack static site detection

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -21,6 +21,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 
 - Fixed a race condition in development mode that could potentially load the app's JS bundle before the Vite runtime, causing the app to fail the load with a "Can't detect preamble" error. ([#4258](https://github.com/wasp-lang/wasp/issues/4258))
 - Fixed `wasp deploy railway launch` sometimes producing a crashed server with an empty `DATABASE_URL`. Wasp now waits for the database service to finish deploying before setting up the other services. ([#4291](https://github.com/wasp-lang/wasp/pull/4291))
+- Fixed a bug where `wasp deploy railway launch` wouldn't correctly build the Wasp app client if the `/` route was not prerendered. ([#4293](https://github.com/wasp-lang/wasp/pull/4293))
 
 ### 🔧 Small improvements
 

--- a/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
@@ -234,6 +234,9 @@ async function setupClient({
       "add",
       ["--service", clientServiceName],
       ["--variables", `PORT=${clientAppPort}`],
+      // So Railpack detects the output as static files even when there's not an
+      // `index.html`.
+      ["--variables", `RAILPACK_STATIC_FILE_ROOT=1`],
       ...options.clientSecret.map((secret) => ["--variables", secret]),
     ].flat(),
   );


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

According to https://railpack.com/languages/staticfile, if there's not an `index.html` page, (i.e. when the `/` route is not prerendered), our app might not be detected as an Static Site. This fixes it.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
