### PR TITLE
Regenerate tutorial app patches

### DIFF
--- a/web/docs/tutorial/05-queries.md
+++ b/web/docs/tutorial/05-queries.md
@@ -27,13 +27,15 @@ We need to add a **query** specification to `main.wasp.ts` so that Wasp knows it
 
 <TutorialAction id="query-get-tasks" action="APPLY_PATCH">
 ```ts title="main.wasp.ts"
-import { app, query } from "@wasp.sh/spec"
+import { app, page, query, route } from "@wasp.sh/spec"
+import { MainPage } from "./src/MainPage" with { type: "ref" }
 // highlight-next-line
 import { getTasks } from "./src/queries" with { type: "ref" }
 
 export default app({
   // ...
   spec: [
+    route("RootRoute", "/", page(MainPage)),
     // Tell Wasp that this query reads from the `Task` entity. Wasp will
     // automatically update the results of this query when tasks are modified.
     // highlight-next-line

--- a/web/docs/tutorial/05-queries.md
+++ b/web/docs/tutorial/05-queries.md
@@ -27,6 +27,7 @@ We need to add a **query** specification to `main.wasp.ts` so that Wasp knows it
 
 <TutorialAction id="query-get-tasks" action="APPLY_PATCH">
 ```ts title="main.wasp.ts"
+// highlight-next-line
 import { app, page, query, route } from "@wasp.sh/spec"
 import { MainPage } from "./src/MainPage" with { type: "ref" }
 // highlight-next-line

--- a/web/docs/tutorial/06-actions.md
+++ b/web/docs/tutorial/06-actions.md
@@ -26,13 +26,17 @@ We must first declare the Action in `main.wasp.ts`:
 <TutorialAction id="action-create-task" action="APPLY_PATCH">
 
 ```ts title="main.wasp.ts"
-import { action, app } from "@wasp.sh/spec"
+import { action, app, page, query, route } from "@wasp.sh/spec"
+import { MainPage } from "./src/MainPage" with { type: "ref" }
+import { getTasks } from "./src/queries" with { type: "ref" }
 // highlight-next-line
 import { createTask } from "./src/actions" with { type: "ref" }
 
 export default app({
   // ...
   spec: [
+    route("RootRoute", "/", page(MainPage)),
+    query(getTasks, { entities: ["Task"] }),
     // highlight-next-line
     action(createTask, { entities: ["Task"] }),
   ],
@@ -87,7 +91,7 @@ import {
   useQuery,
 } from "wasp/client/operations";
 
-// ... MainPage, TaskView, TaskList ...
+// ... MainPage, TaskView, TasksList ...
 
 // highlight-start
 const NewTaskForm = () => {
@@ -129,7 +133,7 @@ import type { FormEvent } from "react";
 import type { Task } from "wasp/entities";
 import { createTask, getTasks, useQuery } from "wasp/client/operations";
 
-const MainPage = () => {
+export const MainPage = () => {
   const { data: tasks, isLoading, error } = useQuery(getTasks);
 
   return (
@@ -143,7 +147,7 @@ const MainPage = () => {
   );
 };
 
-// ... TaskList, TaskView, NewTaskForm ...
+// ... TaskView, TasksList, NewTaskForm ...
 ```
 </TutorialAction>
 
@@ -183,12 +187,17 @@ Since we've already created one task together, try to create this one yourself. 
   <TutorialAction id="action-update-task" action="APPLY_PATCH">
 
 ```ts title="main.wasp.ts"
-import { action, app } from "@wasp.sh/spec"
-import { updateTask } from "./src/actions" with { type: "ref" }
+import { action, app, page, query, route } from "@wasp.sh/spec"
+import { MainPage } from "./src/MainPage" with { type: "ref" }
+import { getTasks } from "./src/queries" with { type: "ref" }
+import { createTask, updateTask } from "./src/actions" with { type: "ref" }
 
 export default app({
   // ...
   spec: [
+    route("RootRoute", "/", page(MainPage)),
+    query(getTasks, { entities: ["Task"] }),
+    action(createTask, { entities: ["Task"] }),
     action(updateTask, { entities: ["Task"] }),
   ],
 })
@@ -200,6 +209,7 @@ Implementing the Action on the server:
   <TutorialAction id="action-update-task-impl" action="APPLY_PATCH">
 
 ```ts title="src/actions.ts" auto-js
+import type { Task } from "wasp/entities";
 import type { CreateTask, UpdateTask } from "wasp/server/operations";
 
 // ...
@@ -268,7 +278,7 @@ const TaskView = ({ task }: { task: Task }) => {
   );
 };
 
-// ... TaskList, NewTaskForm ...
+// ... TasksList, NewTaskForm ...
 ```
 </TutorialAction>
 

--- a/web/docs/tutorial/06-actions.md
+++ b/web/docs/tutorial/06-actions.md
@@ -26,6 +26,7 @@ We must first declare the Action in `main.wasp.ts`:
 <TutorialAction id="action-create-task" action="APPLY_PATCH">
 
 ```ts title="main.wasp.ts"
+// highlight-next-line
 import { action, app, page, query, route } from "@wasp.sh/spec"
 import { MainPage } from "./src/MainPage" with { type: "ref" }
 import { getTasks } from "./src/queries" with { type: "ref" }
@@ -190,6 +191,7 @@ Since we've already created one task together, try to create this one yourself. 
 import { action, app, page, query, route } from "@wasp.sh/spec"
 import { MainPage } from "./src/MainPage" with { type: "ref" }
 import { getTasks } from "./src/queries" with { type: "ref" }
+// highlight-next-line
 import { createTask, updateTask } from "./src/actions" with { type: "ref" }
 
 export default app({
@@ -198,6 +200,7 @@ export default app({
     route("RootRoute", "/", page(MainPage)),
     query(getTasks, { entities: ["Task"] }),
     action(createTask, { entities: ["Task"] }),
+    // highlight-next-line
     action(updateTask, { entities: ["Task"] }),
   ],
 })

--- a/web/docs/tutorial/06-actions.md
+++ b/web/docs/tutorial/06-actions.md
@@ -197,8 +197,7 @@ import { createTask, updateTask } from "./src/actions" with { type: "ref" }
 export default app({
   // ...
   spec: [
-    route("RootRoute", "/", page(MainPage)),
-    query(getTasks, { entities: ["Task"] }),
+    // ... existing routes and queries
     action(createTask, { entities: ["Task"] }),
     // highlight-next-line
     action(updateTask, { entities: ["Task"] }),

--- a/web/docs/tutorial/07-auth.md
+++ b/web/docs/tutorial/07-auth.md
@@ -42,7 +42,10 @@ Next, tell Wasp to use full-stack [authentication](../auth/overview):
 <TutorialAction id="wasp-file-auth" action="APPLY_PATCH">
 
 ```ts title="main.wasp.ts"
-import { app } from "@wasp.sh/spec"
+import { action, app, page, query, route } from "@wasp.sh/spec"
+import { MainPage } from "./src/MainPage" with { type: "ref" }
+import { getTasks } from "./src/queries" with { type: "ref" }
+import { createTask, updateTask } from "./src/actions" with { type: "ref" }
 
 export default app({
   name: "TodoApp",
@@ -66,7 +69,10 @@ export default app({
   },
   // highlight-end
   spec: [
-    // ...
+    route("RootRoute", "/", page(MainPage)),
+    query(getTasks, { entities: ["Task"] }),
+    action(createTask, { entities: ["Task"] }),
+    action(updateTask, { entities: ["Task"] }),
   ],
 })
 ```
@@ -98,19 +104,26 @@ Wasp creates the login and signup forms for us, but we still need to define the 
 <TutorialAction id="wasp-file-auth-routes" action="APPLY_PATCH">
 
 ```ts title="main.wasp.ts"
-import { app, page, route } from "@wasp.sh/spec"
+import { action, app, page, query, route } from "@wasp.sh/spec"
+import { MainPage } from "./src/MainPage" with { type: "ref" }
 // highlight-start
 import { SignupPage } from "./src/SignupPage" with { type: "ref" }
 import { LoginPage } from "./src/LoginPage" with { type: "ref" }
 // highlight-end
+import { getTasks } from "./src/queries" with { type: "ref" }
+import { createTask, updateTask } from "./src/actions" with { type: "ref" }
 
 export default app({
   // ...
   spec: [
+    route("RootRoute", "/", page(MainPage)),
     // highlight-start
     route("SignupRoute", "/signup", page(SignupPage)),
     route("LoginRoute", "/login", page(LoginPage)),
-    // highlight-end    
+    // highlight-end
+    query(getTasks, { entities: ["Task"] }),
+    action(createTask, { entities: ["Task"] }),
+    action(updateTask, { entities: ["Task"] }),
   ],
 })
 ```
@@ -175,8 +188,12 @@ We don't want users who are not logged in to access the main page, because they 
 <TutorialAction id="wasp-file-auth-required" action="APPLY_PATCH">
 
 ```ts title="main.wasp.ts"
-import { app, page, route } from "@wasp.sh/spec"
+import { action, app, page, query, route } from "@wasp.sh/spec"
 import { MainPage } from "./src/MainPage" with { type: "ref" }
+import { SignupPage } from "./src/SignupPage" with { type: "ref" }
+import { LoginPage } from "./src/LoginPage" with { type: "ref" }
+import { getTasks } from "./src/queries" with { type: "ref" }
+import { createTask, updateTask } from "./src/actions" with { type: "ref" }
 
 export default app({
   // ...
@@ -185,6 +202,11 @@ export default app({
       // highlight-next-line
       authRequired: true,
     }),
+    route("SignupRoute", "/signup", page(SignupPage)),
+    route("LoginRoute", "/login", page(LoginPage)),
+    query(getTasks, { entities: ["Task"] }),
+    action(createTask, { entities: ["Task"] }),
+    action(updateTask, { entities: ["Task"] }),
   ],
 })
 ```
@@ -197,11 +219,15 @@ Additionally, when `authRequired` is `true`, the page's React component will be 
 <TutorialAction id="main-page-add-auth" action="APPLY_PATCH">
 
 ```tsx title="src/MainPage.tsx" auto-js
+import type { ChangeEvent, FormEvent } from "react";
 import type { AuthUser } from "wasp/auth";
+import type { Task } from "wasp/entities";
+import { createTask, getTasks, updateTask, useQuery } from "wasp/client/operations";
 
 // highlight-next-line
 export const MainPage = ({ user }: { user: AuthUser }) => {
-  // Do something with the user
+  const { data: tasks, isLoading, error } = useQuery(getTasks);
+
   // ...
 };
 ```
@@ -366,12 +392,12 @@ Last, but not least, let's add the logout functionality:
 <TutorialAction id="main-page-add-logout" action="APPLY_PATCH">
 
 ```tsx title="src/MainPage.tsx" auto-js with-hole
-// ...
+import type { AuthUser } from "wasp/auth";
 // highlight-next-line
 import { logout } from "wasp/client/auth";
-//...
+// ...
 
-const MainPage = () => {
+export const MainPage = ({ user }: { user: AuthUser }) => {
   // ...
   return (
     <div>

--- a/web/docs/tutorial/07-auth.md
+++ b/web/docs/tutorial/07-auth.md
@@ -48,14 +48,7 @@ import { getTasks } from "./src/queries" with { type: "ref" }
 import { createTask, updateTask } from "./src/actions" with { type: "ref" }
 
 export default app({
-  name: "TodoApp",
-  wasp: {
-    version: "{latestWaspVersion}",
-  },
-  title: "TodoApp",
-  head: [
-    "<link rel='icon' href='/favicon.ico' />",
-  ],
+  // ...
   // highlight-start
   auth: {
     // Tells Wasp which entity to use for storing users.
@@ -121,9 +114,7 @@ export default app({
     route("SignupRoute", "/signup", page(SignupPage)),
     route("LoginRoute", "/login", page(LoginPage)),
     // highlight-end
-    query(getTasks, { entities: ["Task"] }),
-    action(createTask, { entities: ["Task"] }),
-    action(updateTask, { entities: ["Task"] }),
+    // ... existing queries and actions
   ],
 })
 ```
@@ -202,11 +193,7 @@ export default app({
       // highlight-next-line
       authRequired: true,
     }),
-    route("SignupRoute", "/signup", page(SignupPage)),
-    route("LoginRoute", "/login", page(LoginPage)),
-    query(getTasks, { entities: ["Task"] }),
-    action(createTask, { entities: ["Task"] }),
-    action(updateTask, { entities: ["Task"] }),
+    // ... existing routes, queries, and actions
   ],
 })
 ```
@@ -219,10 +206,8 @@ Additionally, when `authRequired` is `true`, the page's React component will be 
 <TutorialAction id="main-page-add-auth" action="APPLY_PATCH">
 
 ```tsx title="src/MainPage.tsx" auto-js
-import type { ChangeEvent, FormEvent } from "react";
 import type { AuthUser } from "wasp/auth";
-import type { Task } from "wasp/entities";
-import { createTask, getTasks, updateTask, useQuery } from "wasp/client/operations";
+// ... existing imports
 
 // highlight-next-line
 export const MainPage = ({ user }: { user: AuthUser }) => {
@@ -395,7 +380,7 @@ Last, but not least, let's add the logout functionality:
 import type { AuthUser } from "wasp/auth";
 // highlight-next-line
 import { logout } from "wasp/client/auth";
-// ...
+// ... existing imports
 
 export const MainPage = ({ user }: { user: AuthUser }) => {
   // ...

--- a/web/docs/tutorial/patches/05-queries__query-get-tasks.patch
+++ b/web/docs/tutorial/patches/05-queries__query-get-tasks.patch
@@ -1,12 +1,12 @@
 diff --git a/main.wasp.ts b/main.wasp.ts
-index e3191d4..64b489a 100644
+index dc1b39f..53e10fc 100644
 --- a/main.wasp.ts
 +++ b/main.wasp.ts
 @@ -1,5 +1,6 @@
- import { MainPage } from "./src/MainPage" with { type: "ref" }
--import { app, page, route } from "@wasp.sh/spec"
-+import { getTasks } from "./src/queries" with { type: "ref" }
-+import { app, page, query, route } from "@wasp.sh/spec"
+-import { app, page, route } from "@wasp.sh/spec";
++import { app, page, query, route } from "@wasp.sh/spec";
+ import { MainPage } from "./src/MainPage" with { type: "ref" };
++import { getTasks } from "./src/queries" with { type: "ref" };
  
  export default app({
    name: "TodoApp",

--- a/web/docs/tutorial/patches/06-actions__action-create-task.patch
+++ b/web/docs/tutorial/patches/06-actions__action-create-task.patch
@@ -1,13 +1,13 @@
 diff --git a/main.wasp.ts b/main.wasp.ts
-index 64b489a..b0c2589 100644
+index 53e10fc..b4e49b4 100644
 --- a/main.wasp.ts
 +++ b/main.wasp.ts
 @@ -1,6 +1,7 @@
-+import { createTask } from "./src/actions" with { type: "ref" }
- import { MainPage } from "./src/MainPage" with { type: "ref" }
- import { getTasks } from "./src/queries" with { type: "ref" }
--import { app, page, query, route } from "@wasp.sh/spec"
-+import { action, app, page, query, route } from "@wasp.sh/spec"
+-import { app, page, query, route } from "@wasp.sh/spec";
++import { action, app, page, query, route } from "@wasp.sh/spec";
+ import { MainPage } from "./src/MainPage" with { type: "ref" };
+ import { getTasks } from "./src/queries" with { type: "ref" };
++import { createTask } from "./src/actions" with { type: "ref" };
  
  export default app({
    name: "TodoApp",

--- a/web/docs/tutorial/patches/06-actions__action-update-task.patch
+++ b/web/docs/tutorial/patches/06-actions__action-update-task.patch
@@ -1,13 +1,16 @@
 diff --git a/main.wasp.ts b/main.wasp.ts
-index b0c2589..64d2908 100644
+index b4e49b4..c4ac9bc 100644
 --- a/main.wasp.ts
 +++ b/main.wasp.ts
-@@ -1,4 +1,4 @@
--import { createTask } from "./src/actions" with { type: "ref" }
-+import { createTask, updateTask } from "./src/actions" with { type: "ref" }
- import { MainPage } from "./src/MainPage" with { type: "ref" }
- import { getTasks } from "./src/queries" with { type: "ref" }
- import { action, app, page, query, route } from "@wasp.sh/spec"
+@@ -1,7 +1,7 @@
+ import { action, app, page, query, route } from "@wasp.sh/spec";
+ import { MainPage } from "./src/MainPage" with { type: "ref" };
+ import { getTasks } from "./src/queries" with { type: "ref" };
+-import { createTask } from "./src/actions" with { type: "ref" };
++import { createTask, updateTask } from "./src/actions" with { type: "ref" };
+ 
+ export default app({
+   name: "TodoApp",
 @@ -12,5 +12,6 @@ export default app({
      route("RootRoute", "/", page(MainPage)),
      query(getTasks, { entities: ["Task"] }),

--- a/web/docs/tutorial/patches/06-actions__main-page-update-task.patch
+++ b/web/docs/tutorial/patches/06-actions__main-page-update-task.patch
@@ -1,22 +1,17 @@
 diff --git a/src/MainPage.tsx b/src/MainPage.tsx
-index 6ee0dbe..fc734f5 100644
+index 6ee0dbe..54da50f 100644
 --- a/src/MainPage.tsx
 +++ b/src/MainPage.tsx
-@@ -1,6 +1,11 @@
+@@ -1,6 +1,6 @@
 -import type { FormEvent } from "react";
 +import type { ChangeEvent, FormEvent } from "react";
  import type { Task } from "wasp/entities";
 -import { createTask, getTasks, useQuery } from "wasp/client/operations";
-+import {
-+  updateTask,
-+  createTask,
-+  getTasks,
-+  useQuery,
-+} from "wasp/client/operations";
++import { createTask, getTasks, updateTask, useQuery } from "wasp/client/operations";
  
  export const MainPage = () => {
    const { data: tasks, isLoading, error } = useQuery(getTasks);
-@@ -17,9 +22,25 @@ export const MainPage = () => {
+@@ -17,9 +17,25 @@ export const MainPage = () => {
  };
  
  const TaskView = ({ task }: { task: Task }) => {

--- a/web/docs/tutorial/patches/07-auth__action-add-auth.patch
+++ b/web/docs/tutorial/patches/07-auth__action-add-auth.patch
@@ -1,5 +1,5 @@
 diff --git a/src/actions.ts b/src/actions.ts
-index 973d821..b4a52e8 100644
+index 973d821..6c22a91 100644
 --- a/src/actions.ts
 +++ b/src/actions.ts
 @@ -1,4 +1,5 @@
@@ -8,13 +8,14 @@ index 973d821..b4a52e8 100644
  import type { CreateTask, UpdateTask } from "wasp/server/operations";
  
  type CreateTaskPayload = Pick<Task, "description">;
-@@ -7,21 +8,28 @@ export const createTask: CreateTask<CreateTaskPayload, Task> = async (
+@@ -7,21 +8,30 @@ export const createTask: CreateTask<CreateTaskPayload, Task> = async (
    args,
    context,
  ) => {
 +  if (!context.user) {
 +    throw new HttpError(401);
 +  }
++
    return context.entities.Task.create({
 -    data: { description: args.description },
 +    data: {
@@ -42,6 +43,7 @@ index 973d821..b4a52e8 100644
 +  if (!context.user) {
 +    throw new HttpError(401);
 +  }
++
 +  return context.entities.Task.updateMany({
 +    where: { id: args.id, user: { id: context.user.id } },
 +    data: { isDone: args.isDone },

--- a/web/docs/tutorial/patches/07-auth__main-page-add-auth.patch
+++ b/web/docs/tutorial/patches/07-auth__main-page-add-auth.patch
@@ -1,16 +1,12 @@
 diff --git a/src/MainPage.tsx b/src/MainPage.tsx
-index fc734f5..5bcf7fb 100644
+index 54da50f..e81b0cc 100644
 --- a/src/MainPage.tsx
 +++ b/src/MainPage.tsx
-@@ -1,4 +1,5 @@
+@@ -1,8 +1,9 @@
  import type { ChangeEvent, FormEvent } from "react";
 +import type { AuthUser } from "wasp/auth";
  import type { Task } from "wasp/entities";
- import {
-   updateTask,
-@@ -7,7 +8,7 @@ import {
-   useQuery,
- } from "wasp/client/operations";
+ import { createTask, getTasks, updateTask, useQuery } from "wasp/client/operations";
  
 -export const MainPage = () => {
 +export const MainPage = ({ user }: { user: AuthUser }) => {

--- a/web/docs/tutorial/patches/07-auth__main-page-add-logout.patch
+++ b/web/docs/tutorial/patches/07-auth__main-page-add-logout.patch
@@ -1,5 +1,5 @@
 diff --git a/src/MainPage.tsx b/src/MainPage.tsx
-index 5bcf7fb..4f2e0e1 100644
+index e81b0cc..30e9414 100644
 --- a/src/MainPage.tsx
 +++ b/src/MainPage.tsx
 @@ -1,5 +1,6 @@
@@ -7,9 +7,9 @@ index 5bcf7fb..4f2e0e1 100644
  import type { AuthUser } from "wasp/auth";
 +import { logout } from "wasp/client/auth";
  import type { Task } from "wasp/entities";
- import {
-   updateTask,
-@@ -18,6 +19,7 @@ export const MainPage = ({ user }: { user: AuthUser }) => {
+ import { createTask, getTasks, updateTask, useQuery } from "wasp/client/operations";
+ 
+@@ -13,6 +14,7 @@ export const MainPage = ({ user }: { user: AuthUser }) => {
  
        {isLoading && "Loading..."}
        {error && "Error: " + error}

--- a/web/docs/tutorial/patches/07-auth__query-add-auth.patch
+++ b/web/docs/tutorial/patches/07-auth__query-add-auth.patch
@@ -1,8 +1,8 @@
 diff --git a/src/queries.ts b/src/queries.ts
-index 4e4ba1b..92a513e 100644
+index 4e4ba1b..fe44833 100644
 --- a/src/queries.ts
 +++ b/src/queries.ts
-@@ -1,8 +1,13 @@
+@@ -1,8 +1,14 @@
  import type { Task } from "wasp/entities";
 +import { HttpError } from "wasp/server";
  import type { GetTasks } from "wasp/server/operations";
@@ -11,6 +11,7 @@ index 4e4ba1b..92a513e 100644
 +  if (!context.user) {
 +    throw new HttpError(401);
 +  }
++
    return context.entities.Task.findMany({
 +    where: { user: { id: context.user.id } },
      orderBy: { id: "asc" },

--- a/web/docs/tutorial/patches/07-auth__wasp-file-auth-required.patch
+++ b/web/docs/tutorial/patches/07-auth__wasp-file-auth-required.patch
@@ -1,5 +1,5 @@
 diff --git a/main.wasp.ts b/main.wasp.ts
-index 1d820cf..d558017 100644
+index 52438c9..6a71803 100644
 --- a/main.wasp.ts
 +++ b/main.wasp.ts
 @@ -18,7 +18,13 @@ export default app({
@@ -14,6 +14,6 @@ index 1d820cf..d558017 100644
 +        authRequired: true,
 +      }),
 +    ),
+     route("SignupRoute", "/signup", page(SignupPage)),
+     route("LoginRoute", "/login", page(LoginPage)),
      query(getTasks, { entities: ["Task"] }),
-     action(createTask, { entities: ["Task"] }),
-     action(updateTask, { entities: ["Task"] }),

--- a/web/docs/tutorial/patches/07-auth__wasp-file-auth-routes.patch
+++ b/web/docs/tutorial/patches/07-auth__wasp-file-auth-routes.patch
@@ -1,19 +1,21 @@
 diff --git a/main.wasp.ts b/main.wasp.ts
-index f6d0dfc..1d820cf 100644
+index 894c99a..52438c9 100644
 --- a/main.wasp.ts
 +++ b/main.wasp.ts
-@@ -1,4 +1,6 @@
- import { createTask, updateTask } from "./src/actions" with { type: "ref" }
-+import { SignupPage } from "./src/SignupPage" with { type: "ref" }
-+import { LoginPage } from "./src/LoginPage" with { type: "ref" }
- import { MainPage } from "./src/MainPage" with { type: "ref" }
- import { getTasks } from "./src/queries" with { type: "ref" }
- import { action, app, page, query, route } from "@wasp.sh/spec"
-@@ -20,5 +22,7 @@ export default app({
+@@ -1,5 +1,7 @@
+ import { action, app, page, query, route } from "@wasp.sh/spec";
+ import { MainPage } from "./src/MainPage" with { type: "ref" };
++import { SignupPage } from "./src/SignupPage" with { type: "ref" };
++import { LoginPage } from "./src/LoginPage" with { type: "ref" };
+ import { getTasks } from "./src/queries" with { type: "ref" };
+ import { createTask, updateTask } from "./src/actions" with { type: "ref" };
+ 
+@@ -17,6 +19,8 @@ export default app({
+   },
+   spec: [
+     route("RootRoute", "/", page(MainPage)),
++    route("SignupRoute", "/signup", page(SignupPage)),
++    route("LoginRoute", "/login", page(LoginPage)),
      query(getTasks, { entities: ["Task"] }),
      action(createTask, { entities: ["Task"] }),
      action(updateTask, { entities: ["Task"] }),
-+    route("SignupRoute", "/signup", page(SignupPage)),
-+    route("LoginRoute", "/login", page(LoginPage)),
-   ],
- });

--- a/web/docs/tutorial/patches/07-auth__wasp-file-auth.patch
+++ b/web/docs/tutorial/patches/07-auth__wasp-file-auth.patch
@@ -1,5 +1,5 @@
 diff --git a/main.wasp.ts b/main.wasp.ts
-index 64d2908..f6d0dfc 100644
+index c4ac9bc..894c99a 100644
 --- a/main.wasp.ts
 +++ b/main.wasp.ts
 @@ -8,6 +8,13 @@ export default app({


### PR DESCRIPTION
## Description

Regenerates the tutorial app patches with `web/tutorial-actions-executor` after the minimal template output changed.

Also updates tutorial code blocks to provide better context. The snippets now include the surrounding imports and existing spec entries where omitting them made the examples look inconsistent with the real app.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
