### PR TITLE
Differentiate betweent the TemplateOutputDir and the WaspProjectDir

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -11,6 +11,7 @@ import Wasp.Cli.Command.CreateNewProject.ArgumentsParser (newProjectArgsParser)
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (availableStarterTemplates)
 import Wasp.Cli.Command.CreateNewProject.ProjectDescription
   ( NewProjectDescription (..),
+    getAbsWaspProjectDir,
     obtainNewProjectDescription,
   )
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates
@@ -35,23 +36,18 @@ createNewProject = withArguments "wasp new" newProjectArgsParser $ \args -> do
 
   createProjectOnDisk newProjectDescription
   -- TODO consider removing if we start doing `wasp install` automatically
-  liftIO $ installDepsForNewProject (_absWaspProjectDir newProjectDescription)
+  liftIO $ installDepsForNewProject (getAbsWaspProjectDir newProjectDescription)
   liftIO $ printGettingStartedInstructionsForProject newProjectDescription
 
 createProjectOnDisk :: NewProjectDescription -> Command ()
 createProjectOnDisk
-  NewProjectDescription
-    { _projectName = projectName,
-      _appName = appName,
-      _template = template,
-      _absWaspProjectDir = absWaspProjectDir
-    } = do
+  newProjectDescription@(NewProjectDescription {_template = template}) = do
     cliSendMessageC $ Msg.Start $ "Creating your project from the \"" ++ show template ++ "\" template..."
     case template of
       GhRepoReleaseArchiveTemplate {repo = ghRepoRef, archiveName = archiveName', archivePath = archivePath'} ->
-        createProjectOnDiskFromGhReleaseArchiveTemplate (show template) absWaspProjectDir projectName appName ghRepoRef archiveName' archivePath'
+        createProjectOnDiskFromGhReleaseArchiveTemplate newProjectDescription ghRepoRef archiveName' archivePath'
       BundledStarterTemplate {bundledPath = bundledPath'} ->
-        liftIO $ createProjectOnDiskFromBundledTemplate absWaspProjectDir projectName appName bundledPath'
+        liftIO $ createProjectOnDiskFromBundledTemplate newProjectDescription bundledPath'
 
 installDepsForNewProject :: SP.Path' SP.Abs (SP.Dir WaspProjectDir) -> IO ()
 installDepsForNewProject absWaspProjectDir =
@@ -68,7 +64,7 @@ installDepsForNewProject absWaspProjectDir =
 -- | This function assumes that the project dir was created inside the current working directory.
 printGettingStartedInstructionsForProject :: NewProjectDescription -> IO ()
 printGettingStartedInstructionsForProject projectDescription = do
-  let projectDirName = init . SP.toFilePath . SP.basename $ _absWaspProjectDir projectDescription
+  let projectDirName = init . SP.toFilePath . SP.basename $ _absTemplateOutputDir projectDescription
   let instructions = getTemplateStartingInstructions projectDirName $ _template projectDescription
   cliSendMessage $ Msg.Success $ "Created a new Wasp app in ./" ++ projectDirName ++ " directory!"
   putStrLn instructions

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/AvailableTemplates.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/AvailableTemplates.hs
@@ -33,6 +33,7 @@ minimalStarterTemplate :: StarterTemplate
 minimalStarterTemplate =
   BundledStarterTemplate
     { bundledPath = [reldir|minimal|],
+      waspProjectFromTemplateOutputDir = [reldir|.|],
       metadata =
         TemplateMetadata
           { _name = "minimal",
@@ -52,6 +53,7 @@ basicStarterTemplate :: StarterTemplate
 basicStarterTemplate =
   BundledStarterTemplate
     { bundledPath = [reldir|basic|],
+      waspProjectFromTemplateOutputDir = [reldir|.|],
       metadata =
         TemplateMetadata
           { _name = "basic",
@@ -82,6 +84,7 @@ openSaasStarterTemplate =
         ),
       archiveName = "template.tar.gz",
       archivePath = [reldir|.|],
+      waspProjectFromTemplateOutputDir = [reldir|app|],
       metadata =
         ( TemplateMetadata
             { _name = "saas",

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/AvailableTemplates.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/AvailableTemplates.hs
@@ -33,7 +33,6 @@ minimalStarterTemplate :: StarterTemplate
 minimalStarterTemplate =
   BundledStarterTemplate
     { bundledPath = [reldir|minimal|],
-      waspProjectFromTemplateOutputDir = [reldir|.|],
       metadata =
         TemplateMetadata
           { _name = "minimal",
@@ -53,7 +52,6 @@ basicStarterTemplate :: StarterTemplate
 basicStarterTemplate =
   BundledStarterTemplate
     { bundledPath = [reldir|basic|],
-      waspProjectFromTemplateOutputDir = [reldir|.|],
       metadata =
         TemplateMetadata
           { _name = "basic",
@@ -84,7 +82,7 @@ openSaasStarterTemplate =
         ),
       archiveName = "template.tar.gz",
       archivePath = [reldir|.|],
-      waspProjectFromTemplateOutputDir = [reldir|app|],
+      _waspProjectDirFromTemplateOutputDir = [reldir|app|],
       metadata =
         ( TemplateMetadata
             { _name = "saas",

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/Common.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/Common.hs
@@ -1,6 +1,7 @@
 module Wasp.Cli.Command.CreateNewProject.Common
   ( throwProjectCreationError,
     defaultWaspVersionBounds,
+    TemplateOutputDir,
   )
 where
 
@@ -8,6 +9,8 @@ import Control.Monad.Except (throwError)
 import Wasp.Cli.Command (Command, CommandError (..))
 import qualified Wasp.SemanticVersion as SV
 import qualified Wasp.Version as WV
+
+data TemplateOutputDir
 
 throwProjectCreationError :: String -> Command a
 throwProjectCreationError = throwError . CommandError "Project creation failed"

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
@@ -24,8 +24,9 @@ import Wasp.Cli.Command.CreateNewProject.ArgumentsParser
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (defaultStarterTemplate)
 import Wasp.Cli.Command.CreateNewProject.Common (TemplateOutputDir, throwProjectCreationError)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates
-  ( StarterTemplate (waspProjectFromTemplateOutputDir),
+  ( StarterTemplate,
     findTemplateByString,
+    waspProjectDirFromTemplateOutputDir,
   )
 import Wasp.Cli.FileSystem (getAbsPathToDirInCwd)
 import qualified Wasp.Cli.Interactive as Interactive
@@ -41,7 +42,7 @@ data NewProjectDescription = NewProjectDescription
 
 getAbsWaspProjectDir :: NewProjectDescription -> Path' Abs (Dir WaspProjectDir)
 getAbsWaspProjectDir (NewProjectDescription {_absTemplateOutputDir = absTemplateOutputDir, _template = template}) =
-  absTemplateOutputDir </> waspProjectFromTemplateOutputDir template
+  absTemplateOutputDir </> waspProjectDirFromTemplateOutputDir template
 
 newtype NewProjectName = NewProjectName String
 

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
@@ -4,7 +4,8 @@ module Wasp.Cli.Command.CreateNewProject.ProjectDescription
     NewProjectName (..),
     NewProjectAppName (..),
     parseWaspProjectNameIntoAppName,
-    obtainAvailableProjectDirPath,
+    obtainAvailableTemplateOutputDirPath,
+    getAbsWaspProjectDir,
   )
 where
 
@@ -13,7 +14,7 @@ import Data.List (intercalate)
 import Data.List.NonEmpty (fromList)
 import Data.Maybe (isNothing)
 import Path.IO (doesDirExist)
-import StrongPath (Abs, Dir, Path')
+import StrongPath (Abs, Dir, Path', (</>))
 import StrongPath.Path (toPathAbsDir)
 import Wasp.Analyzer.Parser (isValidWaspIdentifier)
 import Wasp.Cli.Command (Command)
@@ -21,9 +22,9 @@ import Wasp.Cli.Command.CreateNewProject.ArgumentsParser
   ( NewProjectArgs (..),
   )
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (defaultStarterTemplate)
-import Wasp.Cli.Command.CreateNewProject.Common (throwProjectCreationError)
+import Wasp.Cli.Command.CreateNewProject.Common (TemplateOutputDir, throwProjectCreationError)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates
-  ( StarterTemplate,
+  ( StarterTemplate (waspProjectFromTemplateOutputDir),
     findTemplateByString,
   )
 import Wasp.Cli.FileSystem (getAbsPathToDirInCwd)
@@ -35,8 +36,12 @@ data NewProjectDescription = NewProjectDescription
   { _projectName :: NewProjectName,
     _appName :: NewProjectAppName,
     _template :: StarterTemplate,
-    _absWaspProjectDir :: Path' Abs (Dir WaspProjectDir)
+    _absTemplateOutputDir :: Path' Abs (Dir TemplateOutputDir)
   }
+
+getAbsWaspProjectDir :: NewProjectDescription -> Path' Abs (Dir WaspProjectDir)
+getAbsWaspProjectDir (NewProjectDescription {_absTemplateOutputDir = absTemplateOutputDir, _template = template}) =
+  absTemplateOutputDir </> waspProjectFromTemplateOutputDir template
 
 newtype NewProjectName = NewProjectName String
 
@@ -78,8 +83,8 @@ obtainNewProjectDescription NewProjectArgs {_projectName = projectNameArg, _temp
 
   template <- maybe getFallbackTemplate (findTemplateOrThrow starterTemplates) templateNameArg
 
-  absWaspProjectDir <- obtainAvailableProjectDirPath projectName
-  return $ mkNewProjectDescription projectName appName absWaspProjectDir template
+  absTemplateOutputDir <- obtainAvailableTemplateOutputDirPath projectName
+  return $ mkNewProjectDescription projectName appName absTemplateOutputDir template
 
 askForName :: Command String
 askForName =
@@ -114,28 +119,29 @@ findTemplateOrThrow availableTemplates templateName = case findTemplateByString 
         <> intercalate ", " (map show availableTemplates)
         <> "."
 
-obtainAvailableProjectDirPath :: String -> Command (Path' Abs (Dir WaspProjectDir))
-obtainAvailableProjectDirPath projectName = do
-  absWaspProjectDir <- getAbsPathToNewProjectDirInCwd projectName
-  ensureProjectDirDoesNotExist projectName absWaspProjectDir
-  return absWaspProjectDir
+obtainAvailableTemplateOutputDirPath :: String -> Command (Path' Abs (Dir TemplateOutputDir))
+obtainAvailableTemplateOutputDirPath projectName = do
+  absTemplateOutputDir <- getAbsPathToTemplateOutputDirInCwd projectName
+  ensureTemplateOutputDirDoesNotExist projectName absTemplateOutputDir
+  return absTemplateOutputDir
   where
-    getAbsPathToNewProjectDirInCwd :: String -> Command (Path' Abs (Dir WaspProjectDir))
-    getAbsPathToNewProjectDirInCwd projectDirName = do
+    getAbsPathToTemplateOutputDirInCwd :: String -> Command (Path' Abs (Dir TemplateOutputDir))
+    getAbsPathToTemplateOutputDirInCwd projectDirName = do
       liftIO (getAbsPathToDirInCwd projectDirName) >>= either throwError return
       where
-        throwError err = throwProjectCreationError $ "Failed to get absolute path to Wasp project dir: " ++ show err
-    ensureProjectDirDoesNotExist :: String -> Path' Abs (Dir WaspProjectDir) -> Command ()
-    ensureProjectDirDoesNotExist projectDirName absWaspProjectDir = do
-      whenM (doesDirExist $ toPathAbsDir absWaspProjectDir) $
+        throwError err = throwProjectCreationError $ "Failed to get absolute path to template output dir: " ++ show err
+
+    ensureTemplateOutputDirDoesNotExist :: String -> Path' Abs (Dir TemplateOutputDir) -> Command ()
+    ensureTemplateOutputDirDoesNotExist projectDirName absTemplateOutputDir = do
+      whenM (doesDirExist $ toPathAbsDir absTemplateOutputDir) $
         throwProjectCreationError $
           "Directory \"" ++ projectDirName ++ "\" is not empty."
 
-mkNewProjectDescription :: String -> NewProjectAppName -> Path' Abs (Dir WaspProjectDir) -> StarterTemplate -> NewProjectDescription
-mkNewProjectDescription projectName appName absWaspProjectDir template =
+mkNewProjectDescription :: String -> NewProjectAppName -> Path' Abs (Dir TemplateOutputDir) -> StarterTemplate -> NewProjectDescription
+mkNewProjectDescription projectName appName absTemplateOutputDir template =
   NewProjectDescription
     { _projectName = NewProjectName projectName,
       _appName = appName,
       _template = template,
-      _absWaspProjectDir = absWaspProjectDir
+      _absTemplateOutputDir = absTemplateOutputDir
     }

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates.hs
@@ -4,11 +4,12 @@ module Wasp.Cli.Command.CreateNewProject.StarterTemplates
     findTemplateByString,
     getTemplateStartingInstructions,
     skeletonDotfiles,
+    waspProjectDirFromTemplateOutputDir,
   )
 where
 
 import Data.Foldable (find)
-import StrongPath (Dir, Dir', Path', Rel, Rel')
+import StrongPath (Dir, Dir', Path', Rel, Rel', reldir)
 import Wasp.Cli.Command.CreateNewProject.Common (TemplateOutputDir)
 import qualified Wasp.Cli.GithubRepo as GhRepo
 import qualified Wasp.Cli.Interactive as Interactive
@@ -23,15 +24,25 @@ data StarterTemplate
       { repo :: !GhRepo.GithubRepoRef,
         archiveName :: !GhRepo.GithubReleaseArchiveName,
         archivePath :: Path' Rel' Dir',
-        waspProjectFromTemplateOutputDir :: Path' (Rel TemplateOutputDir) (Dir WaspProjectDir),
+        _waspProjectDirFromTemplateOutputDir :: Path' (Rel TemplateOutputDir) (Dir WaspProjectDir),
         metadata :: !TemplateMetadata
       }
   | -- | Template from disk, that comes bundled with wasp CLI.
     BundledStarterTemplate
       { bundledPath :: Path' Rel' Dir',
-        waspProjectFromTemplateOutputDir :: Path' (Rel TemplateOutputDir) (Dir WaspProjectDir),
+        -- No `_waspProjectDirFromTemplateOutputDir` here, since for the two-step
+        -- skeleton+template copy we assume it's `.`.
+        -- You will have to update `waspProjectDirFromTemplateOutputDir` and
+        -- `ProjectDescription.getAbsWaspProjectDir` if you want to change
+        -- this assumption.
         metadata :: !TemplateMetadata
       }
+
+waspProjectDirFromTemplateOutputDir :: StarterTemplate -> Path' (Rel TemplateOutputDir) (Dir WaspProjectDir)
+waspProjectDirFromTemplateOutputDir (BundledStarterTemplate {}) =
+  [reldir|.|]
+waspProjectDirFromTemplateOutputDir template@(GhRepoReleaseArchiveTemplate {}) =
+  _waspProjectDirFromTemplateOutputDir template
 
 data TemplateMetadata = TemplateMetadata
   { _name :: !String,

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates.hs
@@ -8,9 +8,11 @@ module Wasp.Cli.Command.CreateNewProject.StarterTemplates
 where
 
 import Data.Foldable (find)
-import StrongPath (Dir', Path', Rel')
+import StrongPath (Dir, Dir', Path', Rel, Rel')
+import Wasp.Cli.Command.CreateNewProject.Common (TemplateOutputDir)
 import qualified Wasp.Cli.GithubRepo as GhRepo
 import qualified Wasp.Cli.Interactive as Interactive
+import Wasp.Project (WaspProjectDir)
 
 -- More on how starter templates work in Wasp, including the development process,
 -- can be found in the `waspc/data/Cli/starters/README.md` file.
@@ -21,11 +23,13 @@ data StarterTemplate
       { repo :: !GhRepo.GithubRepoRef,
         archiveName :: !GhRepo.GithubReleaseArchiveName,
         archivePath :: Path' Rel' Dir',
+        waspProjectFromTemplateOutputDir :: Path' (Rel TemplateOutputDir) (Dir WaspProjectDir),
         metadata :: !TemplateMetadata
       }
   | -- | Template from disk, that comes bundled with wasp CLI.
     BundledStarterTemplate
       { bundledPath :: Path' Rel' Dir',
+        waspProjectFromTemplateOutputDir :: Path' (Rel TemplateOutputDir) (Dir WaspProjectDir),
         metadata :: !TemplateMetadata
       }
 

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Bundled.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Bundled.hs
@@ -8,18 +8,20 @@ import StrongPath (Abs, Dir, Dir', Path', Rel', fromAbsDir, reldir, (</>))
 import StrongPath.Path (toPathAbsDir)
 import System.Directory (renameFile)
 import qualified System.FilePath as FP
-import Wasp.Cli.Command.CreateNewProject.ProjectDescription (NewProjectAppName, NewProjectName)
+import Wasp.Cli.Command.CreateNewProject.ProjectDescription (NewProjectDescription (..), getAbsWaspProjectDir)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates (skeletonDotfiles)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates.Templating (replaceTemplatePlaceholdersInTemplateFiles)
 import qualified Wasp.Data as Data
 import Wasp.Project (WaspProjectDir)
 
 createProjectOnDiskFromBundledTemplate ::
-  Path' Abs (Dir WaspProjectDir) -> NewProjectName -> NewProjectAppName -> Path' Rel' Dir' -> IO ()
-createProjectOnDiskFromBundledTemplate absWaspProjectDir projectName appName templatePath = do
+  NewProjectDescription -> Path' Rel' Dir' -> IO ()
+createProjectOnDiskFromBundledTemplate newProjectDescription templatePath = do
   copyBundledTemplateToNewProjectDir templatePath
-  replaceTemplatePlaceholdersInTemplateFiles appName projectName absWaspProjectDir
+  replaceTemplatePlaceholdersInTemplateFiles (_appName newProjectDescription) (_projectName newProjectDescription) absWaspProjectDir
   where
+    absWaspProjectDir = getAbsWaspProjectDir newProjectDescription
+
     copyBundledTemplateToNewProjectDir :: Path' Rel' Dir' -> IO ()
     copyBundledTemplateToNewProjectDir templateDir = do
       dataDir <- Data.getAbsDataDirPath

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Bundled.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Bundled.hs
@@ -20,8 +20,6 @@ createProjectOnDiskFromBundledTemplate newProjectDescription templatePath = do
   copyBundledTemplateToNewProjectDir templatePath
   replaceTemplatePlaceholdersInTemplateFiles (_appName newProjectDescription) (_projectName newProjectDescription) absWaspProjectDir
   where
-    absWaspProjectDir = getAbsWaspProjectDir newProjectDescription
-
     copyBundledTemplateToNewProjectDir :: Path' Rel' Dir' -> IO ()
     copyBundledTemplateToNewProjectDir templateDir = do
       dataDir <- Data.getAbsDataDirPath
@@ -39,3 +37,5 @@ createProjectOnDiskFromBundledTemplate newProjectDescription templatePath = do
     renameDotfiles projectDir dotfiles = do
       let dir = fromAbsDir projectDir
       mapM_ (\name -> renameFile (dir FP.</> name) (dir FP.</> ("." <> name))) dotfiles
+
+    absWaspProjectDir = getAbsWaspProjectDir newProjectDescription

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/GhReleaseArchive.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/GhReleaseArchive.hs
@@ -6,10 +6,10 @@ where
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
 import Data.List (intercalate)
-import StrongPath (Abs, Dir, Dir', Path', Rel')
+import StrongPath (Dir', Path', Rel')
 import Wasp.Cli.Command (Command)
 import Wasp.Cli.Command.CreateNewProject.Common (throwProjectCreationError)
-import Wasp.Cli.Command.CreateNewProject.ProjectDescription (NewProjectAppName, NewProjectName)
+import Wasp.Cli.Command.CreateNewProject.ProjectDescription (NewProjectDescription (..), getAbsWaspProjectDir)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates.Templating (replaceTemplatePlaceholdersInTemplateFiles)
 import Wasp.Cli.GithubRepo
   ( GithubReleaseArchiveName,
@@ -17,32 +17,31 @@ import Wasp.Cli.GithubRepo
     checkGitHubReleaseExists,
     fetchFolderFromGithubReleaseArchiveToDisk,
   )
-import Wasp.Project (WaspProjectDir)
 import Wasp.Util (indent)
 import Wasp.Util.InstallMethod (getInstallationCommand)
 
 createProjectOnDiskFromGhReleaseArchiveTemplate ::
-  String ->
-  Path' Abs (Dir WaspProjectDir) ->
-  NewProjectName ->
-  NewProjectAppName ->
+  NewProjectDescription ->
   GithubRepoRef ->
   GithubReleaseArchiveName ->
   Path' Rel' Dir' ->
   Command ()
-createProjectOnDiskFromGhReleaseArchiveTemplate templateName absWaspProjectDir projectName appName ghRepoRef assetName templatePathInRepo = do
+createProjectOnDiskFromGhReleaseArchiveTemplate newProjectDescription ghRepoRef assetName templatePathInRepo = do
   releaseExists <- liftIO (checkGitHubReleaseExists ghRepoRef)
 
   unless releaseExists throwOutdatedTagError
 
-  fetchTemplateFromGhToWaspProjectDir
+  fetchTemplateFromGhToTemplateOutputDir
     >>= either throwProjectCreationError (const replaceTemplatePlaceholders)
   where
-    fetchTemplateFromGhToWaspProjectDir =
-      liftIO $ fetchFolderFromGithubReleaseArchiveToDisk ghRepoRef assetName templatePathInRepo absWaspProjectDir
+    templateName = show $ _template newProjectDescription
+    absWaspProjectDir = getAbsWaspProjectDir newProjectDescription
+
+    fetchTemplateFromGhToTemplateOutputDir =
+      liftIO $ fetchFolderFromGithubReleaseArchiveToDisk ghRepoRef assetName templatePathInRepo (_absTemplateOutputDir newProjectDescription)
 
     replaceTemplatePlaceholders =
-      liftIO $ replaceTemplatePlaceholdersInTemplateFiles appName projectName absWaspProjectDir
+      liftIO $ replaceTemplatePlaceholdersInTemplateFiles (_appName newProjectDescription) (_projectName newProjectDescription) absWaspProjectDir
 
     throwOutdatedTagError =
       throwProjectCreationError $

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/GhReleaseArchive.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/GhReleaseArchive.hs
@@ -34,9 +34,6 @@ createProjectOnDiskFromGhReleaseArchiveTemplate newProjectDescription ghRepoRef 
   fetchTemplateFromGhToTemplateOutputDir
     >>= either throwProjectCreationError (const replaceTemplatePlaceholders)
   where
-    templateName = show $ _template newProjectDescription
-    absWaspProjectDir = getAbsWaspProjectDir newProjectDescription
-
     fetchTemplateFromGhToTemplateOutputDir =
       liftIO $ fetchFolderFromGithubReleaseArchiveToDisk ghRepoRef assetName templatePathInRepo (_absTemplateOutputDir newProjectDescription)
 
@@ -59,3 +56,6 @@ createProjectOnDiskFromGhReleaseArchiveTemplate newProjectDescription ghRepoRef 
           ]
 
     releasesUrl = intercalate "/" ["https://github.com", _repoOwner ghRepoRef, _repoName ghRepoRef, "releases"]
+
+    templateName = show $ _template newProjectDescription
+    absWaspProjectDir = getAbsWaspProjectDir newProjectDescription


### PR DESCRIPTION
## Description

Some starter templates put the Wasp app inside a subdirectory of the extracted template (e.g. the OpenSaaS template, where the app lives in `app/`), rather than at the template root. The code previously assumed these were always the same directory, so steps that operate on the Wasp project (installing dependencies, replacing template placeholders, the "getting started" instructions) targeted the template root instead of the actual app directory.

This PR introduces a distinction between two concepts:

- **`TemplateOutputDir`** — where the template's contents get written on disk.
- **`WaspProjectDir`** — where the actual Wasp app lives, which may be a subdirectory of the template output dir.

Each `StarterTemplate` now declares `waspProjectFromTemplateOutputDir`, the relative path from the template output to the Wasp project (`.` for the regular templates, `./app` for OpenSaaS). `getAbsWaspProjectDir` derives the absolute Wasp project dir from the `NewProjectDescription`.

To reduce the number of positional arguments being threaded around, the `createProjectOnDiskFrom*` helpers now take the whole `NewProjectDescription` instead of individual fields.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
