### PR TITLE
Update migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export default app({
     onAuthFailedRedirectTo: "/login",
   },
   spec: [
-    route("RootRoute", "/", page(MainPage),
+    route("RootRoute", "/", page(MainPage)),
     route(
       "DashboardRoute",
       "/dashboard",

--- a/web/docs/guides/legacy/wasp-dsl.md
+++ b/web/docs/guides/legacy/wasp-dsl.md
@@ -33,14 +33,14 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
 
 ### Overview
 
-| What                      | Before                                                                   | After                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| File name                 | `main.wasp`                                                              | `main.wasp.ts`                                                                                    |
-| Creating an app           | `app Name { ... }`                                                       | `app({ name, ..., spec: [...] })`                                                                 |
-| Configuring the app       | <pre>app Name \{<br/> auth: \{ ... },<br/> server: \{ ... },<br/>}</pre> | <pre>app(\{<br/> auth: ...,<br/> server: ...,<br/>})</pre>                                        |
-| Adding app specifications | <pre>route X \{ ... }<br/>query X \{ ... }<br/>action X \{ ... }</pre>   | <pre>app(\{<br/> spec: [<br/> route(...),<br/> query(...),<br/> action(...),<br/> ]<br/>})</pre>  |
-| Referencing code          | `import { x } from "@src/..."` inside a declaration                      | `import { ... } from "./src/..." with { type: "ref" }` at the top level                           |
-| Entity references         | `Task` (identifier)                                                      | `"Task"` (string)                                                                                 |
+| What                      | Before                                                                   | After                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| File name                 | `main.wasp`                                                              | `main.wasp.ts`                                                                                   |
+| Creating an app           | `app Name { ... }`                                                       | `app({ name, ..., spec: [...] });`                                                                |
+| Configuring the app       | <pre>app Name \{<br/> auth: \{ ... },<br/> server: \{ ... },<br/>}</pre> | <pre>app(\{<br/> auth: ...,<br/> server: ...,<br/>});</pre>                                       |
+| Adding app specifications | <pre>route X \{ ... }<br/>query X \{ ... }<br/>action X \{ ... }</pre>   | <pre>app(\{<br/> spec: [<br/> route(...),<br/> query(...),<br/> action(...),<br/> ]<br/>});</pre> |
+| Referencing code          | `import { x } from "@src/..."` inside a declaration                      | `import { ... } from "./src/..." with { type: "ref" };` at the top level                          |
+| Entity references         | `Task` (identifier)                                                      | `"Task"` (string)                                                                                |
 
 ### App, routes, and pages
 
@@ -60,11 +60,12 @@ In the DSL, a `route` points to a `page` by name. In the Wasp Spec, `route` take
       authRequired: true
     }
     ```
+
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { app, page, route } from "@wasp.sh/spec"
-    import { MainPage } from "./src/MainPage" with { type: "ref" }
+    import { app, page, route } from "@wasp.sh/spec";
+    import { MainPage } from "./src/MainPage" with { type: "ref" };
 
     export default app({
       name: "todoApp",
@@ -73,8 +74,9 @@ In the DSL, a `route` points to a `page` by name. In the Wasp Spec, `route` take
       spec: [
         route("MainRoute", "/", page(MainPage, { authRequired: true })),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -95,12 +97,13 @@ Note that `route` no longer references a page by name (`to: MainPage`); it takes
       entities: [Task]
     }
     ```
+
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { action, app, query } from "@wasp.sh/spec"
-    import { getTasks } from "./src/queries" with { type: "ref" }
-    import { createTask } from "./src/actions" with { type: "ref" }
+    import { action, app, query } from "@wasp.sh/spec";
+    import { getTasks } from "./src/queries" with { type: "ref" };
+    import { createTask } from "./src/actions" with { type: "ref" };
 
     export default app({
       // ...
@@ -108,8 +111,9 @@ Note that `route` no longer references a page by name (`to: MainPage`); it takes
         query(getTasks, { entities: ["Task"] }),
         action(createTask, { entities: ["Task"] }),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -132,11 +136,12 @@ The DSL's `httpRoute: (GET, "/path")` becomes the first two arguments of `api`.
       httpRoute: (GET, "/bar/baz")
     }
     ```
+
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { api, apiNamespace, app } from "@wasp.sh/spec"
-    import { barBaz, barNamespaceMiddlewareFn } from "./src/apis" with { type: "ref" }
+    import { api, apiNamespace, app } from "@wasp.sh/spec";
+    import { barBaz, barNamespaceMiddlewareFn } from "./src/apis" with { type: "ref" };
 
     export default app({
       // ...
@@ -146,8 +151,9 @@ The DSL's `httpRoute: (GET, "/path")` becomes the first two arguments of `api`.
         }),
         api("GET", "/bar/baz", barBaz, { auth: false, entities: ["Task"] }),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -170,8 +176,8 @@ The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the firs
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { app, job } from "@wasp.sh/spec"
-    import { foo } from "./src/jobs/bar" with { type: "ref" }
+    import { app, job } from "@wasp.sh/spec";
+    import { foo } from "./src/jobs/bar" with { type: "ref" };
 
     export default app({
       // ...
@@ -182,8 +188,9 @@ The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the firs
           performExecutorOptions: { pgBoss: { retryLimit: 1 } },
         }),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -203,8 +210,8 @@ The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the firs
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { app, crud } from "@wasp.sh/spec"
-    import { createTask } from "./src/actions" with { type: "ref" }
+    import { app, crud } from "@wasp.sh/spec";
+    import { createTask } from "./src/actions" with { type: "ref" };
 
     export default app({
       // ...
@@ -214,8 +221,9 @@ The DSL's `perform: { fn, executorOptions }` is flattened: `fn` becomes the firs
           create: { overrideFn: createTask },
         }),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -246,8 +254,8 @@ These were top-level fields of the `app` declaration's dictionary in the DSL. In
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import App from "./src/App" with { type: "ref" }
+    import { app } from "@wasp.sh/spec";
+    import App from "./src/App" with { type: "ref" };
 
     export default app({
       name: "todoApp",
@@ -266,8 +274,9 @@ These were top-level fields of the `app` declaration's dictionary in the DSL. In
         defaultFrom: { email: "hi@example.com" },
       },
       // ...
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -326,7 +335,9 @@ Wasp validates the Wasp Spec support files during migration, including the requi
 
    ```json title="package.json"
    {
+     // ...
      "devDependencies": {
+       // ...
        // highlight-next-line
        "@types/node": "^24.0.0",
        // highlight-next-line
@@ -347,7 +358,10 @@ Wasp validates the Wasp Spec support files during migration, including the requi
    import { app } from "@wasp.sh/spec";
 
    export default app({
-     name: "myAppName",
+     name: "myApp",
+     title: "My app",
+     wasp: { version: "^0.24.0" },
+     head: ["<link rel='icon' href='/favicon.ico' />"],
      spec: [
        // ...
      ],

--- a/web/docs/guides/legacy/wasp-ts-config.md
+++ b/web/docs/guides/legacy/wasp-ts-config.md
@@ -26,17 +26,18 @@ In the TS Config you could only reference your code with import objects (`{ impo
     ```ts title="main.wasp.ts"
     const mainPage = app.page("MainPage", {
       component: { importDefault: "MainPage", from: "@src/MainPage" },
-    })
+    });
 
     app.query("getTasks", {
       fn: { import: "getTasks", from: "@src/queries" },
-    })
+    });
     ```
+
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import MainPage from "./src/MainPage" with { type: "ref" }
-    import { getTasks } from "./src/queries" with { type: "ref" }
+    import MainPage from "./src/MainPage" with { type: "ref" };
+    import { getTasks } from "./src/queries" with { type: "ref" };
 
     export default app({
       // ...
@@ -44,8 +45,9 @@ In the TS Config you could only reference your code with import objects (`{ impo
         route("MainRoute", "/", page(MainPage)),
         query(getTasks),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -61,44 +63,45 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
 
 ### Overview
 
-| What                      | Before                                                                                                                                      | After                                                                                                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Creating an app           | `new App(name, { ... })`                                                                                                                    | `app({ name, ..., spec: [...] })`                                                                                                      |
-| Configuring the app       | `app.auth(...)` <br/> `app.server(...)` <br/> `app.client(...)` <br/> `app.db(...)` <br/> `app.emailSender(...)` <br/> `app.webSocket(...)` | <pre>app(\{<br/> auth: ...,<br/> server: ...,<br/> client: ...,<br/> db: ...,<br/> emailSender: ...,<br/> webSocket: ...,<br/>})</pre> |
-| Adding app specifications | `app.route(...)` <br/> `app.query(...)` <br/> `app.action(...)` <br/> etc                                                                   | <pre>app(\{<br/> spec: [<br/> route(...),<br/> query(...),<br/> action(...),<br/> ]<br/>})</pre>                                       |
-| Imports                   | `{ import, from }`                                                                                                                          | `import { ... } from "./src/..." with { type: "ref" }`                                                                                 |
-| Package name              | `wasp-config`                                                                                                                               | `@wasp.sh/spec`                                                                                                                        |
+| What                      | Before                                                                                                                                            | After                                                                                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Creating an app           | `new App(name, { ... });`                                                                                                                         | `app({ name, ..., spec: [...] });`                                                                                                      |
+| Configuring the app       | `app.auth(...);` <br/> `app.server(...);` <br/> `app.client(...);` <br/> `app.db(...);` <br/> `app.emailSender(...);` <br/> `app.webSocket(...);` | <pre>app(\{<br/> auth: ...,<br/> server: ...,<br/> client: ...,<br/> db: ...,<br/> emailSender: ...,<br/> webSocket: ...,<br/>});</pre> |
+| Adding app specifications | `app.route(...);` <br/> `app.query(...);` <br/> `app.action(...);` <br/> etc                                                                      | <pre>app(\{<br/> spec: [<br/> route(...),<br/> query(...),<br/> action(...),<br/> ]<br/>});</pre>                                       |
+| Imports                   | `{ import, from }`                                                                                                                                | `import { ... } from "./src/..." with { type: "ref" };`                                                                                 |
+| Package name              | `wasp-config`                                                                                                                                     | `@wasp.sh/spec`                                                                                                                         |
 
 ### App and specifications
 
 <Tabs sideBySide>
   <TabItem value="before" label="TS Config">
     ```ts title="main.wasp.ts"
-    import { App } from "wasp-config"
+    import { App } from "wasp-config";
 
     const app = new App("todoApp", {
       title: "ToDo App",
       wasp: { version: "^0.24.0" },
-    })
+    });
 
     const mainPage = app.page("MainPage", {
       component: { importDefault: "MainPage", from: "@src/MainPage" },
-    })
-    app.route("MainRoute", { path: "/", to: mainPage })
+    });
+    app.route("MainRoute", { path: "/", to: mainPage });
 
     app.query("getTasks", {
       fn: { import: "getTasks", from: "@src/queries" },
       entities: ["Task"],
-    })
+    });
 
-    export default app
+    export default app;
     ```
+
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { app, page, query, route } from "@wasp.sh/spec"
-    import MainPage from "./src/MainPage" with { type: "ref" }
-    import { getTasks } from "./src/queries" with { type: "ref" }
+    import { app, page, query, route } from "@wasp.sh/spec";
+    import MainPage from "./src/MainPage" with { type: "ref" };
+    import { getTasks } from "./src/queries" with { type: "ref" };
 
     export default app({
       name: "todoApp",
@@ -108,8 +111,9 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
         route("MainRoute", "/", page(MainPage)),
         query(getTasks, { entities: ["Task"] }),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -121,20 +125,21 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
     app.apiNamespace("bar", {
       middlewareConfigFn: { import: "barNamespaceMiddlewareFn", from: "@src/apis" },
       path: "/bar",
-    })
+    });
 
     app.api("barBaz", {
       fn: { import: "barBaz", from: "@src/apis" },
       auth: false,
       entities: ["Task"],
       httpRoute: { method: "GET", route: "/bar/baz" },
-    })
+    });
     ```
+
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { api, apiNamespace, app } from "@wasp.sh/spec"
-    import { barBaz, barNamespaceMiddlewareFn } from "./src/apis" with { type: "ref" }
+    import { api, apiNamespace, app } from "@wasp.sh/spec";
+    import { barBaz, barNamespaceMiddlewareFn } from "./src/apis" with { type: "ref" };
 
     export default app({
       // ...
@@ -144,8 +149,9 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
         }),
         api("GET", "/bar/baz", barBaz, { auth: false, entities: ["Task"] }),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -161,13 +167,13 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
         executorOptions: { pgBoss: { retryLimit: 1 } },
       },
       entities: ["Task"],
-    })
+    });
     ```
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { app, job } from "@wasp.sh/spec"
-    import { foo } from "./src/jobs/bar" with { type: "ref" }
+    import { app, job } from "@wasp.sh/spec";
+    import { foo } from "./src/jobs/bar" with { type: "ref" };
 
     export default app({
       // ...
@@ -178,8 +184,9 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
           performExecutorOptions: { pgBoss: { retryLimit: 1 } },
         }),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -194,13 +201,13 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
         getAll: {},
         create: { overrideFn: { import: "createTask", from: "@src/actions" } },
       },
-    })
+    });
     ```
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { app, crud } from "@wasp.sh/spec"
-    import { createTask } from "./src/actions" with { type: "ref" }
+    import { app, crud } from "@wasp.sh/spec";
+    import { createTask } from "./src/actions" with { type: "ref" };
 
     export default app({
       // ...
@@ -210,8 +217,9 @@ See the [Wasp Spec documentation](../../general/spec.md#splitting-your-spec-into
           create: { overrideFn: createTask },
         }),
       ],
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -225,30 +233,31 @@ These were configured with mutating method calls. They are now keys of the `app(
     const app = new App("todoApp", {
       title: "ToDo App",
       wasp: { version: "^0.24.0" },
-    })
+    });
 
     app.auth({
       userEntity: "User",
       methods: { google: {} },
       onAuthFailedRedirectTo: "/login",
-    })
+    });
 
     app.client({
       rootComponent: { importDefault: "App", from: "@src/App" },
-    })
+    });
 
     app.emailSender({
       provider: "SMTP",
       defaultFrom: { email: "hi@example.com" },
-    })
+    });
 
-    export default app
+    export default app;
     ```
+
   </TabItem>
   <TabItem value="after" label="Wasp Spec">
     ```ts title="main.wasp.ts"
-    import { app } from "@wasp.sh/spec"
-    import App from "./src/App" with { type: "ref" }
+    import { app } from "@wasp.sh/spec";
+    import App from "./src/App" with { type: "ref" };
 
     export default app({
       name: "todoApp",
@@ -267,8 +276,9 @@ These were configured with mutating method calls. They are now keys of the `app(
         defaultFrom: { email: "hi@example.com" },
       },
       // ...
-    })
+    });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -280,101 +290,108 @@ After finishing this guide, return to the [migration guide](../../migration-guid
 
 Wasp validates the Wasp Spec support files during migration, including the required `package.json` entries, `tsconfig.wasp.json` options, and `tsconfig.src.json` exclusions.
 
-1. Update your `package.json` with the new dependencies:
+1.  Update your `package.json` with the new dependencies:
 
-   <Tabs sideBySide>
-     <TabItem value="before" label="Before">
-       ```json title="package.json"
-       {
-         "devDependencies": {
-           "wasp-config": "file:.wasp/wasp-config"
-         }
-       }
-       ```
-     </TabItem>
-     <TabItem value="after" label="After">
-       ```json title="package.json"
-       {
-         "devDependencies": {
-           "@types/node": "^24.0.0",
-           "@wasp.sh/spec": "file:.wasp/spec"
-         }
-       }
-       ```
-     </TabItem>
-   </Tabs>
+    <Tabs sideBySide>
+      <TabItem value="before" label="Before">
+        ```json title="package.json"
+        {
+          // ...
+          "devDependencies": {
+            // ...
+            "wasp-config": "file:.wasp/wasp-config"
+          }
+        }
+        ```
+      </TabItem>
+      <TabItem value="after" label="After">
+        ```json title="package.json"
+        {
+          // ...
+          "devDependencies": {
+            // ...
+            "@types/node": "^24.0.0",
+            "@wasp.sh/spec": "file:.wasp/spec"
+          }
+        }
+        ```
+      </TabItem>
+    </Tabs>
 
-   Keep your existing dependencies, replace `wasp-config` with `@wasp.sh/spec`, and add `@types/node`. `@types/node` is required because the Wasp Spec runs in a Node.js environment.
+    Keep your existing dependencies, replace `wasp-config` with `@wasp.sh/spec`, and add `@types/node`. `@types/node` is required because the Wasp Spec runs in a Node.js environment.
 
-2. Update your `tsconfig.wasp.json` and make sure it includes the following settings:
+2.  Update your `tsconfig.wasp.json` and make sure it includes the following settings:
 
-   ```json title="tsconfig.wasp.json"
-   {
-     "compilerOptions": {
-       "target": "ES2022",
-       "module": "esnext",
-       "moduleResolution": "bundler",
-       "jsx": "preserve",
-       "strict": true,
-       "isolatedModules": true,
-       "moduleDetection": "force",
-       "skipLibCheck": true,
-       "allowJs": true,
-       "noEmit": true,
-       "lib": ["ES2023"]
-     },
-     "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
-   }
-   ```
+    ```json title="tsconfig.wasp.json"
+    {
+      "compilerOptions": {
+        "target": "ES2022",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "jsx": "preserve",
+        "strict": true,
+        "isolatedModules": true,
+        "moduleDetection": "force",
+        "skipLibCheck": true,
+        "allowJs": true,
+        "noEmit": true,
+        "lib": ["ES2023"]
+      },
+      "include": ["**/*.wasp.ts", ".wasp/out/types/spec"]
+    }
+    ```
 
-3. Make sure your `tsconfig.src.json` excludes Wasp Spec files:
+3.  Make sure your `tsconfig.src.json` excludes Wasp Spec files:
 
-   ```json title="tsconfig.src.json"
-   {
-     // ...
-     "include": ["src"],
-     "exclude": ["**/*.wasp.ts"]
-   }
-   ```
+    ```json title="tsconfig.src.json"
+    {
+      // ...
+      "include": ["src"],
+      "exclude": ["**/*.wasp.ts"]
+    }
+    ```
 
-4. Run `wasp install`.
+4.  Run `wasp install`.
 
-5. Rewrite `main.wasp.ts`:
+5.  Rewrite `main.wasp.ts`:
 
-   Replace `new App(...)` and the `app.*(...)` method calls with a single `app({ ... })` call whose `spec` property holds the specifications (see the [mapping above](#changes)), and update the import:
+    Replace `new App(...)` and the `app.*(...)` method calls with a single `app({ ... })` call whose `spec` property holds the specifications (see the [mapping above](#changes)), and update the import:
 
-   <Tabs sideBySide>
-     <TabItem value="before" label="Before">
-       ```ts title="main.wasp.ts"
-       import { App } from "wasp-config"
+    <Tabs sideBySide>
+      <TabItem value="before" label="Before">
+        ```ts title="main.wasp.ts"
+        import { App } from "wasp-config";
 
-       const app = new App("myApp", {
-         title: "My app",
-         wasp: { version: "^0.24.0" },
-       })
-       ```
-     </TabItem>
-     <TabItem value="after" label="After">
-       ```ts title="main.wasp.ts"
-       import { app, page, route, query, action } from "@wasp.sh/spec"
+        const app = new App("myApp", {
+          title: "My app",
+          wasp: { version: "^0.24.0" },
+        });
+        ```
 
-       export default app({
-         name: "myApp",
-         title: "My app",
-         wasp: { version: "^0.24.0" },
-         spec: [
-           // ...
-         ]
-       })
-       ```
-     </TabItem>
-   </Tabs>
+      </TabItem>
+      <TabItem value="after" label="After">
+        ```ts title="main.wasp.ts"
+        import { app } from "@wasp.sh/spec";
 
-   :::note
-   While previously we accepted any `*.wasp.ts` file name, with the Wasp Spec the entry file must be named `main.wasp.ts`. You can still split the rest of your config across other `*.wasp.ts` files.
-   :::
+        export default app({
+          name: "myApp",
+          title: "My app",
+          wasp: { version: "^0.24.0" },
+          head: ["<link rel='icon' href='/favicon.ico' />"],
+          spec: [
+            // ...
+          ]
+        });
+        ```
 
-6. Run your app with `wasp start`. If everything is correct, your app should behave exactly as before.
+      </TabItem>
+    </Tabs>
+
+    :::note
+    While previously we accepted any `*.wasp.ts` file name, with the Wasp Spec the entry file must be named `main.wasp.ts`. You can still split the rest of your config across other `*.wasp.ts` files.
+    :::
+
+6.  Run your app with `wasp start`. If everything is correct, your app should behave exactly as before.
 
 :::note
 At some points, when the Spec needs to be regenerated, Wasp will tell you to run `wasp install` before being able to start the app. Usually, this might happen when upgrading Wasp versions, running `wasp clean`, or removing the `node_modules` folder.

--- a/web/docs/migration-guide.md
+++ b/web/docs/migration-guide.md
@@ -124,37 +124,40 @@ Update the version field in your Wasp config to `^0.24.0`. The syntax depends on
   </TabItem>
   <TabItem value="wasp-ts-config" label="Wasp TS Config">
     ```ts title="main.wasp.ts"
-    import { App } from "wasp-config"
+    import { App } from "wasp-config";
 
     const app = new App("MyApp", {
       wasp: {
         version: "^0.24.0",
       },
       // ...
-    })
+    });
     ```
   </TabItem>
 </Tabs>
 
-### 2. Convert your config to the Wasp Spec
+### 2. Add `vitest` to your `package.json`
+
+Add `vitest` to `devDependencies` because `wasp test client` now runs the Vitest package installed in your project.
+
+```json title="package.json"
+{
+  // ...
+  "devDependencies": {
+    // ...
+    // highlight-next-line
+    "vitest": "^4.0.16"
+  }
+}
+```
+
+### 3. Convert your config to the Wasp Spec
 
 - If your app has a `main.wasp` file, follow [Migrating from the Wasp DSL](./guides/legacy/wasp-dsl.md). This converts your app from the Wasp DSL to the Wasp Spec.
 - If your app already has a `main.wasp.ts` file using the old class-based `new App(...)` API, follow [Migrating from the Wasp TS Config](./guides/legacy/wasp-ts-config.md). This converts your app from the old TS Config to the Wasp Spec.
 
 After you finish the conversion guide, **come back here** and continue with the shared migration steps below.
 
-### 3. Add `vitest` to your `package.json`
-
-Add `vitest` to `devDependencies` because `wasp test client` now runs the Vitest package installed in your project.
-
-```json title="package.json"
-{
-  "devDependencies": {
-    // highlight-next-line
-    "vitest": "^4.0.16"
-  }
-}
-```
 
 ### 4. Update client code that uses `api` from `wasp/client/api`
 
@@ -165,42 +168,42 @@ The `api` object was previously an Axios instance. It is now a [ky](https://gith
 <Tabs sideBySide>
   <TabItem value="before" label="Before">
     ```ts
-    import { api } from "wasp/client/api"
+    import { api } from "wasp/client/api";
 
     // Making requests
-    const response = await api.get("/foo/bar")
-    const data = response.data
+    const response = await api.get("/foo/bar");
+    const data = response.data;
 
     // POST with body
-    await api.post("/foo/bar", { key: "value" })
+    await api.post("/foo/bar", { key: "value" });
 
     // Error handling
-    import { type AxiosError } from "axios"
+    import { type AxiosError } from "axios";
     try {
-      await api.get("/foo/bar")
+      await api.get("/foo/bar");
     } catch (e) {
-      const error = e as AxiosError
-      console.log(error.response?.status)
+      const error = e as AxiosError;
+      console.log(error.response?.status);
     }
     ```
   </TabItem>
   <TabItem value="after" label="After">
     ```ts
-    import { api } from "wasp/client/api"
-    import { isHTTPError } from "ky"
+    import { api } from "wasp/client/api";
+    import { isHTTPError } from "ky";
 
     // Making requests
-    const data = await api.get("/foo/bar").json()
+    const data = await api.get("/foo/bar").json();
 
     // POST with body
-    await api.post("/foo/bar", { json: { key: "value" } })
+    await api.post("/foo/bar", { json: { key: "value" } });
 
     // Error handling
     try {
-      await api.get("/foo/bar").json()
+      await api.get("/foo/bar").json();
     } catch (e) {
       if (isHTTPError(e)) {
-        console.log(e.response.status)
+        console.log(e.response.status);
       }
     }
     ```


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Moves `vitest` step before Wasp Spec migration.
Why?
Wasp Spec migrations instruct users to do `wasp start` to confirm the app works.
By following the migration guide, it would throw an error we are missing the `vitest` in `package.json`.
By completing that step first, for most users, the app will work at that step (besides peeps using Wasp's `axios`).

Adds various semicolons.
Adds `// ...` where content is missing.
Makes "starter" `main.wasp.ts` example have all require fields (e.g. `head`).

Forces format on all 3 edited files.


## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
