### PR TITLE
docs: simplify auth pills to use currentColor border style

### DIFF
--- a/web/docs/auth/Pills.css
+++ b/web/docs/auth/Pills.css
@@ -1,21 +1,9 @@
-:root {
-  --auth-pills-color: #333;
-  --auth-pills-email: #e0f2fe;
-  --auth-pills-slack: #8fb57d;
-  --auth-pills-discord: #d3d6f2;
-  --auth-pills-github: #f1f5f9;
-  --auth-pills-google: #ecfccb;
-  --auth-pills-keycloak: #d0ebf5;
-  --auth-pills-username-and-pass: #fce7f3;
-}
-
-:root[data-theme="dark"] {
-  --auth-pills-color: #fff;
-  --auth-pills-email: #0c4a6e;
-  --auth-pills-slack: #2f7041;
-  --auth-pills-discord: #2f3670;
-  --auth-pills-github: #334155;
-  --auth-pills-google: #365314;
-  --auth-pills-keycloak: #2d5866;
-  --auth-pills-username-and-pass: #831843;
+.pills {
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.375rem;
+  color: currentColor;
+  border: 1px solid currentColor;
+  font-size: 0.9rem;
+  text-decoration: none;
+  display: inline-block;
 }

--- a/web/docs/auth/Pills.jsx
+++ b/web/docs/auth/Pills.jsx
@@ -1,111 +1,42 @@
 import Link from "@docusaurus/Link";
 import "./Pills.css";
 
-export function Pill({ children, linkToPage, style = {} }) {
+export function Pill({ children, linkToPage }) {
   return (
-    <Link
-      to={linkToPage}
-      style={{
-        padding: "0.1rem 0.5rem",
-        borderRadius: "0.375rem",
-        color: "var(--auth-pills-color)",
-        textDecoration: "none",
-        display: "inline-block",
-        ...style,
-      }}
-    >
+    <Link to={linkToPage} className="pills">
       {children}
     </Link>
   );
 }
 
 export function EmailPill() {
-  return (
-    <Pill
-      style={{
-        backgroundColor: "var(--auth-pills-email)",
-      }}
-      linkToPage="/docs/auth/email"
-    >
-      Email
-    </Pill>
-  );
+  return <Pill linkToPage="/docs/auth/email">Email</Pill>;
 }
 
 export function UsernameAndPasswordPill() {
   return (
-    <Pill
-      style={{
-        backgroundColor: "var(--auth-pills-username-and-pass)",
-      }}
-      linkToPage="/docs/auth/username-and-pass"
-    >
+    <Pill linkToPage="/docs/auth/username-and-pass">
       Username & Password
     </Pill>
   );
 }
 
 export function SlackPill() {
-  return (
-    <Pill
-      style={{
-        backgroundColor: "var(--auth-pills-slack)",
-      }}
-      linkToPage="/docs/auth/social-auth/slack"
-    >
-      Slack
-    </Pill>
-  );
+  return <Pill linkToPage="/docs/auth/social-auth/slack">Slack</Pill>;
 }
 
 export function DiscordPill() {
-  return (
-    <Pill
-      style={{
-        backgroundColor: "var(--auth-pills-discord)",
-      }}
-      linkToPage="/docs/auth/social-auth/discord"
-    >
-      Discord
-    </Pill>
-  );
+  return <Pill linkToPage="/docs/auth/social-auth/discord">Discord</Pill>;
 }
 
 export function GithubPill() {
-  return (
-    <Pill
-      style={{
-        backgroundColor: "var(--auth-pills-github)",
-      }}
-      linkToPage="/docs/auth/social-auth/github"
-    >
-      Github
-    </Pill>
-  );
+  return <Pill linkToPage="/docs/auth/social-auth/github">Github</Pill>;
 }
 
 export function GooglePill() {
-  return (
-    <Pill
-      style={{
-        backgroundColor: "var(--auth-pills-google)",
-      }}
-      linkToPage="/docs/auth/social-auth/google"
-    >
-      Google
-    </Pill>
-  );
+  return <Pill linkToPage="/docs/auth/social-auth/google">Google</Pill>;
 }
 
 export function KeycloakPill() {
-  return (
-    <Pill
-      style={{
-        backgroundColor: "var(--auth-pills-keycloak)",
-      }}
-      linkToPage="/docs/auth/social-auth/keycloak"
-    >
-      Keycloak
-    </Pill>
-  );
+  return <Pill linkToPage="/docs/auth/social-auth/keycloak">Keycloak</Pill>;
 }


### PR DESCRIPTION
The auth pills used distinct background colors per auth method, which meant maintaining separate color combinations for each provider and made the pills feel visually heavy.

Replaces per-method background colors with a simpler `currentColor` approach for text and border. Pills are now less dominant, work consistently in light and dark modes, and don't need per-auth-method color logic.

Closes #2775