### PR TITLE
Use doc's own version for {latestWaspVersion} in versioned docs

### DIFF
--- a/web/src/remark/search-and-replace.ts
+++ b/web/src/remark/search-and-replace.ts
@@ -5,21 +5,36 @@ import docsVersions from "../../versions.json";
 
 const latestWaspVersion = docsVersions[0];
 
-const replacer = createReplacer({
-  latestWaspVersion: `^${latestWaspVersion}`,
-  pinnedLatestWaspVersion: latestWaspVersion,
-  // NOTE: Don't change Wasp's lowest supported Node version without updating it
-  // in all required places. Check /.nvmrc for the full list.
-  minimumNodeJsVersion: "24.14.1",
-});
+const plugin: Plugin<[], Root> = () => (tree, file) => {
+  // In versioned docs we want the placeholders to refer to that doc's version,
+  // not to the latest one. For "current" (unversioned) docs we fall back to the
+  // latest version.
+  const waspVersion = getWaspVersionFromFilePath(file.path) ?? latestWaspVersion;
 
-const plugin: Plugin<[], Root> = () => (tree) => {
+  const replacer = createReplacer({
+    latestWaspVersion: `^${waspVersion}`,
+    pinnedLatestWaspVersion: waspVersion,
+    // NOTE: Don't change Wasp's lowest supported Node version without updating it
+    // in all required places. Check /.nvmrc for the full list.
+    minimumNodeJsVersion: "24.14.1",
+  });
+
   visit(tree, (node) => {
     if (node.type === "code" || node.type === "text") {
       node.value = replacer.searchAndReplace(node.value);
     }
   });
 };
+
+/**
+  Extracts the Wasp version from a versioned docs file path
+  (e.g. `.../versioned_docs/version-0.20/...` → `0.20`).
+  Returns `undefined` for "current" (unversioned) docs.
+*/
+function getWaspVersionFromFilePath(filePath: string): string | undefined {
+  const match = filePath.match(/versioned_docs\/version-([^/]+)\//);
+  return match?.[1];
+}
 
 /**
   Accepts a record of key-value pairs. Replaces `{key}` with `value` when

--- a/web/src/remark/search-and-replace.ts
+++ b/web/src/remark/search-and-replace.ts
@@ -9,7 +9,8 @@ const plugin: Plugin<[], Root> = () => (tree, file) => {
   // In versioned docs we want the placeholders to refer to that doc's version,
   // not to the latest one. For "current" (unversioned) docs we fall back to the
   // latest version.
-  const waspVersion = getWaspVersionFromFilePath(file.path) ?? latestWaspVersion;
+  const waspVersion =
+    getWaspVersionFromFilePath(file.path) ?? latestWaspVersion;
 
   const replacer = createReplacer({
     latestWaspVersion: `^${waspVersion}`,


### PR DESCRIPTION
## Description

The `searchAndReplace` remark plugin always replaced `{latestWaspVersion}` / `{pinnedLatestWaspVersion}` with the newest version, even inside versioned docs. It now derives the version from the file path so versioned docs (e.g. `versioned_docs/version-0.20/`) use their own version, while current/unversioned docs still fall back to the latest.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
