### PR TITLE
Add zizmor security checks for GitHub Actions

### DIFF
--- a/.github/actions/compute-artifact-names/action.yaml
+++ b/.github/actions/compute-artifact-names/action.yaml
@@ -52,7 +52,7 @@ runs:
       env:
         BUILD_NAME: ${{ steps.resolve-build-name.outputs.build-name }}
       run: |
-        echo '::error::Invalid build name provided: $BUILD_NAME.'
+        echo "::error::Invalid build name provided: $BUILD_NAME."
         exit 1
 
     - name: Set artifact names
@@ -71,7 +71,7 @@ runs:
       env:
         BUILD_NAME: ${{ steps.resolve-build-name.outputs.build-name }}
       run: |
-        case '$BUILD_NAME' in
+        case "$BUILD_NAME" in
           linux-x86_64)        npm_target='{"os":"linux","cpu":"x64","libc":"glibc"}' ;;
           linux-x86_64-static) npm_target='{"os":"linux","cpu":"x64","libc":"musl"}' ;;
           macos-x86_64)        npm_target='{"os":"darwin","cpu":"x64"}' ;;

--- a/.github/actions/compute-artifact-names/action.yaml
+++ b/.github/actions/compute-artifact-names/action.yaml
@@ -15,12 +15,12 @@ runs:
     - name: Resolve build name
       id: resolve-build-name
       shell: sh
+      env:
+        INPUT_BUILD_NAME: ${{ inputs.build-name }}
       run: |
-        input='${{ inputs.build-name }}'
-
-        if [ "$input" = "all" ]; then
+        if [ "$INPUT_BUILD_NAME" = "all" ]; then
           build_name="*"
-        elif [ "$input" = "current" ]; then
+        elif [ "$INPUT_BUILD_NAME" = "current" ]; then
           case "${{ runner.os }}-${{ runner.arch }}" in
             Linux-X64)   build_name="linux-x86_64" ;;
             macOS-X64)   build_name="macos-x86_64" ;;
@@ -31,7 +31,7 @@ runs:
               ;;
           esac
         else
-          build_name="$input"
+          build_name="$INPUT_BUILD_NAME"
         fi
 
         echo "build-name=$build_name" >> "$GITHUB_OUTPUT"
@@ -49,8 +49,10 @@ runs:
           steps.resolve-build-name.outputs.build-name
         )
       shell: sh
+      env:
+        BUILD_NAME: ${{ steps.resolve-build-name.outputs.build-name }}
       run: |
-        echo '::error::Invalid build name provided: ${{ steps.resolve-build-name.outputs.build-name }}.'
+        echo '::error::Invalid build name provided: $BUILD_NAME.'
         exit 1
 
     - name: Set artifact names
@@ -66,8 +68,10 @@ runs:
       id: set-npm-target
       if: steps.resolve-build-name.outputs.build-name != '*'
       shell: sh
+      env:
+        BUILD_NAME: ${{ steps.resolve-build-name.outputs.build-name }}
       run: |
-        case '${{ steps.resolve-build-name.outputs.build-name }}' in
+        case '$BUILD_NAME' in
           linux-x86_64)        npm_target='{"os":"linux","cpu":"x64","libc":"glibc"}' ;;
           linux-x86_64-static) npm_target='{"os":"linux","cpu":"x64","libc":"musl"}' ;;
           macos-x86_64)        npm_target='{"os":"darwin","cpu":"x64"}' ;;

--- a/.github/actions/install-wasp-cli-artifact/action.yaml
+++ b/.github/actions/install-wasp-cli-artifact/action.yaml
@@ -25,7 +25,11 @@ runs:
       env:
         TARBALL_PATH: ${{ runner.temp }}/wasp-cli-download/${{ steps.artifact-names.outputs.tarball-name }}
         INSTALL_DIR: ${{ runner.temp }}/wasp-cli-install
-      run: |
+      run:
+        # We do need to install the Wasp CLI and modify the environment
+        # variables, so we need to ignore the error here.
+        # zizmor: ignore[github-env]
+        |
         mkdir -p "$INSTALL_DIR"
         tar -xzf "$TARBALL_PATH" -C "$INSTALL_DIR"
         mv "$INSTALL_DIR/wasp-bin" "$INSTALL_DIR/wasp-cli"

--- a/.github/workflows/automation-algolia-restart-crawler.yaml
+++ b/.github/workflows/automation-algolia-restart-crawler.yaml
@@ -11,6 +11,8 @@ concurrency:
   group: "automation-algolia-restart-crawler"
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   restart-crawler:
     name: Restart Algolia Crawler

--- a/.github/workflows/automation-cache-evict.yaml
+++ b/.github/workflows/automation-cache-evict.yaml
@@ -17,12 +17,17 @@ concurrency:
   group: "automation-cache-evict"
   cancel-in-progress: true
 
+permissions:
+  actions: write
+
 jobs:
   evict-cache:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Evict caches
         shell: bash

--- a/.github/workflows/automation-cache-warm.yaml
+++ b/.github/workflows/automation-cache-warm.yaml
@@ -12,5 +12,12 @@ concurrency:
 
 jobs:
   warm-cache-ci:
+    # We call a top-level workflow here, so it needs many permissions to do its
+    # job. The workflow itself is already checked by zizmor too, so we can
+    # safely ignore this warning here.
+    # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci.yaml
-    secrets: inherit
+    secrets:
+      # (Same comment as above)
+      # zizmor: ignore[secrets-inherit]
+      inherit

--- a/.github/workflows/automation-merge-release-to-main.yaml
+++ b/.github/workflows/automation-merge-release-to-main.yaml
@@ -19,6 +19,10 @@ env:
     > [!IMPORTANT]
     > Choose "Create a merge commit"/"Merge pull request." You must **NOT** "Rebase and merge" or "Squash and merge" this PR, so we avoid conflicts in the future.
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   create-pr:
     name: Create Pull Request

--- a/.github/workflows/automation-pr-label-external.yaml
+++ b/.github/workflows/automation-pr-label-external.yaml
@@ -1,22 +1,27 @@
 name: "Automation - Label external PRs"
 
-############################################################
-# CAUTION: This workflow should not check out the PR code! #
-############################################################
+##########################################@@##################
+# CAUTION: This workflow should never check out the PR code! #
+########################################@@####################
 # The `pull_request_target` event is only intended for simple automations on the
-# PRs themselves (e.g., labeling, commenting). If we checked out the PR code here,
-# we would be running untrusted code and giving it access to our repository
-# secrets, which is a major security risk.
+# PRs themselves (e.g., labeling, commenting). If we checked out the PR code
+# here, we would be running untrusted code and giving it access to our
+# repository secrets, which is a major security risk.
 #
 # More info at:
 # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 
 on:
+  # Safe as long as we don't check out the PR code.
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened
       - reopened
       - ready_for_review
+
+env:
+  LABEL_NAME: "external"
 
 jobs:
   label-external-prs:
@@ -26,14 +31,13 @@ jobs:
     permissions:
       pull-requests: write
 
-    # We check if the PR comes from a different repo than ours:
+    # We only label if the PR comes from a different repo than ours:
     if: github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
       - name: Label external PR
         run: gh pr edit "$PR_NUMBER" --add-label "$LABEL_NAME"
         env:
-          LABEL_NAME: "external"
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/ci-actions-check.yaml
+++ b/.github/workflows/ci-actions-check.yaml
@@ -7,17 +7,15 @@ permissions: {}
 
 jobs:
   zizmor:
-    name: Run zizmor 🌈
+    name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
-      contents: read # Only needed for private repos. Needed to clone the repo.
-      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - name: Run zizmor 🌈
+      - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/workflows/ci-actions-check.yaml
+++ b/.github/workflows/ci-actions-check.yaml
@@ -1,0 +1,23 @@
+name: "Check - Analyze Actions security"
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read # Only needed for private repos. Needed to clone the repo.
+      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/workflows/ci-deploy-test.yaml
+++ b/.github/workflows/ci-deploy-test.yaml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -115,6 +117,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -162,6 +166,9 @@ jobs:
       # starts routing. Poll the deployed URLs so e2e tests start against a
       # live app.
       - name: Wait for deployed app to be reachable
+        env:
+          SERVER_HOSTNAME: ${{ steps.get-hostnames.outputs.server }}
+          CLIENT_HOSTNAME: ${{ steps.get-hostnames.outputs.client }}
         run: |
           function wait_for_url() {
             url="$1"
@@ -176,8 +183,8 @@ jobs:
             echo "Timed out waiting for $url"
             return 1
           }
-          wait_for_url "https://${{ steps.get-hostnames.outputs.server }}"
-          wait_for_url "https://${{ steps.get-hostnames.outputs.client }}"
+          wait_for_url "https://${SERVER_HOSTNAME}"
+          wait_for_url "https://${CLIENT_HOSTNAME}"
 
       - name: Run E2E tests against deployed app
         working-directory: ${{ env.APP_TO_DEPLOY }}

--- a/.github/workflows/ci-examples-test.yaml
+++ b/.github/workflows/ci-examples-test.yaml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v6"
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci-formatting.yaml
+++ b/.github/workflows/ci-formatting.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -34,31 +36,37 @@ jobs:
           git config --global core.eol lf
 
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Parse oromolu version
+        id: parse-ormolu-version
         working-directory: waspc
         run: |
-          echo "ORMOLU_VERSION=$(grep 'ormolu ==' dev-tool.project | sed 's/.*==\s*\([0-9.]*\).*/\1/')" >> $GITHUB_ENV
+          echo "ormolu-version=$(grep 'ormolu ==' dev-tool.project | sed 's/.*==\s*\([0-9.]*\).*/\1/')" >> $GITHUB_OUTPUT
 
       # `run-ormolu` versions > 15 require ormolu version >= 0.7.5.0
       - uses: haskell-actions/run-ormolu@v15
         with:
-          version: ${{ env.ORMOLU_VERSION }}
+          version: ${{ steps.parse-ormolu-version.outputs.ormolu-version }}
 
   cabal-gild:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Parse cabal-gild version
         working-directory: waspc
+        id: parse-cabal-gild-version
         run: |
-          echo "CABAL_GILD_VERSION=$(grep 'cabal-gild ==' dev-tool.project | sed 's/.*==\s*\([0-9.]*\).*/\1/')" >> $GITHUB_ENV
+          echo "cabal-gild-version=$(grep 'cabal-gild ==' dev-tool.project | sed 's/.*==\s*\([0-9.]*\).*/\1/')" >> $GITHUB_OUTPUT
 
       - uses: tfausak/cabal-gild-setup-action@v2
         with:
-          version: ${{ env.CABAL_GILD_VERSION }}
+          version: ${{ steps.parse-cabal-gild-version.outputs.cabal-gild-version }}
 
       - name: Run cabal-gild
         working-directory: waspc

--- a/.github/workflows/ci-libs-test.yaml
+++ b/.github/workflows/ci-libs-test.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: "actions/checkout@v6"
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci-npm-package-build.yaml
+++ b/.github/workflows/ci-npm-package-build.yaml
@@ -26,6 +26,8 @@ jobs:
     name: Make npm packages
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Compute artifact names for download
         uses: ./.github/actions/compute-artifact-names
@@ -39,9 +41,11 @@ jobs:
           pattern: ${{ steps.compute-download-artifact-names.outputs.artifact-name }}
 
       - name: Copy artifacts to input folder
+        env:
+          ARTIFACT_NAME: ${{ steps.compute-download-artifact-names.outputs.artifact-name }}
         run: |
           mkdir -p ./input/
-          cp ./download/${{ steps.compute-download-artifact-names.outputs.artifact-name }}/* ./input/
+          cp ./download/${ARTIFACT_NAME}/* ./input/
 
       - name: Create build metadata file
         env:

--- a/.github/workflows/ci-npm-package-publish.yaml
+++ b/.github/workflows/ci-npm-package-publish.yaml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci-npm-package-test.yaml
+++ b/.github/workflows/ci-npm-package-test.yaml
@@ -35,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         if: matrix.runner.install-deps

--- a/.github/workflows/ci-packages-test.yaml
+++ b/.github/workflows/ci-packages-test.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: "actions/checkout@v6"
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci-starters-test.yaml
+++ b/.github/workflows/ci-starters-test.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: "actions/checkout@v6"
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci-tsspec-test.yaml
+++ b/.github/workflows/ci-tsspec-test.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: "actions/checkout@v6"
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci-waspc-build.yaml
+++ b/.github/workflows/ci-waspc-build.yaml
@@ -112,11 +112,17 @@ jobs:
             static: false # Check the comment above for why we can't statically link on macOS
 
     runs-on: ${{ matrix.env.runner }}
-    container: ${{ matrix.env.container }}
+    container:
+      # Zizmor can't follow the matrix to see which container is used so it
+      # marks everything as unpinned, but they _are_ pinned.
+      # zizmor: ignore[unpinned-images]
+      ${{ matrix.env.container }}
     name: Build Wasp (${{ matrix.env.name }})
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Compute artifact names
         uses: ./.github/actions/compute-artifact-names
@@ -142,10 +148,11 @@ jobs:
         env:
           LC_ALL: C.UTF-8 # In some Docker containers the LOCALE is not UTF-8 by default
           BUILD_STATIC: ${{ matrix.env.static && '1' || '' }}
+          TARBALL_NAME: ${{ steps.compute-artifact-names.outputs.tarball-name }}
         run: |
           ./run build
           mkdir -p artifacts
-          ./tools/make_binary_package.sh "artifacts/${{ steps.compute-artifact-names.outputs.tarball-name }}"
+          ./tools/make_binary_package.sh "artifacts/${TARBALL_NAME}"
 
       - name: Compute data files list
         id: data-files

--- a/.github/workflows/ci-waspc-test.yaml
+++ b/.github/workflows/ci-waspc-test.yaml
@@ -51,11 +51,15 @@ jobs:
             node-version: "24.14.1"
 
     steps:
-      - name: Configure git
-        working-directory: "~"
-        # For waspc parser tests, we need to make sure git doesn't convert line
+      - # For waspc parser tests, we need to make sure git doesn't convert line
         # endings to CRLF during checkout on Windows because that would cause
         # the test cases to fail.
+        name: Configure git
+        working-directory:
+          # This gets flagged by the GitHub Actions linter as an incorrect type,
+          # but it actually works. Don't lose time as I did, wrapping it in
+          # quotes makes it not work.
+          ~
         run: |
           git config --global core.autocrlf input
           git config --global core.eol lf

--- a/.github/workflows/ci-waspc-test.yaml
+++ b/.github/workflows/ci-waspc-test.yaml
@@ -12,6 +12,9 @@ defaults:
     shell: bash
     working-directory: waspc
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test waspc (${{ matrix.os }}, node-${{ matrix.node-version }})
@@ -49,7 +52,7 @@ jobs:
 
     steps:
       - name: Configure git
-        working-directory: ~
+        working-directory: "~"
         # For waspc parser tests, we need to make sure git doesn't convert line
         # endings to CRLF during checkout on Windows because that would cause
         # the test cases to fail.
@@ -58,6 +61,8 @@ jobs:
           git config --global core.eol lf
 
       - uses: "actions/checkout@v6"
+        with:
+          persist-credentials: false
 
       - name: Set up Haskell
         uses: ./.github/actions/setup-haskell

--- a/.github/workflows/ci-waspc-test.yaml
+++ b/.github/workflows/ci-waspc-test.yaml
@@ -56,9 +56,10 @@ jobs:
         # the test cases to fail.
         name: Configure git
         working-directory:
-          # This gets flagged by the GitHub Actions linter as an incorrect type,
-          # but it actually works. Don't lose time as I did, wrapping it in
-          # quotes makes it not work.
+          # This gets flagged by the GitHub Actions language server as an
+          # incorrect type, but it actually works. Wrapping it in quotes makes
+          # the language server happy but changes the interpretation on the
+          # runner, and breaks the workflow. So don't do it.
           ~
         run: |
           git config --global core.autocrlf input

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,3 +96,7 @@ jobs:
   waspc-test: # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci-waspc-test.yaml
     secrets: inherit # zizmor: ignore[secrets-inherit]
+
+  actions-check: # zizmor: ignore[excessive-permissions]
+    uses: ./.github/workflows/ci-actions-check.yaml
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
 
   workflow_call:
     inputs:
-      &inputs # This is a YAML "anchor", lets us reuse this same block below
       override-npm-package-version:
         description: >
           If set, overrides the version of npm packages to publish.
@@ -20,67 +19,80 @@ on:
         type: string
 
   workflow_dispatch:
-    inputs: *inputs # This is a YAML "alias", reuses the block defined above
+    inputs:
+      override-npm-package-version:
+        description: >
+          If set, overrides the version of npm packages to publish.
+          Useful for publishing an RC version.
+          Leading 'v' will be stripped if present.
+        required: false
+        type: string
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# This is a kind of meta-workflow that calls other workflows. It is used to
+# orchestrate the CI process. We ignore the zizmor warnings since this workflow
+# will call other workflows that each have their own permissions and secrets
+# defined, so we don't want to define them here. Each workflow is also checked
+# by zizmor separately, so it is moderately safe to ignore the warnings here.
+
 jobs:
-  deploy-test:
+  deploy-test: # zizmor: ignore[excessive-permissions]
     needs: waspc-build
     uses: ./.github/workflows/ci-deploy-test.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  examples-test:
+  examples-test: # zizmor: ignore[excessive-permissions]
     needs: waspc-build
     uses: ./.github/workflows/ci-examples-test.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  formatting:
+  formatting: # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci-formatting.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  starters-test:
+  starters-test: # zizmor: ignore[excessive-permissions]
     needs: waspc-build
     uses: ./.github/workflows/ci-starters-test.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  tsspec-test:
+  tsspec-test: # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci-tsspec-test.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  libs-test:
+  libs-test: # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci-libs-test.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  packages-test:
+  packages-test: # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci-packages-test.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  waspc-build:
+  waspc-build: # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci-waspc-build.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  npm-package-build:
+  npm-package-build: # zizmor: ignore[excessive-permissions]
     needs: waspc-build
     uses: ./.github/workflows/ci-npm-package-build.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     with:
       build-outputs-json: ${{ toJson(needs.waspc-build.outputs) }}
       override-npm-package-version: ${{ inputs.override-npm-package-version }}
 
-  npm-package-publish:
+  npm-package-publish: # zizmor: ignore[excessive-permissions]
     needs: npm-package-build
     uses: ./.github/workflows/ci-npm-package-publish.yaml
 
-  npm-package-test:
+  npm-package-test: # zizmor: ignore[excessive-permissions]
     needs: [npm-package-publish, waspc-build]
     uses: ./.github/workflows/ci-npm-package-test.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     with:
       data-files-list: ${{ needs.waspc-build.outputs.data_files_list }}
 
-  waspc-test:
+  waspc-test: # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci-waspc-test.yaml
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/release-create.yaml
+++ b/.github/workflows/release-create.yaml
@@ -11,8 +11,15 @@ concurrency:
 
 jobs:
   ci:
+    # We call a top-level workflow here, so it needs many permissions to do its
+    # job. The workflow itself is already checked by zizmor too, so we can
+    # safely ignore this warning here.
+    # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci.yaml
-    secrets: inherit
+    secrets:
+      # (Same comment as above)
+      # zizmor: ignore[secrets-inherit]
+      inherit
     with:
       override-npm-package-version: ${{ github.ref_name }}
 
@@ -34,13 +41,11 @@ jobs:
       # folders, not the folders themselves.
 
       - name: Create Github release
-        uses: ncipollo/release-action@v1
-        with:
-          draft: true
-          allowUpdates: true
-          artifacts: "./wasp-cli-*/*"
-          artifactErrorsFailBuild: true
-          replacesArtifacts: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create --draft --verify-tag ${REF_NAME} "./wasp-cli-*/*"
 
   publish-npm:
     needs: ci
@@ -52,10 +57,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          # Disable caching to avoid a potentially poisoned cache introducing a
+          # vulnerability not present in the stored artifacts.
+          # https://docs.zizmor.sh/audits/#cache-poisoning
+          cache: false
+          package-manager-cache: false
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release-create.yaml
+++ b/.github/workflows/release-create.yaml
@@ -42,8 +42,10 @@ jobs:
 
       - name: Create Github release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
+          # Env for the `gh` CLI tool
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release create --draft --verify-tag ${REF_NAME} "./wasp-cli-*/*"
 

--- a/.github/workflows/release-examples-deploy.yaml
+++ b/.github/workflows/release-examples-deploy.yaml
@@ -29,6 +29,9 @@ concurrency:
 env:
   WASP_TELEMETRY_DISABLE: 1
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     strategy:
@@ -51,6 +54,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -58,7 +63,9 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install Wasp
-        run: npm i -g @wasp.sh/wasp-cli@"${{  inputs.version }}"
+        run: npm i -g "@wasp.sh/wasp-cli@${WASP_VERSION}"
+        env:
+          WASP_VERSION: ${{ inputs.version }}
 
       - name: Install Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@v1

--- a/.github/workflows/release-examples-deploy.yaml
+++ b/.github/workflows/release-examples-deploy.yaml
@@ -63,9 +63,9 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install Wasp
-        run: npm i -g "@wasp.sh/wasp-cli@${WASP_VERSION}"
         env:
           WASP_VERSION: ${{ inputs.version }}
+        run: npm i -g "@wasp.sh/wasp-cli@${WASP_VERSION}"
 
       - name: Install Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@v1

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,8 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # While we don't have an autoupdater, we don't want to pin dependencies
+        # to a specific version, or we'd miss out on security updates. This rule
+        # will only enforce pinning to major versions.
+        "*": ref-pin

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -5,4 +5,5 @@ rules:
         # While we don't have an autoupdater, we don't want to pin dependencies
         # to a specific version, or we'd miss out on security updates. This rule
         # will only enforce pinning to major versions.
+        # https://github.com/wasp-lang/wasp/issues/4344
         "*": ref-pin


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Found [zizmor](https://zizmor.sh/) while contributing to mise. It statically analyzes GitHub Actions / Workflows and brings up potential security issues. It's a nice extra check for our repo.

### Changes

- Fix security warnings
  - Autofixed
    - Adds `persist-credentials: false` to every `actions/checkout` [(rule)](https://docs.zizmor.sh/audits/#artipacked)
    - Changes every interpolation of workflow variables into scripts, to passing environment variables [(rule)](https://docs.zizmor.sh/audits/#template-injection) -- we already used this pattern in new code, but this automatically fixed it in old places too
  - Manual
    - Added narrower permissions where possible
  - Ignored
    - Many warnings around calling other workflows, since we do that extensively, and the called workflows are checked by zizmor too.
    - Pinning action version numbers, since we don't have an autoupdater to later keep them updated for us
    - Some specific lines, will flag them as comments
- Add zizmor as a CI step

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
