### PR TITLE
Add GitHub Action to close stale PRs

### DIFF
--- a/.github/workflows/automation-pr-close-stale.yaml
+++ b/.github/workflows/automation-pr-close-stale.yaml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   actions: write
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
 

--- a/.github/workflows/automation-pr-close-stale.yaml
+++ b/.github/workflows/automation-pr-close-stale.yaml
@@ -1,0 +1,70 @@
+name: "Automation - Close stale PRs"
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  close-stale-prs:
+    name: Close stale PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # First we mark a PR or issue as "Stale".
+          # PRs get it automatically after 7 days of inactivity, while issues
+          # are never marked as stale automatically (we can do it manually if we
+          # want to).
+
+          days-before-issue-stale: -1 # Don't mark issues as stale automatically.
+          days-before-pr-stale: 7
+
+          stale-pr-message: |
+            This pull request is now **stale**.
+            That means that it hasn't seen any activity for a while, and needs to be updated or addressed before it can be merged.
+
+            **Next steps** if the PR is still relevant, and you are able to devote time to it:
+            - If you received any questions or feedback, please address them.
+            - Merge the latest `main` into your branch to ensure that you are up to date.
+            - If you are still working on the changes, please leave a comment telling us so.
+            - Otherwise, just leave a comment explaining why the PR is still relevant.
+
+            If no action is taken, this PR will be automatically closed in 7 days.
+
+          stale-issue-message: |
+            This issue is now **stale**.
+            That means that it might not be relevant anymore, or is outdated enough that it might no longer be applicable.
+
+            **Next steps** if the issue is still relevant:
+            - If you received any questions or feedback, please address them.
+            - Test your bug or feature request with the latest version of Wasp and leave a comment if it is still present.
+            - Otherwise, just leave a comment explaining why the issue is still relevant.
+
+            If no action is taken, this issue will be automatically closed in 7 days.
+
+          # After a PR or issue has been marked as stale for 7 days, we close it.
+
+          days-before-close: 7
+
+          close-pr-message: |
+            This pull request is now **closed**.
+            This doesn't mean that we don't care about it anymore, but rather that it has been inactive for a while and needs some attention to keep it relevant.
+
+            **Next steps** if the PR is still relevant:
+            - Follow the **next steps** in the message above.
+            - Create a new PR, linking to this one.
+
+          close-issue-message: |
+            This issue is now **closed**.
+            This doesn't mean that we don't care about it anymore, but rather that it has been inactive for a while and needs some attention to keep it relevant.
+
+            **Next steps** if the issue is still relevant:
+            - Follow the **next steps** in the message above.
+            - Create a new issue, linking to this one.


### PR DESCRIPTION
## Description

Adds a daily GitHub Action that marks PRs stale after 7 days of inactivity and closes them 7 days later, posting helpful next-step messages at each stage. Issues are not marked stale automatically.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
