### PR TITLE
Update release docs with Algolia crawler check

### DIFF
--- a/waspc/README.md
+++ b/waspc/README.md
@@ -457,7 +457,7 @@ Do the non-bold steps when necessary (decide for each step depending on the chan
 - 👉 Push your local `release` branch to remote.
 - 👉 You will have been tagged in an automated PR to merge `release` back to `main` (you can also find it [here](https://github.com/wasp-lang/wasp/pulls?q=is%3Apr+head%3Arelease+base%3Amain+is%3Aopen)). Make sure to merge that PR (create a merge commit, **don't squash or rebase**). This ensures that `main` is ahead of `release` and we won't have merge conflicts in future releases.
 - Deploy the example apps to Fly.io by running the [release-examples-deploy workflow](https://github.com/wasp-lang/wasp/actions/workflows/release-examples-deploy.yaml) (see "Deployment / CI" section for more details).
-- If there are changes to the docs, [publish the new version](/web#deployment) from the `release` branch.
+- If there are changes to the docs, [publish the new version](../web/README.md#deployment) from the `release` branch.
 - If there are changes to Mage, [publish the new version](/mage#deployment) from the `release` branch.
 - If there are changes to the [Wasp VSCode extension](https://github.com/wasp-lang/vscode-wasp), publish the new version.
 - Announce the new release in Discord.

--- a/web/README.md
+++ b/web/README.md
@@ -59,7 +59,8 @@ git merge release
 git push
 ```
 5. Cloudflare Pages will automatically pick up the changes and deploy them.
-6. Go back to the `release` branch so you don't accidentally commit to `deploy-web`:
+6. Check that the [Algolia docs search crawler restart](https://github.com/wasp-lang/wasp/actions/workflows/automation-algolia-restart-crawler.yaml) succeeded.
+7. Go back to the `release` branch so you don't accidentally commit to `deploy-web`:
 ```
 git checkout release
 ```


### PR DESCRIPTION
## Description

Updates release instructions to make the docs deployment link easier to navigate from `waspc/README.md`, and adds a docs deployment step to check that the Algolia docs search crawler restart workflow succeeded.

Context: #4311.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. --> Docs-only release instruction update.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
