### PR TITLE
Print wasp version on stdout, rest of message on stderr

### DIFF
--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -10,7 +10,7 @@ import Main.Utf8 (withUtf8)
 import System.Environment (getArgs)
 import qualified System.Environment as Env
 import System.Exit (exitFailure)
-import System.IO (hPutStrLn, stderr)
+import System.IO (hPutStrLn, stderr, stdout)
 import Wasp.Cli.Command (runCommand)
 import Wasp.Cli.Command.BashCompletion (bashCompletion, printBashCompletionInstruction)
 import Wasp.Cli.Command.Build (build)
@@ -198,7 +198,7 @@ printUsage =
 
 printVersion :: IO ()
 printVersion = do
-  putStrLn $ show waspVersion
+  hPutStrLn stdout $ show waspVersion
   hPutStrLn stderr $
     unlines
       [ "",

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -10,6 +10,7 @@ import Main.Utf8 (withUtf8)
 import System.Environment (getArgs)
 import qualified System.Environment as Env
 import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
 import Wasp.Cli.Command (runCommand)
 import Wasp.Cli.Command.BashCompletion (bashCompletion, printBashCompletionInstruction)
 import Wasp.Cli.Command.Build (build)
@@ -196,11 +197,11 @@ printUsage =
 {- ORMOLU_ENABLE -}
 
 printVersion :: IO ()
-printVersion =
-  putStrLn $
+printVersion = do
+  putStrLn $ show waspVersion
+  hPutStrLn stderr $
     unlines
-      [ show waspVersion,
-        "",
+      [ "",
         "If you wish to install/switch to the latest version of Wasp, do:",
         indent 2 $ getInstallationCommand Nothing,
         "",

--- a/waspc/e2e-tests/Tests/WaspVersionTest.hs
+++ b/waspc/e2e-tests/Tests/WaspVersionTest.hs
@@ -10,7 +10,7 @@ waspVersionTest =
     "wasp-version"
     [ TestCase
         "match-waspc-version"
-        (return . (: []) $ (~| ("{ read ver; [ \"$ver\" = '" ++ show waspVersion ++ "' ]; }")) . (~| "head -n1") $ waspCliVersion)
+        (return . (: []) $ (~| ("{ read ver; [ \"$ver\" = '" ++ show waspVersion ++ "' ]; }")) $ waspCliVersion)
     ]
 
 waspCliVersion :: ShellCommand


### PR DESCRIPTION
## Description

`wasp version` now prints just the version number to stdout, while the installation instructions go to stderr. This is the convention where the output of the tool (that might be acted on programmatically) should be stdout and information for the user that is just prose goes to stderr.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
