### PR TITLE
Move CI package installation into mise bootstrap

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -15,47 +15,11 @@ runs:
   using: composite
 
   steps:
-    - name: Install system dependencies
-      if: runner.os == 'Linux'
-      shell: sh
-      run: |
-        # Detect Alpine via /etc/alpine-release. We can't rely on `uname`
-        # because inside a container it reports the host kernel, not the
-        # container's distro.
-        # We can fold this step into Mise when apk packages are supported
-        # (https://github.com/jdx/mise/discussions/10449) and curl is no longer
-        # needed to use the Mise action
-        # (https://github.com/jdx/mise/discussions/10488).
-
-        if [ -f /etc/alpine-release ]; then
-          # GHCup dependencies (https://www.haskell.org/ghcup/install/reqs/#linux-alpine)
-          apk add binutils-gold curl gcc g++ gmp-dev gmp-static libc-dev libffi-dev make musl-dev ncurses-dev perl pkgconfig tar xz
-          # `./run` script dependencies
-          apk add bash
-          # Cabal dependencies
-          apk add zlib-dev zlib-static
-          # Prisma dependencies
-          apk add openssl
-        else
-          # If we have sudo, we need to use it to install dependencies. If we
-          # don't have sudo, we assume we're running as root and can just use
-          # apt-get directly.
-          if command -v sudo >/dev/null 2>&1; then
-            APT_GET="sudo apt-get"
-          else
-            APT_GET="apt-get"
-          fi
-
-          export DEBIAN_FRONTEND=noninteractive
-          $APT_GET update -y
-          # GHCup dependencies (https://www.haskell.org/ghcup/install/reqs/#linux-ubuntu)
-          $APT_GET install -y build-essential curl libffi-dev libgmp-dev libncurses-dev
-          # Cabal dependencies
-          $APT_GET install -y zlib1g-dev
-        fi
-
     - name: Install Mise
       uses: jdx/mise-action@v4
+      with:
+        bootstrap: true
+        bootstrap_args: --update --yes
 
     - # `cabal.project` sets `with-compiler: x.y.z`, so Cabal resolves the bare
       # program name `ghc-x.y.z` on PATH. On Windows, that hits Mise's shim,

--- a/.github/workflows/ci-waspc-build.yaml
+++ b/.github/workflows/ci-waspc-build.yaml
@@ -61,6 +61,12 @@ jobs:
             # glibc than what it was built with (e.g. an older Ubuntu version).
             container: ubuntu:20.04
             static: false
+            install-deps: |
+              # We need either `curl` or `wget` to install Mise, which then
+              # installs everything else.
+              export DEBIAN_FRONTEND=noninteractive
+              apt get update -y
+              apt-get install -y curl
 
           - name: linux-x86_64-static
             runner: ubuntu-latest
@@ -90,6 +96,10 @@ jobs:
     name: Build Wasp (${{ matrix.env.name }})
 
     steps:
+      - name: Install dependencies
+        if: ${{ matrix.env.install-deps }}
+        run: ${{ matrix.env.install-deps }}
+
       - uses: actions/checkout@v6
         with:
           persist-credentials: false

--- a/.github/workflows/ci-waspc-build.yaml
+++ b/.github/workflows/ci-waspc-build.yaml
@@ -65,7 +65,7 @@ jobs:
               # We need either `curl` or `wget` to install Mise, which then
               # installs everything else.
               export DEBIAN_FRONTEND=noninteractive
-              apt get update -y
+              apt-get update -y
               apt-get install -y curl
 
           - name: linux-x86_64-static

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
-min_version = "2026.6.10"
+min_version = "2026.6.11"
 
 [tools]
 "aqua:ghcup" = "0.2.6.1"
@@ -25,6 +25,42 @@ min_version = "2026.6.10"
 
 [plugins]
 "vfox:mise-ghcup" = "https://github.com/cprecioso/mise-ghcup.git"
+
+[bootstrap.packages]
+# Dependencies for Ubuntu / Debian
+# GHCup dependencies (https://www.haskell.org/ghcup/install/reqs/#linux-ubuntu)
+"apt:build-essential" = "latest"
+"apt:curl" = "latest"
+"apt:libffi-dev" = "latest"
+"apt:libgmp-dev" = "latest"
+"apt:libncurses-dev" = "latest"
+# Cabal dependencies
+"apt:zlib1g-dev" = "latest"
+
+# Dependencies for Alpine
+# GHCup dependencies (https://www.haskell.org/ghcup/install/reqs/#linux-alpine)
+"apk:binutils-gold" = "latest"
+"apk:curl" = "latest"
+"apk:gcc" = "latest"
+"apk:g++" = "latest"
+"apk:gmp-dev" = "latest"
+"apk:gmp-static" = "latest"
+"apk:libc-dev" = "latest"
+"apk:libffi-dev" = "latest"
+"apk:make" = "latest"
+"apk:musl-dev" = "latest"
+"apk:ncurses-dev" = "latest"
+"apk:perl" = "latest"
+"apk:pkgconfig" = "latest"
+"apk:tar" = "latest"
+"apk:xz" = "latest"
+# `./run` script dependencies
+"apk:bash" = "latest"
+# Cabal dependencies
+"apk:zlib-dev" = "latest"
+"apk:zlib-static" = "latest"
+# Prisma dependencies
+"apk:openssl" = "latest"
 
 [settings]
 lockfile = true


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Moves the CI system-dependency installation out of the hand-rolled `apt-get`/`apk` shell step in `setup-env` and into a `[bootstrap.packages]` table in `mise.toml`, run via the mise-action `bootstrap`. mise installs only the package manager available on each runner, so apt is used on Ubuntu, apk on Alpine, and macOS/Windows are no-ops, removing the need for the manual OS detection. `min_version` is pinned to `2026.6.11`, the release that added apk support to `[bootstrap.packages]`. CI-only change with no effect on the framework.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
