### PR TITLE
Run `wasp test client` for example apps in CI

### DIFF
--- a/.github/workflows/ci-examples-test.yaml
+++ b/.github/workflows/ci-examples-test.yaml
@@ -42,6 +42,10 @@ jobs:
         working-directory: examples/${{ matrix.example }}
         run: wasp-cli compile
 
+      - name: Run client tests for ${{ matrix.example }}
+        working-directory: examples/${{ matrix.example }}
+        run: wasp-cli test client run --passWithNoTests
+
       - name: Setup project environment for ${{ matrix.example }}
         working-directory: examples/${{ matrix.example }}
         run: |

--- a/examples/ask-the-documents/vite.config.ts
+++ b/examples/ask-the-documents/vite.config.ts
@@ -1,5 +1,5 @@
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import { wasp } from "wasp/client/vite";
 
 export default defineConfig({
@@ -7,4 +7,7 @@ export default defineConfig({
     open: false,
   },
   plugins: [wasp(), tailwindcss()],
+  test: {
+    exclude: ["./e2e-tests/**"],
+  },
 });

--- a/examples/tutorials/TodoApp/vite.config.ts
+++ b/examples/tutorials/TodoApp/vite.config.ts
@@ -1,9 +1,12 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import { wasp } from "wasp/client/vite";
 
 export default defineConfig({
   plugins: [wasp()],
   server: {
     open: true,
+  },
+  test: {
+    exclude: ["./e2e-tests/**"],
   },
 });

--- a/examples/tutorials/TodoAppTs/vite.config.ts
+++ b/examples/tutorials/TodoAppTs/vite.config.ts
@@ -1,9 +1,12 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import { wasp } from "wasp/client/vite";
 
 export default defineConfig({
   plugins: [wasp()],
   server: {
     open: true,
+  },
+  test: {
+    exclude: ["./e2e-tests/**"],
   },
 });

--- a/examples/waspello/vite.config.ts
+++ b/examples/waspello/vite.config.ts
@@ -1,5 +1,5 @@
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import { wasp } from "wasp/client/vite";
 
 export default defineConfig({
@@ -7,4 +7,7 @@ export default defineConfig({
     open: false,
   },
   plugins: [wasp(), tailwindcss()],
+  test: {
+    exclude: ["./e2e-tests/**"],
+  },
 });

--- a/examples/waspleau/vite.config.ts
+++ b/examples/waspleau/vite.config.ts
@@ -1,9 +1,12 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import { wasp } from "wasp/client/vite";
 
 export default defineConfig({
   plugins: [wasp()],
   server: {
     open: true,
+  },
+  test: {
+    exclude: ["./e2e-tests/**"],
   },
 });

--- a/examples/websockets-realtime-voting/vite.config.ts
+++ b/examples/websockets-realtime-voting/vite.config.ts
@@ -1,6 +1,6 @@
 import tailwindcss from "@tailwindcss/vite";
 import flowbiteReact from "flowbite-react/plugin/vite";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import { wasp } from "wasp/client/vite";
 
 export default defineConfig({
@@ -8,4 +8,7 @@ export default defineConfig({
     open: true,
   },
   plugins: [wasp(), tailwindcss(), flowbiteReact()],
+  test: {
+    exclude: ["./e2e-tests/**"],
+  },
 });


### PR DESCRIPTION
## Description

Adds a step to the example apps CI workflow (`ci-examples-test.yaml`) that runs `wasp test client run` for every example app in the matrix. It uses `--passWithNoTests` so apps without client tests don't fail the job, which means kitchen-sink's client tests now run in CI while other apps simply pass.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
