### PR TITLE
test: tighten #3009 cache-invalidation regression test

### DIFF
--- a/examples/kitchen-sink/src/features/operations/cacheInvalidation.test.ts
+++ b/examples/kitchen-sink/src/features/operations/cacheInvalidation.test.ts
@@ -1,6 +1,6 @@
 import { QueryObserver } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "wasp/client";
 import {
   createTask,
@@ -14,21 +14,17 @@ import { serialize } from "wasp/core/serialization";
 // Regression test for https://github.com/wasp-lang/wasp/issues/3009
 //
 // When an action declares `entities: [X]` and a query also depends on `X`, the
-// query is supposed to be up to date by the time the action's promise resolves.
-// `useAuth()` is just a special case of this: its `auth/me` query depends on the
-// `User` entity, so an action that updates `User` (e.g. "complete profile")
-// should leave the cached auth user fresh once it resolves.
+// query must be up to date by the time the action's promise resolves.
 //
-// The bug: `registerActionDone` fires `queryClient.invalidateQueries(...)` for
-// the affected queries but does NOT await the triggered refetches
-// (see client/operations/internal/resources.js, `invalidateQueriesUsing`). So
-// `await someAction()` returns while the refetch is still in flight, and code
-// that runs right after (a redirect, a `user.x` check) sees stale data.
+// This guards the fix in client/operations/internal/resources.js: if
+// `invalidateQueriesUsing` stopped awaiting the refetches it triggers,
+// `await someAction()` would resolve while the refetch was still in flight, and
+// code running right after (a redirect, a `user.x` check) would see stale data.
 //
 // We assert SYNCHRONOUSLY right after `await createTask(...)` that the
 // `getTasks` cache already reflects the update. A `waitFor(...)` would pass even
-// with the bug, because the refetch does eventually land. The whole point of the
-// bug is the timing, so the assertion must not wait.
+// with the bug, because the refetch does eventually land. The point is the
+// timing, so the assertion must not wait.
 
 const { server } = mockServer();
 
@@ -38,17 +34,23 @@ type FakeTask = { id: number; description: string; isDone: boolean };
 
 let tasksOnServer: FakeTask[] = [];
 
+const apiUrlPattern = new RegExp(
+  "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+);
+
 beforeAll(async () => {
   // `mockServer()` (called above) already wires up server.listen/resetHandlers/
-  // close via beforeAll/afterEach/afterAll, so we only need to add our handler.
+  // close via beforeAll/afterEach/afterAll.
   initializeQueryClient();
   await queryClientInitialized;
+});
 
+beforeEach(() => {
+  // `mockServer()`'s afterEach calls `server.resetHandlers()`, so the handler
+  // has to be (re)registered before each test rather than once in `beforeAll`.
+  //
   // One handler for every operation POST. `getTasks` returns the current server
   // state; any other operation (i.e. `createTask`) just acknowledges.
-  const apiUrlPattern = new RegExp(
-    "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-  );
   server.use(
     http.post(apiUrlPattern, ({ request }) => {
       const { pathname } = new URL(request.url);

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1621,7 +1621,7 @@
             "file",
             "sdk/wasp/src/features/operations/cacheInvalidation.test.ts"
         ],
-        "ded2b0b5e027e412384d980aaa416dae0eca051db46dde26822789cffab6b4e4"
+        "0bf9d9216c118effd6d7fc23ac35df2c6b90cc7c68c536562dc73a4668251bde"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/src/features/operations/cacheInvalidation.test.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/src/features/operations/cacheInvalidation.test.ts
@@ -1,6 +1,6 @@
 import { QueryObserver } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "wasp/client";
 import {
   createTask,
@@ -14,21 +14,17 @@ import { serialize } from "wasp/core/serialization";
 // Regression test for https://github.com/wasp-lang/wasp/issues/3009
 //
 // When an action declares `entities: [X]` and a query also depends on `X`, the
-// query is supposed to be up to date by the time the action's promise resolves.
-// `useAuth()` is just a special case of this: its `auth/me` query depends on the
-// `User` entity, so an action that updates `User` (e.g. "complete profile")
-// should leave the cached auth user fresh once it resolves.
+// query must be up to date by the time the action's promise resolves.
 //
-// The bug: `registerActionDone` fires `queryClient.invalidateQueries(...)` for
-// the affected queries but does NOT await the triggered refetches
-// (see client/operations/internal/resources.js, `invalidateQueriesUsing`). So
-// `await someAction()` returns while the refetch is still in flight, and code
-// that runs right after (a redirect, a `user.x` check) sees stale data.
+// This guards the fix in client/operations/internal/resources.js: if
+// `invalidateQueriesUsing` stopped awaiting the refetches it triggers,
+// `await someAction()` would resolve while the refetch was still in flight, and
+// code running right after (a redirect, a `user.x` check) would see stale data.
 //
 // We assert SYNCHRONOUSLY right after `await createTask(...)` that the
 // `getTasks` cache already reflects the update. A `waitFor(...)` would pass even
-// with the bug, because the refetch does eventually land. The whole point of the
-// bug is the timing, so the assertion must not wait.
+// with the bug, because the refetch does eventually land. The point is the
+// timing, so the assertion must not wait.
 
 const { server } = mockServer();
 
@@ -38,17 +34,23 @@ type FakeTask = { id: number; description: string; isDone: boolean };
 
 let tasksOnServer: FakeTask[] = [];
 
+const apiUrlPattern = new RegExp(
+  "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+);
+
 beforeAll(async () => {
   // `mockServer()` (called above) already wires up server.listen/resetHandlers/
-  // close via beforeAll/afterEach/afterAll, so we only need to add our handler.
+  // close via beforeAll/afterEach/afterAll.
   initializeQueryClient();
   await queryClientInitialized;
+});
 
+beforeEach(() => {
+  // `mockServer()`'s afterEach calls `server.resetHandlers()`, so the handler
+  // has to be (re)registered before each test rather than once in `beforeAll`.
+  //
   // One handler for every operation POST. `getTasks` returns the current server
   // state; any other operation (i.e. `createTask`) just acknowledges.
-  const apiUrlPattern = new RegExp(
-    "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-  );
   server.use(
     http.post(apiUrlPattern, ({ request }) => {
       const { pathname } = new URL(request.url);

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/features/operations/cacheInvalidation.test.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/features/operations/cacheInvalidation.test.ts
@@ -1,6 +1,6 @@
 import { QueryObserver } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "wasp/client";
 import {
   createTask,
@@ -14,21 +14,17 @@ import { serialize } from "wasp/core/serialization";
 // Regression test for https://github.com/wasp-lang/wasp/issues/3009
 //
 // When an action declares `entities: [X]` and a query also depends on `X`, the
-// query is supposed to be up to date by the time the action's promise resolves.
-// `useAuth()` is just a special case of this: its `auth/me` query depends on the
-// `User` entity, so an action that updates `User` (e.g. "complete profile")
-// should leave the cached auth user fresh once it resolves.
+// query must be up to date by the time the action's promise resolves.
 //
-// The bug: `registerActionDone` fires `queryClient.invalidateQueries(...)` for
-// the affected queries but does NOT await the triggered refetches
-// (see client/operations/internal/resources.js, `invalidateQueriesUsing`). So
-// `await someAction()` returns while the refetch is still in flight, and code
-// that runs right after (a redirect, a `user.x` check) sees stale data.
+// This guards the fix in client/operations/internal/resources.js: if
+// `invalidateQueriesUsing` stopped awaiting the refetches it triggers,
+// `await someAction()` would resolve while the refetch was still in flight, and
+// code running right after (a redirect, a `user.x` check) would see stale data.
 //
 // We assert SYNCHRONOUSLY right after `await createTask(...)` that the
 // `getTasks` cache already reflects the update. A `waitFor(...)` would pass even
-// with the bug, because the refetch does eventually land. The whole point of the
-// bug is the timing, so the assertion must not wait.
+// with the bug, because the refetch does eventually land. The point is the
+// timing, so the assertion must not wait.
 
 const { server } = mockServer();
 
@@ -38,17 +34,23 @@ type FakeTask = { id: number; description: string; isDone: boolean };
 
 let tasksOnServer: FakeTask[] = [];
 
+const apiUrlPattern = new RegExp(
+  "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+);
+
 beforeAll(async () => {
   // `mockServer()` (called above) already wires up server.listen/resetHandlers/
-  // close via beforeAll/afterEach/afterAll, so we only need to add our handler.
+  // close via beforeAll/afterEach/afterAll.
   initializeQueryClient();
   await queryClientInitialized;
+});
 
+beforeEach(() => {
+  // `mockServer()`'s afterEach calls `server.resetHandlers()`, so the handler
+  // has to be (re)registered before each test rather than once in `beforeAll`.
+  //
   // One handler for every operation POST. `getTasks` returns the current server
   // state; any other operation (i.e. `createTask`) just acknowledges.
-  const apiUrlPattern = new RegExp(
-    "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-  );
   server.use(
     http.post(apiUrlPattern, ({ request }) => {
       const { pathname } = new URL(request.url);


### PR DESCRIPTION
## Description

This refines the existing #3009 action cache-invalidation regression test in `examples/kitchen-sink`. The header comment now describes the regression it guards against (the `await` in `invalidateQueriesUsing` was already added by the #3009 fix) instead of claiming the current code fails to await, and the msw handler moves from `beforeAll` to `beforeEach` so it survives `mockServer`'s `afterEach` `resetHandlers()` if a second test is ever added to the block. The kitchen-sink golden snapshots are regenerated to match. There is no functional/framework change.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
