### PR TITLE
Add AI policy to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,3 +53,34 @@ Please make sure to **base your feature branches and PRs on the `release` branch
 If you'd like to write a blog post about Wasp, please contact us via [Discord](https://discord.gg/zKFDFrsHa9) to discuss the topic and the details.
 
 Happy hacking!
+
+# Policies
+
+These are some general policies that we follow when it comes to contributions. They are not meant to be strict or exhaustive, but rather to give you a sense of what we value and expect. If you are linked here from a PR, it means that we think your contribution could be improved in some way, and following these guidelines is the best way to do it.
+
+## AIs and LLMs
+
+**You are free to use AI/LLM tools and agents, but every contribution must come from a human. The human must have read it, run it, understand it, and they must stand behind the contribution.** AIs can generate code faster that we can review it, and they're not always right. Everything that lands in Wasp becomes ours to maintain, so we hold a high bar for what makes it in.
+
+We also have agents; and because we work on Wasp every day, we can generally prompt them faster and better than an outside contributor can, and review them more easily. Therefore, just asking your agent for code and then sending it to us without review is not a good use of our time, nor your tokens.
+
+By just seeing a PR, we can't definitively know whether a human has supervised it. So **your job is to convince us that your contribution is worth it, by communicating clearly and demonstrating understanding and care**. This might not necessarily be about the immediate measurable qualities of the work; but about trust that it is going to save us time also in the long run. Tell-tale signs of an automatically generated PR will make it hard for us to trust it, and will likely lead to it being closed.
+
+> [!NOTE]
+> We will close PRs that we think don't clear these bars, simply to protect our time. If you think we misjudged yours, tell us and we'll gladly take another look. We're all human in the end, even if AI-assisted.
+
+We're genuinely happy to mentor newcomers and help them improve. But we're not happy to see drive-by PRs that the author can't explain or won't follow up on. If you open one, be ready to respond to review, answer questions, and address feedback.
+
+Before you open a PR, make sure you (the human) do these:
+
+- **Understand both the code change and its motivation.** You should be able to explain what it does and why.
+- **Test it locally in a real context.** Depending on the type of change, that might mean compiling Haskell code, creating real-looking tests, and/or running it in an actual Wasp app and manually clicking buttons.
+- **Review it thoroughly, and make changes as needed.** The code might be correct, but is it clear? Does it use tools or abstraction that we already have in the code?
+- **Communicate clearly that you've done the above, and what you found.** Fill out the [pull request template](./.github/pull_request_template.md), do not remove it, and represent your changes and process honestly.
+
+Please don't do the following:
+
+- **Don't set autonomous tools to do work on the Wasp repo without oversight.** A bunch of slop PRs might get your account blocked and/or reported to GitHub.
+- **Don't send LLM output that you haven't reviewed and understood.** Especially, don't just copy-paste messages back and forth between an LLM and a PR. Understand what is being said or asked.
+- **Don't send code you haven't run locally, in a relevant context.** Don't have your AI hand-craft files that just make it look right.
+- **Don't hand-edit generated files, such as E2E snapshots.** This rule is already explained in our [CLAUDE.md](./CLAUDE.md), but lots of slop PRs do not seem to have read it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,27 +60,6 @@ These are some general policies that we follow when it comes to contributions. T
 
 ## AIs and LLMs
 
-**You are free to use AI/LLM tools and agents, but every contribution must come from a human. The human must have read it, run it, understand it, and they must stand behind the contribution.** AIs can generate code faster that we can review it, and they're not always right. Everything that lands in Wasp becomes ours to maintain, so we hold a high bar for what makes it in.
+**You are free to use AI/LLM tools and agents. But the standard remains the same: you must own and stand behind every line of code and every decision in your PR, exactly as if no AI was involved.** That means you've read it, run it, understood it, and you can explain and defend it under review.
 
-We also have agents; and because we work on Wasp every day, we can generally prompt them faster and better than an outside contributor can, and review them more easily. Therefore, just asking your agent for code and then sending it to us without review is not a good use of our time, nor your tokens.
-
-By just seeing a PR, we can't definitively know whether a human has supervised it. So **your job is to convince us that your contribution is worth it, by communicating clearly and demonstrating understanding and care**. This might not necessarily be about the immediate measurable qualities of the work; but about trust that it is going to save us time also in the long run. Tell-tale signs of an automatically generated PR will make it hard for us to trust it, and will likely lead to it being closed.
-
-> [!NOTE]
-> We will close PRs that we think don't clear these bars, simply to protect our time. If you think we misjudged yours, tell us and we'll gladly take another look. We're all human in the end, even if AI-assisted.
-
-We're genuinely happy to mentor newcomers and help them improve. But we're not happy to see drive-by PRs that the author can't explain or won't follow up on. If you open one, be ready to respond to review, answer questions, and address feedback.
-
-Before you open a PR, make sure you (the human) do these:
-
-- **Understand both the code change and its motivation.** You should be able to explain what it does and why.
-- **Test it locally in a real context.** Depending on the type of change, that might mean compiling Haskell code, creating real-looking tests, and/or running it in an actual Wasp app and manually clicking buttons.
-- **Review it thoroughly, and make changes as needed.** The code might be correct, but is it clear? Does it use tools or abstraction that we already have in the code?
-- **Communicate clearly that you've done the above, and what you found.** Fill out the [pull request template](./.github/pull_request_template.md), do not remove it, and represent your changes and process honestly.
-
-Please don't do the following:
-
-- **Don't set autonomous tools to do work on the Wasp repo without oversight.** A bunch of slop PRs might get your account blocked and/or reported to GitHub.
-- **Don't send LLM output that you haven't reviewed and understood.** Especially, don't just copy-paste messages back and forth between an LLM and a PR. Understand what is being said or asked.
-- **Don't send code you haven't run locally, in a relevant context.** Don't have your AI hand-craft files that just make it look right.
-- **Don't hand-edit generated files, such as E2E snapshots.** This rule is already explained in our [CLAUDE.md](./CLAUDE.md), but lots of slop PRs do not seem to have read it.
+Everything that lands in Wasp becomes ours to maintain, so the bar is the same regardless of how the code was written. If a PR shows clear signs that no human supervised it, we'll close it to protect our time. If you think we got that wrong, just tell us and we'll take another look.


### PR DESCRIPTION
## Description

Adds a new "Policies" section to `CONTRIBUTING.md`, starting with an "AIs and LLMs" policy. It states that AI tooling is allowed but every contribution must come from a human. It has a small "Do"s and "Don't"s list that we can link to when triaging low-effort PRs.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
