### PR TITLE
Remove Windows GHC pinning workaround from setup-tools

### DIFF
--- a/.github/actions/setup-tools/action.yaml
+++ b/.github/actions/setup-tools/action.yaml
@@ -13,17 +13,6 @@ runs:
         bootstrap: true
         bootstrap_args: --update --yes
 
-    - # Cabal inspects the version of the GHC binary to determine which compiler
-      # to use. On Windows, Mise shims GHC in a way that Cabal cannot detect, so
-      # we'll point it to the real GHC binary.
-      name: Pin Cabal to the real GHC binary (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      working-directory: waspc
-      run: |
-        $ghc = (mise which ghc) -replace '\\', '/' # Convert to Unix-style path for Cabal
-        "with-compiler: $ghc" | Set-Content -Path cabal.project.local -Encoding ascii
-
     - name: Cache npm dependencies
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
## Description

This removes the Windows-specific workaround from the `setup-tools` composite action.

The workaround added a step that pinned Cabal to the "real" GHC binary on Windows by writing a `with-compiler:` line into `cabal.project.local`. It existed because Mise's GHC shim on Windows couldn't be detected by Cabal (Cabal inspects the GHC binary's version to pick a compiler).

We suspect this is no longer needed, so this PR removes the step to verify whether CI on Windows still passes without it. If Windows CI fails, we'll revert; if it passes, we get a simpler action.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4gz1of8FGr22hUuf59SW3)_