### PR TITLE
Fix mise.lock for mise &gt;= 2026.6.13 --locked installs (record node options)

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -101,6 +101,9 @@ backend = "mise-ghcup:hls"
 version = "24.14.1"
 backend = "core:node"
 
+[tools.node.options]
+compile = "false"
+
 [tools.node."platforms.linux-arm64"]
 checksum = "sha256:734ff04fa7f8ed2e8a78d40cacf5ac3fc4515dac2858757cbab313eb483ba8a2"
 url = "https://nodejs.org/dist/v24.14.1/node-v24.14.1-linux-arm64.tar.gz"


### PR DESCRIPTION
## Description

CI on `cprecioso/minnetonka-v3` started failing with:

```
Error: Failed to install core:node@24.14.1: node@24.14.1 is not in the lockfile
```

even though `node` **is** in `mise.lock`.

**Root cause (bisected locally):** `node` installs fine under mise `2026.6.11`/`2026.6.12` and fails under `2026.6.13`/`2026.6.14`. In **2026.6.13** (PR jdx/mise#10547, "fix(node): save source lock outcomes") mise began recording artifact-affecting tool *options* in the lockfile and enforcing them during `--locked` installs. Our `mise.toml` sets `[settings.node] compile = false`, but our committed `mise.lock` was generated by an older mise and has no `[tools.node.options]` block. Under the stricter check the configured option no longer matches the lockfile entry, so mise treats `node@24.14.1` as "not in the lockfile" and aborts. `node` is the only affected tool because it's the only one with a configured option. Our `setup-tools` action runs `mise-action` with `bootstrap_args: --update`, so CI self-updated into the broken release.

**Fix:** add the `[tools.node.options]` block that mise &gt;= 2026.6.13 writes for our `compile = false` setting. Verified locally: with this block, `mise install --locked` resolves `node` again under `2026.6.14` (and remains valid on older versions).

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)