### PR TITLE
Move "last checked with version" guides notice inside of markdown content

### DIFF
--- a/web/src/theme/DocItem/Content/index.tsx
+++ b/web/src/theme/DocItem/Content/index.tsx
@@ -18,18 +18,16 @@ interface FrontMatter {
 }
 
 /**
- * Reimplements Docusaurus's original `DocItemContent` so the "Last checked
- * with versions" notice can live inside the `markdown` container, above the
- * title.
+ * Modified Docusaurus's `DocItem/Content` component.
+ * Modifications:
+ * - Adds the "Last checked with versions" notice inside the `markdown` container,
+ *   before any other content. The original component only lets us inject the notice
+ *   on top of `MDXContent`'s children, which renders it below a frontmatter (synthetic)
+ *   title but above an inline `# h1` title.
  *
- * The original component only lets us inject the notice into `MDXContent`'s
- * children, which renders below a frontmatter (synthetic) title but above an
- * inline `# h1` title.
- *
- * Mirrors the upstream component:
- * @see {@link https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocItem/Content/index.tsx}
+ * @see {@link https://docusaurus.io/docs/swizzling Docasaurus swizzling}
  */
-export default function ContentWrapper({ children }: Props): ReactNode {
+export default function Content({ children }: Props): ReactNode {
   const frontMatter = useDoc().frontMatter as FrontMatter;
   const syntheticTitle = useSyntheticTitle();
 

--- a/web/src/theme/DocItem/Content/index.tsx
+++ b/web/src/theme/DocItem/Content/index.tsx
@@ -18,12 +18,11 @@ interface FrontMatter {
 }
 
 /**
- * Modified Docusaurus's `DocItem/Content` component.
+ * Ejected and modified Docusaurus `DocItem/Content` component.
  * Modifications:
- * - Adds the "Last checked with versions" notice inside the `markdown` container,
+ * - Adds the "Last checked with versions" notice inside the markdown container, but
  *   before any other content. The original component only lets us inject the notice
- *   on top of `MDXContent`'s children, which renders it below a frontmatter (synthetic)
- *   title but above an inline `# h1` title.
+ *   as `<MDXContent>`'s child, which always renders it below the frontmatter title.
  *
  * @see {@link https://docusaurus.io/docs/swizzling Docasaurus swizzling}
  */

--- a/web/src/theme/DocItem/Content/index.tsx
+++ b/web/src/theme/DocItem/Content/index.tsx
@@ -1,32 +1,63 @@
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import { ThemeClassNames } from "@docusaurus/theme-common";
 import type { WrapperProps } from "@docusaurus/types";
 import LastCheckedWithVersionsNotice, {
   LastCheckedWithVersions,
 } from "@site/src/components/VersionNotice";
-import Content from "@theme-original/DocItem/Content";
 import type ContentType from "@theme/DocItem/Content";
+import Heading from "@theme/Heading";
+import MDXContent from "@theme/MDXContent";
+import clsx from "clsx";
 import type { ReactNode } from "react";
 
 type Props = WrapperProps<typeof ContentType>;
 
 interface FrontMatter {
+  hide_title?: boolean;
   last_checked_with_versions?: LastCheckedWithVersions;
 }
 
-export default function ContentWrapper(props: Props): ReactNode {
+/**
+ * Reimplements Docusaurus's original `DocItemContent` so the "Last checked
+ * with versions" notice can live inside the `markdown` container, above the
+ * title.
+ *
+ * The original component only lets us inject the notice into `MDXContent`'s
+ * children, which renders below a frontmatter (synthetic) title but above an
+ * inline `# h1` title.
+ *
+ * Mirrors the upstream component:
+ * @see {@link https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocItem/Content/index.tsx}
+ */
+export default function ContentWrapper({ children }: Props): ReactNode {
   const frontMatter = useDoc().frontMatter as FrontMatter;
+  const syntheticTitle = useSyntheticTitle();
 
   return (
-    <>
+    <div className={clsx(ThemeClassNames.docs.docMarkdown, "markdown")}>
       {frontMatter.last_checked_with_versions && (
-        <div className="mt-4">
-          <LastCheckedWithVersionsNotice
-            lastCheckedWithVersions={frontMatter.last_checked_with_versions}
-          />
-        </div>
+        <LastCheckedWithVersionsNotice
+          lastCheckedWithVersions={frontMatter.last_checked_with_versions}
+        />
       )}
 
-      <Content {...props} />
-    </>
+      {syntheticTitle && (
+        <header>
+          <Heading as="h1">{syntheticTitle}</Heading>
+        </header>
+      )}
+
+      <MDXContent>{children}</MDXContent>
+    </div>
   );
+}
+
+function useSyntheticTitle(): string | null {
+  const { metadata, frontMatter, contentTitle } = useDoc();
+  const shouldRender =
+    !frontMatter.hide_title && typeof contentTitle === "undefined";
+  if (!shouldRender) {
+    return null;
+  }
+  return metadata.title;
 }


### PR DESCRIPTION
Demo of possible solution for #4361 

For this solution we swizzle the component:
https://docusaurus.io/docs/swizzling

Even before this PR we swizzled it by wrapping it.
This is a bit safer, but it makes it impossible to have the "notice" consistently rendered above the title (due to `children` prop).

So for a consistent solution, we now have to "eject it" and change the internal implementation. 

NOTE: DocItemContent` is an unsafe swizzle component, meaning it can break on minor changes:
<img width="552" height="40" alt="image" src="https://github.com/user-attachments/assets/524a0496-0909-4adb-b510-b65ac20f376a" />



