### PR TITLE
Allow extra globs in tsconfig.wasp.json include (#4319)

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -19,7 +19,7 @@
 
 - Added a `wasp doctor` command that runs common sanity checks on your setup to check that Wasp can work correctly, and prints a report. ([#4283](https://github.com/wasp-lang/wasp/pull/4283))
 - `wasp deps` no longer shows internal Wasp packages in its output (by @okxint). ([#4342](https://github.com/wasp-lang/wasp/issues/4342))
-- `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4319](https://github.com/wasp-lang/wasp/issues/4319))
+- `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4398](https://github.com/wasp-lang/wasp/pull/4398))
 
 ## 0.24.0
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -19,6 +19,7 @@
 
 - Added a `wasp doctor` command that runs common sanity checks on your setup to check that Wasp can work correctly, and prints a report. ([#4283](https://github.com/wasp-lang/wasp/pull/4283))
 - `wasp deps` no longer shows internal Wasp packages in its output (by @okxint). ([#4342](https://github.com/wasp-lang/wasp/issues/4342))
+- `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4319](https://github.com/wasp-lang/wasp/issues/4319))
 
 ## 0.24.0
 

--- a/waspc/src/Wasp/Project/ExternalConfig/WaspTsConfig.hs
+++ b/waspc/src/Wasp/Project/ExternalConfig/WaspTsConfig.hs
@@ -22,7 +22,10 @@ parseAndValidateWaspTsConfig = parseAndValidateTsConfigFile waspTsConfigValidato
 waspTsConfigValidator :: V.Validator T.TsConfig
 waspTsConfigValidator =
   V.all
-    [ V.inField ("include", T.include) $ V.eqJust ["**/*.wasp.ts", ".wasp/out/types/spec"],
+    [ -- The user is free to add more globs (e.g. for shared helpers or
+      -- libraries used by their `.wasp.ts` files), so we only require that the
+      -- Wasp-specific entries are present.
+      V.inField ("include", T.include) $ V.containsAllJust ["**/*.wasp.ts", ".wasp/out/types/spec"],
       V.inField ("compilerOptions", T.compilerOptions) $ V.required compilerOptionsValidator
     ]
   where

--- a/waspc/src/Wasp/Project/ExternalConfig/WaspTsConfig.hs
+++ b/waspc/src/Wasp/Project/ExternalConfig/WaspTsConfig.hs
@@ -22,10 +22,7 @@ parseAndValidateWaspTsConfig = parseAndValidateTsConfigFile waspTsConfigValidato
 waspTsConfigValidator :: V.Validator T.TsConfig
 waspTsConfigValidator =
   V.all
-    [ -- The user is free to add more globs (e.g. for shared helpers or
-      -- libraries used by their `.wasp.ts` files), so we only require that the
-      -- Wasp-specific entries are present.
-      V.inField ("include", T.include) $ V.required $ V.containsAll ["**/*.wasp.ts", ".wasp/out/types/spec"],
+    [ V.inField ("include", T.include) $ V.required $ V.containsAll ["**/*.wasp.ts", ".wasp/out/types/spec"],
       V.inField ("compilerOptions", T.compilerOptions) $ V.required compilerOptionsValidator
     ]
   where

--- a/waspc/src/Wasp/Project/ExternalConfig/WaspTsConfig.hs
+++ b/waspc/src/Wasp/Project/ExternalConfig/WaspTsConfig.hs
@@ -25,7 +25,7 @@ waspTsConfigValidator =
     [ -- The user is free to add more globs (e.g. for shared helpers or
       -- libraries used by their `.wasp.ts` files), so we only require that the
       -- Wasp-specific entries are present.
-      V.inField ("include", T.include) $ V.containsAllJust ["**/*.wasp.ts", ".wasp/out/types/spec"],
+      V.inField ("include", T.include) $ V.required $ V.containsAll ["**/*.wasp.ts", ".wasp/out/types/spec"],
       V.inField ("compilerOptions", T.compilerOptions) $ V.required compilerOptionsValidator
     ]
   where

--- a/waspc/src/Wasp/Validator.hs
+++ b/waspc/src/Wasp/Validator.hs
@@ -85,6 +85,16 @@ eqJust expected (Just actual)
 eqJust expected Nothing =
   failure $ "Missing value, expected " ++ show expected ++ "."
 
+-- | Validates that the value exists and is a list containing all of the
+-- expected elements. Additional elements are allowed.
+containsAllJust :: (Eq a, Show a) => [a] -> Validator (Maybe [a])
+containsAllJust expected (Just actual)
+  | Prelude.all (`elem` actual) expected = success
+  | otherwise =
+      failure $ "Expected to contain all of " ++ show expected ++ " but got " ++ show actual ++ "."
+containsAllJust expected Nothing =
+  failure $ "Missing value, expected to contain all of " ++ show expected ++ "."
+
 -- | Runs the inner validator only if the value is Just. If the value is
 -- Nothing, no validation is needed and the validation succeeds.
 ifJust :: Validator a -> Validator (Maybe a)

--- a/waspc/src/Wasp/Validator.hs
+++ b/waspc/src/Wasp/Validator.hs
@@ -85,15 +85,14 @@ eqJust expected (Just actual)
 eqJust expected Nothing =
   failure $ "Missing value, expected " ++ show expected ++ "."
 
--- | Validates that the value exists and is a list containing all of the
--- expected elements. Additional elements are allowed.
-containsAllJust :: (Eq a, Show a) => [a] -> Validator (Maybe [a])
-containsAllJust expected (Just actual)
+-- | Validates that the list contains all of the expected elements. Additional
+-- elements are allowed. Combine with 'required' or 'ifJust' to validate an
+-- optional field.
+containsAll :: (Eq a, Show a) => [a] -> Validator [a]
+containsAll expected actual
   | Prelude.all (`elem` actual) expected = success
   | otherwise =
       failure $ "Expected to contain all of " ++ show expected ++ " but got " ++ show actual ++ "."
-containsAllJust expected Nothing =
-  failure $ "Missing value, expected to contain all of " ++ show expected ++ "."
 
 -- | Runs the inner validator only if the value is Just. If the value is
 -- Nothing, no validation is needed and the validation succeeds.

--- a/waspc/tests/Project/ExternalConfig/WaspTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/WaspTsConfigTest.hs
@@ -32,9 +32,17 @@ spec_WaspTsConfig = do
       assertReturnsValidationErrorMentioningField "compilerOptions" $
         validTsConfig {T.compilerOptions = Nothing}
 
+    it "returns an error when include is missing a required glob" $
+      assertReturnsValidationErrorMentioningField "include" $
+        validTsConfig {T.include = Just ["**/*.wasp.ts"]}
+
     it "returns an error when include is wrong" $
       assertReturnsValidationErrorMentioningField "include" $
         validTsConfig {T.include = Just ["src"]}
+
+    it "returns no errors when include has the required globs plus extra ones" $
+      validate (validTsConfig {T.include = Just ["**/*.wasp.ts", ".wasp/out/types/spec", "lib/**/*.ts"]})
+        `shouldBe` []
 
 validate :: T.TsConfig -> [String]
 validate = validateTsConfig waspTsConfigValidator "tsconfig.wasp.json"

--- a/waspc/tests/ValidatorTest.hs
+++ b/waspc/tests/ValidatorTest.hs
@@ -61,16 +61,13 @@ spec_Validator = do
       V.eqJust True <-- Just False ~> ["Expected True but got False."]
       V.eqJust True <-- Nothing ~> ["Missing value, expected True."]
 
-    specify "containsAllJust" $ do
-      V.containsAllJust ["a", "b"] <-- Just ["a", "b"] ~> []
-      V.containsAllJust ["a", "b"] <-- Just ["a", "b", "c"] ~> []
-      V.containsAllJust ["a", "b"] <-- Just ["b", "a"] ~> []
-      V.containsAllJust ["a", "b"]
-        <-- Just ["a"]
+    specify "containsAll" $ do
+      V.containsAll ["a", "b"] <-- ["a", "b"] ~> []
+      V.containsAll ["a", "b"] <-- ["a", "b", "c"] ~> []
+      V.containsAll ["a", "b"] <-- ["b", "a"] ~> []
+      V.containsAll ["a", "b"]
+        <-- ["a"]
         ~> ["Expected to contain all of [\"a\",\"b\"] but got [\"a\"]."]
-      V.containsAllJust ["a", "b"]
-        <-- Nothing
-        ~> ["Missing value, expected to contain all of [\"a\",\"b\"]."]
 
     specify "combined usage" $ do
       let mockData = Map.fromList [("database", "mysql")] :: Map.Map String String

--- a/waspc/tests/ValidatorTest.hs
+++ b/waspc/tests/ValidatorTest.hs
@@ -61,6 +61,17 @@ spec_Validator = do
       V.eqJust True <-- Just False ~> ["Expected True but got False."]
       V.eqJust True <-- Nothing ~> ["Missing value, expected True."]
 
+    specify "containsAllJust" $ do
+      V.containsAllJust ["a", "b"] <-- Just ["a", "b"] ~> []
+      V.containsAllJust ["a", "b"] <-- Just ["a", "b", "c"] ~> []
+      V.containsAllJust ["a", "b"] <-- Just ["b", "a"] ~> []
+      V.containsAllJust ["a", "b"]
+        <-- Just ["a"]
+        ~> ["Expected to contain all of [\"a\",\"b\"] but got [\"a\"]."]
+      V.containsAllJust ["a", "b"]
+        <-- Nothing
+        ~> ["Missing value, expected to contain all of [\"a\",\"b\"]."]
+
     specify "combined usage" $ do
       let mockData = Map.fromList [("database", "mysql")] :: Map.Map String String
           validator =


### PR DESCRIPTION
## Description

The `include` field in `tsconfig.wasp.json` was validated with an exact-equality check, so users couldn't add their own globs (e.g. for shared helpers or libraries used by their `.wasp.ts` files) without triggering a compiler error. This relaxes the validation to require only that the Wasp-specific entries (`**/*.wasp.ts` and `.wasp/out/types/spec`) are present, allowing any additional globs. It adds a `containsAllJust` validator combinator (used for the `include` field) with unit tests for both the combinator and the Wasp TS config validator. Fixes [#4319](https://github.com/wasp-lang/wasp/issues/4319).

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [x] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
