### PR TITLE
Fix e2e tests racing on concurrent `cabal run` invocations

### DIFF
--- a/waspc/e2e-tests/Main.hs
+++ b/waspc/e2e-tests/Main.hs
@@ -5,6 +5,7 @@ import StrongPath ((</>))
 import qualified StrongPath as SP
 import System.Environment (lookupEnv, setEnv)
 import System.Info (os)
+import System.Process (callCommand)
 import Test (testTreeFromTest)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Tests.SdkPackageExportsTest (makeSdkPackageExportsTestTree)
@@ -39,6 +40,7 @@ main = do
     then putStrLn "Skipping end-to-end tests on Windows due to tests using *nix-only commands"
     else do
       ensureE2eTestsEnvironment
+      warmUpWaspCli
       e2eTests >>= defaultMain
 
 ensureE2eTestsEnvironment :: IO ()
@@ -51,6 +53,18 @@ ensureE2eTestsEnvironment = do
       waspcDir <- getWaspcDirPath
       let devWaspCliCmd = SP.fromAbsFile (waspcDir </> waspCliDevToolInWaspcDir)
       setEnv "WASP_CLI_CMD" devWaspCliCmd
+
+-- | Builds the dev Wasp CLI once, serially, before the snapshot tests start
+-- invoking it concurrently (via 'mapConcurrently' in 'e2eTests').
+--
+-- The dev CLI runs through `cabal run`, and Cabal does not support several
+-- concurrent invocations sharing a single `dist-newstyle`: if the first build
+-- isn't finished, the parallel invocations race to register the inplace package
+-- and fail with "package.conf.inplace already exists". Doing one serial
+-- invocation here forces that build to complete first, so the concurrent
+-- invocations only ever run the already-built CLI.
+warmUpWaspCli :: IO ()
+warmUpWaspCli = callCommand "$WASP_CLI_CMD version > /dev/null"
 
 -- TODO: Investigate automatically discovering the tests.
 -- TODO: Refactor tests DSL so it does not depend on bash commands. Use pure Haskell instead.


### PR DESCRIPTION
## Description

The `waspc` e2e snapshot tests run concurrently (via `mapConcurrently` in `waspc/e2e-tests/Main.hs`), and each one invokes the dev Wasp CLI, which runs through `cabal run` (`tools/wasp-cli-dev.ts`).

Cabal does not support several concurrent invocations sharing a single `dist-newstyle`. When the first build hasn't finished, the parallel invocations race to register the inplace package and fail with:

```
ghc-pkg: cannot create: .../dist-newstyle/.../waspc-0.25.0/package.conf.inplace already exists
Error: [Cabal-7125]
```

This was failing the `Test waspc` CI jobs on all platforms (ubuntu-22.04, macos-15, macos-15-intel).

Fix: warm up the CLI build once, serially, before the concurrent tests start, so they only ever execute the already-built CLI.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)