### PR TITLE
Pretty-print installedNpmDepsLog.json

### DIFF
--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
@@ -1,1 +1,353 @@
-{"_userNpmDeps":{"fromUser":{"dependencies":[{"name":"@tanstack/react-query","version":"~4.42.0"},{"name":"chai","version":"^5.2.0"},{"name":"clsx","version":"^2.1.1"},{"name":"linebyline","version":"^1.3.0"},{"name":"react","version":"^19.2.1"},{"name":"react-dom","version":"^19.2.1"},{"name":"react-router","version":"^7.12.0"},{"name":"tailwind-merge","version":"^3.4.0"},{"name":"tailwindcss","version":"^4.1.18"},{"name":"wait-port","version":"^1.1.0"}],"devDependencies":[{"name":"@playwright/test","version":"1.55.1"},{"name":"@tailwindcss/forms","version":"^0.5.11"},{"name":"@tailwindcss/typography","version":"^0.5.19"},{"name":"@tailwindcss/vite","version":"^4.1.18"},{"name":"@types/chai","version":"^5.2.2"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/node","version":"^24.0.0"},{"name":"@types/react","version":"^19.2.7"},{"name":"@types/react-dom","version":"^19.2.3"},{"name":"@types/uuid","version":"^9.0.8"},{"name":"@wasp.sh/spec","version":"file:.wasp/spec"},{"name":"@wasp.sh/wasp-app-runner","version":"^0.0.16"},{"name":"prisma","version":"5.19.1"},{"name":"typescript","version":"6.0.3"},{"name":"vite","version":"^7.0.6"},{"name":"vitest","version":"^4.0.16"}],"peerDependencies":[]}},"_waspSdkNpmDeps":{"dependencies":[{"name":"@prisma/client","version":"5.19.1"},{"name":"prisma","version":"5.19.1"},{"name":"dotenv","version":"^16.6.1"},{"name":"dotenv-expand","version":"^12.0.3"},{"name":"express","version":"~5.1.0"},{"name":"ky","version":"^2.0.0"},{"name":"mitt","version":"3.0.0"},{"name":"react","version":"^19.2.1"},{"name":"react-dom","version":"^19.2.1"},{"name":"@tanstack/react-query","version":"~4.42.0"},{"name":"react-router","version":"^7.12.0"},{"name":"react-hook-form","version":"^7.45.4"},{"name":"superjson","version":"^2.2.1"},{"name":"arctic","version":"^1.2.1"},{"name":"lucia","version":"^3.0.1"},{"name":"@lucia-auth/adapter-prisma","version":"^4.0.0"},{"name":"nodemailer","version":"^8.0.1"},{"name":"socket.io","version":"^4.6.1"},{"name":"socket.io-client","version":"^4.6.1"},{"name":"@socket.io/component-emitter","version":"^4.0.0"},{"name":"@vitest/ui","version":"^4.0.16"},{"name":"jsdom","version":"^27.4.0"},{"name":"@testing-library/react","version":"^16.3.1"},{"name":"@testing-library/jest-dom","version":"^6.9.1"},{"name":"msw","version":"^2.12.7"},{"name":"pg-boss","version":"^8.4.2"},{"name":"zod","version":"^4.3.6"},{"name":"@wasp.sh/lib-auth","version":"file:../../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"},{"name":"@wasp.sh/lib-vite-ssr","version":"file:../../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"}],"devDependencies":[{"name":"typescript","version":"6.0.3"},{"name":"@vitejs/plugin-react","version":"^4.7.0"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/express-serve-static-core","version":"^5.0.0"},{"name":"@types/react","version":"^19.2.7"},{"name":"@types/react-dom","version":"^19.2.3"}],"peerDependencies":[]},"_waspServerNpmDeps":{"dependencies":[{"name":"@socket.io/component-emitter","version":"^4.0.0"},{"name":"@wasp.sh/lib-auth","version":"file:../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"},{"name":"@wasp.sh/lib-vite-ssr","version":"file:../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"},{"name":"cookie-parser","version":"~1.4.6"},{"name":"cors","version":"^2.8.5"},{"name":"dotenv","version":"^16.6.1"},{"name":"express","version":"~5.1.0"},{"name":"helmet","version":"^6.0.0"},{"name":"morgan","version":"~1.10.0"},{"name":"socket.io","version":"^4.6.1"},{"name":"superjson","version":"^2.2.1"}],"devDependencies":[{"name":"@rollup/plugin-node-resolve","version":"^16.0.0"},{"name":"@tsconfig/node24","version":"latest"},{"name":"@types/cors","version":"^2.8.5"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/express-serve-static-core","version":"^5.0.0"},{"name":"@types/node","version":"^24.0.0"},{"name":"nodemon","version":"^2.0.19"},{"name":"rollup","version":"^4.9.6"},{"name":"rollup-plugin-esbuild","version":"^6.1.1"},{"name":"typescript","version":"6.0.3"}],"peerDependencies":[]}}
+{
+    "_userNpmDeps": {
+        "fromUser": {
+            "dependencies": [
+                {
+                    "name": "@tanstack/react-query",
+                    "version": "~4.42.0"
+                },
+                {
+                    "name": "chai",
+                    "version": "^5.2.0"
+                },
+                {
+                    "name": "clsx",
+                    "version": "^2.1.1"
+                },
+                {
+                    "name": "linebyline",
+                    "version": "^1.3.0"
+                },
+                {
+                    "name": "react",
+                    "version": "^19.2.1"
+                },
+                {
+                    "name": "react-dom",
+                    "version": "^19.2.1"
+                },
+                {
+                    "name": "react-router",
+                    "version": "^7.12.0"
+                },
+                {
+                    "name": "tailwind-merge",
+                    "version": "^3.4.0"
+                },
+                {
+                    "name": "tailwindcss",
+                    "version": "^4.1.18"
+                },
+                {
+                    "name": "wait-port",
+                    "version": "^1.1.0"
+                }
+            ],
+            "devDependencies": [
+                {
+                    "name": "@playwright/test",
+                    "version": "1.55.1"
+                },
+                {
+                    "name": "@tailwindcss/forms",
+                    "version": "^0.5.11"
+                },
+                {
+                    "name": "@tailwindcss/typography",
+                    "version": "^0.5.19"
+                },
+                {
+                    "name": "@tailwindcss/vite",
+                    "version": "^4.1.18"
+                },
+                {
+                    "name": "@types/chai",
+                    "version": "^5.2.2"
+                },
+                {
+                    "name": "@types/express",
+                    "version": "^5.0.0"
+                },
+                {
+                    "name": "@types/node",
+                    "version": "^24.0.0"
+                },
+                {
+                    "name": "@types/react",
+                    "version": "^19.2.7"
+                },
+                {
+                    "name": "@types/react-dom",
+                    "version": "^19.2.3"
+                },
+                {
+                    "name": "@types/uuid",
+                    "version": "^9.0.8"
+                },
+                {
+                    "name": "@wasp.sh/spec",
+                    "version": "file:.wasp/spec"
+                },
+                {
+                    "name": "@wasp.sh/wasp-app-runner",
+                    "version": "^0.0.16"
+                },
+                {
+                    "name": "prisma",
+                    "version": "5.19.1"
+                },
+                {
+                    "name": "typescript",
+                    "version": "6.0.3"
+                },
+                {
+                    "name": "vite",
+                    "version": "^7.0.6"
+                },
+                {
+                    "name": "vitest",
+                    "version": "^4.0.16"
+                }
+            ],
+            "peerDependencies": []
+        }
+    },
+    "_waspSdkNpmDeps": {
+        "dependencies": [
+            {
+                "name": "@prisma/client",
+                "version": "5.19.1"
+            },
+            {
+                "name": "prisma",
+                "version": "5.19.1"
+            },
+            {
+                "name": "dotenv",
+                "version": "^16.6.1"
+            },
+            {
+                "name": "dotenv-expand",
+                "version": "^12.0.3"
+            },
+            {
+                "name": "express",
+                "version": "~5.1.0"
+            },
+            {
+                "name": "ky",
+                "version": "^2.0.0"
+            },
+            {
+                "name": "mitt",
+                "version": "3.0.0"
+            },
+            {
+                "name": "react",
+                "version": "^19.2.1"
+            },
+            {
+                "name": "react-dom",
+                "version": "^19.2.1"
+            },
+            {
+                "name": "@tanstack/react-query",
+                "version": "~4.42.0"
+            },
+            {
+                "name": "react-router",
+                "version": "^7.12.0"
+            },
+            {
+                "name": "react-hook-form",
+                "version": "^7.45.4"
+            },
+            {
+                "name": "superjson",
+                "version": "^2.2.1"
+            },
+            {
+                "name": "arctic",
+                "version": "^1.2.1"
+            },
+            {
+                "name": "lucia",
+                "version": "^3.0.1"
+            },
+            {
+                "name": "@lucia-auth/adapter-prisma",
+                "version": "^4.0.0"
+            },
+            {
+                "name": "nodemailer",
+                "version": "^8.0.1"
+            },
+            {
+                "name": "socket.io",
+                "version": "^4.6.1"
+            },
+            {
+                "name": "socket.io-client",
+                "version": "^4.6.1"
+            },
+            {
+                "name": "@socket.io/component-emitter",
+                "version": "^4.0.0"
+            },
+            {
+                "name": "@vitest/ui",
+                "version": "^4.0.16"
+            },
+            {
+                "name": "jsdom",
+                "version": "^27.4.0"
+            },
+            {
+                "name": "@testing-library/react",
+                "version": "^16.3.1"
+            },
+            {
+                "name": "@testing-library/jest-dom",
+                "version": "^6.9.1"
+            },
+            {
+                "name": "msw",
+                "version": "^2.12.7"
+            },
+            {
+                "name": "pg-boss",
+                "version": "^8.4.2"
+            },
+            {
+                "name": "zod",
+                "version": "^4.3.6"
+            },
+            {
+                "name": "@wasp.sh/lib-auth",
+                "version": "file:../../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"
+            },
+            {
+                "name": "@wasp.sh/lib-vite-ssr",
+                "version": "file:../../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
+            }
+        ],
+        "devDependencies": [
+            {
+                "name": "typescript",
+                "version": "6.0.3"
+            },
+            {
+                "name": "@vitejs/plugin-react",
+                "version": "^4.7.0"
+            },
+            {
+                "name": "@types/express",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/express-serve-static-core",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/react",
+                "version": "^19.2.7"
+            },
+            {
+                "name": "@types/react-dom",
+                "version": "^19.2.3"
+            }
+        ],
+        "peerDependencies": []
+    },
+    "_waspServerNpmDeps": {
+        "dependencies": [
+            {
+                "name": "@socket.io/component-emitter",
+                "version": "^4.0.0"
+            },
+            {
+                "name": "@wasp.sh/lib-auth",
+                "version": "file:../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"
+            },
+            {
+                "name": "@wasp.sh/lib-vite-ssr",
+                "version": "file:../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
+            },
+            {
+                "name": "cookie-parser",
+                "version": "~1.4.6"
+            },
+            {
+                "name": "cors",
+                "version": "^2.8.5"
+            },
+            {
+                "name": "dotenv",
+                "version": "^16.6.1"
+            },
+            {
+                "name": "express",
+                "version": "~5.1.0"
+            },
+            {
+                "name": "helmet",
+                "version": "^6.0.0"
+            },
+            {
+                "name": "morgan",
+                "version": "~1.10.0"
+            },
+            {
+                "name": "socket.io",
+                "version": "^4.6.1"
+            },
+            {
+                "name": "superjson",
+                "version": "^2.2.1"
+            }
+        ],
+        "devDependencies": [
+            {
+                "name": "@rollup/plugin-node-resolve",
+                "version": "^16.0.0"
+            },
+            {
+                "name": "@tsconfig/node24",
+                "version": "latest"
+            },
+            {
+                "name": "@types/cors",
+                "version": "^2.8.5"
+            },
+            {
+                "name": "@types/express",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/express-serve-static-core",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/node",
+                "version": "^24.0.0"
+            },
+            {
+                "name": "nodemon",
+                "version": "^2.0.19"
+            },
+            {
+                "name": "rollup",
+                "version": "^4.9.6"
+            },
+            {
+                "name": "rollup-plugin-esbuild",
+                "version": "^6.1.1"
+            },
+            {
+                "name": "typescript",
+                "version": "6.0.3"
+            }
+        ],
+        "peerDependencies": []
+    }
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
@@ -1,1 +1,253 @@
-{"_userNpmDeps":{"fromUser":{"dependencies":[{"name":"react","version":"^19.2.1"},{"name":"react-dom","version":"^19.2.1"},{"name":"react-router","version":"^7.12.0"}],"devDependencies":[{"name":"@types/node","version":"^24.0.0"},{"name":"@types/react","version":"^19.2.7"},{"name":"@types/react-dom","version":"^19.2.3"},{"name":"@wasp.sh/spec","version":"file:.wasp/spec/"},{"name":"prisma","version":"5.19.1"},{"name":"typescript","version":"6.0.3"},{"name":"vite","version":"^7.0.6"},{"name":"vitest","version":"^4.0.16"}],"peerDependencies":[]}},"_waspSdkNpmDeps":{"dependencies":[{"name":"@prisma/client","version":"5.19.1"},{"name":"prisma","version":"5.19.1"},{"name":"dotenv","version":"^16.6.1"},{"name":"dotenv-expand","version":"^12.0.3"},{"name":"express","version":"~5.1.0"},{"name":"ky","version":"^2.0.0"},{"name":"mitt","version":"3.0.0"},{"name":"react","version":"^19.2.1"},{"name":"react-dom","version":"^19.2.1"},{"name":"@tanstack/react-query","version":"~4.42.0"},{"name":"react-router","version":"^7.12.0"},{"name":"react-hook-form","version":"^7.45.4"},{"name":"superjson","version":"^2.2.1"},{"name":"@vitest/ui","version":"^4.0.16"},{"name":"jsdom","version":"^27.4.0"},{"name":"@testing-library/react","version":"^16.3.1"},{"name":"@testing-library/jest-dom","version":"^6.9.1"},{"name":"msw","version":"^2.12.7"},{"name":"zod","version":"^4.3.6"},{"name":"@wasp.sh/lib-auth","version":"file:../../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"},{"name":"@wasp.sh/lib-vite-ssr","version":"file:../../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"}],"devDependencies":[{"name":"typescript","version":"6.0.3"},{"name":"@vitejs/plugin-react","version":"^4.7.0"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/express-serve-static-core","version":"^5.0.0"},{"name":"@types/react","version":"^19.2.7"},{"name":"@types/react-dom","version":"^19.2.3"}],"peerDependencies":[]},"_waspServerNpmDeps":{"dependencies":[{"name":"@wasp.sh/lib-auth","version":"file:../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"},{"name":"@wasp.sh/lib-vite-ssr","version":"file:../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"},{"name":"cookie-parser","version":"~1.4.6"},{"name":"cors","version":"^2.8.5"},{"name":"dotenv","version":"^16.6.1"},{"name":"express","version":"~5.1.0"},{"name":"helmet","version":"^6.0.0"},{"name":"morgan","version":"~1.10.0"},{"name":"superjson","version":"^2.2.1"}],"devDependencies":[{"name":"@rollup/plugin-node-resolve","version":"^16.0.0"},{"name":"@tsconfig/node24","version":"latest"},{"name":"@types/cors","version":"^2.8.5"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/express-serve-static-core","version":"^5.0.0"},{"name":"@types/node","version":"^24.0.0"},{"name":"nodemon","version":"^2.0.19"},{"name":"rollup","version":"^4.9.6"},{"name":"rollup-plugin-esbuild","version":"^6.1.1"},{"name":"typescript","version":"6.0.3"}],"peerDependencies":[]}}
+{
+    "_userNpmDeps": {
+        "fromUser": {
+            "dependencies": [
+                {
+                    "name": "react",
+                    "version": "^19.2.1"
+                },
+                {
+                    "name": "react-dom",
+                    "version": "^19.2.1"
+                },
+                {
+                    "name": "react-router",
+                    "version": "^7.12.0"
+                }
+            ],
+            "devDependencies": [
+                {
+                    "name": "@types/node",
+                    "version": "^24.0.0"
+                },
+                {
+                    "name": "@types/react",
+                    "version": "^19.2.7"
+                },
+                {
+                    "name": "@types/react-dom",
+                    "version": "^19.2.3"
+                },
+                {
+                    "name": "@wasp.sh/spec",
+                    "version": "file:.wasp/spec/"
+                },
+                {
+                    "name": "prisma",
+                    "version": "5.19.1"
+                },
+                {
+                    "name": "typescript",
+                    "version": "6.0.3"
+                },
+                {
+                    "name": "vite",
+                    "version": "^7.0.6"
+                },
+                {
+                    "name": "vitest",
+                    "version": "^4.0.16"
+                }
+            ],
+            "peerDependencies": []
+        }
+    },
+    "_waspSdkNpmDeps": {
+        "dependencies": [
+            {
+                "name": "@prisma/client",
+                "version": "5.19.1"
+            },
+            {
+                "name": "prisma",
+                "version": "5.19.1"
+            },
+            {
+                "name": "dotenv",
+                "version": "^16.6.1"
+            },
+            {
+                "name": "dotenv-expand",
+                "version": "^12.0.3"
+            },
+            {
+                "name": "express",
+                "version": "~5.1.0"
+            },
+            {
+                "name": "ky",
+                "version": "^2.0.0"
+            },
+            {
+                "name": "mitt",
+                "version": "3.0.0"
+            },
+            {
+                "name": "react",
+                "version": "^19.2.1"
+            },
+            {
+                "name": "react-dom",
+                "version": "^19.2.1"
+            },
+            {
+                "name": "@tanstack/react-query",
+                "version": "~4.42.0"
+            },
+            {
+                "name": "react-router",
+                "version": "^7.12.0"
+            },
+            {
+                "name": "react-hook-form",
+                "version": "^7.45.4"
+            },
+            {
+                "name": "superjson",
+                "version": "^2.2.1"
+            },
+            {
+                "name": "@vitest/ui",
+                "version": "^4.0.16"
+            },
+            {
+                "name": "jsdom",
+                "version": "^27.4.0"
+            },
+            {
+                "name": "@testing-library/react",
+                "version": "^16.3.1"
+            },
+            {
+                "name": "@testing-library/jest-dom",
+                "version": "^6.9.1"
+            },
+            {
+                "name": "msw",
+                "version": "^2.12.7"
+            },
+            {
+                "name": "zod",
+                "version": "^4.3.6"
+            },
+            {
+                "name": "@wasp.sh/lib-auth",
+                "version": "file:../../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"
+            },
+            {
+                "name": "@wasp.sh/lib-vite-ssr",
+                "version": "file:../../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
+            }
+        ],
+        "devDependencies": [
+            {
+                "name": "typescript",
+                "version": "6.0.3"
+            },
+            {
+                "name": "@vitejs/plugin-react",
+                "version": "^4.7.0"
+            },
+            {
+                "name": "@types/express",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/express-serve-static-core",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/react",
+                "version": "^19.2.7"
+            },
+            {
+                "name": "@types/react-dom",
+                "version": "^19.2.3"
+            }
+        ],
+        "peerDependencies": []
+    },
+    "_waspServerNpmDeps": {
+        "dependencies": [
+            {
+                "name": "@wasp.sh/lib-auth",
+                "version": "file:../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"
+            },
+            {
+                "name": "@wasp.sh/lib-vite-ssr",
+                "version": "file:../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
+            },
+            {
+                "name": "cookie-parser",
+                "version": "~1.4.6"
+            },
+            {
+                "name": "cors",
+                "version": "^2.8.5"
+            },
+            {
+                "name": "dotenv",
+                "version": "^16.6.1"
+            },
+            {
+                "name": "express",
+                "version": "~5.1.0"
+            },
+            {
+                "name": "helmet",
+                "version": "^6.0.0"
+            },
+            {
+                "name": "morgan",
+                "version": "~1.10.0"
+            },
+            {
+                "name": "superjson",
+                "version": "^2.2.1"
+            }
+        ],
+        "devDependencies": [
+            {
+                "name": "@rollup/plugin-node-resolve",
+                "version": "^16.0.0"
+            },
+            {
+                "name": "@tsconfig/node24",
+                "version": "latest"
+            },
+            {
+                "name": "@types/cors",
+                "version": "^2.8.5"
+            },
+            {
+                "name": "@types/express",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/express-serve-static-core",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/node",
+                "version": "^24.0.0"
+            },
+            {
+                "name": "nodemon",
+                "version": "^2.0.19"
+            },
+            {
+                "name": "rollup",
+                "version": "^4.9.6"
+            },
+            {
+                "name": "rollup-plugin-esbuild",
+                "version": "^6.1.1"
+            },
+            {
+                "name": "typescript",
+                "version": "6.0.3"
+            }
+        ],
+        "peerDependencies": []
+    }
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
@@ -1,1 +1,253 @@
-{"_userNpmDeps":{"fromUser":{"dependencies":[{"name":"react","version":"^19.2.1"},{"name":"react-dom","version":"^19.2.1"},{"name":"react-router","version":"^7.12.0"}],"devDependencies":[{"name":"@types/node","version":"^24.0.0"},{"name":"@types/react","version":"^19.2.7"},{"name":"@types/react-dom","version":"^19.2.3"},{"name":"@wasp.sh/spec","version":"file:.wasp/spec/"},{"name":"prisma","version":"5.19.1"},{"name":"typescript","version":"6.0.3"},{"name":"vite","version":"^7.0.6"},{"name":"vitest","version":"^4.0.16"}],"peerDependencies":[]}},"_waspSdkNpmDeps":{"dependencies":[{"name":"@prisma/client","version":"5.19.1"},{"name":"prisma","version":"5.19.1"},{"name":"dotenv","version":"^16.6.1"},{"name":"dotenv-expand","version":"^12.0.3"},{"name":"express","version":"~5.1.0"},{"name":"ky","version":"^2.0.0"},{"name":"mitt","version":"3.0.0"},{"name":"react","version":"^19.2.1"},{"name":"react-dom","version":"^19.2.1"},{"name":"@tanstack/react-query","version":"~4.42.0"},{"name":"react-router","version":"^7.12.0"},{"name":"react-hook-form","version":"^7.45.4"},{"name":"superjson","version":"^2.2.1"},{"name":"@vitest/ui","version":"^4.0.16"},{"name":"jsdom","version":"^27.4.0"},{"name":"@testing-library/react","version":"^16.3.1"},{"name":"@testing-library/jest-dom","version":"^6.9.1"},{"name":"msw","version":"^2.12.7"},{"name":"zod","version":"^4.3.6"},{"name":"@wasp.sh/lib-auth","version":"file:../../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"},{"name":"@wasp.sh/lib-vite-ssr","version":"file:../../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"}],"devDependencies":[{"name":"typescript","version":"6.0.3"},{"name":"@vitejs/plugin-react","version":"^4.7.0"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/express-serve-static-core","version":"^5.0.0"},{"name":"@types/react","version":"^19.2.7"},{"name":"@types/react-dom","version":"^19.2.3"}],"peerDependencies":[]},"_waspServerNpmDeps":{"dependencies":[{"name":"@wasp.sh/lib-auth","version":"file:../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"},{"name":"@wasp.sh/lib-vite-ssr","version":"file:../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"},{"name":"cookie-parser","version":"~1.4.6"},{"name":"cors","version":"^2.8.5"},{"name":"dotenv","version":"^16.6.1"},{"name":"express","version":"~5.1.0"},{"name":"helmet","version":"^6.0.0"},{"name":"morgan","version":"~1.10.0"},{"name":"superjson","version":"^2.2.1"}],"devDependencies":[{"name":"@rollup/plugin-node-resolve","version":"^16.0.0"},{"name":"@tsconfig/node24","version":"latest"},{"name":"@types/cors","version":"^2.8.5"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/express-serve-static-core","version":"^5.0.0"},{"name":"@types/node","version":"^24.0.0"},{"name":"nodemon","version":"^2.0.19"},{"name":"rollup","version":"^4.9.6"},{"name":"rollup-plugin-esbuild","version":"^6.1.1"},{"name":"typescript","version":"6.0.3"}],"peerDependencies":[]}}
+{
+    "_userNpmDeps": {
+        "fromUser": {
+            "dependencies": [
+                {
+                    "name": "react",
+                    "version": "^19.2.1"
+                },
+                {
+                    "name": "react-dom",
+                    "version": "^19.2.1"
+                },
+                {
+                    "name": "react-router",
+                    "version": "^7.12.0"
+                }
+            ],
+            "devDependencies": [
+                {
+                    "name": "@types/node",
+                    "version": "^24.0.0"
+                },
+                {
+                    "name": "@types/react",
+                    "version": "^19.2.7"
+                },
+                {
+                    "name": "@types/react-dom",
+                    "version": "^19.2.3"
+                },
+                {
+                    "name": "@wasp.sh/spec",
+                    "version": "file:.wasp/spec/"
+                },
+                {
+                    "name": "prisma",
+                    "version": "5.19.1"
+                },
+                {
+                    "name": "typescript",
+                    "version": "6.0.3"
+                },
+                {
+                    "name": "vite",
+                    "version": "^7.0.6"
+                },
+                {
+                    "name": "vitest",
+                    "version": "^4.0.16"
+                }
+            ],
+            "peerDependencies": []
+        }
+    },
+    "_waspSdkNpmDeps": {
+        "dependencies": [
+            {
+                "name": "@prisma/client",
+                "version": "5.19.1"
+            },
+            {
+                "name": "prisma",
+                "version": "5.19.1"
+            },
+            {
+                "name": "dotenv",
+                "version": "^16.6.1"
+            },
+            {
+                "name": "dotenv-expand",
+                "version": "^12.0.3"
+            },
+            {
+                "name": "express",
+                "version": "~5.1.0"
+            },
+            {
+                "name": "ky",
+                "version": "^2.0.0"
+            },
+            {
+                "name": "mitt",
+                "version": "3.0.0"
+            },
+            {
+                "name": "react",
+                "version": "^19.2.1"
+            },
+            {
+                "name": "react-dom",
+                "version": "^19.2.1"
+            },
+            {
+                "name": "@tanstack/react-query",
+                "version": "~4.42.0"
+            },
+            {
+                "name": "react-router",
+                "version": "^7.12.0"
+            },
+            {
+                "name": "react-hook-form",
+                "version": "^7.45.4"
+            },
+            {
+                "name": "superjson",
+                "version": "^2.2.1"
+            },
+            {
+                "name": "@vitest/ui",
+                "version": "^4.0.16"
+            },
+            {
+                "name": "jsdom",
+                "version": "^27.4.0"
+            },
+            {
+                "name": "@testing-library/react",
+                "version": "^16.3.1"
+            },
+            {
+                "name": "@testing-library/jest-dom",
+                "version": "^6.9.1"
+            },
+            {
+                "name": "msw",
+                "version": "^2.12.7"
+            },
+            {
+                "name": "zod",
+                "version": "^4.3.6"
+            },
+            {
+                "name": "@wasp.sh/lib-auth",
+                "version": "file:../../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"
+            },
+            {
+                "name": "@wasp.sh/lib-vite-ssr",
+                "version": "file:../../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
+            }
+        ],
+        "devDependencies": [
+            {
+                "name": "typescript",
+                "version": "6.0.3"
+            },
+            {
+                "name": "@vitejs/plugin-react",
+                "version": "^4.7.0"
+            },
+            {
+                "name": "@types/express",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/express-serve-static-core",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/react",
+                "version": "^19.2.7"
+            },
+            {
+                "name": "@types/react-dom",
+                "version": "^19.2.3"
+            }
+        ],
+        "peerDependencies": []
+    },
+    "_waspServerNpmDeps": {
+        "dependencies": [
+            {
+                "name": "@wasp.sh/lib-auth",
+                "version": "file:../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"
+            },
+            {
+                "name": "@wasp.sh/lib-vite-ssr",
+                "version": "file:../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
+            },
+            {
+                "name": "cookie-parser",
+                "version": "~1.4.6"
+            },
+            {
+                "name": "cors",
+                "version": "^2.8.5"
+            },
+            {
+                "name": "dotenv",
+                "version": "^16.6.1"
+            },
+            {
+                "name": "express",
+                "version": "~5.1.0"
+            },
+            {
+                "name": "helmet",
+                "version": "^6.0.0"
+            },
+            {
+                "name": "morgan",
+                "version": "~1.10.0"
+            },
+            {
+                "name": "superjson",
+                "version": "^2.2.1"
+            }
+        ],
+        "devDependencies": [
+            {
+                "name": "@rollup/plugin-node-resolve",
+                "version": "^16.0.0"
+            },
+            {
+                "name": "@tsconfig/node24",
+                "version": "latest"
+            },
+            {
+                "name": "@types/cors",
+                "version": "^2.8.5"
+            },
+            {
+                "name": "@types/express",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/express-serve-static-core",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/node",
+                "version": "^24.0.0"
+            },
+            {
+                "name": "nodemon",
+                "version": "^2.0.19"
+            },
+            {
+                "name": "rollup",
+                "version": "^4.9.6"
+            },
+            {
+                "name": "rollup-plugin-esbuild",
+                "version": "^6.1.1"
+            },
+            {
+                "name": "typescript",
+                "version": "6.0.3"
+            }
+        ],
+        "peerDependencies": []
+    }
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
@@ -1,1 +1,253 @@
-{"_userNpmDeps":{"fromUser":{"dependencies":[{"name":"react","version":"^19.2.1"},{"name":"react-dom","version":"^19.2.1"},{"name":"react-router","version":"^7.12.0"}],"devDependencies":[{"name":"@types/node","version":"^24.0.0"},{"name":"@types/react","version":"^19.2.7"},{"name":"@types/react-dom","version":"^19.2.3"},{"name":"@wasp.sh/spec","version":"file:.wasp/spec/"},{"name":"prisma","version":"5.19.1"},{"name":"typescript","version":"6.0.3"},{"name":"vite","version":"^7.0.6"},{"name":"vitest","version":"^4.0.16"}],"peerDependencies":[]}},"_waspSdkNpmDeps":{"dependencies":[{"name":"@prisma/client","version":"5.19.1"},{"name":"prisma","version":"5.19.1"},{"name":"dotenv","version":"^16.6.1"},{"name":"dotenv-expand","version":"^12.0.3"},{"name":"express","version":"~5.1.0"},{"name":"ky","version":"^2.0.0"},{"name":"mitt","version":"3.0.0"},{"name":"react","version":"^19.2.1"},{"name":"react-dom","version":"^19.2.1"},{"name":"@tanstack/react-query","version":"~4.42.0"},{"name":"react-router","version":"^7.12.0"},{"name":"react-hook-form","version":"^7.45.4"},{"name":"superjson","version":"^2.2.1"},{"name":"@vitest/ui","version":"^4.0.16"},{"name":"jsdom","version":"^27.4.0"},{"name":"@testing-library/react","version":"^16.3.1"},{"name":"@testing-library/jest-dom","version":"^6.9.1"},{"name":"msw","version":"^2.12.7"},{"name":"zod","version":"^4.3.6"},{"name":"@wasp.sh/lib-auth","version":"file:../../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"},{"name":"@wasp.sh/lib-vite-ssr","version":"file:../../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"}],"devDependencies":[{"name":"typescript","version":"6.0.3"},{"name":"@vitejs/plugin-react","version":"^4.7.0"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/express-serve-static-core","version":"^5.0.0"},{"name":"@types/react","version":"^19.2.7"},{"name":"@types/react-dom","version":"^19.2.3"}],"peerDependencies":[]},"_waspServerNpmDeps":{"dependencies":[{"name":"@wasp.sh/lib-auth","version":"file:../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"},{"name":"@wasp.sh/lib-vite-ssr","version":"file:../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"},{"name":"cookie-parser","version":"~1.4.6"},{"name":"cors","version":"^2.8.5"},{"name":"dotenv","version":"^16.6.1"},{"name":"express","version":"~5.1.0"},{"name":"helmet","version":"^6.0.0"},{"name":"morgan","version":"~1.10.0"},{"name":"superjson","version":"^2.2.1"}],"devDependencies":[{"name":"@rollup/plugin-node-resolve","version":"^16.0.0"},{"name":"@tsconfig/node24","version":"latest"},{"name":"@types/cors","version":"^2.8.5"},{"name":"@types/express","version":"^5.0.0"},{"name":"@types/express-serve-static-core","version":"^5.0.0"},{"name":"@types/node","version":"^24.0.0"},{"name":"nodemon","version":"^2.0.19"},{"name":"rollup","version":"^4.9.6"},{"name":"rollup-plugin-esbuild","version":"^6.1.1"},{"name":"typescript","version":"6.0.3"}],"peerDependencies":[]}}
+{
+    "_userNpmDeps": {
+        "fromUser": {
+            "dependencies": [
+                {
+                    "name": "react",
+                    "version": "^19.2.1"
+                },
+                {
+                    "name": "react-dom",
+                    "version": "^19.2.1"
+                },
+                {
+                    "name": "react-router",
+                    "version": "^7.12.0"
+                }
+            ],
+            "devDependencies": [
+                {
+                    "name": "@types/node",
+                    "version": "^24.0.0"
+                },
+                {
+                    "name": "@types/react",
+                    "version": "^19.2.7"
+                },
+                {
+                    "name": "@types/react-dom",
+                    "version": "^19.2.3"
+                },
+                {
+                    "name": "@wasp.sh/spec",
+                    "version": "file:.wasp/spec/"
+                },
+                {
+                    "name": "prisma",
+                    "version": "5.19.1"
+                },
+                {
+                    "name": "typescript",
+                    "version": "6.0.3"
+                },
+                {
+                    "name": "vite",
+                    "version": "^7.0.6"
+                },
+                {
+                    "name": "vitest",
+                    "version": "^4.0.16"
+                }
+            ],
+            "peerDependencies": []
+        }
+    },
+    "_waspSdkNpmDeps": {
+        "dependencies": [
+            {
+                "name": "@prisma/client",
+                "version": "5.19.1"
+            },
+            {
+                "name": "prisma",
+                "version": "5.19.1"
+            },
+            {
+                "name": "dotenv",
+                "version": "^16.6.1"
+            },
+            {
+                "name": "dotenv-expand",
+                "version": "^12.0.3"
+            },
+            {
+                "name": "express",
+                "version": "~5.1.0"
+            },
+            {
+                "name": "ky",
+                "version": "^2.0.0"
+            },
+            {
+                "name": "mitt",
+                "version": "3.0.0"
+            },
+            {
+                "name": "react",
+                "version": "^19.2.1"
+            },
+            {
+                "name": "react-dom",
+                "version": "^19.2.1"
+            },
+            {
+                "name": "@tanstack/react-query",
+                "version": "~4.42.0"
+            },
+            {
+                "name": "react-router",
+                "version": "^7.12.0"
+            },
+            {
+                "name": "react-hook-form",
+                "version": "^7.45.4"
+            },
+            {
+                "name": "superjson",
+                "version": "^2.2.1"
+            },
+            {
+                "name": "@vitest/ui",
+                "version": "^4.0.16"
+            },
+            {
+                "name": "jsdom",
+                "version": "^27.4.0"
+            },
+            {
+                "name": "@testing-library/react",
+                "version": "^16.3.1"
+            },
+            {
+                "name": "@testing-library/jest-dom",
+                "version": "^6.9.1"
+            },
+            {
+                "name": "msw",
+                "version": "^2.12.7"
+            },
+            {
+                "name": "zod",
+                "version": "^4.3.6"
+            },
+            {
+                "name": "@wasp.sh/lib-auth",
+                "version": "file:../../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"
+            },
+            {
+                "name": "@wasp.sh/lib-vite-ssr",
+                "version": "file:../../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
+            }
+        ],
+        "devDependencies": [
+            {
+                "name": "typescript",
+                "version": "6.0.3"
+            },
+            {
+                "name": "@vitejs/plugin-react",
+                "version": "^4.7.0"
+            },
+            {
+                "name": "@types/express",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/express-serve-static-core",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/react",
+                "version": "^19.2.7"
+            },
+            {
+                "name": "@types/react-dom",
+                "version": "^19.2.3"
+            }
+        ],
+        "peerDependencies": []
+    },
+    "_waspServerNpmDeps": {
+        "dependencies": [
+            {
+                "name": "@wasp.sh/lib-auth",
+                "version": "file:../libs/auth/wasp.sh-lib-auth-0.25.0.tgz"
+            },
+            {
+                "name": "@wasp.sh/lib-vite-ssr",
+                "version": "file:../libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
+            },
+            {
+                "name": "cookie-parser",
+                "version": "~1.4.6"
+            },
+            {
+                "name": "cors",
+                "version": "^2.8.5"
+            },
+            {
+                "name": "dotenv",
+                "version": "^16.6.1"
+            },
+            {
+                "name": "express",
+                "version": "~5.1.0"
+            },
+            {
+                "name": "helmet",
+                "version": "^6.0.0"
+            },
+            {
+                "name": "morgan",
+                "version": "~1.10.0"
+            },
+            {
+                "name": "superjson",
+                "version": "^2.2.1"
+            }
+        ],
+        "devDependencies": [
+            {
+                "name": "@rollup/plugin-node-resolve",
+                "version": "^16.0.0"
+            },
+            {
+                "name": "@tsconfig/node24",
+                "version": "latest"
+            },
+            {
+                "name": "@types/cors",
+                "version": "^2.8.5"
+            },
+            {
+                "name": "@types/express",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/express-serve-static-core",
+                "version": "^5.0.0"
+            },
+            {
+                "name": "@types/node",
+                "version": "^24.0.0"
+            },
+            {
+                "name": "nodemon",
+                "version": "^2.0.19"
+            },
+            {
+                "name": "rollup",
+                "version": "^4.9.6"
+            },
+            {
+                "name": "rollup-plugin-esbuild",
+                "version": "^6.1.1"
+            },
+            {
+                "name": "typescript",
+                "version": "6.0.3"
+            }
+        ],
+        "peerDependencies": []
+    }
+}

--- a/waspc/src/Wasp/Generator/NpmInstall/InstalledNpmDepsLog.hs
+++ b/waspc/src/Wasp/Generator/NpmInstall/InstalledNpmDepsLog.hs
@@ -6,6 +6,7 @@ module Wasp.Generator.NpmInstall.InstalledNpmDepsLog
 where
 
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encode.Pretty as AesonPretty
 import qualified Data.ByteString.Lazy as B
 import StrongPath (Abs, Dir, File', Path', Rel, relfile, (</>))
 import qualified StrongPath as SP
@@ -29,7 +30,7 @@ loadInstalledNpmDepsLog dstDir = do
 -- Save the record of the Wasp's (webapp + server) npm dependencies we installed, to disk.
 saveInstalledNpmDepsLog :: AllNpmDeps -> Path' Abs (Dir GeneratedAppDir) -> IO ()
 saveInstalledNpmDepsLog deps dstDir =
-  B.writeFile (SP.fromAbsFile $ getInstalledNpmDepsLogFilePath dstDir) (Aeson.encode deps)
+  B.writeFile (SP.fromAbsFile $ getInstalledNpmDepsLogFilePath dstDir) (AesonPretty.encodePretty deps)
 
 forgetInstalledNpmDepsLog :: Path' Abs (Dir GeneratedAppDir) -> IO ()
 forgetInstalledNpmDepsLog dstDir =


### PR DESCRIPTION
## Description

The generated `installedNpmDepsLog.json` was written as a single minified line, which made it hard to read and produced noisy diffs. This switches `saveInstalledNpmDepsLog` from `Aeson.encode` to `AesonPretty.encodePretty` so the file is pretty-printed. The affected e2e golden snapshots were regenerated to match.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
