### PR TITLE
Don't install HLS in CI

### DIFF
--- a/.config/mise/config.ci.toml
+++ b/.config/mise/config.ci.toml
@@ -1,0 +1,8 @@
+# CI-only mise config, loaded on top of the base `mise.toml` when `MISE_ENV=ci`.
+# CI enables it via the `MISE_ENV` env var in `.github/actions/setup-tools`.
+# See https://mise.jdx.dev/configuration/environments.html
+#
+# These tools are only used locally, so we don't install them in CI, because
+# they take up more time and cache space.
+[settings]
+disable_tools = ["mise-ghcup:hls"]

--- a/.github/actions/setup-tools/action.yaml
+++ b/.github/actions/setup-tools/action.yaml
@@ -9,9 +9,19 @@ runs:
   steps:
     - name: Install Mise
       uses: jdx/mise-action@v4
+      env:
+        # Loads `.config/mise/config.ci.toml` on top of `mise.toml`, which
+        # disables dev-only tools that are not used in CI.
+        MISE_ENV: ci
       with:
         bootstrap: true
         bootstrap_args: --update --yes
+
+    - name: Persist Mise environment
+      shell: bash
+      # Write the MISE_ENV variable to the GitHub env so that future steps that
+      # might include `mise install`s still don't pick up dev-only tools.
+      run: echo "MISE_ENV=ci" >> "$GITHUB_ENV"
 
     - name: Cache npm dependencies
       uses: actions/setup-node@v6


### PR DESCRIPTION
## Description

Adds a CI-only mise config (`.config/mise/config.ci.toml`, layered on top of `mise.toml` when `MISE_ENV=ci`) that disables `mise-ghcup:hls`, so CI no longer installs the Haskell Language Server. HLS is only useful for local editor tooling, and installing it through ghcup wastes CI time and cache space (it's also prone to flaky ghcup failures). The `setup-tools` action now sets `MISE_ENV=ci` when bootstrapping mise and persists it to `$GITHUB_ENV`, so every job that uses the action skips HLS.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
