### PR TITLE
Use StaticRouter in SSR

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -17,6 +17,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 ### 🐞 Bug fixes
 
 - Fixed a race condition where `useAuth()` could return stale user data after an action that modifies the `User` entity (by @okxint). ([#4343](https://github.com/wasp-lang/wasp/issues/4343))
+- Fixed a hydration mismatch on prerendered pages by using React Router's `StaticRouter` during SSR and serializing the hydration data ourselves. ([#4417](https://github.com/wasp-lang/wasp/pull/4417))
 
 ### 🔧 Small improvements
 

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -9,15 +9,13 @@ import { WaspApp } from "wasp/client/app";
 
 {=& routeObjects.importStatement =}
 
+// We embed this data at prerendering time.
+const { isFallbackPage, routerHydrationData } = window.__WASP_SSR_DATA__ ?? {}
+
 const router = createBrowserRouter({= routeObjects.importIdentifier =}, {
   basename: "{= baseDir =}",
-  // React Router will put hydration data on this property of the `window` object.
-  // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
-  hydrationData: window.__staticRouterHydrationData,
+  hydrationData: routerHydrationData,
 })
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
 function App() {
   return (

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -6,7 +6,8 @@ import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
   createStaticHandler,
   createStaticRouter,
-  RouterProvider,
+  StaticRouterProvider,
+  type HydrationState,
 } from "react-router";
 
 import { Layout } from "wasp/client/app/layout";
@@ -14,6 +15,7 @@ import { WaspApp } from "wasp/client/app";
 
 {=& routeObjects.importStatement =}
 
+const WASP_SSR_DATA_KEY = "__WASP_SSR_DATA__" satisfies keyof typeof globalThis;
 const SPA_FALLBACK_FILE = "{= spaFallbackFile =}";
 
 const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
@@ -36,16 +38,29 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     return (
       <Layout isFallbackPage={isFallbackPage} clientEntrySrc={clientEntrySrc}>
         <WaspApp>
-          <RouterProvider router={router} />
+          {/*
+            `hydrate={false}` because the default hydration script would be
+            rendered inside the React tree, causing a hydration mismatch. We
+            serialize the hydration data ourselves in `bootstrapScriptContent`,
+            which is React's recommended way of adding SSR-only script tags.
+          */}
+          <StaticRouterProvider router={router} context={context} hydrate={false} />
         </WaspApp>
       </Layout>
     )
   }
 
-  const WASP_SSR_DATA: WaspSSRData = { isFallbackPage }
+  // The fallback page's static handler context is a 404 (nothing matches the
+  // literal fallback file URL), so its state must not leak into the client router.
+  const routerHydrationData: HydrationState | undefined =
+    isFallbackPage
+      ? undefined
+      : context;
+
+  const waspSsrData: WaspSSRData = { isFallbackPage, routerHydrationData }
 
   const html = await reactPrerender(<App/>, {
-    bootstrapScriptContent: `window.__WASP_SSR_DATA__=${JSON.stringify(WASP_SSR_DATA)};`,
+    bootstrapScriptContent: `window.${WASP_SSR_DATA_KEY}=${JSON.stringify(waspSsrData)};`,
   })
     .then((result) => streamConsumers.text(result.prelude))
 

--- a/waspc/data/Generator/templates/sdk/wasp/vite-env.d.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/vite-env.d.ts
@@ -2,9 +2,9 @@
 
 interface WaspSSRData {
   isFallbackPage: boolean
+  routerHydrationData?: import("react-router").HydrationState
 }
 
 interface Window {
   __WASP_SSR_DATA__?: WaspSSRData
-  __staticRouterHydrationData?: import("react-router").HydrationState
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -788,7 +788,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "413c3dc30af130acc68fb319915348aab647f0b6d73bddacfcc5b5c3b7dbb766"
+        "ac5a9f2c10a7b0196b5bf01d6e3f78ac842ba56a6345d8c70afff419990d0a0c"
     ],
     [
         [
@@ -802,7 +802,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx"
         ],
-        "f1b19e131b16c7dc39254a841ad836ba5ea7200cb7e11d06999c3b276bca30f6"
+        "fea502a67528cc0ee911c2ab0bc778d52eeef56cb22439c71bd7434434163c20"
     ],
     [
         [
@@ -1859,7 +1859,7 @@
             "file",
             "sdk/wasp/vite-env.d.ts"
         ],
-        "665f3198e423071ad1101003d223d09386605ddd32bcf8efba857619dd6dbb9f"
+        "158be0d44b5f11b0acbbb8386e2517affb5acd27a1ac1248a07bd44ea4859dd4"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -8,15 +8,13 @@ import { WaspApp } from "wasp/client/app";
 
 import { routeObjects } from '/@wasp/routes.tsx'
 
+// We embed this data at prerendering time.
+const { isFallbackPage, routerHydrationData } = window.__WASP_SSR_DATA__ ?? {}
+
 const router = createBrowserRouter(routeObjects, {
   basename: "/",
-  // React Router will put hydration data on this property of the `window` object.
-  // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
-  hydrationData: window.__staticRouterHydrationData,
+  hydrationData: routerHydrationData,
 })
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
 function App() {
   return (

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -5,7 +5,8 @@ import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
   createStaticHandler,
   createStaticRouter,
-  RouterProvider,
+  StaticRouterProvider,
+  type HydrationState,
 } from "react-router";
 
 import { Layout } from "wasp/client/app/layout";
@@ -13,6 +14,7 @@ import { WaspApp } from "wasp/client/app";
 
 import { routeObjects } from '/@wasp/routes.tsx'
 
+const WASP_SSR_DATA_KEY = "__WASP_SSR_DATA__" satisfies keyof typeof globalThis;
 const SPA_FALLBACK_FILE = "200.html";
 
 const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
@@ -35,16 +37,29 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     return (
       <Layout isFallbackPage={isFallbackPage} clientEntrySrc={clientEntrySrc}>
         <WaspApp>
-          <RouterProvider router={router} />
+          {/*
+            `hydrate={false}` because the default hydration script would be
+            rendered inside the React tree, causing a hydration mismatch. We
+            serialize the hydration data ourselves in `bootstrapScriptContent`,
+            which is React's recommended way of adding SSR-only script tags.
+          */}
+          <StaticRouterProvider router={router} context={context} hydrate={false} />
         </WaspApp>
       </Layout>
     )
   }
 
-  const WASP_SSR_DATA: WaspSSRData = { isFallbackPage }
+  // The fallback page's static handler context is a 404 (nothing matches the
+  // literal fallback file URL), so its state must not leak into the client router.
+  const routerHydrationData: HydrationState | undefined =
+    isFallbackPage
+      ? undefined
+      : context;
+
+  const waspSsrData: WaspSSRData = { isFallbackPage, routerHydrationData }
 
   const html = await reactPrerender(<App/>, {
-    bootstrapScriptContent: `window.__WASP_SSR_DATA__=${JSON.stringify(WASP_SSR_DATA)};`,
+    bootstrapScriptContent: `window.${WASP_SSR_DATA_KEY}=${JSON.stringify(waspSsrData)};`,
   })
     .then((result) => streamConsumers.text(result.prelude))
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
@@ -2,9 +2,9 @@
 
 interface WaspSSRData {
   isFallbackPage: boolean
+  routerHydrationData?: import("react-router").HydrationState
 }
 
 interface Window {
   __WASP_SSR_DATA__?: WaspSSRData
-  __staticRouterHydrationData?: import("react-router").HydrationState
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "413c3dc30af130acc68fb319915348aab647f0b6d73bddacfcc5b5c3b7dbb766"
+        "ac5a9f2c10a7b0196b5bf01d6e3f78ac842ba56a6345d8c70afff419990d0a0c"
     ],
     [
         [
@@ -361,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx"
         ],
-        "f1b19e131b16c7dc39254a841ad836ba5ea7200cb7e11d06999c3b276bca30f6"
+        "fea502a67528cc0ee911c2ab0bc778d52eeef56cb22439c71bd7434434163c20"
     ],
     [
         [
@@ -641,7 +641,7 @@
             "file",
             "sdk/wasp/vite-env.d.ts"
         ],
-        "665f3198e423071ad1101003d223d09386605ddd32bcf8efba857619dd6dbb9f"
+        "158be0d44b5f11b0acbbb8386e2517affb5acd27a1ac1248a07bd44ea4859dd4"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -8,15 +8,13 @@ import { WaspApp } from "wasp/client/app";
 
 import { routeObjects } from '/@wasp/routes.tsx'
 
+// We embed this data at prerendering time.
+const { isFallbackPage, routerHydrationData } = window.__WASP_SSR_DATA__ ?? {}
+
 const router = createBrowserRouter(routeObjects, {
   basename: "/",
-  // React Router will put hydration data on this property of the `window` object.
-  // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
-  hydrationData: window.__staticRouterHydrationData,
+  hydrationData: routerHydrationData,
 })
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
 function App() {
   return (

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -5,7 +5,8 @@ import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
   createStaticHandler,
   createStaticRouter,
-  RouterProvider,
+  StaticRouterProvider,
+  type HydrationState,
 } from "react-router";
 
 import { Layout } from "wasp/client/app/layout";
@@ -13,6 +14,7 @@ import { WaspApp } from "wasp/client/app";
 
 import { routeObjects } from '/@wasp/routes.tsx'
 
+const WASP_SSR_DATA_KEY = "__WASP_SSR_DATA__" satisfies keyof typeof globalThis;
 const SPA_FALLBACK_FILE = "200.html";
 
 const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
@@ -35,16 +37,29 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     return (
       <Layout isFallbackPage={isFallbackPage} clientEntrySrc={clientEntrySrc}>
         <WaspApp>
-          <RouterProvider router={router} />
+          {/*
+            `hydrate={false}` because the default hydration script would be
+            rendered inside the React tree, causing a hydration mismatch. We
+            serialize the hydration data ourselves in `bootstrapScriptContent`,
+            which is React's recommended way of adding SSR-only script tags.
+          */}
+          <StaticRouterProvider router={router} context={context} hydrate={false} />
         </WaspApp>
       </Layout>
     )
   }
 
-  const WASP_SSR_DATA: WaspSSRData = { isFallbackPage }
+  // The fallback page's static handler context is a 404 (nothing matches the
+  // literal fallback file URL), so its state must not leak into the client router.
+  const routerHydrationData: HydrationState | undefined =
+    isFallbackPage
+      ? undefined
+      : context;
+
+  const waspSsrData: WaspSSRData = { isFallbackPage, routerHydrationData }
 
   const html = await reactPrerender(<App/>, {
-    bootstrapScriptContent: `window.__WASP_SSR_DATA__=${JSON.stringify(WASP_SSR_DATA)};`,
+    bootstrapScriptContent: `window.${WASP_SSR_DATA_KEY}=${JSON.stringify(waspSsrData)};`,
   })
     .then((result) => streamConsumers.text(result.prelude))
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
@@ -2,9 +2,9 @@
 
 interface WaspSSRData {
   isFallbackPage: boolean
+  routerHydrationData?: import("react-router").HydrationState
 }
 
 interface Window {
   __WASP_SSR_DATA__?: WaspSSRData
-  __staticRouterHydrationData?: import("react-router").HydrationState
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -393,13 +393,11 @@ const routeObjects = getRouteObjects({
   routesMapping,
   rootElement
 });
+const { isFallbackPage, routerHydrationData } = window.__WASP_SSR_DATA__ ?? {};
 const router = createBrowserRouter(routeObjects, {
   basename: "/",
-  // React Router will put hydration data on this property of the `window` object.
-  // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
-  hydrationData: window.__staticRouterHydrationData
+  hydrationData: routerHydrationData
 });
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {};
 function App() {
   return /* @__PURE__ */ jsx(Layout, { isFallbackPage, children: /* @__PURE__ */ jsx(WaspApp, { children: /* @__PURE__ */ jsx(RouterProvider, { router }) }) });
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "413c3dc30af130acc68fb319915348aab647f0b6d73bddacfcc5b5c3b7dbb766"
+        "ac5a9f2c10a7b0196b5bf01d6e3f78ac842ba56a6345d8c70afff419990d0a0c"
     ],
     [
         [
@@ -361,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx"
         ],
-        "f1b19e131b16c7dc39254a841ad836ba5ea7200cb7e11d06999c3b276bca30f6"
+        "fea502a67528cc0ee911c2ab0bc778d52eeef56cb22439c71bd7434434163c20"
     ],
     [
         [
@@ -641,7 +641,7 @@
             "file",
             "sdk/wasp/vite-env.d.ts"
         ],
-        "665f3198e423071ad1101003d223d09386605ddd32bcf8efba857619dd6dbb9f"
+        "158be0d44b5f11b0acbbb8386e2517affb5acd27a1ac1248a07bd44ea4859dd4"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -8,15 +8,13 @@ import { WaspApp } from "wasp/client/app";
 
 import { routeObjects } from '/@wasp/routes.tsx'
 
+// We embed this data at prerendering time.
+const { isFallbackPage, routerHydrationData } = window.__WASP_SSR_DATA__ ?? {}
+
 const router = createBrowserRouter(routeObjects, {
   basename: "/",
-  // React Router will put hydration data on this property of the `window` object.
-  // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
-  hydrationData: window.__staticRouterHydrationData,
+  hydrationData: routerHydrationData,
 })
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
 function App() {
   return (

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -5,7 +5,8 @@ import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
   createStaticHandler,
   createStaticRouter,
-  RouterProvider,
+  StaticRouterProvider,
+  type HydrationState,
 } from "react-router";
 
 import { Layout } from "wasp/client/app/layout";
@@ -13,6 +14,7 @@ import { WaspApp } from "wasp/client/app";
 
 import { routeObjects } from '/@wasp/routes.tsx'
 
+const WASP_SSR_DATA_KEY = "__WASP_SSR_DATA__" satisfies keyof typeof globalThis;
 const SPA_FALLBACK_FILE = "200.html";
 
 const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
@@ -35,16 +37,29 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     return (
       <Layout isFallbackPage={isFallbackPage} clientEntrySrc={clientEntrySrc}>
         <WaspApp>
-          <RouterProvider router={router} />
+          {/*
+            `hydrate={false}` because the default hydration script would be
+            rendered inside the React tree, causing a hydration mismatch. We
+            serialize the hydration data ourselves in `bootstrapScriptContent`,
+            which is React's recommended way of adding SSR-only script tags.
+          */}
+          <StaticRouterProvider router={router} context={context} hydrate={false} />
         </WaspApp>
       </Layout>
     )
   }
 
-  const WASP_SSR_DATA: WaspSSRData = { isFallbackPage }
+  // The fallback page's static handler context is a 404 (nothing matches the
+  // literal fallback file URL), so its state must not leak into the client router.
+  const routerHydrationData: HydrationState | undefined =
+    isFallbackPage
+      ? undefined
+      : context;
+
+  const waspSsrData: WaspSSRData = { isFallbackPage, routerHydrationData }
 
   const html = await reactPrerender(<App/>, {
-    bootstrapScriptContent: `window.__WASP_SSR_DATA__=${JSON.stringify(WASP_SSR_DATA)};`,
+    bootstrapScriptContent: `window.${WASP_SSR_DATA_KEY}=${JSON.stringify(waspSsrData)};`,
   })
     .then((result) => streamConsumers.text(result.prelude))
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
@@ -2,9 +2,9 @@
 
 interface WaspSSRData {
   isFallbackPage: boolean
+  routerHydrationData?: import("react-router").HydrationState
 }
 
 interface Window {
   __WASP_SSR_DATA__?: WaspSSRData
-  __staticRouterHydrationData?: import("react-router").HydrationState
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "413c3dc30af130acc68fb319915348aab647f0b6d73bddacfcc5b5c3b7dbb766"
+        "ac5a9f2c10a7b0196b5bf01d6e3f78ac842ba56a6345d8c70afff419990d0a0c"
     ],
     [
         [
@@ -361,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx"
         ],
-        "f1b19e131b16c7dc39254a841ad836ba5ea7200cb7e11d06999c3b276bca30f6"
+        "fea502a67528cc0ee911c2ab0bc778d52eeef56cb22439c71bd7434434163c20"
     ],
     [
         [
@@ -648,7 +648,7 @@
             "file",
             "sdk/wasp/vite-env.d.ts"
         ],
-        "665f3198e423071ad1101003d223d09386605ddd32bcf8efba857619dd6dbb9f"
+        "158be0d44b5f11b0acbbb8386e2517affb5acd27a1ac1248a07bd44ea4859dd4"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -8,15 +8,13 @@ import { WaspApp } from "wasp/client/app";
 
 import { routeObjects } from '/@wasp/routes.tsx'
 
+// We embed this data at prerendering time.
+const { isFallbackPage, routerHydrationData } = window.__WASP_SSR_DATA__ ?? {}
+
 const router = createBrowserRouter(routeObjects, {
   basename: "/",
-  // React Router will put hydration data on this property of the `window` object.
-  // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
-  hydrationData: window.__staticRouterHydrationData,
+  hydrationData: routerHydrationData,
 })
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
 function App() {
   return (

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -5,7 +5,8 @@ import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
   createStaticHandler,
   createStaticRouter,
-  RouterProvider,
+  StaticRouterProvider,
+  type HydrationState,
 } from "react-router";
 
 import { Layout } from "wasp/client/app/layout";
@@ -13,6 +14,7 @@ import { WaspApp } from "wasp/client/app";
 
 import { routeObjects } from '/@wasp/routes.tsx'
 
+const WASP_SSR_DATA_KEY = "__WASP_SSR_DATA__" satisfies keyof typeof globalThis;
 const SPA_FALLBACK_FILE = "200.html";
 
 const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
@@ -35,16 +37,29 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     return (
       <Layout isFallbackPage={isFallbackPage} clientEntrySrc={clientEntrySrc}>
         <WaspApp>
-          <RouterProvider router={router} />
+          {/*
+            `hydrate={false}` because the default hydration script would be
+            rendered inside the React tree, causing a hydration mismatch. We
+            serialize the hydration data ourselves in `bootstrapScriptContent`,
+            which is React's recommended way of adding SSR-only script tags.
+          */}
+          <StaticRouterProvider router={router} context={context} hydrate={false} />
         </WaspApp>
       </Layout>
     )
   }
 
-  const WASP_SSR_DATA: WaspSSRData = { isFallbackPage }
+  // The fallback page's static handler context is a 404 (nothing matches the
+  // literal fallback file URL), so its state must not leak into the client router.
+  const routerHydrationData: HydrationState | undefined =
+    isFallbackPage
+      ? undefined
+      : context;
+
+  const waspSsrData: WaspSSRData = { isFallbackPage, routerHydrationData }
 
   const html = await reactPrerender(<App/>, {
-    bootstrapScriptContent: `window.__WASP_SSR_DATA__=${JSON.stringify(WASP_SSR_DATA)};`,
+    bootstrapScriptContent: `window.${WASP_SSR_DATA_KEY}=${JSON.stringify(waspSsrData)};`,
   })
     .then((result) => streamConsumers.text(result.prelude))
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
@@ -2,9 +2,9 @@
 
 interface WaspSSRData {
   isFallbackPage: boolean
+  routerHydrationData?: import("react-router").HydrationState
 }
 
 interface Window {
   __WASP_SSR_DATA__?: WaspSSRData
-  __staticRouterHydrationData?: import("react-router").HydrationState
 }


### PR DESCRIPTION
## Description

In SSR/prerendering we were rendering routes with React Router's data
`RouterProvider` and relying on React Router to inject its hydration data onto
`window.__staticRouterHydrationData`. That default hydration script is emitted
inside the React tree, which caused a hydration mismatch on the client. It also
meant the client router picked up whatever state the static handler produced,
including the 404 context of the SPA fallback page.

This PR switches the server entry to `StaticRouterProvider` with
`hydrate={false}` and serializes the hydration data ourselves, alongside the
existing `isFallbackPage` flag, into `window.__WASP_SSR_DATA__` via
`bootstrapScriptContent` (React's recommended way of adding SSR-only script
tags). The client entry then reads `routerHydrationData` from that same object.

For the SPA fallback page we deliberately send `undefined` hydration data, since
its static handler context is a 404 (nothing matches the literal fallback file
URL) and that state must not leak into the client router.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Covered by existing e2e prerendering snapshots. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
