### PR TITLE
Extract client initialization from routes

### DIFF
--- a/examples/kitchen-sink/src/features/operations/cacheInvalidation.test.ts
+++ b/examples/kitchen-sink/src/features/operations/cacheInvalidation.test.ts
@@ -1,12 +1,11 @@
 import { QueryObserver } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "wasp/client";
 import {
   createTask,
   getTasks,
   initializeQueryClient,
-  queryClientInitialized,
 } from "wasp/client/operations";
 import { mockServer } from "wasp/client/test";
 import { serialize } from "wasp/core/serialization";
@@ -38,13 +37,6 @@ const apiUrlPattern = new RegExp(
   "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
 );
 
-beforeAll(async () => {
-  // `mockServer()` (called above) already wires up server.listen/resetHandlers/
-  // close via beforeAll/afterEach/afterAll.
-  initializeQueryClient();
-  await queryClientInitialized;
-});
-
 beforeEach(() => {
   // `mockServer()`'s afterEach calls `server.resetHandlers()`, so the handler
   // has to be (re)registered before each test rather than once in `beforeAll`.
@@ -66,7 +58,7 @@ beforeEach(() => {
 
 describe("action cache invalidation (#3009)", () => {
   it("queries depending on the action's entities are fresh once the action resolves", async () => {
-    const queryClient = await queryClientInitialized;
+    const queryClient = initializeQueryClient();
     const queryKey = getTasks.queryCacheKey;
 
     // Server starts with a single task.

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -23,6 +23,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 - Added a `wasp doctor` command that runs common sanity checks on your setup to check that Wasp can work correctly, and prints a report. ([#4283](https://github.com/wasp-lang/wasp/pull/4283))
 - `wasp deps` no longer shows internal Wasp packages in its output (by @okxint). ([#4342](https://github.com/wasp-lang/wasp/issues/4342))
 - `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4398](https://github.com/wasp-lang/wasp/pull/4398))
+- The client's `QueryClient` and your `app.client.setupFn` are now set up in a dedicated setup module instead of inside the generated router, so your client setup function reliably runs before the rest of the app loads. ([#4418](https://github.com/wasp-lang/wasp/pull/4418))
 
 ## 0.24.0
 

--- a/waspc/data/Generator/templates/sdk/wasp/client/app/client-setup.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/app/client-setup.ts
@@ -1,0 +1,17 @@
+{{={= =}=}}
+{=# setupFn.isDefined =}
+{=& setupFn.importStatement =}
+{=/ setupFn.isDefined =}
+import { initializeQueryClient } from '../operations/queryClient'
+
+{=# setupFn.isDefined =}
+// The user-defined setup function must run before anything else in the app.
+// Since this is a top-level await, every module that (transitively) imports
+// this one waits for it to finish before executing its own code.
+await {= setupFn.importIdentifier =}()
+{=/ setupFn.isDefined =}
+
+// PRIVATE API (framework code)
+// The QueryClient must be created only after the setup function completes,
+// because the setup function may call `configureQueryClient`.
+export const queryClient = initializeQueryClient()

--- a/waspc/data/Generator/templates/sdk/wasp/client/app/components/WaspApp.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/app/components/WaspApp.tsx
@@ -1,16 +1,14 @@
 {{={= =}=}}
-import { use, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 
-import { queryClientInitialized } from '../../operations/index'
+import { queryClient } from '../client-setup'
 
 {=# areWebSocketsUsed =}
 import { WebSocketProvider } from '../../webSocket/WebSocketProvider'
 {=/ areWebSocketsUsed =}
 
 export function WaspApp({ children }: { children: ReactNode }) {
-  const queryClient = use(queryClientInitialized)
-
   return (
     <QueryClientProvider client={queryClient}>
       {=# areWebSocketsUsed =}

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/index.ts
@@ -17,8 +17,6 @@ export {
     configureQueryClient,
     // PRIVATE API (framework code)
     initializeQueryClient,
-    // PRIVATE API (framework code)
-    queryClientInitialized
 } from './queryClient'
 
 export {

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/internal/resources.js
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/internal/resources.js
@@ -1,4 +1,4 @@
-import { queryClientInitialized } from '../queryClient.js'
+import { getQueryClient } from '../queryClient.js'
 import { makeUpdateHandlersMap } from './updateHandlersMap'
 import { hashQueryKey } from '@tanstack/react-query'
 
@@ -43,7 +43,7 @@ export function getActiveOptimisticUpdates(queryKey) {
 }
 
 export async function invalidateAndRemoveQueries() {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
   // If we don't reset the queries before removing them, Wasp will stay on
   // the same page. The user would have to manually refresh the page to "finish"
   // logging out.
@@ -62,7 +62,7 @@ export async function invalidateAndRemoveQueries() {
  * @param {string[]} resources - Names of resources.
  */
 async function invalidateQueriesUsing(resources) {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
 
   const queryCacheKeysToInvalidate = getQueriesUsingResources(resources)
   await Promise.all(

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.ts
@@ -3,19 +3,11 @@ import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
 const defaultQueryClientConfig = {};
 
 let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
-);
+  queryClient: QueryClient | undefined;
 
 // PUBLIC API
 export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
+  if (queryClient) {
     throw new Error(
       "Attempted to configure the QueryClient after initialization"
     );
@@ -25,10 +17,21 @@ export function configureQueryClient(config: QueryClientConfig): void {
 }
 
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
+// Idempotent: the first call creates the QueryClient, later calls return it.
+export function initializeQueryClient(): QueryClient {
+  queryClient ??= new QueryClient(queryClientConfig ?? defaultQueryClientConfig);
+  return queryClient;
+}
+
+// PRIVATE API (framework code)
+export function getQueryClient(): QueryClient {
+  if (!queryClient) {
+    throw new Error(
+      "Attempted to access the QueryClient before initialization. " +
+        "The QueryClient is initialized in `wasp/client/app/client-setup`, " +
+        "after the user-defined client setup function completes."
+    );
+  }
+
+  return queryClient;
 }

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,6 +1,5 @@
 {{={= =}=}}
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
 
 {=# isAuthEnabled =}
@@ -10,10 +9,6 @@ import { createAuthRequiredPage } from "wasp/client/app"
 {=# rootComponent.isDefined =}
 {=& rootComponent.importStatement =}
 {=/ rootComponent.isDefined =}
-
-{=# setupFn.isDefined =}
-{=& setupFn.importStatement =}
-{=/ setupFn.isDefined =}
 
 {=# routes =}
 {=^ isLazy =}
@@ -52,12 +47,6 @@ const routesMapping = {
   {=/ isLazy =}
   {=/ routes =}
 } as const;
-
-{=# setupFn.isDefined =}
-await {= setupFn.importIdentifier =}()
-{=/ setupFn.isDefined =}
-
-initializeQueryClient()
 
 const rootElement =
   {=# rootComponent.isDefined =}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
@@ -74,6 +74,7 @@ wasp-app/.wasp/out/sdk/wasp/auth/useAuth.ts
 wasp-app/.wasp/out/sdk/wasp/auth/user.ts
 wasp-app/.wasp/out/sdk/wasp/auth/utils.ts
 wasp-app/.wasp/out/sdk/wasp/auth/validation.ts
+wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
 wasp-app/.wasp/out/sdk/wasp/client/app/components/DefaultRootErrorBoundary.tsx
 wasp-app/.wasp/out/sdk/wasp/client/app/components/FullPageWrapper.tsx
 wasp-app/.wasp/out/sdk/wasp/client/app/components/Loader.module.css
@@ -324,6 +325,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/auth/validation.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/auth/validation.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/auth/validation.js
 wasp-app/.wasp/out/sdk/wasp/dist/auth/validation.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.js
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.jsx

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -401,6 +401,13 @@
     [
         [
             "file",
+            "sdk/wasp/client/app/client-setup.ts"
+        ],
+        "6902a7e64a4088f37c6011d0518a0525c6c375478e060b9423f673db3879808d"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/client/app/components/DefaultRootErrorBoundary.tsx"
         ],
         "303821bb9b02b284835f571618c5f92e3da1b97709b7ed6cb3313fb33cc871f6"
@@ -438,7 +445,7 @@
             "file",
             "sdk/wasp/client/app/components/WaspApp.tsx"
         ],
-        "3add5d6ad5a3290bb2a6ac13a463773e6a725fbc0383bd5c0cd4db5f8500662a"
+        "975c0684cb4f9f67312d8e962458f2e07993fd2f5164acdaa54c4f80b28e29d1"
     ],
     [
         [
@@ -620,7 +627,7 @@
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "c96965e460ada3ad0369ed17a0dc8ebce623781ba02ab8059e61856024d12df2"
+        "66f85f8b8c10f0fc3417cddb19463af7772ffb5ed71de4c15b445b7b3154b221"
     ],
     [
         [
@@ -634,7 +641,7 @@
             "file",
             "sdk/wasp/client/operations/internal/resources.js"
         ],
-        "fa3e3b77c1d6f62889b613706fff1ee92bd70aa68ae80751df05c0ac72d844a4"
+        "48900f0c0c194b961467dd736de84a515a2d1ec703ec4195750f59f0a026ef7f"
     ],
     [
         [
@@ -662,7 +669,7 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "3b4eb2cdd4c19140455b7e03ce8099e2fd19268f41ca272d80f4f6f760d44a5a"
     ],
     [
         [
@@ -795,7 +802,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "602d74f37a55ee7dfa2322d28687a580bf1710a5ab1929a0c81cabb386a12b14"
+        "fc65953c6524ef546b0b664e675d905426e0f297677c973b1aad85b78830051f"
     ],
     [
         [
@@ -1621,7 +1628,7 @@
             "file",
             "sdk/wasp/src/features/operations/cacheInvalidation.test.ts"
         ],
-        "0bf9d9216c118effd6d7fc23ac35df2c6b90cc7c68c536562dc73a4668251bde"
+        "3a2585bf1d3ec96675539ab5ebebbdf3c192e9232dde4609a41534e136d93639"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
@@ -1,0 +1,12 @@
+import { clientSetup as clientSetup_ext } from 'wasp/src/clientSetup'
+import { initializeQueryClient } from '../operations/queryClient'
+
+// The user-defined setup function must run before anything else in the app.
+// Since this is a top-level await, every module that (transitively) imports
+// this one waits for it to finish before executing its own code.
+await clientSetup_ext()
+
+// PRIVATE API (framework code)
+// The QueryClient must be created only after the setup function completes,
+// because the setup function may call `configureQueryClient`.
+export const queryClient = initializeQueryClient()

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/components/WaspApp.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/components/WaspApp.tsx
@@ -1,13 +1,11 @@
-import { use, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 
-import { queryClientInitialized } from '../../operations/index'
+import { queryClient } from '../client-setup'
 
 import { WebSocketProvider } from '../../webSocket/WebSocketProvider'
 
 export function WaspApp({ children }: { children: ReactNode }) {
-  const queryClient = use(queryClientInitialized)
-
   return (
     <QueryClientProvider client={queryClient}>
       <WebSocketProvider>

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -17,8 +17,6 @@ export {
     configureQueryClient,
     // PRIVATE API (framework code)
     initializeQueryClient,
-    // PRIVATE API (framework code)
-    queryClientInitialized
 } from './queryClient'
 
 export {

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
@@ -1,4 +1,4 @@
-import { queryClientInitialized } from '../queryClient.js'
+import { getQueryClient } from '../queryClient.js'
 import { makeUpdateHandlersMap } from './updateHandlersMap'
 import { hashQueryKey } from '@tanstack/react-query'
 
@@ -43,7 +43,7 @@ export function getActiveOptimisticUpdates(queryKey) {
 }
 
 export async function invalidateAndRemoveQueries() {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
   // If we don't reset the queries before removing them, Wasp will stay on
   // the same page. The user would have to manually refresh the page to "finish"
   // logging out.
@@ -62,7 +62,7 @@ export async function invalidateAndRemoveQueries() {
  * @param {string[]} resources - Names of resources.
  */
 async function invalidateQueriesUsing(resources) {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
 
   const queryCacheKeysToInvalidate = getQueriesUsingResources(resources)
   await Promise.all(

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -3,19 +3,11 @@ import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
 const defaultQueryClientConfig = {};
 
 let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
-);
+  queryClient: QueryClient | undefined;
 
 // PUBLIC API
 export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
+  if (queryClient) {
     throw new Error(
       "Attempted to configure the QueryClient after initialization"
     );
@@ -25,10 +17,21 @@ export function configureQueryClient(config: QueryClientConfig): void {
 }
 
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
+// Idempotent: the first call creates the QueryClient, later calls return it.
+export function initializeQueryClient(): QueryClient {
+  queryClient ??= new QueryClient(queryClientConfig ?? defaultQueryClientConfig);
+  return queryClient;
+}
+
+// PRIVATE API (framework code)
+export function getQueryClient(): QueryClient {
+  if (!queryClient) {
+    throw new Error(
+      "Attempted to access the QueryClient before initialization. " +
+        "The QueryClient is initialized in `wasp/client/app/client-setup`, " +
+        "after the user-defined client setup function completes."
+    );
+  }
+
+  return queryClient;
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,12 +1,9 @@
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
 
 import { createAuthRequiredPage } from "wasp/client/app"
 
 import { App as App_ext } from './src/App'
-
-import { clientSetup as clientSetup_ext } from './src/clientSetup'
 
 import { EagerPage } from './src/features/lazy-loading/pages/EagerPage'
 
@@ -183,10 +180,6 @@ const routesMapping = {
       ),
   },
 } as const;
-
-await clientSetup_ext()
-
-initializeQueryClient()
 
 const rootElement =
   <App_ext />

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/src/features/operations/cacheInvalidation.test.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/src/features/operations/cacheInvalidation.test.ts
@@ -1,12 +1,11 @@
 import { QueryObserver } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "wasp/client";
 import {
   createTask,
   getTasks,
   initializeQueryClient,
-  queryClientInitialized,
 } from "wasp/client/operations";
 import { mockServer } from "wasp/client/test";
 import { serialize } from "wasp/core/serialization";
@@ -38,13 +37,6 @@ const apiUrlPattern = new RegExp(
   "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
 );
 
-beforeAll(async () => {
-  // `mockServer()` (called above) already wires up server.listen/resetHandlers/
-  // close via beforeAll/afterEach/afterAll.
-  initializeQueryClient();
-  await queryClientInitialized;
-});
-
 beforeEach(() => {
   // `mockServer()`'s afterEach calls `server.resetHandlers()`, so the handler
   // has to be (re)registered before each test rather than once in `beforeAll`.
@@ -66,7 +58,7 @@ beforeEach(() => {
 
 describe("action cache invalidation (#3009)", () => {
   it("queries depending on the action's entities are fresh once the action resolves", async () => {
-    const queryClient = await queryClientInitialized;
+    const queryClient = initializeQueryClient();
     const queryKey = getTasks.queryCacheKey;
 
     // Server starts with a single task.

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/features/operations/cacheInvalidation.test.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/features/operations/cacheInvalidation.test.ts
@@ -1,12 +1,11 @@
 import { QueryObserver } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { config } from "wasp/client";
 import {
   createTask,
   getTasks,
   initializeQueryClient,
-  queryClientInitialized,
 } from "wasp/client/operations";
 import { mockServer } from "wasp/client/test";
 import { serialize } from "wasp/core/serialization";
@@ -38,13 +37,6 @@ const apiUrlPattern = new RegExp(
   "^" + config.apiUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
 );
 
-beforeAll(async () => {
-  // `mockServer()` (called above) already wires up server.listen/resetHandlers/
-  // close via beforeAll/afterEach/afterAll.
-  initializeQueryClient();
-  await queryClientInitialized;
-});
-
 beforeEach(() => {
   // `mockServer()`'s afterEach calls `server.resetHandlers()`, so the handler
   // has to be (re)registered before each test rather than once in `beforeAll`.
@@ -66,7 +58,7 @@ beforeEach(() => {
 
 describe("action cache invalidation (#3009)", () => {
   it("queries depending on the action's entities are fresh once the action resolves", async () => {
-    const queryClient = await queryClientInitialized;
+    const queryClient = initializeQueryClient();
     const queryKey = getTasks.queryCacheKey;
 
     // Server starts with a single task.

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
@@ -10,6 +10,7 @@ wasp-app/.wasp/out/package-lock.json
 wasp-app/.wasp/out/package.json
 wasp-app/.wasp/out/sdk/wasp/api/events.ts
 wasp-app/.wasp/out/sdk/wasp/api/index.ts
+wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
 wasp-app/.wasp/out/sdk/wasp/client/app/components/DefaultRootErrorBoundary.tsx
 wasp-app/.wasp/out/sdk/wasp/client/app/components/FullPageWrapper.tsx
 wasp-app/.wasp/out/sdk/wasp/client/app/components/Loader.module.css
@@ -68,6 +69,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/api/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.js
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.jsx

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -51,6 +51,13 @@
     [
         [
             "file",
+            "sdk/wasp/client/app/client-setup.ts"
+        ],
+        "a7313d9c6391a81661546b2ec51d23eb78cb55c1830322d5f6407cea88139fa6"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/client/app/components/DefaultRootErrorBoundary.tsx"
         ],
         "303821bb9b02b284835f571618c5f92e3da1b97709b7ed6cb3313fb33cc871f6"
@@ -88,7 +95,7 @@
             "file",
             "sdk/wasp/client/app/components/WaspApp.tsx"
         ],
-        "e70518ff937c59c28d85782e1ccc86aa4e088f491130d31a8a8d9f43a86308c6"
+        "663121e506487fe479d64b1b72fce432809d4c835125adbed68bbaa41984836e"
     ],
     [
         [
@@ -179,7 +186,7 @@
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "c96965e460ada3ad0369ed17a0dc8ebce623781ba02ab8059e61856024d12df2"
+        "66f85f8b8c10f0fc3417cddb19463af7772ffb5ed71de4c15b445b7b3154b221"
     ],
     [
         [
@@ -193,7 +200,7 @@
             "file",
             "sdk/wasp/client/operations/internal/resources.js"
         ],
-        "fa3e3b77c1d6f62889b613706fff1ee92bd70aa68ae80751df05c0ac72d844a4"
+        "48900f0c0c194b961467dd736de84a515a2d1ec703ec4195750f59f0a026ef7f"
     ],
     [
         [
@@ -221,7 +228,7 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "3b4eb2cdd4c19140455b7e03ce8099e2fd19268f41ca272d80f4f6f760d44a5a"
     ],
     [
         [
@@ -354,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "1da18649210169b8383b876b5c5fe708528e28e47f3acec333b7bb84304a8e8b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
@@ -1,0 +1,7 @@
+import { initializeQueryClient } from '../operations/queryClient'
+
+
+// PRIVATE API (framework code)
+// The QueryClient must be created only after the setup function completes,
+// because the setup function may call `configureQueryClient`.
+export const queryClient = initializeQueryClient()

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/components/WaspApp.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/components/WaspApp.tsx
@@ -1,12 +1,10 @@
-import { use, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 
-import { queryClientInitialized } from '../../operations/index'
+import { queryClient } from '../client-setup'
 
 
 export function WaspApp({ children }: { children: ReactNode }) {
-  const queryClient = use(queryClientInitialized)
-
   return (
     <QueryClientProvider client={queryClient}>
       {children}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -17,8 +17,6 @@ export {
     configureQueryClient,
     // PRIVATE API (framework code)
     initializeQueryClient,
-    // PRIVATE API (framework code)
-    queryClientInitialized
 } from './queryClient'
 
 export {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
@@ -1,4 +1,4 @@
-import { queryClientInitialized } from '../queryClient.js'
+import { getQueryClient } from '../queryClient.js'
 import { makeUpdateHandlersMap } from './updateHandlersMap'
 import { hashQueryKey } from '@tanstack/react-query'
 
@@ -43,7 +43,7 @@ export function getActiveOptimisticUpdates(queryKey) {
 }
 
 export async function invalidateAndRemoveQueries() {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
   // If we don't reset the queries before removing them, Wasp will stay on
   // the same page. The user would have to manually refresh the page to "finish"
   // logging out.
@@ -62,7 +62,7 @@ export async function invalidateAndRemoveQueries() {
  * @param {string[]} resources - Names of resources.
  */
 async function invalidateQueriesUsing(resources) {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
 
   const queryCacheKeysToInvalidate = getQueriesUsingResources(resources)
   await Promise.all(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -3,19 +3,11 @@ import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
 const defaultQueryClientConfig = {};
 
 let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
-);
+  queryClient: QueryClient | undefined;
 
 // PUBLIC API
 export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
+  if (queryClient) {
     throw new Error(
       "Attempted to configure the QueryClient after initialization"
     );
@@ -25,10 +17,21 @@ export function configureQueryClient(config: QueryClientConfig): void {
 }
 
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
+// Idempotent: the first call creates the QueryClient, later calls return it.
+export function initializeQueryClient(): QueryClient {
+  queryClient ??= new QueryClient(queryClientConfig ?? defaultQueryClientConfig);
+  return queryClient;
+}
+
+// PRIVATE API (framework code)
+export function getQueryClient(): QueryClient {
+  if (!queryClient) {
+    throw new Error(
+      "Attempted to access the QueryClient before initialization. " +
+        "The QueryClient is initialized in `wasp/client/app/client-setup`, " +
+        "after the user-defined client setup function completes."
+    );
+  }
+
+  return queryClient;
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,7 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
-
 
 
 
@@ -15,9 +13,6 @@ const routesMapping = {
       ),
   },
 } as const;
-
-
-initializeQueryClient()
 
 const rootElement =
   undefined

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -1,14 +1,10 @@
 const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/MainPage.js","assets/MainPage.css"])))=>i.map(i=>d[i]);
 import { jsx, jsxs } from "react/jsx-runtime";
-import { useState, useEffect, StrictMode, use, lazy, startTransition } from "react";
+import { useState, useEffect, StrictMode, lazy, startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { useRouteError, createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import ky from "ky";
-import * as z from "zod";
-import mitt from "mitt";
-import "superjson";
 (function polyfill() {
   const relList = document.createElement("link").relList;
   if (relList && relList.supports && relList.supports("modulepreload")) return;
@@ -74,211 +70,14 @@ function Layout({ children, isFallbackPage: isFallbackPage2 = false, clientEntry
     ] })
   ] }) });
 }
-function stripTrailingSlash(url) {
-  return url?.replace(/\/$/, "");
-}
-var define_process_env_default = {};
-function colorize(color, text) {
-  if (!supportsAnsiFormatting()) {
-    return text;
-  }
-  const ansiColorCode = ansiColorCodes[color];
-  return text.split("\n").map((line) => `${ansiColorCode}${line}${ansiResetCode}`).join("\n");
-}
-function supportsAnsiFormatting() {
-  const isBrowser = !!globalThis.window;
-  const isNode = !!globalThis.process;
-  if (isBrowser && "chrome" in window) {
-    return true;
-  }
-  if (isNode) {
-    if ("NO_COLOR" in define_process_env_default) {
-      return false;
-    }
-    return true;
-  }
-  return false;
-}
-const ansiColorCodes = {
-  red: "\x1B[31m",
-  yellow: "\x1B[33m"
-};
-const ansiResetCode = "\x1B[0m";
-function ensureEnvSchema(data, schema) {
-  const result = getValidatedEnvOrError(data, schema);
-  if (result.success) {
-    return result.data;
-  } else {
-    console.error(colorize("red", formatZodEnvError(result.error)));
-    throw new Error("Error parsing environment variables");
-  }
-}
-function getValidatedEnvOrError(env2, schema) {
-  return schema.safeParse(env2);
-}
-function formatZodEnvError(error) {
-  const flattenedIssues = z.flattenError(error);
-  return [
-    "══ Env vars validation failed ══",
-    "",
-    // Top-level errors
-    ...flattenedIssues.formErrors,
-    "",
-    // Errors per field
-    ...Object.entries(flattenedIssues.fieldErrors).map(([prop, error2]) => `${prop} - ${error2}`),
-    "",
-    "════════════════════════════════"
-  ].join("\n");
-}
-const userClientEnvSchema = z.object({});
-const serverUrlSchema = z.string({
-  error: "REACT_APP_API_URL is required"
-}).pipe(z.url({
-  error: "REACT_APP_API_URL must be a valid URL"
-}));
-z.object({
-  "REACT_APP_API_URL": serverUrlSchema.default("http://localhost:3001")
-});
-const waspProdClientEnvSchema = z.object({
-  "REACT_APP_API_URL": serverUrlSchema
-});
-const waspClientEnvSchema = waspProdClientEnvSchema;
-const clientEnvSchema = z.object({
-  ...userClientEnvSchema.shape,
-  ...waspClientEnvSchema.shape
-});
-const __vite_import_meta_env__ = { "BASE_URL": "/", "DEV": false, "MODE": "production", "PROD": true, "REACT_APP_API_URL": "http://localhost:3001", "SSR": false };
-const env = ensureEnvSchema(__vite_import_meta_env__, clientEnvSchema);
-const apiUrl = stripTrailingSlash(env["REACT_APP_API_URL"]);
-const config = {
-  apiUrl
-};
-var HttpMethod;
-(function(HttpMethod2) {
-  HttpMethod2["Get"] = "GET";
-  HttpMethod2["Post"] = "POST";
-  HttpMethod2["Put"] = "PUT";
-  HttpMethod2["Delete"] = "DELETE";
-})(HttpMethod || (HttpMethod = {}));
-const createStorage = typeof window === "undefined" || !window.localStorage ? createMemoryDataStore : createLocalStorageDataStore;
-const storage = createStorage("wasp");
-function createMemoryDataStore(prefix) {
-  const store = /* @__PURE__ */ new Map();
-  function getPrefixedKey(key) {
-    return `${prefix}:${key}`;
-  }
-  return {
-    getPrefixedKey,
-    set(key, value) {
-      store.set(getPrefixedKey(key), value);
-    },
-    get(key) {
-      return store.get(getPrefixedKey(key));
-    },
-    remove(key) {
-      store.delete(getPrefixedKey(key));
-    },
-    clear() {
-      store.clear();
-    }
-  };
-}
-function createLocalStorageDataStore(prefix) {
-  if (!window.localStorage) {
-    throw new Error("Local storage is not available.");
-  }
-  function getPrefixedKey(key) {
-    return `${prefix}:${key}`;
-  }
-  return {
-    getPrefixedKey,
-    set(key, value) {
-      localStorage.setItem(getPrefixedKey(key), JSON.stringify(value));
-    },
-    get(key) {
-      const value = localStorage.getItem(getPrefixedKey(key));
-      try {
-        return value ? JSON.parse(value) : void 0;
-      } catch (e) {
-        return void 0;
-      }
-    },
-    remove(key) {
-      localStorage.removeItem(getPrefixedKey(key));
-    },
-    clear() {
-      Object.keys(localStorage).forEach((key) => {
-        if (key.startsWith(prefix)) {
-          localStorage.removeItem(key);
-        }
-      });
-    }
-  };
-}
-const apiEventsEmitter = mitt();
-const WASP_APP_AUTH_SESSION_ID_NAME = "sessionId";
-function getSessionId() {
-  const sessionId = storage.get(WASP_APP_AUTH_SESSION_ID_NAME);
-  return sessionId ?? null;
-}
-function clearSessionId() {
-  storage.remove(WASP_APP_AUTH_SESSION_ID_NAME);
-  apiEventsEmitter.emit("sessionId.clear");
-}
-ky.extend({
-  prefix: config.apiUrl,
-  hooks: {
-    beforeRequest: [
-      ({ request }) => {
-        const sessionId = getSessionId();
-        if (sessionId !== null) {
-          request.headers.set("Authorization", `Bearer ${sessionId}`);
-        }
-      }
-    ],
-    afterResponse: [
-      ({ request, response }) => {
-        if (response.status === 401) {
-          const failingSessionId = getSessionIdFromAuthorizationHeader(request.headers.get("Authorization"));
-          const currentSessionId = getSessionId();
-          if (failingSessionId === currentSessionId) {
-            clearSessionId();
-          }
-        }
-      }
-    ]
-  }
-});
-if (typeof window !== "undefined") {
-  window.addEventListener("storage", (event) => {
-    if (event.key === storage.getPrefixedKey(WASP_APP_AUTH_SESSION_ID_NAME)) {
-      if (!!event.newValue) {
-        apiEventsEmitter.emit("sessionId.set");
-      } else {
-        apiEventsEmitter.emit("sessionId.clear");
-      }
-    }
-  });
-}
-function getSessionIdFromAuthorizationHeader(header) {
-  const prefix = "Bearer ";
-  if (header && header.startsWith(prefix)) {
-    return header.substring(prefix.length);
-  } else {
-    return null;
-  }
-}
 const defaultQueryClientConfig = {};
-let resolveQueryClientInitialized;
-const queryClientInitialized = new Promise((resolve) => {
-  resolveQueryClientInitialized = resolve;
-});
+let queryClient$1;
 function initializeQueryClient() {
-  const queryClient = new QueryClient(defaultQueryClientConfig);
-  resolveQueryClientInitialized(queryClient);
+  queryClient$1 ??= new QueryClient(defaultQueryClientConfig);
+  return queryClient$1;
 }
+const queryClient = initializeQueryClient();
 function WaspApp({ children }) {
-  const queryClient = use(queryClientInitialized);
   return /* @__PURE__ */ jsx(QueryClientProvider, { client: queryClient, children });
 }
 const scriptRel = "modulepreload";
@@ -387,7 +186,6 @@ const routesMapping = {
     )
   }
 };
-initializeQueryClient();
 const rootElement = void 0;
 const routeObjects = getRouteObjects({
   routesMapping,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
@@ -8,6 +8,7 @@ wasp-app/.wasp/out/db/schema.prisma
 wasp-app/.wasp/out/installedNpmDepsLog.json
 wasp-app/.wasp/out/sdk/wasp/api/events.ts
 wasp-app/.wasp/out/sdk/wasp/api/index.ts
+wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
 wasp-app/.wasp/out/sdk/wasp/client/app/components/DefaultRootErrorBoundary.tsx
 wasp-app/.wasp/out/sdk/wasp/client/app/components/FullPageWrapper.tsx
 wasp-app/.wasp/out/sdk/wasp/client/app/components/Loader.module.css
@@ -66,6 +67,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/api/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.js
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.jsx

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -51,6 +51,13 @@
     [
         [
             "file",
+            "sdk/wasp/client/app/client-setup.ts"
+        ],
+        "a7313d9c6391a81661546b2ec51d23eb78cb55c1830322d5f6407cea88139fa6"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/client/app/components/DefaultRootErrorBoundary.tsx"
         ],
         "303821bb9b02b284835f571618c5f92e3da1b97709b7ed6cb3313fb33cc871f6"
@@ -88,7 +95,7 @@
             "file",
             "sdk/wasp/client/app/components/WaspApp.tsx"
         ],
-        "e70518ff937c59c28d85782e1ccc86aa4e088f491130d31a8a8d9f43a86308c6"
+        "663121e506487fe479d64b1b72fce432809d4c835125adbed68bbaa41984836e"
     ],
     [
         [
@@ -179,7 +186,7 @@
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "c96965e460ada3ad0369ed17a0dc8ebce623781ba02ab8059e61856024d12df2"
+        "66f85f8b8c10f0fc3417cddb19463af7772ffb5ed71de4c15b445b7b3154b221"
     ],
     [
         [
@@ -193,7 +200,7 @@
             "file",
             "sdk/wasp/client/operations/internal/resources.js"
         ],
-        "fa3e3b77c1d6f62889b613706fff1ee92bd70aa68ae80751df05c0ac72d844a4"
+        "48900f0c0c194b961467dd736de84a515a2d1ec703ec4195750f59f0a026ef7f"
     ],
     [
         [
@@ -221,7 +228,7 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "3b4eb2cdd4c19140455b7e03ce8099e2fd19268f41ca272d80f4f6f760d44a5a"
     ],
     [
         [
@@ -354,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "1da18649210169b8383b876b5c5fe708528e28e47f3acec333b7bb84304a8e8b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
@@ -1,0 +1,7 @@
+import { initializeQueryClient } from '../operations/queryClient'
+
+
+// PRIVATE API (framework code)
+// The QueryClient must be created only after the setup function completes,
+// because the setup function may call `configureQueryClient`.
+export const queryClient = initializeQueryClient()

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/components/WaspApp.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/components/WaspApp.tsx
@@ -1,12 +1,10 @@
-import { use, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 
-import { queryClientInitialized } from '../../operations/index'
+import { queryClient } from '../client-setup'
 
 
 export function WaspApp({ children }: { children: ReactNode }) {
-  const queryClient = use(queryClientInitialized)
-
   return (
     <QueryClientProvider client={queryClient}>
       {children}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -17,8 +17,6 @@ export {
     configureQueryClient,
     // PRIVATE API (framework code)
     initializeQueryClient,
-    // PRIVATE API (framework code)
-    queryClientInitialized
 } from './queryClient'
 
 export {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
@@ -1,4 +1,4 @@
-import { queryClientInitialized } from '../queryClient.js'
+import { getQueryClient } from '../queryClient.js'
 import { makeUpdateHandlersMap } from './updateHandlersMap'
 import { hashQueryKey } from '@tanstack/react-query'
 
@@ -43,7 +43,7 @@ export function getActiveOptimisticUpdates(queryKey) {
 }
 
 export async function invalidateAndRemoveQueries() {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
   // If we don't reset the queries before removing them, Wasp will stay on
   // the same page. The user would have to manually refresh the page to "finish"
   // logging out.
@@ -62,7 +62,7 @@ export async function invalidateAndRemoveQueries() {
  * @param {string[]} resources - Names of resources.
  */
 async function invalidateQueriesUsing(resources) {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
 
   const queryCacheKeysToInvalidate = getQueriesUsingResources(resources)
   await Promise.all(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -3,19 +3,11 @@ import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
 const defaultQueryClientConfig = {};
 
 let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
-);
+  queryClient: QueryClient | undefined;
 
 // PUBLIC API
 export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
+  if (queryClient) {
     throw new Error(
       "Attempted to configure the QueryClient after initialization"
     );
@@ -25,10 +17,21 @@ export function configureQueryClient(config: QueryClientConfig): void {
 }
 
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
+// Idempotent: the first call creates the QueryClient, later calls return it.
+export function initializeQueryClient(): QueryClient {
+  queryClient ??= new QueryClient(queryClientConfig ?? defaultQueryClientConfig);
+  return queryClient;
+}
+
+// PRIVATE API (framework code)
+export function getQueryClient(): QueryClient {
+  if (!queryClient) {
+    throw new Error(
+      "Attempted to access the QueryClient before initialization. " +
+        "The QueryClient is initialized in `wasp/client/app/client-setup`, " +
+        "after the user-defined client setup function completes."
+    );
+  }
+
+  return queryClient;
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,7 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
-
 
 
 
@@ -15,9 +13,6 @@ const routesMapping = {
       ),
   },
 } as const;
-
-
-initializeQueryClient()
 
 const rootElement =
   undefined

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
@@ -14,6 +14,7 @@ wasp-app/.wasp/out/db/schema.prisma.wasp-last-db-concurrence-checksum
 wasp-app/.wasp/out/installedNpmDepsLog.json
 wasp-app/.wasp/out/sdk/wasp/api/events.ts
 wasp-app/.wasp/out/sdk/wasp/api/index.ts
+wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
 wasp-app/.wasp/out/sdk/wasp/client/app/components/DefaultRootErrorBoundary.tsx
 wasp-app/.wasp/out/sdk/wasp/client/app/components/FullPageWrapper.tsx
 wasp-app/.wasp/out/sdk/wasp/client/app/components/Loader.module.css
@@ -73,6 +74,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/api/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/api/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.js
+wasp-app/.wasp/out/sdk/wasp/dist/client/app/client-setup.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/client/app/components/DefaultRootErrorBoundary.jsx

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -51,6 +51,13 @@
     [
         [
             "file",
+            "sdk/wasp/client/app/client-setup.ts"
+        ],
+        "a7313d9c6391a81661546b2ec51d23eb78cb55c1830322d5f6407cea88139fa6"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/client/app/components/DefaultRootErrorBoundary.tsx"
         ],
         "303821bb9b02b284835f571618c5f92e3da1b97709b7ed6cb3313fb33cc871f6"
@@ -88,7 +95,7 @@
             "file",
             "sdk/wasp/client/app/components/WaspApp.tsx"
         ],
-        "e70518ff937c59c28d85782e1ccc86aa4e088f491130d31a8a8d9f43a86308c6"
+        "663121e506487fe479d64b1b72fce432809d4c835125adbed68bbaa41984836e"
     ],
     [
         [
@@ -179,7 +186,7 @@
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "c96965e460ada3ad0369ed17a0dc8ebce623781ba02ab8059e61856024d12df2"
+        "66f85f8b8c10f0fc3417cddb19463af7772ffb5ed71de4c15b445b7b3154b221"
     ],
     [
         [
@@ -193,7 +200,7 @@
             "file",
             "sdk/wasp/client/operations/internal/resources.js"
         ],
-        "fa3e3b77c1d6f62889b613706fff1ee92bd70aa68ae80751df05c0ac72d844a4"
+        "48900f0c0c194b961467dd736de84a515a2d1ec703ec4195750f59f0a026ef7f"
     ],
     [
         [
@@ -221,7 +228,7 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "3b4eb2cdd4c19140455b7e03ce8099e2fd19268f41ca272d80f4f6f760d44a5a"
     ],
     [
         [
@@ -354,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "1da18649210169b8383b876b5c5fe708528e28e47f3acec333b7bb84304a8e8b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/client-setup.ts
@@ -1,0 +1,7 @@
+import { initializeQueryClient } from '../operations/queryClient'
+
+
+// PRIVATE API (framework code)
+// The QueryClient must be created only after the setup function completes,
+// because the setup function may call `configureQueryClient`.
+export const queryClient = initializeQueryClient()

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/components/WaspApp.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/components/WaspApp.tsx
@@ -1,12 +1,10 @@
-import { use, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 
-import { queryClientInitialized } from '../../operations/index'
+import { queryClient } from '../client-setup'
 
 
 export function WaspApp({ children }: { children: ReactNode }) {
-  const queryClient = use(queryClientInitialized)
-
   return (
     <QueryClientProvider client={queryClient}>
       {children}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -17,8 +17,6 @@ export {
     configureQueryClient,
     // PRIVATE API (framework code)
     initializeQueryClient,
-    // PRIVATE API (framework code)
-    queryClientInitialized
 } from './queryClient'
 
 export {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/internal/resources.js
@@ -1,4 +1,4 @@
-import { queryClientInitialized } from '../queryClient.js'
+import { getQueryClient } from '../queryClient.js'
 import { makeUpdateHandlersMap } from './updateHandlersMap'
 import { hashQueryKey } from '@tanstack/react-query'
 
@@ -43,7 +43,7 @@ export function getActiveOptimisticUpdates(queryKey) {
 }
 
 export async function invalidateAndRemoveQueries() {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
   // If we don't reset the queries before removing them, Wasp will stay on
   // the same page. The user would have to manually refresh the page to "finish"
   // logging out.
@@ -62,7 +62,7 @@ export async function invalidateAndRemoveQueries() {
  * @param {string[]} resources - Names of resources.
  */
 async function invalidateQueriesUsing(resources) {
-  const queryClient = await queryClientInitialized
+  const queryClient = getQueryClient()
 
   const queryCacheKeysToInvalidate = getQueriesUsingResources(resources)
   await Promise.all(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -3,19 +3,11 @@ import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
 const defaultQueryClientConfig = {};
 
 let queryClientConfig: QueryClientConfig,
-  resolveQueryClientInitialized: (...args: any[]) => any,
-  isQueryClientInitialized: boolean;
-
-// PRIVATE API (framework code)
-export const queryClientInitialized: Promise<QueryClient> = new Promise(
-  (resolve) => {
-    resolveQueryClientInitialized = resolve;
-  }
-);
+  queryClient: QueryClient | undefined;
 
 // PUBLIC API
 export function configureQueryClient(config: QueryClientConfig): void {
-  if (isQueryClientInitialized) {
+  if (queryClient) {
     throw new Error(
       "Attempted to configure the QueryClient after initialization"
     );
@@ -25,10 +17,21 @@ export function configureQueryClient(config: QueryClientConfig): void {
 }
 
 // PRIVATE API (framework code)
-export function initializeQueryClient(): void {
-  const queryClient = new QueryClient(
-    queryClientConfig ?? defaultQueryClientConfig
-  );
-  isQueryClientInitialized = true;
-  resolveQueryClientInitialized(queryClient);
+// Idempotent: the first call creates the QueryClient, later calls return it.
+export function initializeQueryClient(): QueryClient {
+  queryClient ??= new QueryClient(queryClientConfig ?? defaultQueryClientConfig);
+  return queryClient;
+}
+
+// PRIVATE API (framework code)
+export function getQueryClient(): QueryClient {
+  if (!queryClient) {
+    throw new Error(
+      "Attempted to access the QueryClient before initialization. " +
+        "The QueryClient is initialized in `wasp/client/app/client-setup`, " +
+        "after the user-defined client setup function completes."
+    );
+  }
+
+  return queryClient;
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,7 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
-import { initializeQueryClient } from "wasp/client/operations";
 import { lazy } from "react"
-
 
 
 
@@ -15,9 +13,6 @@ const routesMapping = {
       ),
   },
 } as const;
-
-
-initializeQueryClient()
 
 const rootElement =
   undefined

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/AppG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/AppG.hs
@@ -10,6 +10,7 @@ import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import qualified Wasp.AppSpec.App.Client as AS.App.Client
 import Wasp.AppSpec.Valid (getApp, isAuthEnabled)
 import Wasp.Generator.AuthProviders.OAuth (clientOAuthCallbackPath)
 import Wasp.Generator.FileDraft (FileDraft)
@@ -17,6 +18,7 @@ import Wasp.Generator.Monad (Generator)
 import Wasp.Generator.SdkGenerator.Auth.Common (getOnAuthSucceededRedirectToOrDefault)
 import Wasp.Generator.SdkGenerator.Common (SdkTemplatesDir)
 import qualified Wasp.Generator.SdkGenerator.Common as C
+import Wasp.Generator.SdkGenerator.JsImport (extImportToImportJson)
 import qualified Wasp.Generator.WebAppGenerator.Common as WebApp
 import qualified Wasp.Generator.WebSocket as WS
 import Wasp.Util ((<++>))
@@ -25,7 +27,8 @@ genClientApp :: AppSpec -> Generator [FileDraft]
 genClientApp spec =
   sequence
     [ genAppIndex spec,
-      genWaspAppComponent spec
+      genWaspAppComponent spec,
+      genClientSetup spec
     ]
     <++> genLayout spec
     <++> genAppComponents
@@ -45,6 +48,15 @@ genWaspAppComponent spec =
     C.mkTmplFdWithData
       [relfile|client/app/components/WaspApp.tsx|]
       (object ["areWebSocketsUsed" .= WS.areWebSocketsUsed spec])
+
+genClientSetup :: AppSpec -> Generator FileDraft
+genClientSetup spec =
+  return $
+    C.mkTmplFdWithData
+      [relfile|client/app/client-setup.ts|]
+      (object ["setupFn" .= extImportToImportJson maybeSetupJsFunction])
+  where
+    maybeSetupJsFunction = AS.App.Client.setupFn =<< AS.App.client (snd $ getApp spec)
 
 genAppComponents :: Generator [FileDraft]
 genAppComponents =

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/VitePlugin/VirtualModulesPlugin/VirtualRoutesG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/VitePlugin/VirtualModulesPlugin/VirtualRoutesG.hs
@@ -32,10 +32,8 @@ genVirtualRoutesTsx spec =
       object
         [ "routes" .= map (createRouteTemplateData spec) (AS.getRoutes spec),
           "isAuthEnabled" .= isAuthEnabled spec,
-          "setupFn" .= GJI.jsImportToImportJson (GJI.extImportToRelativeSrcImportFromViteExecution <$> maybeSetupJsFunction),
           "rootComponent" .= GJI.jsImportToImportJson (GJI.extImportToRelativeSrcImportFromViteExecution <$> maybeRootComponent)
         ]
-    maybeSetupJsFunction = AS.App.Client.setupFn =<< AS.App.client (snd $ getApp spec)
     maybeRootComponent = AS.App.Client.rootComponent =<< AS.App.client (snd $ getApp spec)
 
 isRouteLazy :: AS.Route.Route -> Bool


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Extracts the client initialization logic (running the user's `app.client.setupFn` and creating the React Query `QueryClient`) out of the generated `routes.tsx` virtual module and into a dedicated `client/app/client-setup.ts` module.

**Before:** `routes.tsx` awaited the user's setup function and then called `initializeQueryClient()`. The `QueryClient` was exposed as a promise (`queryClientInitialized`) that consumers `await`ed, and `WaspApp` unwrapped it with React's `use()` hook.

**After:** the setup function and `QueryClient` creation live in `client-setup.ts`:

- The user's setup function runs as a top-level `await`, so every module that (transitively) imports the setup module waits for it to finish before running its own code.
- The `QueryClient` is created synchronously right after setup and exported directly, removing the promise/Suspense indirection in `WaspApp`.
- `initializeQueryClient()` is now idempotent and returns the `QueryClient`. A new `getQueryClient()` accessor throws a clear error if it's called before initialization. The promise-based `queryClientInitialized` (private API) is removed.

This decouples query-client/setup initialization from routing and makes the initialization order explicit and predictable. All the touched exports (`queryClientInitialized`, `initializeQueryClient`) were private framework APIs, so there is no change to the documented public API.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
