### PR TITLE
Clarify SSR client-entry script comment and fix lib README prop name

### DIFF
--- a/waspc/data/Generator/libs/vite-ssr/README.md
+++ b/waspc/data/Generator/libs/vite-ssr/README.md
@@ -76,7 +76,7 @@ const prerender: PrerenderFn = async (route, ctx) => {
   const html = await streamConsumers.text(
     prerenderToNodeStream(
       <App
-        scriptSrc={ctx.clientEntrySrc}
+        clientEntrySrc={ctx.clientEntrySrc}
         renderType={
           isFallback ? { type: "fallback" } : { type: "route", route }
         }

--- a/waspc/data/Generator/templates/sdk/wasp/client/app/layout.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/app/layout.tsx
@@ -52,17 +52,30 @@ export function Layout({
           <title>{= title =}</title>
 
           {
-            // We pass that argument in SSR builds and not in client builds.
-            // This would usually cause a hydration mismatch, but React has an
-            // exception for `<script>` tags, for this specific usecase, so it
-            // will work fine.
+            /*
+              This script tag's job is to load the client entry so the browser
+              downloads and runs it, hydrating the prerendered HTML.
+
+              We only need it in SSR builds, as by the time the client is
+              running this code, it doesn't need to run itself again (and could
+              lead to duplication).
+
+              Rendering it only on the server and not on the client would
+              normally cause a hydration mismatch, but React skips erroring on
+              server-only nodes if they are **direct children** of `<head>` and
+              `<body>`, to support this kind of usecase. (See
+              https://react.dev/reference/react-dom/static/prerenderToNodeStream)
+
+              We'd usually inject this via React prerender's `bootstrapModules`
+              option, but that has two problems:
+                1. React also emits a `<link rel="modulepreload"
+                   href="@/wasp/client">` for the bootstrap scripts, but Vite
+                   doesn't rewrite `link.href`s, so it would end up as a broken
+                   link.
+                2. It hardcodes `async` on the script, which in dev races the
+                   `@vitejs/plugin-react` refresh preamble (see #4258).
+            */
             clientEntrySrc ? (
-              // We'd usually use React prerender's `bootstrapModules` options for
-              // injecting this script, but it would also add a `<link
-              // rel="modulepreload">` tag that Vite doesn't handle correctly. So
-              // we just add the script ourselves in the regular way.
-              //
-              // https://react.dev/reference/react-dom/static/prerenderToNodeStream
               <script type="module" src={clientEntrySrc} />
             ) : null
           }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -39,7 +39,7 @@
             "file",
             "libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
         ],
-        "c1e32f2f59b2d67026d11f5c0e4026cfb42dce9963c48203d51685b6171f3f59"
+        "f6dc5ce1dd3d05ea0004f2b33c8f2e2a8f61fcf5bec87d9eb3bb962f96e4306f"
     ],
     [
         [
@@ -459,7 +459,7 @@
             "file",
             "sdk/wasp/client/app/layout.tsx"
         ],
-        "9beef4e9bd21b93ce3e5246e55f0ff9db2557e7144bcb1fc7784897c91a2e90f"
+        "57123ac0bbb9f098edeef79305413289ea0954cbae088f3a9f37435b2b0d77e0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
@@ -52,17 +52,30 @@ export function Layout({
           <title>Wasp Kitchen Sink</title>
 
           {
-            // We pass that argument in SSR builds and not in client builds.
-            // This would usually cause a hydration mismatch, but React has an
-            // exception for `<script>` tags, for this specific usecase, so it
-            // will work fine.
+            /*
+              This script tag's job is to load the client entry so the browser
+              downloads and runs it, hydrating the prerendered HTML.
+
+              We only need it in SSR builds, as by the time the client is
+              running this code, it doesn't need to run itself again (and could
+              lead to duplication).
+
+              Rendering it only on the server and not on the client would
+              normally cause a hydration mismatch, but React skips erroring on
+              server-only nodes if they are **direct children** of `<head>` and
+              `<body>`, to support this kind of usecase. (See
+              https://react.dev/reference/react-dom/static/prerenderToNodeStream)
+
+              We'd usually inject this via React prerender's `bootstrapModules`
+              option, but that has two problems:
+                1. React also emits a `<link rel="modulepreload"
+                   href="@/wasp/client">` for the bootstrap scripts, but Vite
+                   doesn't rewrite `link.href`s, so it would end up as a broken
+                   link.
+                2. It hardcodes `async` on the script, which in dev races the
+                   `@vitejs/plugin-react` refresh preamble (see #4258).
+            */
             clientEntrySrc ? (
-              // We'd usually use React prerender's `bootstrapModules` options for
-              // injecting this script, but it would also add a `<link
-              // rel="modulepreload">` tag that Vite doesn't handle correctly. So
-              // we just add the script ourselves in the regular way.
-              //
-              // https://react.dev/reference/react-dom/static/prerenderToNodeStream
               <script type="module" src={clientEntrySrc} />
             ) : null
           }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
         ],
-        "c1e32f2f59b2d67026d11f5c0e4026cfb42dce9963c48203d51685b6171f3f59"
+        "f6dc5ce1dd3d05ea0004f2b33c8f2e2a8f61fcf5bec87d9eb3bb962f96e4306f"
     ],
     [
         [
@@ -109,7 +109,7 @@
             "file",
             "sdk/wasp/client/app/layout.tsx"
         ],
-        "e2e453d10b129803681e6cec3dccead055cfde26a20a1a81b374a0a1ed43001c"
+        "3e1e6e4180da8faa0038fec130cc9a14408be55f2d2bb9d1a08af23060de59af"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
@@ -51,17 +51,30 @@ export function Layout({
           <title>wasp-app</title>
 
           {
-            // We pass that argument in SSR builds and not in client builds.
-            // This would usually cause a hydration mismatch, but React has an
-            // exception for `<script>` tags, for this specific usecase, so it
-            // will work fine.
+            /*
+              This script tag's job is to load the client entry so the browser
+              downloads and runs it, hydrating the prerendered HTML.
+
+              We only need it in SSR builds, as by the time the client is
+              running this code, it doesn't need to run itself again (and could
+              lead to duplication).
+
+              Rendering it only on the server and not on the client would
+              normally cause a hydration mismatch, but React skips erroring on
+              server-only nodes if they are **direct children** of `<head>` and
+              `<body>`, to support this kind of usecase. (See
+              https://react.dev/reference/react-dom/static/prerenderToNodeStream)
+
+              We'd usually inject this via React prerender's `bootstrapModules`
+              option, but that has two problems:
+                1. React also emits a `<link rel="modulepreload"
+                   href="@/wasp/client">` for the bootstrap scripts, but Vite
+                   doesn't rewrite `link.href`s, so it would end up as a broken
+                   link.
+                2. It hardcodes `async` on the script, which in dev races the
+                   `@vitejs/plugin-react` refresh preamble (see #4258).
+            */
             clientEntrySrc ? (
-              // We'd usually use React prerender's `bootstrapModules` options for
-              // injecting this script, but it would also add a `<link
-              // rel="modulepreload">` tag that Vite doesn't handle correctly. So
-              // we just add the script ourselves in the regular way.
-              //
-              // https://react.dev/reference/react-dom/static/prerenderToNodeStream
               <script type="module" src={clientEntrySrc} />
             ) : null
           }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -54,19 +54,30 @@ function Layout({ children, isFallbackPage: isFallbackPage2 = false, clientEntry
       /* @__PURE__ */ jsx("meta", { name: "viewport", content: "minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no" }),
       /* @__PURE__ */ jsx("link", { rel: "icon", href: "/favicon.ico" }),
       /* @__PURE__ */ jsx("title", { children: "wasp-app" }),
-      // We pass that argument in SSR builds and not in client builds.
-      // This would usually cause a hydration mismatch, but React has an
-      // exception for `<script>` tags, for this specific usecase, so it
-      // will work fine.
-      clientEntrySrc ? (
-        // We'd usually use React prerender's `bootstrapModules` options for
-        // injecting this script, but it would also add a `<link
-        // rel="modulepreload">` tag that Vite doesn't handle correctly. So
-        // we just add the script ourselves in the regular way.
-        //
-        // https://react.dev/reference/react-dom/static/prerenderToNodeStream
-        /* @__PURE__ */ jsx("script", { type: "module", src: clientEntrySrc })
-      ) : null
+      /*
+                This script tag's job is to load the client entry so the browser
+                downloads and runs it, hydrating the prerendered HTML.
+      
+                We only need it in SSR builds, as by the time the client is
+                running this code, it doesn't need to run itself again (and could
+                lead to duplication).
+      
+                Rendering it only on the server and not on the client would
+                normally cause a hydration mismatch, but React skips erroring on
+                server-only nodes if they are **direct children** of `<head>` and
+                `<body>`, to support this kind of usecase. (See
+                https://react.dev/reference/react-dom/static/prerenderToNodeStream)
+      
+                We'd usually inject this via React prerender's `bootstrapModules`
+                option, but that has two problems:
+                  1. React also emits a `<link rel="modulepreload"
+                     href="@/wasp/client">` for the bootstrap scripts, but Vite
+                     doesn't rewrite `link.href`s, so it would end up as a broken
+                     link.
+                  2. It hardcodes `async` on the script, which in dev races the
+                     `@vitejs/plugin-react` refresh preamble (see #4258).
+              */
+      clientEntrySrc ? /* @__PURE__ */ jsx("script", { type: "module", src: clientEntrySrc }) : null
     ] }),
     /* @__PURE__ */ jsxs("body", { children: [
       /* @__PURE__ */ jsx("noscript", { children: "You need to enable JavaScript to run this app." }),

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
         ],
-        "c1e32f2f59b2d67026d11f5c0e4026cfb42dce9963c48203d51685b6171f3f59"
+        "f6dc5ce1dd3d05ea0004f2b33c8f2e2a8f61fcf5bec87d9eb3bb962f96e4306f"
     ],
     [
         [
@@ -109,7 +109,7 @@
             "file",
             "sdk/wasp/client/app/layout.tsx"
         ],
-        "e2e453d10b129803681e6cec3dccead055cfde26a20a1a81b374a0a1ed43001c"
+        "3e1e6e4180da8faa0038fec130cc9a14408be55f2d2bb9d1a08af23060de59af"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
@@ -51,17 +51,30 @@ export function Layout({
           <title>wasp-app</title>
 
           {
-            // We pass that argument in SSR builds and not in client builds.
-            // This would usually cause a hydration mismatch, but React has an
-            // exception for `<script>` tags, for this specific usecase, so it
-            // will work fine.
+            /*
+              This script tag's job is to load the client entry so the browser
+              downloads and runs it, hydrating the prerendered HTML.
+
+              We only need it in SSR builds, as by the time the client is
+              running this code, it doesn't need to run itself again (and could
+              lead to duplication).
+
+              Rendering it only on the server and not on the client would
+              normally cause a hydration mismatch, but React skips erroring on
+              server-only nodes if they are **direct children** of `<head>` and
+              `<body>`, to support this kind of usecase. (See
+              https://react.dev/reference/react-dom/static/prerenderToNodeStream)
+
+              We'd usually inject this via React prerender's `bootstrapModules`
+              option, but that has two problems:
+                1. React also emits a `<link rel="modulepreload"
+                   href="@/wasp/client">` for the bootstrap scripts, but Vite
+                   doesn't rewrite `link.href`s, so it would end up as a broken
+                   link.
+                2. It hardcodes `async` on the script, which in dev races the
+                   `@vitejs/plugin-react` refresh preamble (see #4258).
+            */
             clientEntrySrc ? (
-              // We'd usually use React prerender's `bootstrapModules` options for
-              // injecting this script, but it would also add a `<link
-              // rel="modulepreload">` tag that Vite doesn't handle correctly. So
-              // we just add the script ourselves in the regular way.
-              //
-              // https://react.dev/reference/react-dom/static/prerenderToNodeStream
               <script type="module" src={clientEntrySrc} />
             ) : null
           }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
         ],
-        "c1e32f2f59b2d67026d11f5c0e4026cfb42dce9963c48203d51685b6171f3f59"
+        "f6dc5ce1dd3d05ea0004f2b33c8f2e2a8f61fcf5bec87d9eb3bb962f96e4306f"
     ],
     [
         [
@@ -109,7 +109,7 @@
             "file",
             "sdk/wasp/client/app/layout.tsx"
         ],
-        "e2e453d10b129803681e6cec3dccead055cfde26a20a1a81b374a0a1ed43001c"
+        "3e1e6e4180da8faa0038fec130cc9a14408be55f2d2bb9d1a08af23060de59af"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/layout.tsx
@@ -51,17 +51,30 @@ export function Layout({
           <title>wasp-app</title>
 
           {
-            // We pass that argument in SSR builds and not in client builds.
-            // This would usually cause a hydration mismatch, but React has an
-            // exception for `<script>` tags, for this specific usecase, so it
-            // will work fine.
+            /*
+              This script tag's job is to load the client entry so the browser
+              downloads and runs it, hydrating the prerendered HTML.
+
+              We only need it in SSR builds, as by the time the client is
+              running this code, it doesn't need to run itself again (and could
+              lead to duplication).
+
+              Rendering it only on the server and not on the client would
+              normally cause a hydration mismatch, but React skips erroring on
+              server-only nodes if they are **direct children** of `<head>` and
+              `<body>`, to support this kind of usecase. (See
+              https://react.dev/reference/react-dom/static/prerenderToNodeStream)
+
+              We'd usually inject this via React prerender's `bootstrapModules`
+              option, but that has two problems:
+                1. React also emits a `<link rel="modulepreload"
+                   href="@/wasp/client">` for the bootstrap scripts, but Vite
+                   doesn't rewrite `link.href`s, so it would end up as a broken
+                   link.
+                2. It hardcodes `async` on the script, which in dev races the
+                   `@vitejs/plugin-react` refresh preamble (see #4258).
+            */
             clientEntrySrc ? (
-              // We'd usually use React prerender's `bootstrapModules` options for
-              // injecting this script, but it would also add a `<link
-              // rel="modulepreload">` tag that Vite doesn't handle correctly. So
-              // we just add the script ourselves in the regular way.
-              //
-              // https://react.dev/reference/react-dom/static/prerenderToNodeStream
               <script type="module" src={clientEntrySrc} />
             ) : null
           }


### PR DESCRIPTION
## Description

Documentation-only cleanup of the SSR client-entry workaround. The comment in the generated `layout.tsx` now explains why the client-entry `<script>` is rendered only in SSR builds (to bootstrap hydration; on the client the entry is already running), why rendering it server-only survives hydration (React skips server-only nodes that are direct children of `<head>`/`<body>`), and why we inject the tag by hand instead of using React's `bootstrapModules` (broken `modulepreload` href in Vite, and the hardcoded `async` that races the react-refresh preamble, #4258). Also fixes doc drift in the `vite-ssr` lib README, where the SSR-entry example passed `ctx.clientEntrySrc` into a prop confusingly named `scriptSrc`. No functional change.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
