### PR TITLE
Fix SSR route matching for query strings, trailing slashes, and base dir

### DIFF
--- a/examples/kitchen-sink/e2e-tests/tests/prerender.spec.ts
+++ b/examples/kitchen-sink/e2e-tests/tests/prerender.spec.ts
@@ -18,6 +18,28 @@ test.describe("prerender", () => {
     await expect(page.getByTestId("render-location")).toHaveText("client");
   });
 
+  test("prerendered content is served for a URL with a query string", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+
+    await page.goto("/prerender?utm_source=test");
+
+    await expect(page.getByTestId("render-location")).toHaveText("server");
+  });
+
+  test("prerendered content is served for a URL with a trailing slash", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+
+    await page.goto("/prerender/");
+
+    await expect(page.getByTestId("render-location")).toHaveText("server");
+  });
+
   test("listed instances of a dynamic route are prerendered with no javascript", async ({
     browser,
   }) => {

--- a/waspc/data/Generator/libs/vite-ssr/package-lock.json
+++ b/waspc/data/Generator/libs/vite-ssr/package-lock.json
@@ -13,7 +13,8 @@
         "@types/node": "~22.12",
         "tsdown": "^0.21.5",
         "typescript": "~6.0.3",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.0.10"
       },
       "peerDependencies": {
         "vite": "^7"
@@ -1276,6 +1277,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node-ts": {
       "version": "23.6.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node-ts/-/node-ts-23.6.4.tgz",
@@ -1301,6 +1309,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1325,6 +1351,117 @@
         "undici-types": "~6.20.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.10.tgz",
+      "integrity": "sha512-3QkTX/lK39FBNwARCQRSQr0TP9+ywSdxSX+LgbJ2M1WmveXP72anTbnp2yl5fH+dU6SUmBzNMrDHs80G8G2DZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.10",
+        "@vitest/utils": "4.0.10",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.10.tgz",
+      "integrity": "sha512-e2OfdexYkjkg8Hh3L9NVEfbwGXq5IZbDovkf30qW2tOh7Rh9sVtmSr2ztEXOFbymNxS4qjzLXUQIvATvN4B+lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.10.tgz",
+      "integrity": "sha512-99EQbpa/zuDnvVjthwz5bH9o8iPefoQZ63WV8+bsRJZNw3qQSvSltfut8yu1Jc9mqOYi7pEbsKxYTi/rjaq6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.10.tgz",
+      "integrity": "sha512-EXU2iSkKvNwtlL8L8doCpkyclw0mc/t4t9SeOnfOFPyqLmQwuceMPA4zJBa6jw0MKsZYbw7kAn+gl7HxrlB8UQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.10.tgz",
+      "integrity": "sha512-2N4X2ZZl7kZw0qeGdQ41H0KND96L3qX1RgwuCfy6oUsF2ISGD/HpSbmms+CkIOsQmg2kulwfhJ4CI0asnZlvkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.10.tgz",
+      "integrity": "sha512-AsY6sVS8OLb96GV5RoG8B6I35GAbNrC49AO+jNRF9YVGb/g9t+hzNm1H6kD0NDp8tt7VJLs6hb7YMkDXqu03iw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.10.tgz",
+      "integrity": "sha512-kOuqWnEwZNtQxMKg3WmPK1vmhZu9WcoX69iwWjVz+jvKTsF1emzsv3eoPcDr6ykA3qP2bsCQE7CwqfNtAVzsmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.10",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/ansis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
@@ -1333,6 +1470,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-kit": {
@@ -1413,6 +1560,34 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -1450,6 +1625,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1501,6 +1683,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1581,6 +1773,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1823,6 +2032,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1832,6 +2048,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
@@ -1858,6 +2095,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tree-kill": {
@@ -2092,6 +2339,108 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.10.tgz",
+      "integrity": "sha512-2Fqty3MM9CDwOVet/jaQalYlbcjATZwPYGcqpiYQqgQ/dLC7GuHdISKgTYIVF/kaishKxLzleKWWfbSDklyIKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.10",
+        "@vitest/mocker": "4.0.10",
+        "@vitest/pretty-format": "4.0.10",
+        "@vitest/runner": "4.0.10",
+        "@vitest/snapshot": "4.0.10",
+        "@vitest/spy": "4.0.10",
+        "@vitest/utils": "4.0.10",
+        "debug": "^4.4.3",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.10",
+        "@vitest/browser-preview": "4.0.10",
+        "@vitest/browser-webdriverio": "4.0.10",
+        "@vitest/ui": "4.0.10",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/waspc/data/Generator/libs/vite-ssr/package.json
+++ b/waspc/data/Generator/libs/vite-ssr/package.json
@@ -21,7 +21,9 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "prepare": "npm run build",
-    "test": "exit 0"
+    "test": "npm run test:types && npm run test:unit",
+    "test:types": "tsc --noEmit",
+    "test:unit": "vitest run"
   },
   "peerDependencies": {
     "vite": "^7"
@@ -32,6 +34,7 @@
     "@types/node": "~22.12",
     "tsdown": "^0.21.5",
     "typescript": "~6.0.3",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.10"
   }
 }

--- a/waspc/data/Generator/libs/vite-ssr/src/plugins/common/routes.ts
+++ b/waspc/data/Generator/libs/vite-ssr/src/plugins/common/routes.ts
@@ -1,5 +1,9 @@
 import * as posixPath from "node:path/posix";
-import { removeLeadingSlash } from "../util/path";
+import {
+  getRoutablePathname,
+  removeLeadingSlash,
+  removeTrailingSlash,
+} from "../util/path";
 
 export interface SsrRoute {
   /** The pathname visible in the browser's address bar. */
@@ -38,10 +42,26 @@ export class SsrRoutes {
     ];
 
     this.byId = new Map(routes.map((route) => [route.id, route]));
-    this.byPath = new Map(routes.map((route) => [route.path, route]));
+    this.byPath = new Map(
+      routes.map((route) => [removeTrailingSlash(route.path), route]),
+    );
   }
 
   getAllIds() {
     return Array.from(this.byId.keys());
+  }
+
+  /**
+   * Finds the route matching a request URL, falling back to the SPA fallback
+   * when nothing matches. Unlike the configured route paths, the request URL
+   * may contain a query string, percent-encoding, a trailing slash, or Vite's
+   * `base` prefix, so it's normalized before lookup.
+   */
+  match(requestUrl: string, base: string): Readonly<SsrRoute> {
+    const pathname = getRoutablePathname(requestUrl, base);
+    if (pathname === null) {
+      return this.spaFallbackFile;
+    }
+    return this.byPath.get(pathname) ?? this.spaFallbackFile;
   }
 }

--- a/waspc/data/Generator/libs/vite-ssr/src/plugins/dev/index.ts
+++ b/waspc/data/Generator/libs/vite-ssr/src/plugins/dev/index.ts
@@ -53,14 +53,17 @@ export const ssrDev = (
             rewritten it to `/index.html`. With `req.url` we get `/index.html`
             so we know we're looking for the HTML file; but `req.originalUrl` is
             still `/some-page`, and we can pass that to our prerendering logic.
+
+            Note that Vite rewrites `req.url` but not `req.originalUrl`, so the
+            latter still carries the query string and the `base` prefix (if
+            any); `routes.match` normalizes those away before looking up the
+            route.
           */
           if (!url || url !== "/index.html" || !originalUrl) {
             return next();
           }
 
-          const route = routes.byPath.has(originalUrl)
-            ? originalUrl
-            : routes.spaFallbackFile.path;
+          const route = routes.match(originalUrl, server.config.base);
 
           // Clear the SSR module cache on every request, so that we always run the latest code.
           ssrEnv.runner.clearCache();
@@ -68,7 +71,7 @@ export const ssrDev = (
           const html = await withRegisteredCss(ssrEnv.hot, async () => {
             const { default: prerenderApp }: { default: PrerenderFn } =
               await ssrEnv.runner.import(ssrEntrySrc);
-            return await prerenderApp(route, { clientEntrySrc });
+            return await prerenderApp(route.path, { clientEntrySrc });
           });
 
           if (!html) {

--- a/waspc/data/Generator/libs/vite-ssr/src/plugins/preview.ts
+++ b/waspc/data/Generator/libs/vite-ssr/src/plugins/preview.ts
@@ -29,13 +29,17 @@ export const ssrPreview = (routes: SsrRoutes): Plugin => {
             rewritten it to `/index.html`. With `req.url` we get `/index.html`
             so we know we're looking for the HTML file; but `req.originalUrl` is
             still `/some-page`, and we can pass that to our prerendering logic.
+
+            Note that Vite rewrites `req.url` but not `req.originalUrl`, so the
+            latter still carries the query string and the `base` prefix (if
+            any); `routes.match` normalizes those away before looking up the
+            route.
           */
           if (!url || url !== "/index.html" || !originalUrl) {
             return next();
           }
 
-          const route =
-            routes.byPath.get(originalUrl) ?? routes.spaFallbackFile;
+          const route = routes.match(originalUrl, server.config.base);
 
           const htmlPath = path.resolve(clientOutDir, route.id);
           if (!(await pathExists(htmlPath))) {

--- a/waspc/data/Generator/libs/vite-ssr/src/plugins/util/path.ts
+++ b/waspc/data/Generator/libs/vite-ssr/src/plugins/util/path.ts
@@ -4,6 +4,64 @@ export function removeLeadingSlash(path: string) {
   return path.replace(/^\//, "");
 }
 
+/** Removes a single trailing slash, keeping the root path ("/") intact. */
+export function removeTrailingSlash(path: string) {
+  return path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+}
+
+/**
+ * Extracts the app-relative pathname from a raw request URL so it can be
+ * compared against configured route paths: drops the query string and hash,
+ * percent-decodes it, removes Vite's `base` prefix, and normalizes the
+ * trailing slash.
+ *
+ * Returns `null` when the URL can't be mapped to a route pathname (malformed
+ * percent-encoding, or a URL outside `base`).
+ */
+export function getRoutablePathname(
+  requestUrl: string,
+  base: string,
+): string | null {
+  let pathname: string;
+  try {
+    // The dummy origin lets `URL` parse the origin-relative URLs that
+    // middlewares receive (e.g. "/about?tab=1").
+    pathname = decodeURIComponent(
+      new URL(requestUrl, "http://localhost").pathname,
+    );
+  } catch {
+    return null;
+  }
+
+  const pathnameWithoutBase = stripBase(pathname, base);
+  if (pathnameWithoutBase === null) {
+    return null;
+  }
+
+  return removeTrailingSlash(pathnameWithoutBase);
+}
+
+/**
+ * Removes Vite's `base` prefix from a decoded pathname, returning `null` for
+ * pathnames outside `base`. A resolved Vite base is "/" or a path with
+ * leading and trailing slashes (e.g. "/app/"); other forms (a full URL or
+ * the relative "./") never match a request pathname and yield `null`.
+ */
+function stripBase(pathname: string, base: string): string | null {
+  if (base === "/") {
+    return pathname;
+  }
+
+  const baseWithoutTrailingSlash = removeTrailingSlash(base);
+  if (pathname === baseWithoutTrailingSlash) {
+    return "/";
+  }
+  if (pathname.startsWith(baseWithoutTrailingSlash + "/")) {
+    return pathname.slice(baseWithoutTrailingSlash.length);
+  }
+  return null;
+}
+
 export async function pathExists(...params: Parameters<typeof fs.access>) {
   try {
     await fs.access(...params);

--- a/waspc/data/Generator/libs/vite-ssr/tests/routes.test.ts
+++ b/waspc/data/Generator/libs/vite-ssr/tests/routes.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { SsrRoutes } from "../src/plugins/common/routes";
+
+const SPA_FALLBACK_FILE = "200.html";
+
+describe("SsrRoutes", () => {
+  describe("route ids", () => {
+    it("maps paths to directory-style html files", () => {
+      const routes = new SsrRoutes(["/", "/about"], SPA_FALLBACK_FILE);
+
+      expect(routes.getAllIds()).toEqual([
+        "index.html",
+        "about/index.html",
+        "200.html",
+      ]);
+    });
+  });
+
+  describe("match", () => {
+    const routes = new SsrRoutes(
+      ["/", "/about", "/docs/intro"],
+      SPA_FALLBACK_FILE,
+    );
+
+    it("matches an exact route path", () => {
+      expect(routes.match("/about", "/").path).toBe("/about");
+      expect(routes.match("/docs/intro", "/").path).toBe("/docs/intro");
+    });
+
+    it("matches the root path", () => {
+      expect(routes.match("/", "/").path).toBe("/");
+    });
+
+    it("falls back to the SPA fallback for unknown paths", () => {
+      expect(routes.match("/faq", "/")).toBe(routes.spaFallbackFile);
+      expect(routes.match("/about/team", "/")).toBe(routes.spaFallbackFile);
+    });
+
+    it("ignores query strings and hashes", () => {
+      expect(routes.match("/about?tab=1", "/").path).toBe("/about");
+      expect(routes.match("/about#team", "/").path).toBe("/about");
+      expect(routes.match("/?utm_source=x", "/").path).toBe("/");
+    });
+
+    it("ignores a trailing slash", () => {
+      expect(routes.match("/about/", "/").path).toBe("/about");
+      expect(routes.match("/about/?tab=1", "/").path).toBe("/about");
+    });
+
+    it("matches percent-encoded paths", () => {
+      expect(routes.match("/ab%6Fut", "/").path).toBe("/about");
+    });
+
+    it("falls back to the SPA fallback for malformed percent-encoding", () => {
+      expect(routes.match("/%zz", "/")).toBe(routes.spaFallbackFile);
+    });
+
+    it("matches routes configured with a trailing slash", () => {
+      const routesWithTrailingSlash = new SsrRoutes(
+        ["/docs/"],
+        SPA_FALLBACK_FILE,
+      );
+
+      expect(routesWithTrailingSlash.match("/docs", "/").path).toBe("/docs/");
+      expect(routesWithTrailingSlash.match("/docs/", "/").path).toBe("/docs/");
+    });
+
+    describe("with a non-root base", () => {
+      it("strips the base prefix before matching", () => {
+        expect(routes.match("/app/about", "/app/").path).toBe("/about");
+        expect(routes.match("/app/about/", "/app/").path).toBe("/about");
+        expect(routes.match("/app/about?tab=1", "/app/").path).toBe("/about");
+      });
+
+      it("matches the root path at the base, with or without its trailing slash", () => {
+        expect(routes.match("/app/", "/app/").path).toBe("/");
+        expect(routes.match("/app", "/app/").path).toBe("/");
+      });
+
+      it("falls back to the SPA fallback for paths outside the base", () => {
+        expect(routes.match("/about", "/app/")).toBe(routes.spaFallbackFile);
+        expect(routes.match("/apple/about", "/app/")).toBe(
+          routes.spaFallbackFile,
+        );
+      });
+    });
+  });
+});

--- a/waspc/data/Generator/libs/vite-ssr/tsconfig.json
+++ b/waspc/data/Generator/libs/vite-ssr/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "tests/**/*"],
   "extends": ["@tsconfig/node22", "@tsconfig/node-ts"],
   "compilerOptions": {
     "target": "esnext",

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -1,6 +1,7 @@
 {{={= =}=}}
 import type { PrerenderFn } from "@wasp.sh/lib-vite-ssr/types";
 import * as streamConsumers from "node:stream/consumers";
+import * as posixPath from "node:path/posix";
 import assert from "node:assert/strict";
 import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
@@ -21,7 +22,13 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     basename: "{= baseDir =}",
   });
 
-  const req = new Request(new URL(route, "http://localhost"));
+  // `route` is an app-relative path (e.g. "/about"), but the static handler
+  // matches request URLs against its `basename`, so the base dir has to be
+  // added back in. (The SPA fallback's `route` never matches anyway; its
+  // render is the route-less shell.)
+  const req = new Request(
+    new URL(posixPath.join("{= baseDir =}", route), "http://localhost"),
+  );
 
   const context = await query(req);
   assert(

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -39,7 +39,7 @@
             "file",
             "libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
         ],
-        "c1e32f2f59b2d67026d11f5c0e4026cfb42dce9963c48203d51685b6171f3f59"
+        "2b0206cef42e894a73f3c619d40019a2f999b9e8a1898889b630a8611f429b9b"
     ],
     [
         [
@@ -802,7 +802,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx"
         ],
-        "f1b19e131b16c7dc39254a841ad836ba5ea7200cb7e11d06999c3b276bca30f6"
+        "68f1ff72e4c381ccab8a215317f76b81a95cbb3253def2c12f7225d6a4b3c756"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -1,5 +1,6 @@
 import type { PrerenderFn } from "@wasp.sh/lib-vite-ssr/types";
 import * as streamConsumers from "node:stream/consumers";
+import * as posixPath from "node:path/posix";
 import assert from "node:assert/strict";
 import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
@@ -20,7 +21,13 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     basename: "/",
   });
 
-  const req = new Request(new URL(route, "http://localhost"));
+  // `route` is an app-relative path (e.g. "/about"), but the static handler
+  // matches request URLs against its `basename`, so the base dir has to be
+  // added back in. (The SPA fallback's `route` never matches anyway; its
+  // render is the route-less shell.)
+  const req = new Request(
+    new URL(posixPath.join("/", route), "http://localhost"),
+  );
 
   const context = await query(req);
   assert(

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/e2e-tests/tests/prerender.spec.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/e2e-tests/tests/prerender.spec.ts
@@ -18,6 +18,28 @@ test.describe("prerender", () => {
     await expect(page.getByTestId("render-location")).toHaveText("client");
   });
 
+  test("prerendered content is served for a URL with a query string", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+
+    await page.goto("/prerender?utm_source=test");
+
+    await expect(page.getByTestId("render-location")).toHaveText("server");
+  });
+
+  test("prerendered content is served for a URL with a trailing slash", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+
+    await page.goto("/prerender/");
+
+    await expect(page.getByTestId("render-location")).toHaveText("server");
+  });
+
   test("listed instances of a dynamic route are prerendered with no javascript", async ({
     browser,
   }) => {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
         ],
-        "c1e32f2f59b2d67026d11f5c0e4026cfb42dce9963c48203d51685b6171f3f59"
+        "2b0206cef42e894a73f3c619d40019a2f999b9e8a1898889b630a8611f429b9b"
     ],
     [
         [
@@ -361,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx"
         ],
-        "f1b19e131b16c7dc39254a841ad836ba5ea7200cb7e11d06999c3b276bca30f6"
+        "68f1ff72e4c381ccab8a215317f76b81a95cbb3253def2c12f7225d6a4b3c756"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -1,5 +1,6 @@
 import type { PrerenderFn } from "@wasp.sh/lib-vite-ssr/types";
 import * as streamConsumers from "node:stream/consumers";
+import * as posixPath from "node:path/posix";
 import assert from "node:assert/strict";
 import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
@@ -20,7 +21,13 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     basename: "/",
   });
 
-  const req = new Request(new URL(route, "http://localhost"));
+  // `route` is an app-relative path (e.g. "/about"), but the static handler
+  // matches request URLs against its `basename`, so the base dir has to be
+  // added back in. (The SPA fallback's `route` never matches anyway; its
+  // render is the route-less shell.)
+  const req = new Request(
+    new URL(posixPath.join("/", route), "http://localhost"),
+  );
 
   const context = await query(req);
   assert(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
         ],
-        "c1e32f2f59b2d67026d11f5c0e4026cfb42dce9963c48203d51685b6171f3f59"
+        "2b0206cef42e894a73f3c619d40019a2f999b9e8a1898889b630a8611f429b9b"
     ],
     [
         [
@@ -361,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx"
         ],
-        "f1b19e131b16c7dc39254a841ad836ba5ea7200cb7e11d06999c3b276bca30f6"
+        "68f1ff72e4c381ccab8a215317f76b81a95cbb3253def2c12f7225d6a4b3c756"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -1,5 +1,6 @@
 import type { PrerenderFn } from "@wasp.sh/lib-vite-ssr/types";
 import * as streamConsumers from "node:stream/consumers";
+import * as posixPath from "node:path/posix";
 import assert from "node:assert/strict";
 import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
@@ -20,7 +21,13 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     basename: "/",
   });
 
-  const req = new Request(new URL(route, "http://localhost"));
+  // `route` is an app-relative path (e.g. "/about"), but the static handler
+  // matches request URLs against its `basename`, so the base dir has to be
+  // added back in. (The SPA fallback's `route` never matches anyway; its
+  // render is the route-less shell.)
+  const req = new Request(
+    new URL(posixPath.join("/", route), "http://localhost"),
+  );
 
   const context = await query(req);
   assert(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/vite-ssr/wasp.sh-lib-vite-ssr-0.25.0.tgz"
         ],
-        "c1e32f2f59b2d67026d11f5c0e4026cfb42dce9963c48203d51685b6171f3f59"
+        "2b0206cef42e894a73f3c619d40019a2f999b9e8a1898889b630a8611f429b9b"
     ],
     [
         [
@@ -361,7 +361,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx"
         ],
-        "f1b19e131b16c7dc39254a841ad836ba5ea7200cb7e11d06999c3b276bca30f6"
+        "68f1ff72e4c381ccab8a215317f76b81a95cbb3253def2c12f7225d6a4b3c756"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/ssr-entry.tsx
@@ -1,5 +1,6 @@
 import type { PrerenderFn } from "@wasp.sh/lib-vite-ssr/types";
 import * as streamConsumers from "node:stream/consumers";
+import * as posixPath from "node:path/posix";
 import assert from "node:assert/strict";
 import { prerenderToNodeStream as reactPrerender } from "react-dom/static";
 import {
@@ -20,7 +21,13 @@ const prerenderApp: PrerenderFn = async (route, { clientEntrySrc }) => {
     basename: "/",
   });
 
-  const req = new Request(new URL(route, "http://localhost"));
+  // `route` is an app-relative path (e.g. "/about"), but the static handler
+  // matches request URLs against its `basename`, so the base dir has to be
+  // added back in. (The SPA fallback's `route` never matches anyway; its
+  // render is the route-less shell.)
+  const req = new Request(
+    new URL(posixPath.join("/", route), "http://localhost"),
+  );
 
   const context = await query(req);
   assert(


### PR DESCRIPTION
## Description

The vite-ssr dev and preview middlewares matched prerendered routes by exact string comparison on `req.originalUrl`, so a query string, trailing slash, percent-encoding, or a non-root `baseDir` made prerendered pages silently fall back to the SPA shell. Request URLs are now normalized (query/hash dropped, percent-decoded, Vite `base` stripped, trailing slash removed) before the route lookup. The SSR entry also joins `baseDir` back into the prerender request URL, since React Router's basename-aware static handler otherwise produced a 404 context for every route when a non-root `baseDir` is configured. Adds a vitest suite to the vite-ssr lib (12 tests) and two regression tests to kitchen-sink's prerender e2e spec, verified against a running kitchen-sink app in dev mode and a standalone Vite app in dev/preview with both `/` and `/app/` bases. E2E golden snapshots are regenerated (lib tarball checksums + ssr-entry template).

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [x] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [x] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->

Note: changelog/version bump skipped since this fixes the in-development SSR prerendering work, which is not part of a released version.