### PR TITLE
Replace React.lazy SSR workaround with route-level lazy and hydration wait

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/client/app/router.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/app/router.tsx
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import type { ReactNode, ComponentType } from 'react'
+import type { ReactNode } from 'react'
 import type { RouteObject } from 'react-router'
 
 {=# isExternalAuthEnabled =}
@@ -12,7 +12,7 @@ import { routes } from '../router/index'
 
 type RouteMapping = Record<
   string,
-  { Component: ComponentType }
+  Pick<RouteObject, 'Component' | 'lazy'>
 >;
 
 export function getRouteObjects({

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import { startTransition } from "react";
+import { startTransition, use } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -16,6 +16,41 @@ const router = createBrowserRouter({= routeObjects.importIdentifier =}, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// The router is not ready to render until it has loaded the matched route's
+// `lazy` module. If `RouterProvider` rendered before that, it would commit its
+// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
+// The React Router team recommends waiting until the router reports
+// `state.initialized`:
+// https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
+const routerInitialized = new Promise<void>((resolve) => {
+  // `createBrowserRouter` initializes the router synchronously when there is
+  // nothing to load lazily, and subscribers are only called on state changes,
+  // so we must check the current state first.
+  if (router.state.initialized) {
+    resolve()
+    return
+  }
+
+  const unsubscribe = router.subscribe((state) => {
+    if (state.initialized) {
+      unsubscribe()
+      resolve()
+    }
+  })
+})
+
+// We suspend on router initialization here, right above `RouterProvider`,
+// instead of `await`ing the promise before calling `hydrateRoot`. This way
+// React hydrates the rest of the tree concurrently with the route module
+// download, while the commit still happens in one go once the router is
+// initialized. Suspending is safe because we render inside a transition with
+// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
+// and just delays the commit.
+function InitializedRouterProvider() {
+  use(routerInitialized)
+  return <RouterProvider router={router} />
+}
+
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
@@ -23,7 +58,7 @@ function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
       <WaspApp>
-        <RouterProvider router={router} />
+        <InitializedRouterProvider />
       </WaspApp>
     </Layout>
   );

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,7 +1,7 @@
 {{={= =}=}}
-import { startTransition, use } from "react";
+import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, type DataRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 
 import { Layout } from "wasp/client/app/layout";
@@ -16,50 +16,40 @@ const router = createBrowserRouter({= routeObjects.importIdentifier =}, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
-// The router is not ready to render until it has loaded the matched route's
-// `lazy` module. If `RouterProvider` rendered before that, it would commit its
-// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
-// The React Router team recommends waiting until the router reports
-// `state.initialized`:
+// Rendering `RouterProvider` before the router has loaded the matched route's
+// `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
-const routerInitialized = new Promise<void>((resolve) => {
-  // `createBrowserRouter` initializes the router synchronously when there is
-  // nothing to load lazily, and subscribers are only called on state changes,
-  // so we must check the current state first.
-  if (router.state.initialized) {
-    resolve()
-    return
-  }
-
-  const unsubscribe = router.subscribe((state) => {
-    if (state.initialized) {
-      unsubscribe()
-      resolve()
+function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
+  return new Promise((resolve) => {
+    // The router initializes synchronously when there is nothing to load lazily.
+    if (router.state.initialized) {
+      resolve(router)
+      return
     }
-  })
-})
 
-// We suspend on router initialization here, right above `RouterProvider`,
-// instead of `await`ing the promise before calling `hydrateRoot`. This way
-// React hydrates the rest of the tree concurrently with the route module
-// download, while the commit still happens in one go once the router is
-// initialized. Suspending is safe because we render inside a transition with
-// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
-// and just delays the commit.
-function InitializedRouterProvider() {
-  use(routerInitialized)
-  return <RouterProvider router={router} />
+    const unsubscribe = router.subscribe((state) => {
+      if (state.initialized) {
+        unsubscribe()
+        resolve(router)
+      }
+    })
+  })
 }
 
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
+// Created once, outside of render: re-renders (e.g. hydration mismatch
+// recovery) must see the same, already-settled promise so React can unwrap it
+// synchronously instead of suspending again.
+const routerProvider = waitForRouterInitialized(router).then((router) => (
+  <RouterProvider router={router} />
+))
+
 function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>
-        <InitializedRouterProvider />
-      </WaspApp>
+      <WaspApp>{routerProvider}</WaspApp>
     </Layout>
   );
 }

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -16,6 +16,25 @@ const router = createBrowserRouter({= routeObjects.importIdentifier =}, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// We embed this data at prerendering time.
+const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
+
+const routerProviderPromise = waitForRouterInitialized(router).then(
+  (router) => <RouterProvider router={router} />,
+)
+
+function App() {
+  return (
+    <Layout isFallbackPage={isFallbackPage}>
+      <WaspApp>{routerProviderPromise}</WaspApp>
+    </Layout>
+  );
+}
+
+startTransition(() => {
+  hydrateRoot(document, <App />);
+});
+
 // Rendering `RouterProvider` before the router has loaded the matched route's
 // `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
@@ -35,25 +54,3 @@ function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
     })
   })
 }
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
-
-// Created once, outside of render: re-renders (e.g. hydration mismatch
-// recovery) must see the same, already-settled promise so React can unwrap it
-// synchronously instead of suspending again.
-const routerProvider = waitForRouterInitialized(router).then((router) => (
-  <RouterProvider router={router} />
-))
-
-function App() {
-  return (
-    <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>{routerProvider}</WaspApp>
-    </Layout>
-  );
-}
-
-startTransition(() => {
-  hydrateRoot(document, <App />);
-});

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,7 +1,6 @@
 {{={= =}=}}
 import { getRouteObjects } from "wasp/client/app/router";
 import { initializeQueryClient } from "wasp/client/operations";
-import { lazy } from "react"
 
 {=# isAuthEnabled =}
 import { createAuthRequiredPage } from "wasp/client/app"
@@ -25,19 +24,16 @@ const routesMapping = {
   {=# routes =}
   {=# isLazy =}
   {= name =}: {
-    Component:
-      {=! We use React's `lazy()` instead of defining a Lazy Route on React =}
-      {=! Router's side because there's a bug where it will ask for a =}
-      {=! HydrationFallback and commit it immediately even when working with =}
-      {=! prerendered pages. =}
-      {=! https://github.com/remix-run/react-router/issues/14955 =}
-      lazy(() =>
-        {=& import.dynamicImportExpression =}
-        {=# isAuthRequired =}
-        .then(component => createAuthRequiredPage(component))
-        {=/ isAuthRequired =}
-        .then(component => ({ default: component }))
-      ),
+    {=! Lazy Route Modules are only safe during hydration because the client =}
+    {=! entry waits for the router to be initialized (i.e. for the matched =}
+    {=! route's `lazy` module to be loaded) before rendering `RouterProvider`. =}
+    {=! See `client-entry.tsx` for details. =}
+    lazy: () =>
+      {=& import.dynamicImportExpression =}
+      {=# isAuthRequired =}
+      .then(component => createAuthRequiredPage(component))
+      {=/ isAuthRequired =}
+      .then(component => ({ Component: component })),
   },
   {=/ isLazy =}
   {=^ isLazy =}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -480,7 +480,7 @@
             "file",
             "sdk/wasp/client/app/router.tsx"
         ],
-        "6f47a064d242e0a6c952f619585669c990c08a8612cdf43f8419526153651293"
+        "7d751102f2566c884fa7bc9f9caf8cf5573b8338634701dc989bfba661e424e0"
     ],
     [
         [
@@ -788,14 +788,14 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "413c3dc30af130acc68fb319915348aab647f0b6d73bddacfcc5b5c3b7dbb766"
+        "b6f52189ec485dc1397781f59f87ea2f243b09d4e72bbd0522ac40ccfd313383"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "602d74f37a55ee7dfa2322d28687a580bf1710a5ab1929a0c81cabb386a12b14"
+        "b690e6a97864f0222fe8b7d06032ca1e5bb64c41f501b026d2ca76a087a13648"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -788,7 +788,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "b6f52189ec485dc1397781f59f87ea2f243b09d4e72bbd0522ac40ccfd313383"
+        "01d550eb11b0a630ab9d42730837f28322ba49be57d720492ce7d49c398d8c06"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -788,7 +788,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "01d550eb11b0a630ab9d42730837f28322ba49be57d720492ce7d49c398d8c06"
+        "34e6cc8475533f471b7c14a4df42be206a8803185ca2c25fa29211d9c2c6839f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/router.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/app/router.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, ComponentType } from 'react'
+import type { ReactNode } from 'react'
 import type { RouteObject } from 'react-router'
 
 import { OAuthCallbackPage } from "./pages/OAuthCallback"
@@ -9,7 +9,7 @@ import { routes } from '../router/index'
 
 type RouteMapping = Record<
   string,
-  { Component: ComponentType }
+  Pick<RouteObject, 'Component' | 'lazy'>
 >;
 
 export function getRouteObjects({

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,4 +1,4 @@
-import { startTransition } from "react";
+import { startTransition, use } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -15,6 +15,41 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// The router is not ready to render until it has loaded the matched route's
+// `lazy` module. If `RouterProvider` rendered before that, it would commit its
+// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
+// The React Router team recommends waiting until the router reports
+// `state.initialized`:
+// https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
+const routerInitialized = new Promise<void>((resolve) => {
+  // `createBrowserRouter` initializes the router synchronously when there is
+  // nothing to load lazily, and subscribers are only called on state changes,
+  // so we must check the current state first.
+  if (router.state.initialized) {
+    resolve()
+    return
+  }
+
+  const unsubscribe = router.subscribe((state) => {
+    if (state.initialized) {
+      unsubscribe()
+      resolve()
+    }
+  })
+})
+
+// We suspend on router initialization here, right above `RouterProvider`,
+// instead of `await`ing the promise before calling `hydrateRoot`. This way
+// React hydrates the rest of the tree concurrently with the route module
+// download, while the commit still happens in one go once the router is
+// initialized. Suspending is safe because we render inside a transition with
+// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
+// and just delays the commit.
+function InitializedRouterProvider() {
+  use(routerInitialized)
+  return <RouterProvider router={router} />
+}
+
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
@@ -22,7 +57,7 @@ function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
       <WaspApp>
-        <RouterProvider router={router} />
+        <InitializedRouterProvider />
       </WaspApp>
     </Layout>
   );

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -15,6 +15,25 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// We embed this data at prerendering time.
+const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
+
+const routerProviderPromise = waitForRouterInitialized(router).then(
+  (router) => <RouterProvider router={router} />,
+)
+
+function App() {
+  return (
+    <Layout isFallbackPage={isFallbackPage}>
+      <WaspApp>{routerProviderPromise}</WaspApp>
+    </Layout>
+  );
+}
+
+startTransition(() => {
+  hydrateRoot(document, <App />);
+});
+
 // Rendering `RouterProvider` before the router has loaded the matched route's
 // `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
@@ -34,25 +53,3 @@ function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
     })
   })
 }
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
-
-// Created once, outside of render: re-renders (e.g. hydration mismatch
-// recovery) must see the same, already-settled promise so React can unwrap it
-// synchronously instead of suspending again.
-const routerProvider = waitForRouterInitialized(router).then((router) => (
-  <RouterProvider router={router} />
-))
-
-function App() {
-  return (
-    <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>{routerProvider}</WaspApp>
-    </Layout>
-  );
-}
-
-startTransition(() => {
-  hydrateRoot(document, <App />);
-});

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,6 +1,6 @@
-import { startTransition, use } from "react";
+import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, type DataRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 
 import { Layout } from "wasp/client/app/layout";
@@ -15,50 +15,40 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
-// The router is not ready to render until it has loaded the matched route's
-// `lazy` module. If `RouterProvider` rendered before that, it would commit its
-// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
-// The React Router team recommends waiting until the router reports
-// `state.initialized`:
+// Rendering `RouterProvider` before the router has loaded the matched route's
+// `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
-const routerInitialized = new Promise<void>((resolve) => {
-  // `createBrowserRouter` initializes the router synchronously when there is
-  // nothing to load lazily, and subscribers are only called on state changes,
-  // so we must check the current state first.
-  if (router.state.initialized) {
-    resolve()
-    return
-  }
-
-  const unsubscribe = router.subscribe((state) => {
-    if (state.initialized) {
-      unsubscribe()
-      resolve()
+function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
+  return new Promise((resolve) => {
+    // The router initializes synchronously when there is nothing to load lazily.
+    if (router.state.initialized) {
+      resolve(router)
+      return
     }
-  })
-})
 
-// We suspend on router initialization here, right above `RouterProvider`,
-// instead of `await`ing the promise before calling `hydrateRoot`. This way
-// React hydrates the rest of the tree concurrently with the route module
-// download, while the commit still happens in one go once the router is
-// initialized. Suspending is safe because we render inside a transition with
-// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
-// and just delays the commit.
-function InitializedRouterProvider() {
-  use(routerInitialized)
-  return <RouterProvider router={router} />
+    const unsubscribe = router.subscribe((state) => {
+      if (state.initialized) {
+        unsubscribe()
+        resolve(router)
+      }
+    })
+  })
 }
 
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
+// Created once, outside of render: re-renders (e.g. hydration mismatch
+// recovery) must see the same, already-settled promise so React can unwrap it
+// synchronously instead of suspending again.
+const routerProvider = waitForRouterInitialized(router).then((router) => (
+  <RouterProvider router={router} />
+))
+
 function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>
-        <InitializedRouterProvider />
-      </WaspApp>
+      <WaspApp>{routerProvider}</WaspApp>
     </Layout>
   );
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,6 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
 import { initializeQueryClient } from "wasp/client/operations";
-import { lazy } from "react"
 
 import { createAuthRequiredPage } from "wasp/client/app"
 
@@ -12,175 +11,129 @@ import { EagerPage } from './src/features/lazy-loading/pages/EagerPage'
 
 const routesMapping = {
   HomeRoute: {
-    Component:
-      lazy(() =>
-        import('./src/pages/HomePage').then(m => m.HomePage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/pages/HomePage').then(m => m.HomePage)
+      .then(component => ({ Component: component })),
   },
   CatchAllRoute: {
-    Component:
-      lazy(() =>
-        import('./src/pages/CatchAllPage').then(m => m.CatchAllPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/pages/CatchAllPage').then(m => m.CatchAllPage)
+      .then(component => ({ Component: component })),
   },
   SignupRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/auth/pages/Signup').then(m => m.default)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/auth/pages/Signup').then(m => m.default)
+      .then(component => ({ Component: component })),
   },
   LoginRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/auth/pages/Login').then(m => m.default)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/auth/pages/Login').then(m => m.default)
+      .then(component => ({ Component: component })),
   },
   PasswordResetRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/auth/pages/PasswordReset').then(m => m.PasswordReset)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/auth/pages/PasswordReset').then(m => m.PasswordReset)
+      .then(component => ({ Component: component })),
   },
   EmailVerificationRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/auth/pages/EmailVerification').then(m => m.EmailVerification)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/auth/pages/EmailVerification').then(m => m.EmailVerification)
+      .then(component => ({ Component: component })),
   },
   RequestPasswordResetRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/auth/pages/RequestPasswordReset').then(m => m.RequestPasswordReset)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/auth/pages/RequestPasswordReset').then(m => m.RequestPasswordReset)
+      .then(component => ({ Component: component })),
   },
   ProfileRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/auth/pages/ProfilePage').then(m => m.ProfilePage)
-        .then(component => createAuthRequiredPage(component))
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/auth/pages/ProfilePage').then(m => m.ProfilePage)
+      .then(component => createAuthRequiredPage(component))
+      .then(component => ({ Component: component })),
   },
   ManualSignupRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/auth/pages/ManualSignupPage').then(m => m.ManualSignupPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/auth/pages/ManualSignupPage').then(m => m.ManualSignupPage)
+      .then(component => ({ Component: component })),
   },
   CustomSignupRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/auth/pages/CustomSignupPage').then(m => m.CustomSignupPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/auth/pages/CustomSignupPage').then(m => m.CustomSignupPage)
+      .then(component => ({ Component: component })),
   },
   TasksRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/operations/pages/TasksPage').then(m => m.TasksPage)
-        .then(component => createAuthRequiredPage(component))
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/operations/pages/TasksPage').then(m => m.TasksPage)
+      .then(component => createAuthRequiredPage(component))
+      .then(component => ({ Component: component })),
   },
   TaskRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/operations/pages/TaskDetailPage').then(m => m.TaskDetailPage)
-        .then(component => createAuthRequiredPage(component))
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/operations/pages/TaskDetailPage').then(m => m.TaskDetailPage)
+      .then(component => createAuthRequiredPage(component))
+      .then(component => ({ Component: component })),
   },
   SerializationRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/operations/pages/SerializationPage').then(m => m.SerializationPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/operations/pages/SerializationPage').then(m => m.SerializationPage)
+      .then(component => ({ Component: component })),
   },
   JobsRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/jobs/pages/JobsPage').then(m => m.JobsPage)
-        .then(component => createAuthRequiredPage(component))
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/jobs/pages/JobsPage').then(m => m.JobsPage)
+      .then(component => createAuthRequiredPage(component))
+      .then(component => ({ Component: component })),
   },
   ApisRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/apis/pages/ApisPage').then(m => m.ApisPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/apis/pages/ApisPage').then(m => m.ApisPage)
+      .then(component => ({ Component: component })),
   },
   CrudListRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/crud/pages/ListPage').then(m => m.ListPage)
-        .then(component => createAuthRequiredPage(component))
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/crud/pages/ListPage').then(m => m.ListPage)
+      .then(component => createAuthRequiredPage(component))
+      .then(component => ({ Component: component })),
   },
   CrudDetailRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/crud/pages/DetailPage').then(m => m.DetailPage)
-        .then(component => createAuthRequiredPage(component))
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/crud/pages/DetailPage').then(m => m.DetailPage)
+      .then(component => createAuthRequiredPage(component))
+      .then(component => ({ Component: component })),
   },
   StreamingRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/streaming/pages/StreamingTestPage').then(m => m.StreamingTestPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/streaming/pages/StreamingTestPage').then(m => m.StreamingTestPage)
+      .then(component => ({ Component: component })),
   },
   ChatRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/chat/pages/ChatPage').then(m => m.ChatPage)
-        .then(component => createAuthRequiredPage(component))
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/chat/pages/ChatPage').then(m => m.ChatPage)
+      .then(component => createAuthRequiredPage(component))
+      .then(component => ({ Component: component })),
   },
   EagerRoute: {
     Component: EagerPage,
   },
   LazyRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/lazy-loading/pages/LazyPage').then(m => m.LazyPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/lazy-loading/pages/LazyPage').then(m => m.LazyPage)
+      .then(component => ({ Component: component })),
   },
   PrerenderRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/prerender/pages/PrerenderPage').then(m => m.PrerenderPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/prerender/pages/PrerenderPage').then(m => m.PrerenderPage)
+      .then(component => ({ Component: component })),
   },
   PrerenderInstancesRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/prerender/pages/PrerenderInstancesPage').then(m => m.PrerenderInstancesPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/prerender/pages/PrerenderInstancesPage').then(m => m.PrerenderInstancesPage)
+      .then(component => ({ Component: component })),
   },
   HydrationMismatchRoute: {
-    Component:
-      lazy(() =>
-        import('./src/features/prerender/pages/HydrationMismatchPage').then(m => m.HydrationMismatchPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/features/prerender/pages/HydrationMismatchPage').then(m => m.HydrationMismatchPage)
+      .then(component => ({ Component: component })),
   },
 } as const;
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "01d550eb11b0a630ab9d42730837f28322ba49be57d720492ce7d49c398d8c06"
+        "34e6cc8475533f471b7c14a4df42be206a8803185ca2c25fa29211d9c2c6839f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "b6f52189ec485dc1397781f59f87ea2f243b09d4e72bbd0522ac40ccfd313383"
+        "01d550eb11b0a630ab9d42730837f28322ba49be57d720492ce7d49c398d8c06"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -116,7 +116,7 @@
             "file",
             "sdk/wasp/client/app/router.tsx"
         ],
-        "2b5dc997d1f01dfb8121e415a2d41ea035ce18ae877403036eec61009967f92b"
+        "8f2dbdea62ef4f0c78d3ce3d6b46896eef1909146c2ef5c6f6228f4991cd20a5"
     ],
     [
         [
@@ -347,14 +347,14 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "413c3dc30af130acc68fb319915348aab647f0b6d73bddacfcc5b5c3b7dbb766"
+        "b6f52189ec485dc1397781f59f87ea2f243b09d4e72bbd0522ac40ccfd313383"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "414b1611518493420eb087ca111d4423bd8562115a72bb9b53f0c4f146fcc955"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/router.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/app/router.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, ComponentType } from 'react'
+import type { ReactNode } from 'react'
 import type { RouteObject } from 'react-router'
 
 
@@ -8,7 +8,7 @@ import { routes } from '../router/index'
 
 type RouteMapping = Record<
   string,
-  { Component: ComponentType }
+  Pick<RouteObject, 'Component' | 'lazy'>
 >;
 
 export function getRouteObjects({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,4 +1,4 @@
-import { startTransition } from "react";
+import { startTransition, use } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -15,6 +15,41 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// The router is not ready to render until it has loaded the matched route's
+// `lazy` module. If `RouterProvider` rendered before that, it would commit its
+// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
+// The React Router team recommends waiting until the router reports
+// `state.initialized`:
+// https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
+const routerInitialized = new Promise<void>((resolve) => {
+  // `createBrowserRouter` initializes the router synchronously when there is
+  // nothing to load lazily, and subscribers are only called on state changes,
+  // so we must check the current state first.
+  if (router.state.initialized) {
+    resolve()
+    return
+  }
+
+  const unsubscribe = router.subscribe((state) => {
+    if (state.initialized) {
+      unsubscribe()
+      resolve()
+    }
+  })
+})
+
+// We suspend on router initialization here, right above `RouterProvider`,
+// instead of `await`ing the promise before calling `hydrateRoot`. This way
+// React hydrates the rest of the tree concurrently with the route module
+// download, while the commit still happens in one go once the router is
+// initialized. Suspending is safe because we render inside a transition with
+// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
+// and just delays the commit.
+function InitializedRouterProvider() {
+  use(routerInitialized)
+  return <RouterProvider router={router} />
+}
+
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
@@ -22,7 +57,7 @@ function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
       <WaspApp>
-        <RouterProvider router={router} />
+        <InitializedRouterProvider />
       </WaspApp>
     </Layout>
   );

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -15,6 +15,25 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// We embed this data at prerendering time.
+const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
+
+const routerProviderPromise = waitForRouterInitialized(router).then(
+  (router) => <RouterProvider router={router} />,
+)
+
+function App() {
+  return (
+    <Layout isFallbackPage={isFallbackPage}>
+      <WaspApp>{routerProviderPromise}</WaspApp>
+    </Layout>
+  );
+}
+
+startTransition(() => {
+  hydrateRoot(document, <App />);
+});
+
 // Rendering `RouterProvider` before the router has loaded the matched route's
 // `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
@@ -34,25 +53,3 @@ function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
     })
   })
 }
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
-
-// Created once, outside of render: re-renders (e.g. hydration mismatch
-// recovery) must see the same, already-settled promise so React can unwrap it
-// synchronously instead of suspending again.
-const routerProvider = waitForRouterInitialized(router).then((router) => (
-  <RouterProvider router={router} />
-))
-
-function App() {
-  return (
-    <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>{routerProvider}</WaspApp>
-    </Layout>
-  );
-}
-
-startTransition(() => {
-  hydrateRoot(document, <App />);
-});

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,6 +1,6 @@
-import { startTransition, use } from "react";
+import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, type DataRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 
 import { Layout } from "wasp/client/app/layout";
@@ -15,50 +15,40 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
-// The router is not ready to render until it has loaded the matched route's
-// `lazy` module. If `RouterProvider` rendered before that, it would commit its
-// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
-// The React Router team recommends waiting until the router reports
-// `state.initialized`:
+// Rendering `RouterProvider` before the router has loaded the matched route's
+// `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
-const routerInitialized = new Promise<void>((resolve) => {
-  // `createBrowserRouter` initializes the router synchronously when there is
-  // nothing to load lazily, and subscribers are only called on state changes,
-  // so we must check the current state first.
-  if (router.state.initialized) {
-    resolve()
-    return
-  }
-
-  const unsubscribe = router.subscribe((state) => {
-    if (state.initialized) {
-      unsubscribe()
-      resolve()
+function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
+  return new Promise((resolve) => {
+    // The router initializes synchronously when there is nothing to load lazily.
+    if (router.state.initialized) {
+      resolve(router)
+      return
     }
-  })
-})
 
-// We suspend on router initialization here, right above `RouterProvider`,
-// instead of `await`ing the promise before calling `hydrateRoot`. This way
-// React hydrates the rest of the tree concurrently with the route module
-// download, while the commit still happens in one go once the router is
-// initialized. Suspending is safe because we render inside a transition with
-// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
-// and just delays the commit.
-function InitializedRouterProvider() {
-  use(routerInitialized)
-  return <RouterProvider router={router} />
+    const unsubscribe = router.subscribe((state) => {
+      if (state.initialized) {
+        unsubscribe()
+        resolve(router)
+      }
+    })
+  })
 }
 
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
+// Created once, outside of render: re-renders (e.g. hydration mismatch
+// recovery) must see the same, already-settled promise so React can unwrap it
+// synchronously instead of suspending again.
+const routerProvider = waitForRouterInitialized(router).then((router) => (
+  <RouterProvider router={router} />
+))
+
 function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>
-        <InitializedRouterProvider />
-      </WaspApp>
+      <WaspApp>{routerProvider}</WaspApp>
     </Layout>
   );
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,6 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
 import { initializeQueryClient } from "wasp/client/operations";
-import { lazy } from "react"
 
 
 
@@ -8,11 +7,9 @@ import { lazy } from "react"
 
 const routesMapping = {
   RootRoute: {
-    Component:
-      lazy(() =>
-        import('./src/MainPage').then(m => m.MainPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/MainPage').then(m => m.MainPage)
+      .then(component => ({ Component: component })),
   },
 } as const;
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -397,25 +397,24 @@ const router = createBrowserRouter(routeObjects, {
   // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
   hydrationData: window.__staticRouterHydrationData
 });
-const routerInitialized = new Promise((resolve) => {
-  if (router.state.initialized) {
-    resolve();
-    return;
-  }
-  const unsubscribe = router.subscribe((state) => {
-    if (state.initialized) {
-      unsubscribe();
-      resolve();
+function waitForRouterInitialized(router2) {
+  return new Promise((resolve) => {
+    if (router2.state.initialized) {
+      resolve(router2);
+      return;
     }
+    const unsubscribe = router2.subscribe((state) => {
+      if (state.initialized) {
+        unsubscribe();
+        resolve(router2);
+      }
+    });
   });
-});
-function InitializedRouterProvider() {
-  use(routerInitialized);
-  return /* @__PURE__ */ jsx(RouterProvider, { router });
 }
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {};
+const routerProvider = waitForRouterInitialized(router).then((router2) => /* @__PURE__ */ jsx(RouterProvider, { router: router2 }));
 function App() {
-  return /* @__PURE__ */ jsx(Layout, { isFallbackPage, children: /* @__PURE__ */ jsx(WaspApp, { children: /* @__PURE__ */ jsx(InitializedRouterProvider, {}) }) });
+  return /* @__PURE__ */ jsx(Layout, { isFallbackPage, children: /* @__PURE__ */ jsx(WaspApp, { children: routerProvider }) });
 }
 startTransition(() => {
   hydrateRoot(document, /* @__PURE__ */ jsx(App, {}));

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -1,6 +1,6 @@
 const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/MainPage.js","assets/MainPage.css"])))=>i.map(i=>d[i]);
 import { jsx, jsxs } from "react/jsx-runtime";
-import { useState, useEffect, StrictMode, use, lazy, startTransition } from "react";
+import { useState, useEffect, StrictMode, use, startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { useRouteError, createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -382,9 +382,7 @@ function getRouteObjects({ routesMapping: routesMapping2, rootElement: rootEleme
 }
 const routesMapping = {
   RootRoute: {
-    Component: lazy(
-      () => __vitePreload(() => import("./MainPage.js"), true ? __vite__mapDeps([0,1]) : void 0).then((m) => m.MainPage).then((component) => ({ default: component }))
-    )
+    lazy: () => __vitePreload(() => import("./MainPage.js"), true ? __vite__mapDeps([0,1]) : void 0).then((m) => m.MainPage).then((component) => ({ Component: component }))
   }
 };
 initializeQueryClient();
@@ -399,9 +397,25 @@ const router = createBrowserRouter(routeObjects, {
   // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
   hydrationData: window.__staticRouterHydrationData
 });
+const routerInitialized = new Promise((resolve) => {
+  if (router.state.initialized) {
+    resolve();
+    return;
+  }
+  const unsubscribe = router.subscribe((state) => {
+    if (state.initialized) {
+      unsubscribe();
+      resolve();
+    }
+  });
+});
+function InitializedRouterProvider() {
+  use(routerInitialized);
+  return /* @__PURE__ */ jsx(RouterProvider, { router });
+}
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {};
 function App() {
-  return /* @__PURE__ */ jsx(Layout, { isFallbackPage, children: /* @__PURE__ */ jsx(WaspApp, { children: /* @__PURE__ */ jsx(RouterProvider, { router }) }) });
+  return /* @__PURE__ */ jsx(Layout, { isFallbackPage, children: /* @__PURE__ */ jsx(WaspApp, { children: /* @__PURE__ */ jsx(InitializedRouterProvider, {}) }) });
 }
 startTransition(() => {
   hydrateRoot(document, /* @__PURE__ */ jsx(App, {}));

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -397,6 +397,16 @@ const router = createBrowserRouter(routeObjects, {
   // https://reactrouter.com/7.13.1/start/data/custom#4-hydrate-in-the-browser
   hydrationData: window.__staticRouterHydrationData
 });
+const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {};
+const routerProviderPromise = waitForRouterInitialized(router).then(
+  (router2) => /* @__PURE__ */ jsx(RouterProvider, { router: router2 })
+);
+function App() {
+  return /* @__PURE__ */ jsx(Layout, { isFallbackPage, children: /* @__PURE__ */ jsx(WaspApp, { children: routerProviderPromise }) });
+}
+startTransition(() => {
+  hydrateRoot(document, /* @__PURE__ */ jsx(App, {}));
+});
 function waitForRouterInitialized(router2) {
   return new Promise((resolve) => {
     if (router2.state.initialized) {
@@ -411,11 +421,3 @@ function waitForRouterInitialized(router2) {
     });
   });
 }
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {};
-const routerProvider = waitForRouterInitialized(router).then((router2) => /* @__PURE__ */ jsx(RouterProvider, { router: router2 }));
-function App() {
-  return /* @__PURE__ */ jsx(Layout, { isFallbackPage, children: /* @__PURE__ */ jsx(WaspApp, { children: routerProvider }) });
-}
-startTransition(() => {
-  hydrateRoot(document, /* @__PURE__ */ jsx(App, {}));
-});

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "01d550eb11b0a630ab9d42730837f28322ba49be57d720492ce7d49c398d8c06"
+        "34e6cc8475533f471b7c14a4df42be206a8803185ca2c25fa29211d9c2c6839f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "b6f52189ec485dc1397781f59f87ea2f243b09d4e72bbd0522ac40ccfd313383"
+        "01d550eb11b0a630ab9d42730837f28322ba49be57d720492ce7d49c398d8c06"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -116,7 +116,7 @@
             "file",
             "sdk/wasp/client/app/router.tsx"
         ],
-        "2b5dc997d1f01dfb8121e415a2d41ea035ce18ae877403036eec61009967f92b"
+        "8f2dbdea62ef4f0c78d3ce3d6b46896eef1909146c2ef5c6f6228f4991cd20a5"
     ],
     [
         [
@@ -347,14 +347,14 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "413c3dc30af130acc68fb319915348aab647f0b6d73bddacfcc5b5c3b7dbb766"
+        "b6f52189ec485dc1397781f59f87ea2f243b09d4e72bbd0522ac40ccfd313383"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "414b1611518493420eb087ca111d4423bd8562115a72bb9b53f0c4f146fcc955"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/router.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/app/router.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, ComponentType } from 'react'
+import type { ReactNode } from 'react'
 import type { RouteObject } from 'react-router'
 
 
@@ -8,7 +8,7 @@ import { routes } from '../router/index'
 
 type RouteMapping = Record<
   string,
-  { Component: ComponentType }
+  Pick<RouteObject, 'Component' | 'lazy'>
 >;
 
 export function getRouteObjects({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,4 +1,4 @@
-import { startTransition } from "react";
+import { startTransition, use } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -15,6 +15,41 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// The router is not ready to render until it has loaded the matched route's
+// `lazy` module. If `RouterProvider` rendered before that, it would commit its
+// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
+// The React Router team recommends waiting until the router reports
+// `state.initialized`:
+// https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
+const routerInitialized = new Promise<void>((resolve) => {
+  // `createBrowserRouter` initializes the router synchronously when there is
+  // nothing to load lazily, and subscribers are only called on state changes,
+  // so we must check the current state first.
+  if (router.state.initialized) {
+    resolve()
+    return
+  }
+
+  const unsubscribe = router.subscribe((state) => {
+    if (state.initialized) {
+      unsubscribe()
+      resolve()
+    }
+  })
+})
+
+// We suspend on router initialization here, right above `RouterProvider`,
+// instead of `await`ing the promise before calling `hydrateRoot`. This way
+// React hydrates the rest of the tree concurrently with the route module
+// download, while the commit still happens in one go once the router is
+// initialized. Suspending is safe because we render inside a transition with
+// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
+// and just delays the commit.
+function InitializedRouterProvider() {
+  use(routerInitialized)
+  return <RouterProvider router={router} />
+}
+
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
@@ -22,7 +57,7 @@ function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
       <WaspApp>
-        <RouterProvider router={router} />
+        <InitializedRouterProvider />
       </WaspApp>
     </Layout>
   );

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -15,6 +15,25 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// We embed this data at prerendering time.
+const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
+
+const routerProviderPromise = waitForRouterInitialized(router).then(
+  (router) => <RouterProvider router={router} />,
+)
+
+function App() {
+  return (
+    <Layout isFallbackPage={isFallbackPage}>
+      <WaspApp>{routerProviderPromise}</WaspApp>
+    </Layout>
+  );
+}
+
+startTransition(() => {
+  hydrateRoot(document, <App />);
+});
+
 // Rendering `RouterProvider` before the router has loaded the matched route's
 // `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
@@ -34,25 +53,3 @@ function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
     })
   })
 }
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
-
-// Created once, outside of render: re-renders (e.g. hydration mismatch
-// recovery) must see the same, already-settled promise so React can unwrap it
-// synchronously instead of suspending again.
-const routerProvider = waitForRouterInitialized(router).then((router) => (
-  <RouterProvider router={router} />
-))
-
-function App() {
-  return (
-    <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>{routerProvider}</WaspApp>
-    </Layout>
-  );
-}
-
-startTransition(() => {
-  hydrateRoot(document, <App />);
-});

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,6 +1,6 @@
-import { startTransition, use } from "react";
+import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, type DataRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 
 import { Layout } from "wasp/client/app/layout";
@@ -15,50 +15,40 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
-// The router is not ready to render until it has loaded the matched route's
-// `lazy` module. If `RouterProvider` rendered before that, it would commit its
-// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
-// The React Router team recommends waiting until the router reports
-// `state.initialized`:
+// Rendering `RouterProvider` before the router has loaded the matched route's
+// `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
-const routerInitialized = new Promise<void>((resolve) => {
-  // `createBrowserRouter` initializes the router synchronously when there is
-  // nothing to load lazily, and subscribers are only called on state changes,
-  // so we must check the current state first.
-  if (router.state.initialized) {
-    resolve()
-    return
-  }
-
-  const unsubscribe = router.subscribe((state) => {
-    if (state.initialized) {
-      unsubscribe()
-      resolve()
+function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
+  return new Promise((resolve) => {
+    // The router initializes synchronously when there is nothing to load lazily.
+    if (router.state.initialized) {
+      resolve(router)
+      return
     }
-  })
-})
 
-// We suspend on router initialization here, right above `RouterProvider`,
-// instead of `await`ing the promise before calling `hydrateRoot`. This way
-// React hydrates the rest of the tree concurrently with the route module
-// download, while the commit still happens in one go once the router is
-// initialized. Suspending is safe because we render inside a transition with
-// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
-// and just delays the commit.
-function InitializedRouterProvider() {
-  use(routerInitialized)
-  return <RouterProvider router={router} />
+    const unsubscribe = router.subscribe((state) => {
+      if (state.initialized) {
+        unsubscribe()
+        resolve(router)
+      }
+    })
+  })
 }
 
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
+// Created once, outside of render: re-renders (e.g. hydration mismatch
+// recovery) must see the same, already-settled promise so React can unwrap it
+// synchronously instead of suspending again.
+const routerProvider = waitForRouterInitialized(router).then((router) => (
+  <RouterProvider router={router} />
+))
+
 function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>
-        <InitializedRouterProvider />
-      </WaspApp>
+      <WaspApp>{routerProvider}</WaspApp>
     </Layout>
   );
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,6 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
 import { initializeQueryClient } from "wasp/client/operations";
-import { lazy } from "react"
 
 
 
@@ -8,11 +7,9 @@ import { lazy } from "react"
 
 const routesMapping = {
   RootRoute: {
-    Component:
-      lazy(() =>
-        import('./src/MainPage').then(m => m.MainPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/MainPage').then(m => m.MainPage)
+      .then(component => ({ Component: component })),
   },
 } as const;
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "01d550eb11b0a630ab9d42730837f28322ba49be57d720492ce7d49c398d8c06"
+        "34e6cc8475533f471b7c14a4df42be206a8803185ca2c25fa29211d9c2c6839f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -347,7 +347,7 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "b6f52189ec485dc1397781f59f87ea2f243b09d4e72bbd0522ac40ccfd313383"
+        "01d550eb11b0a630ab9d42730837f28322ba49be57d720492ce7d49c398d8c06"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -116,7 +116,7 @@
             "file",
             "sdk/wasp/client/app/router.tsx"
         ],
-        "2b5dc997d1f01dfb8121e415a2d41ea035ce18ae877403036eec61009967f92b"
+        "8f2dbdea62ef4f0c78d3ce3d6b46896eef1909146c2ef5c6f6228f4991cd20a5"
     ],
     [
         [
@@ -347,14 +347,14 @@
             "file",
             "sdk/wasp/client/vite/virtual-files/files/client-entry.tsx"
         ],
-        "413c3dc30af130acc68fb319915348aab647f0b6d73bddacfcc5b5c3b7dbb766"
+        "b6f52189ec485dc1397781f59f87ea2f243b09d4e72bbd0522ac40ccfd313383"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/virtual-files/files/routes.tsx"
         ],
-        "f61fadf421a8c1fb21eb0a2e2fa9a3823e82442dde46dd710b80c616ef434c35"
+        "414b1611518493420eb087ca111d4423bd8562115a72bb9b53f0c4f146fcc955"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/router.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/app/router.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, ComponentType } from 'react'
+import type { ReactNode } from 'react'
 import type { RouteObject } from 'react-router'
 
 
@@ -8,7 +8,7 @@ import { routes } from '../router/index'
 
 type RouteMapping = Record<
   string,
-  { Component: ComponentType }
+  Pick<RouteObject, 'Component' | 'lazy'>
 >;
 
 export function getRouteObjects({

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,4 +1,4 @@
-import { startTransition } from "react";
+import { startTransition, use } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -15,6 +15,41 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// The router is not ready to render until it has loaded the matched route's
+// `lazy` module. If `RouterProvider` rendered before that, it would commit its
+// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
+// The React Router team recommends waiting until the router reports
+// `state.initialized`:
+// https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
+const routerInitialized = new Promise<void>((resolve) => {
+  // `createBrowserRouter` initializes the router synchronously when there is
+  // nothing to load lazily, and subscribers are only called on state changes,
+  // so we must check the current state first.
+  if (router.state.initialized) {
+    resolve()
+    return
+  }
+
+  const unsubscribe = router.subscribe((state) => {
+    if (state.initialized) {
+      unsubscribe()
+      resolve()
+    }
+  })
+})
+
+// We suspend on router initialization here, right above `RouterProvider`,
+// instead of `await`ing the promise before calling `hydrateRoot`. This way
+// React hydrates the rest of the tree concurrently with the route module
+// download, while the commit still happens in one go once the router is
+// initialized. Suspending is safe because we render inside a transition with
+// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
+// and just delays the commit.
+function InitializedRouterProvider() {
+  use(routerInitialized)
+  return <RouterProvider router={router} />
+}
+
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
@@ -22,7 +57,7 @@ function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
       <WaspApp>
-        <RouterProvider router={router} />
+        <InitializedRouterProvider />
       </WaspApp>
     </Layout>
   );

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -15,6 +15,25 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
+// We embed this data at prerendering time.
+const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
+
+const routerProviderPromise = waitForRouterInitialized(router).then(
+  (router) => <RouterProvider router={router} />,
+)
+
+function App() {
+  return (
+    <Layout isFallbackPage={isFallbackPage}>
+      <WaspApp>{routerProviderPromise}</WaspApp>
+    </Layout>
+  );
+}
+
+startTransition(() => {
+  hydrateRoot(document, <App />);
+});
+
 // Rendering `RouterProvider` before the router has loaded the matched route's
 // `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
@@ -34,25 +53,3 @@ function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
     })
   })
 }
-
-// We embed this data at prerendering time.
-const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
-
-// Created once, outside of render: re-renders (e.g. hydration mismatch
-// recovery) must see the same, already-settled promise so React can unwrap it
-// synchronously instead of suspending again.
-const routerProvider = waitForRouterInitialized(router).then((router) => (
-  <RouterProvider router={router} />
-))
-
-function App() {
-  return (
-    <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>{routerProvider}</WaspApp>
-    </Layout>
-  );
-}
-
-startTransition(() => {
-  hydrateRoot(document, <App />);
-});

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/client-entry.tsx
@@ -1,6 +1,6 @@
-import { startTransition, use } from "react";
+import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
-import { createBrowserRouter } from "react-router";
+import { createBrowserRouter, type DataRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 
 import { Layout } from "wasp/client/app/layout";
@@ -15,50 +15,40 @@ const router = createBrowserRouter(routeObjects, {
   hydrationData: window.__staticRouterHydrationData,
 })
 
-// The router is not ready to render until it has loaded the matched route's
-// `lazy` module. If `RouterProvider` rendered before that, it would commit its
-// `HydrateFallback` over the prerendered HTML, causing a hydration mismatch.
-// The React Router team recommends waiting until the router reports
-// `state.initialized`:
+// Rendering `RouterProvider` before the router has loaded the matched route's
+// `lazy` module would commit its `HydrateFallback` over the prerendered HTML.
 // https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287
-const routerInitialized = new Promise<void>((resolve) => {
-  // `createBrowserRouter` initializes the router synchronously when there is
-  // nothing to load lazily, and subscribers are only called on state changes,
-  // so we must check the current state first.
-  if (router.state.initialized) {
-    resolve()
-    return
-  }
-
-  const unsubscribe = router.subscribe((state) => {
-    if (state.initialized) {
-      unsubscribe()
-      resolve()
+function waitForRouterInitialized(router: DataRouter): Promise<DataRouter> {
+  return new Promise((resolve) => {
+    // The router initializes synchronously when there is nothing to load lazily.
+    if (router.state.initialized) {
+      resolve(router)
+      return
     }
-  })
-})
 
-// We suspend on router initialization here, right above `RouterProvider`,
-// instead of `await`ing the promise before calling `hydrateRoot`. This way
-// React hydrates the rest of the tree concurrently with the route module
-// download, while the commit still happens in one go once the router is
-// initialized. Suspending is safe because we render inside a transition with
-// no `Suspense` boundary above, so React keeps the prerendered HTML on screen
-// and just delays the commit.
-function InitializedRouterProvider() {
-  use(routerInitialized)
-  return <RouterProvider router={router} />
+    const unsubscribe = router.subscribe((state) => {
+      if (state.initialized) {
+        unsubscribe()
+        resolve(router)
+      }
+    })
+  })
 }
 
 // We embed this data at prerendering time.
 const { isFallbackPage } = window.__WASP_SSR_DATA__ ?? {}
 
+// Created once, outside of render: re-renders (e.g. hydration mismatch
+// recovery) must see the same, already-settled promise so React can unwrap it
+// synchronously instead of suspending again.
+const routerProvider = waitForRouterInitialized(router).then((router) => (
+  <RouterProvider router={router} />
+))
+
 function App() {
   return (
     <Layout isFallbackPage={isFallbackPage}>
-      <WaspApp>
-        <InitializedRouterProvider />
-      </WaspApp>
+      <WaspApp>{routerProvider}</WaspApp>
     </Layout>
   );
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/virtual-files/files/routes.tsx
@@ -1,6 +1,5 @@
 import { getRouteObjects } from "wasp/client/app/router";
 import { initializeQueryClient } from "wasp/client/operations";
-import { lazy } from "react"
 
 
 
@@ -8,11 +7,9 @@ import { lazy } from "react"
 
 const routesMapping = {
   RootRoute: {
-    Component:
-      lazy(() =>
-        import('./src/MainPage').then(m => m.MainPage)
-        .then(component => ({ default: component }))
-      ),
+    lazy: () =>
+      import('./src/MainPage').then(m => m.MainPage)
+      .then(component => ({ Component: component })),
   },
 } as const;
 


### PR DESCRIPTION
## Description

Our SSR setup used React's `lazy()` for lazy routes as a workaround for RouterProvider committing its `HydrateFallback` over prerendered HTML when using route-level lazy (remix-run/react-router#14955). That workaround has drawbacks, so we asked the React Router team for the proper approach, and they recommended keeping route-level `lazy` and delaying hydration until the router reports `state.initialized` (at which point all matched `lazy` modules are resolved): https://github.com/remix-run/react-router/issues/14955#issuecomment-4407850287

This PR adopts that solution with two adjustments:

- **Suspend inside the hydration transition instead of awaiting before `hydrateRoot`.** `createBrowserRouter` starts loading the matched route's `lazy` module at module evaluation, so with a top-level `await` React sits idle until the module arrives. Instead, the client entry renders `waitForRouterInitialized(router).then((router) => <RouterProvider router={router} />)` as a child (React 19 supports promises as children), so React hydrates and warms the rest of the tree (`Layout`, `WaspApp`) concurrently with the module download, and the commit still happens in one go once the router is initialized. The promise is created once at module scope: it must stay stable across render passes, because React's synchronous hydration-mismatch recovery render can only unwrap an already-tracked settled promise; a fresh promise per render makes recovery suspend with no boundary and tear down the page.
- **Guard for synchronously-initialized routers.** The snippet from the React Router team only subscribes; if the matched routes have no `lazy` (eager-only apps, or no match at all), the router initializes synchronously, subscribers never fire, and the app would never render. `waitForRouterInitialized` checks `router.state.initialized` before subscribing.

`ssr-entry.tsx` needs no changes: React Router's static handler marks routes with `lazy` as needing load even without loaders and awaits all lazy module promises during `query()` (verified in the react-router 7.12.0 source), so prerendering still renders full page content.

Verification:

- E2E golden snapshots regenerated; comparison-mode run passes (984/984).
- Kitchen-sink Playwright specs (`prerender`, `lazy-loading`, `catch-all-route`) pass in both dev and build modes (28/28 each), including "prerender page has no hydration warnings", "hydration mismatch page triggers a hydration warning" (recovery still works), "content visible with no JavaScript", and "lazy page is not loaded on unrelated pages" (code splitting preserved).

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

  No new tests: this is a template-only change to generated client code with no behavior change, already covered by the e2e golden snapshots and the existing kitchen-sink `prerender.spec.ts` / `lazy-loading.spec.ts` Playwright tests.

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
