### PR TITLE
Fix missing punctuation in appAnalyzer error message

### DIFF
--- a/waspc/data/packages/spec/src/spec/appAnalyzer.ts
+++ b/waspc/data/packages/spec/src/spec/appAnalyzer.ts
@@ -39,7 +39,7 @@ function getApp(
 
   if (!isApp(waspTsDefaultExport)) {
     throw new SpecUserError(
-      `The default export of '${waspTsSpecFile}' file must be of type 'App'` +
+      `The default export of '${waspTsSpecFile}' file must be of type 'App'. ` +
         "Make sure you export the result of calling 'app({ ... })'",
     );
   }


### PR DESCRIPTION
## Description

Fixes a missing period and space in the "App" default export error message thrown by `appAnalyzer.ts`, which previously read `...must be of type 'App'Make sure...` with no separation between sentences.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.