### PR TITLE
Group kitchen sink sidebar links

### DIFF
--- a/examples/kitchen-sink/src/components/FeatureContainer.tsx
+++ b/examples/kitchen-sink/src/components/FeatureContainer.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router";
 import { NavLink, type Routes } from "wasp/client/router";
 import { cn } from "../cn";
 
@@ -28,11 +29,7 @@ function DesktopFeatureListMenu() {
   return (
     <div className="hidden w-80 overflow-y-auto border-r border-gray-200 bg-white lg:block">
       <div className="p-6">
-        <nav className="space-y-2">
-          {features.map((feature) => (
-            <FeatureCard {...feature} key={feature.to} />
-          ))}
-        </nav>
+        <FeatureTree />
       </div>
     </div>
   );
@@ -45,16 +42,12 @@ function MobileFeatureListMenu() {
     <>
       <div
         className={cn(
-          "fixed inset-x-0 bottom-0 z-40 border-t border-gray-200 bg-white transition-transform duration-300 lg:hidden",
+          "fixed inset-x-0 bottom-0 z-40 max-h-[calc(100dvh-4rem)] overflow-y-auto border-t border-gray-200 bg-white transition-transform duration-300 lg:hidden",
           isMobileMenuOpen ? "translate-y-0" : "translate-y-full",
         )}
       >
-        <div className="overflow-y-auto p-6">
-          <nav className="space-y-2">
-            {features.map((feature) => (
-              <FeatureCard {...feature} key={feature.to} />
-            ))}
-          </nav>
+        <div className="px-8 pt-8 pb-28">
+          <FeatureTree />
         </div>
       </div>
 
@@ -96,72 +89,198 @@ type Feature = {
   to: string;
 } & Routes;
 
-const features: Feature[] = [
+type FeatureGroup = {
+  title: string;
+  features: Feature[];
+};
+
+const featureGroups: FeatureGroup[] = [
   {
-    to: "/tasks",
-    title: "Operations",
+    title: "Data & Operations",
+    features: [
+      {
+        to: "/tasks",
+        title: "Operations",
+      },
+      {
+        to: "/crud",
+        title: "Automatic CRUD",
+      },
+      {
+        to: "/serialization",
+        title: "Serialization Test",
+        isPublic: true,
+      },
+    ],
   },
   {
-    to: "/custom-signup",
-    title: "Custom Signup",
-    isPublic: true,
+    title: "Server Features",
+    features: [
+      {
+        to: "/apis",
+        title: "Custom APIs",
+        isPublic: true,
+      },
+      {
+        to: "/jobs",
+        title: "Async Jobs",
+      },
+      {
+        to: "/chat",
+        title: "Websockets",
+      },
+      {
+        to: "/streaming",
+        title: "Streaming",
+      },
+    ],
   },
   {
-    to: "/manual-signup",
-    title: "Manual Signup",
-    isPublic: true,
+    title: "Auth & Account",
+    features: [
+      {
+        to: "/profile",
+        title: "User Profile",
+      },
+      {
+        to: "/custom-signup",
+        title: "Custom Signup",
+        isPublic: true,
+      },
+      {
+        to: "/manual-signup",
+        title: "Manual Signup",
+        isPublic: true,
+      },
+    ],
   },
   {
-    to: "/apis",
-    title: "Custom APIs",
-    isPublic: true,
-  },
-  {
-    to: "/jobs",
-    title: "Async Jobs",
-  },
-  {
-    to: "/chat",
-    title: "Websockets",
-  },
-  {
-    to: "/crud",
-    title: "Automatic CRUD",
-  },
-  {
-    to: "/streaming",
-    title: "Streaming",
-  },
-  {
-    to: "/serialization",
-    title: "Serialization Test",
-    isPublic: true,
-  },
-  {
-    to: "/profile",
-    title: "User Profile",
-  },
-  {
-    to: "/lazy/no",
-    title: "Eager Route",
-    isPublic: true,
-  },
-  {
-    to: "/lazy/yes",
-    title: "Lazy Route",
-    isPublic: true,
-  },
-  {
-    to: "/prerender",
-    title: "Prerendering",
-    isPublic: true,
-  },
-  {
-    to: "/hydration-mismatch",
-    title: "Hydration Mismatch",
-    isPublic: true,
+    title: "Routing & Rendering",
+    features: [
+      {
+        to: "/lazy/no",
+        title: "Eager Route",
+        isPublic: true,
+      },
+      {
+        to: "/lazy/yes",
+        title: "Lazy Route",
+        isPublic: true,
+      },
+      {
+        to: "/prerender",
+        title: "Prerendering",
+        isPublic: true,
+      },
+      {
+        to: "/hydration-mismatch",
+        title: "Hydration Mismatch",
+        isPublic: true,
+      },
+    ],
   },
 ];
+
+function FeatureTree() {
+  const location = useLocation();
+  const activeGroup = getFeatureGroupForPath(location.pathname);
+  const [openGroups, setOpenGroups] = useState(() =>
+    getInitiallyOpenGroups(location.pathname),
+  );
+
+  useEffect(() => {
+    if (!activeGroup) {
+      return;
+    }
+
+    setOpenGroups((currentOpenGroups) => {
+      if (currentOpenGroups.has(activeGroup.title)) {
+        return currentOpenGroups;
+      }
+
+      return new Set(currentOpenGroups).add(activeGroup.title);
+    });
+  }, [activeGroup]);
+
+  function toggleGroup(title: string) {
+    setOpenGroups((currentOpenGroups) => {
+      const nextOpenGroups = new Set(currentOpenGroups);
+
+      if (nextOpenGroups.has(title)) {
+        nextOpenGroups.delete(title);
+      } else {
+        nextOpenGroups.add(title);
+      }
+
+      return nextOpenGroups;
+    });
+  }
+
+  return (
+    <nav aria-label="Features" className="space-y-4">
+      {featureGroups.map((group) => {
+        const isOpen = openGroups.has(group.title);
+
+        return (
+          <section className="space-y-1" key={group.title}>
+            <button
+              type="button"
+              aria-expanded={isOpen}
+              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase transition-colors hover:bg-gray-50 hover:text-gray-700"
+              onClick={() => toggleGroup(group.title)}
+            >
+              <svg
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-200",
+                  isOpen && "rotate-90",
+                )}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="m9 5 7 7-7 7"
+                />
+              </svg>
+              <span>{group.title}</span>
+            </button>
+
+            {isOpen && (
+              <div className="ml-3 space-y-1 border-l border-gray-200 pl-3">
+                {group.features.map((feature) => (
+                  <FeatureCard {...feature} key={feature.to} />
+                ))}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </nav>
+  );
+}
+
+function getInitiallyOpenGroups(pathname: string) {
+  const activeGroup = getFeatureGroupForPath(pathname);
+
+  if (activeGroup) {
+    return new Set([activeGroup.title]);
+  }
+
+  return new Set(featureGroups[0] ? [featureGroups[0].title] : []);
+}
+
+function getFeatureGroupForPath(pathname: string) {
+  return featureGroups.find((group) =>
+    group.features.some((feature) => isFeaturePathActive(pathname, feature.to)),
+  );
+}
+
+function isFeaturePathActive(pathname: string, featurePath: string) {
+  return pathname === featurePath || pathname.startsWith(`${featurePath}/`);
+}
 
 function FeatureCard({ title, isPublic, ...routeProps }: Feature) {
   return (

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1299,7 +1299,7 @@
             "file",
             "sdk/wasp/src/components/FeatureContainer.tsx"
         ],
-        "b2a88f5eaf930f2daf2523b0206cad4398f7c77e2e478008af342c235b1ca765"
+        "c6cbfa3afcba062f19838327d1a23e017d830e9cd55dd30eaaa944d96b2ac714"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/src/components/FeatureContainer.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/src/components/FeatureContainer.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router";
 import { NavLink, type Routes } from "wasp/client/router";
 import { cn } from "../cn";
 
@@ -28,11 +29,7 @@ function DesktopFeatureListMenu() {
   return (
     <div className="hidden w-80 overflow-y-auto border-r border-gray-200 bg-white lg:block">
       <div className="p-6">
-        <nav className="space-y-2">
-          {features.map((feature) => (
-            <FeatureCard {...feature} key={feature.to} />
-          ))}
-        </nav>
+        <FeatureTree />
       </div>
     </div>
   );
@@ -45,16 +42,12 @@ function MobileFeatureListMenu() {
     <>
       <div
         className={cn(
-          "fixed inset-x-0 bottom-0 z-40 border-t border-gray-200 bg-white transition-transform duration-300 lg:hidden",
+          "fixed inset-x-0 bottom-0 z-40 max-h-[calc(100dvh-4rem)] overflow-y-auto border-t border-gray-200 bg-white transition-transform duration-300 lg:hidden",
           isMobileMenuOpen ? "translate-y-0" : "translate-y-full",
         )}
       >
-        <div className="overflow-y-auto p-6">
-          <nav className="space-y-2">
-            {features.map((feature) => (
-              <FeatureCard {...feature} key={feature.to} />
-            ))}
-          </nav>
+        <div className="px-8 pt-8 pb-28">
+          <FeatureTree />
         </div>
       </div>
 
@@ -96,72 +89,198 @@ type Feature = {
   to: string;
 } & Routes;
 
-const features: Feature[] = [
+type FeatureGroup = {
+  title: string;
+  features: Feature[];
+};
+
+const featureGroups: FeatureGroup[] = [
   {
-    to: "/tasks",
-    title: "Operations",
+    title: "Data & Operations",
+    features: [
+      {
+        to: "/tasks",
+        title: "Operations",
+      },
+      {
+        to: "/crud",
+        title: "Automatic CRUD",
+      },
+      {
+        to: "/serialization",
+        title: "Serialization Test",
+        isPublic: true,
+      },
+    ],
   },
   {
-    to: "/custom-signup",
-    title: "Custom Signup",
-    isPublic: true,
+    title: "Server Features",
+    features: [
+      {
+        to: "/apis",
+        title: "Custom APIs",
+        isPublic: true,
+      },
+      {
+        to: "/jobs",
+        title: "Async Jobs",
+      },
+      {
+        to: "/chat",
+        title: "Websockets",
+      },
+      {
+        to: "/streaming",
+        title: "Streaming",
+      },
+    ],
   },
   {
-    to: "/manual-signup",
-    title: "Manual Signup",
-    isPublic: true,
+    title: "Auth & Account",
+    features: [
+      {
+        to: "/profile",
+        title: "User Profile",
+      },
+      {
+        to: "/custom-signup",
+        title: "Custom Signup",
+        isPublic: true,
+      },
+      {
+        to: "/manual-signup",
+        title: "Manual Signup",
+        isPublic: true,
+      },
+    ],
   },
   {
-    to: "/apis",
-    title: "Custom APIs",
-    isPublic: true,
-  },
-  {
-    to: "/jobs",
-    title: "Async Jobs",
-  },
-  {
-    to: "/chat",
-    title: "Websockets",
-  },
-  {
-    to: "/crud",
-    title: "Automatic CRUD",
-  },
-  {
-    to: "/streaming",
-    title: "Streaming",
-  },
-  {
-    to: "/serialization",
-    title: "Serialization Test",
-    isPublic: true,
-  },
-  {
-    to: "/profile",
-    title: "User Profile",
-  },
-  {
-    to: "/lazy/no",
-    title: "Eager Route",
-    isPublic: true,
-  },
-  {
-    to: "/lazy/yes",
-    title: "Lazy Route",
-    isPublic: true,
-  },
-  {
-    to: "/prerender",
-    title: "Prerendering",
-    isPublic: true,
-  },
-  {
-    to: "/hydration-mismatch",
-    title: "Hydration Mismatch",
-    isPublic: true,
+    title: "Routing & Rendering",
+    features: [
+      {
+        to: "/lazy/no",
+        title: "Eager Route",
+        isPublic: true,
+      },
+      {
+        to: "/lazy/yes",
+        title: "Lazy Route",
+        isPublic: true,
+      },
+      {
+        to: "/prerender",
+        title: "Prerendering",
+        isPublic: true,
+      },
+      {
+        to: "/hydration-mismatch",
+        title: "Hydration Mismatch",
+        isPublic: true,
+      },
+    ],
   },
 ];
+
+function FeatureTree() {
+  const location = useLocation();
+  const activeGroup = getFeatureGroupForPath(location.pathname);
+  const [openGroups, setOpenGroups] = useState(() =>
+    getInitiallyOpenGroups(location.pathname),
+  );
+
+  useEffect(() => {
+    if (!activeGroup) {
+      return;
+    }
+
+    setOpenGroups((currentOpenGroups) => {
+      if (currentOpenGroups.has(activeGroup.title)) {
+        return currentOpenGroups;
+      }
+
+      return new Set(currentOpenGroups).add(activeGroup.title);
+    });
+  }, [activeGroup]);
+
+  function toggleGroup(title: string) {
+    setOpenGroups((currentOpenGroups) => {
+      const nextOpenGroups = new Set(currentOpenGroups);
+
+      if (nextOpenGroups.has(title)) {
+        nextOpenGroups.delete(title);
+      } else {
+        nextOpenGroups.add(title);
+      }
+
+      return nextOpenGroups;
+    });
+  }
+
+  return (
+    <nav aria-label="Features" className="space-y-4">
+      {featureGroups.map((group) => {
+        const isOpen = openGroups.has(group.title);
+
+        return (
+          <section className="space-y-1" key={group.title}>
+            <button
+              type="button"
+              aria-expanded={isOpen}
+              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase transition-colors hover:bg-gray-50 hover:text-gray-700"
+              onClick={() => toggleGroup(group.title)}
+            >
+              <svg
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-200",
+                  isOpen && "rotate-90",
+                )}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="m9 5 7 7-7 7"
+                />
+              </svg>
+              <span>{group.title}</span>
+            </button>
+
+            {isOpen && (
+              <div className="ml-3 space-y-1 border-l border-gray-200 pl-3">
+                {group.features.map((feature) => (
+                  <FeatureCard {...feature} key={feature.to} />
+                ))}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </nav>
+  );
+}
+
+function getInitiallyOpenGroups(pathname: string) {
+  const activeGroup = getFeatureGroupForPath(pathname);
+
+  if (activeGroup) {
+    return new Set([activeGroup.title]);
+  }
+
+  return new Set(featureGroups[0] ? [featureGroups[0].title] : []);
+}
+
+function getFeatureGroupForPath(pathname: string) {
+  return featureGroups.find((group) =>
+    group.features.some((feature) => isFeaturePathActive(pathname, feature.to)),
+  );
+}
+
+function isFeaturePathActive(pathname: string, featurePath: string) {
+  return pathname === featurePath || pathname.startsWith(`${featurePath}/`);
+}
 
 function FeatureCard({ title, isPublic, ...routeProps }: Feature) {
   return (

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/components/FeatureContainer.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/components/FeatureContainer.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router";
 import { NavLink, type Routes } from "wasp/client/router";
 import { cn } from "../cn";
 
@@ -28,11 +29,7 @@ function DesktopFeatureListMenu() {
   return (
     <div className="hidden w-80 overflow-y-auto border-r border-gray-200 bg-white lg:block">
       <div className="p-6">
-        <nav className="space-y-2">
-          {features.map((feature) => (
-            <FeatureCard {...feature} key={feature.to} />
-          ))}
-        </nav>
+        <FeatureTree />
       </div>
     </div>
   );
@@ -45,16 +42,12 @@ function MobileFeatureListMenu() {
     <>
       <div
         className={cn(
-          "fixed inset-x-0 bottom-0 z-40 border-t border-gray-200 bg-white transition-transform duration-300 lg:hidden",
+          "fixed inset-x-0 bottom-0 z-40 max-h-[calc(100dvh-4rem)] overflow-y-auto border-t border-gray-200 bg-white transition-transform duration-300 lg:hidden",
           isMobileMenuOpen ? "translate-y-0" : "translate-y-full",
         )}
       >
-        <div className="overflow-y-auto p-6">
-          <nav className="space-y-2">
-            {features.map((feature) => (
-              <FeatureCard {...feature} key={feature.to} />
-            ))}
-          </nav>
+        <div className="px-8 pt-8 pb-28">
+          <FeatureTree />
         </div>
       </div>
 
@@ -96,72 +89,198 @@ type Feature = {
   to: string;
 } & Routes;
 
-const features: Feature[] = [
+type FeatureGroup = {
+  title: string;
+  features: Feature[];
+};
+
+const featureGroups: FeatureGroup[] = [
   {
-    to: "/tasks",
-    title: "Operations",
+    title: "Data & Operations",
+    features: [
+      {
+        to: "/tasks",
+        title: "Operations",
+      },
+      {
+        to: "/crud",
+        title: "Automatic CRUD",
+      },
+      {
+        to: "/serialization",
+        title: "Serialization Test",
+        isPublic: true,
+      },
+    ],
   },
   {
-    to: "/custom-signup",
-    title: "Custom Signup",
-    isPublic: true,
+    title: "Server Features",
+    features: [
+      {
+        to: "/apis",
+        title: "Custom APIs",
+        isPublic: true,
+      },
+      {
+        to: "/jobs",
+        title: "Async Jobs",
+      },
+      {
+        to: "/chat",
+        title: "Websockets",
+      },
+      {
+        to: "/streaming",
+        title: "Streaming",
+      },
+    ],
   },
   {
-    to: "/manual-signup",
-    title: "Manual Signup",
-    isPublic: true,
+    title: "Auth & Account",
+    features: [
+      {
+        to: "/profile",
+        title: "User Profile",
+      },
+      {
+        to: "/custom-signup",
+        title: "Custom Signup",
+        isPublic: true,
+      },
+      {
+        to: "/manual-signup",
+        title: "Manual Signup",
+        isPublic: true,
+      },
+    ],
   },
   {
-    to: "/apis",
-    title: "Custom APIs",
-    isPublic: true,
-  },
-  {
-    to: "/jobs",
-    title: "Async Jobs",
-  },
-  {
-    to: "/chat",
-    title: "Websockets",
-  },
-  {
-    to: "/crud",
-    title: "Automatic CRUD",
-  },
-  {
-    to: "/streaming",
-    title: "Streaming",
-  },
-  {
-    to: "/serialization",
-    title: "Serialization Test",
-    isPublic: true,
-  },
-  {
-    to: "/profile",
-    title: "User Profile",
-  },
-  {
-    to: "/lazy/no",
-    title: "Eager Route",
-    isPublic: true,
-  },
-  {
-    to: "/lazy/yes",
-    title: "Lazy Route",
-    isPublic: true,
-  },
-  {
-    to: "/prerender",
-    title: "Prerendering",
-    isPublic: true,
-  },
-  {
-    to: "/hydration-mismatch",
-    title: "Hydration Mismatch",
-    isPublic: true,
+    title: "Routing & Rendering",
+    features: [
+      {
+        to: "/lazy/no",
+        title: "Eager Route",
+        isPublic: true,
+      },
+      {
+        to: "/lazy/yes",
+        title: "Lazy Route",
+        isPublic: true,
+      },
+      {
+        to: "/prerender",
+        title: "Prerendering",
+        isPublic: true,
+      },
+      {
+        to: "/hydration-mismatch",
+        title: "Hydration Mismatch",
+        isPublic: true,
+      },
+    ],
   },
 ];
+
+function FeatureTree() {
+  const location = useLocation();
+  const activeGroup = getFeatureGroupForPath(location.pathname);
+  const [openGroups, setOpenGroups] = useState(() =>
+    getInitiallyOpenGroups(location.pathname),
+  );
+
+  useEffect(() => {
+    if (!activeGroup) {
+      return;
+    }
+
+    setOpenGroups((currentOpenGroups) => {
+      if (currentOpenGroups.has(activeGroup.title)) {
+        return currentOpenGroups;
+      }
+
+      return new Set(currentOpenGroups).add(activeGroup.title);
+    });
+  }, [activeGroup]);
+
+  function toggleGroup(title: string) {
+    setOpenGroups((currentOpenGroups) => {
+      const nextOpenGroups = new Set(currentOpenGroups);
+
+      if (nextOpenGroups.has(title)) {
+        nextOpenGroups.delete(title);
+      } else {
+        nextOpenGroups.add(title);
+      }
+
+      return nextOpenGroups;
+    });
+  }
+
+  return (
+    <nav aria-label="Features" className="space-y-4">
+      {featureGroups.map((group) => {
+        const isOpen = openGroups.has(group.title);
+
+        return (
+          <section className="space-y-1" key={group.title}>
+            <button
+              type="button"
+              aria-expanded={isOpen}
+              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs font-semibold tracking-wide text-gray-500 uppercase transition-colors hover:bg-gray-50 hover:text-gray-700"
+              onClick={() => toggleGroup(group.title)}
+            >
+              <svg
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-200",
+                  isOpen && "rotate-90",
+                )}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="m9 5 7 7-7 7"
+                />
+              </svg>
+              <span>{group.title}</span>
+            </button>
+
+            {isOpen && (
+              <div className="ml-3 space-y-1 border-l border-gray-200 pl-3">
+                {group.features.map((feature) => (
+                  <FeatureCard {...feature} key={feature.to} />
+                ))}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </nav>
+  );
+}
+
+function getInitiallyOpenGroups(pathname: string) {
+  const activeGroup = getFeatureGroupForPath(pathname);
+
+  if (activeGroup) {
+    return new Set([activeGroup.title]);
+  }
+
+  return new Set(featureGroups[0] ? [featureGroups[0].title] : []);
+}
+
+function getFeatureGroupForPath(pathname: string) {
+  return featureGroups.find((group) =>
+    group.features.some((feature) => isFeaturePathActive(pathname, feature.to)),
+  );
+}
+
+function isFeaturePathActive(pathname: string, featurePath: string) {
+  return pathname === featurePath || pathname.startsWith(`${featurePath}/`);
+}
 
 function FeatureCard({ title, isPublic, ...routeProps }: Feature) {
   return (


### PR DESCRIPTION
## Description

<img width="1629" height="817" alt="image" src="https://github.com/user-attachments/assets/ca813a0e-2b15-4866-95ba-054322ca31d0" />

Kitchen Sink sidebar is now a tree because the plain list good _too long_.

- Groups existing pages.
- Opens matching route group by default.
- Falls back to first group.
- Mobile menu gets bounded scroll + more padding.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If unsure about any of them, ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
