### PR TITLE
Expose Wasp Spec config types (PageConfig, RouteConfig, etc.)

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -28,7 +28,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 - `wasp deps` no longer shows internal Wasp packages in its output (by @okxint). ([#4342](https://github.com/wasp-lang/wasp/issues/4342))
 - `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4398](https://github.com/wasp-lang/wasp/pull/4398))
 - Improved some prerendering internals for a faster first paint and more accurate lazy-loading of pages. ([#4428](https://github.com/wasp-lang/wasp/pull/4428))
-- The Wasp Spec now exports the config object types for its constructors (`AppConfig`, `PageConfig`, `RouteConfig`, `QueryConfig`, `ActionConfig`, `ApiConfig`, `ApiNamespaceConfig`, and `JobConfig`) from `@wasp.sh/spec`, so libraries built on top of the Spec can reuse the type of a constructor's optional config argument. ([#4447](https://github.com/wasp-lang/wasp/pull/4447))
+- The Wasp Spec package now exports the config object types for its constructors from `@wasp.sh/spec`, so libraries built on top of the Spec can reuse the type of a constructor's optional config argument. ([#4447](https://github.com/wasp-lang/wasp/pull/4447))
 
 ## 0.24.0
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -28,6 +28,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 - `wasp deps` no longer shows internal Wasp packages in its output (by @okxint). ([#4342](https://github.com/wasp-lang/wasp/issues/4342))
 - `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4398](https://github.com/wasp-lang/wasp/pull/4398))
 - Improved some prerendering internals for a faster first paint and more accurate lazy-loading of pages. ([#4428](https://github.com/wasp-lang/wasp/pull/4428))
+- The Wasp Spec now exports the config object types for its constructors (`AppConfig`, `PageConfig`, `RouteConfig`, `QueryConfig`, `ActionConfig`, `ApiConfig`, `ApiNamespaceConfig`, and `JobConfig`) from `@wasp.sh/spec`, so libraries built on top of the Spec can reuse the type of a constructor's optional config argument. ([#4447](https://github.com/wasp-lang/wasp/pull/4447))
 
 ## 0.24.0
 

--- a/waspc/data/packages/spec/src/spec/publicApi/constructors.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/constructors.ts
@@ -54,6 +54,8 @@ export function app(config: AppConfig): App {
 /**
  * The configuration object accepted by the {@link app} constructor.
  *
+ * @category Wasp Spec
+ *
  * @inline
  * @expandType App
  */
@@ -90,6 +92,8 @@ export function page(component: Page["component"], config?: PageConfig): Page {
 /**
  * The optional configuration object accepted as the last argument of the
  * {@link page} constructor.
+ *
+ * @category Constructors
  *
  * @inline
  * @expandType Page
@@ -140,6 +144,8 @@ export function route(
 /**
  * The optional configuration object accepted as the last argument of the
  * {@link route} constructor.
+ *
+ * @category Constructors
  *
  * @inline
  * @expandType Route
@@ -192,6 +198,8 @@ export function query(fn: Query["fn"], config?: QueryConfig): Query {
  * The optional configuration object accepted as the last argument of the
  * {@link query} constructor.
  *
+ * @category Constructors
+ *
  * @inline
  * @expandType Query
  */
@@ -235,6 +243,8 @@ export function action(fn: Action["fn"], config?: ActionConfig): Action {
 /**
  * The optional configuration object accepted as the last argument of the
  * {@link action} constructor.
+ *
+ * @category Constructors
  *
  * @inline
  * @expandType Action
@@ -280,6 +290,8 @@ export function api(
  * The optional configuration object accepted as the last argument of the
  * {@link api} constructor.
  *
+ * @category Constructors
+ *
  * @inline
  * @expandType Api
  */
@@ -320,6 +332,8 @@ export function apiNamespace(
 /**
  * The configuration object accepted as the last argument of the
  * {@link apiNamespace} constructor.
+ *
+ * @category Constructors
  *
  * @inline
  * @expandType ApiNamespace
@@ -364,6 +378,8 @@ export function job(fn: Job["fn"], config: JobConfig): Job {
 /**
  * The configuration object accepted as the last argument of the
  * {@link job} constructor.
+ *
+ * @category Constructors
  *
  * @inline
  * @expandType Job

--- a/waspc/data/packages/spec/src/spec/publicApi/constructors.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/constructors.ts
@@ -12,10 +12,10 @@ import type {
 
 // Throughout this file, in order for the constructor's input type to be
 // expanded in the docs, but not the resulting type; we do one bit of
-// indirection, by creating a {Type}Config file, and setting it with the
+// indirection, by creating a {Type}Config type, and setting it with the
 // `@inline` and `@expandType {Type}` tags. This makes sure that the config
-// option appear right in the documentation of the so users don't have to move
-// to another page to see the fields.
+// options appear right in the documentation so users don't have to move to
+// another page to see the fields.
 
 /**
  * Creates a Wasp {@link App}.
@@ -52,10 +52,12 @@ export function app(config: AppConfig): App {
 }
 
 /**
+ * The configuration object accepted by the {@link app} constructor.
+ *
  * @inline
  * @expandType App
  */
-type AppConfig = Omit<App, "kind">;
+export type AppConfig = Omit<App, "kind">;
 
 /**
  * Creates a {@link Page} definition.
@@ -86,10 +88,13 @@ export function page(component: Page["component"], config?: PageConfig): Page {
 }
 
 /**
+ * The optional configuration object accepted as the last argument of the
+ * {@link page} constructor.
+ *
  * @inline
  * @expandType Page
  */
-type PageConfig = Omit<Page, "kind" | "component">;
+export type PageConfig = Omit<Page, "kind" | "component">;
 
 /**
  * Creates a {@link Route} definition.
@@ -133,10 +138,13 @@ export function route(
 }
 
 /**
+ * The optional configuration object accepted as the last argument of the
+ * {@link route} constructor.
+ *
  * @inline
  * @expandType Route
  */
-type RouteConfig = Omit<Route, "kind" | "name" | "path" | "page">;
+export type RouteConfig = Omit<Route, "kind" | "name" | "path" | "page">;
 
 /**
  * Creates a {@link Query} definition.
@@ -181,10 +189,13 @@ export function query(fn: Query["fn"], config?: QueryConfig): Query {
 }
 
 /**
+ * The optional configuration object accepted as the last argument of the
+ * {@link query} constructor.
+ *
  * @inline
  * @expandType Query
  */
-type QueryConfig = Omit<Query, "kind" | "fn">;
+export type QueryConfig = Omit<Query, "kind" | "fn">;
 
 /**
  * Creates an {@link Action} definition.
@@ -222,10 +233,13 @@ export function action(fn: Action["fn"], config?: ActionConfig): Action {
 }
 
 /**
+ * The optional configuration object accepted as the last argument of the
+ * {@link action} constructor.
+ *
  * @inline
  * @expandType Action
  */
-type ActionConfig = Omit<Action, "kind" | "fn">;
+export type ActionConfig = Omit<Action, "kind" | "fn">;
 
 /**
  * Creates an {@link Api} endpoint definition.
@@ -263,10 +277,13 @@ export function api(
 }
 
 /**
+ * The optional configuration object accepted as the last argument of the
+ * {@link api} constructor.
+ *
  * @inline
  * @expandType Api
  */
-type ApiConfig = Omit<Api, "kind" | "method" | "path" | "fn">;
+export type ApiConfig = Omit<Api, "kind" | "method" | "path" | "fn">;
 
 /**
  * Creates an {@link ApiNamespace} definition.
@@ -301,10 +318,13 @@ export function apiNamespace(
 }
 
 /**
+ * The configuration object accepted as the last argument of the
+ * {@link apiNamespace} constructor.
+ *
  * @inline
  * @expandType ApiNamespace
  */
-type ApiNamespaceConfig = Omit<ApiNamespace, "kind" | "path">;
+export type ApiNamespaceConfig = Omit<ApiNamespace, "kind" | "path">;
 
 /**
  * Creates a {@link Job} definition.
@@ -342,10 +362,13 @@ export function job(fn: Job["fn"], config: JobConfig): Job {
 }
 
 /**
+ * The configuration object accepted as the last argument of the
+ * {@link job} constructor.
+ *
  * @inline
  * @expandType Job
  */
-type JobConfig = Omit<Job, "kind" | "fn">;
+export type JobConfig = Omit<Job, "kind" | "fn">;
 
 /**
  * Creates a {@link Crud} definition.

--- a/waspc/data/packages/spec/src/spec/publicApi/index.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/index.ts
@@ -10,5 +10,15 @@ export {
   query,
   route,
 } from "./constructors.js";
+export type {
+  ActionConfig,
+  ApiConfig,
+  ApiNamespaceConfig,
+  AppConfig,
+  JobConfig,
+  PageConfig,
+  QueryConfig,
+  RouteConfig,
+} from "./constructors.js";
 export type { Register } from "./register.js";
 export type * from "./waspSpec.js";


### PR DESCRIPTION
## Description

Exposes the `*Config` object types from `@wasp.sh/spec` (`AppConfig`, `PageConfig`, `RouteConfig`, `QueryConfig`, `ActionConfig`, `ApiConfig`, `ApiNamespaceConfig`, `JobConfig`) as part of the public API. These types were already defined internally as a documentation helper, so userland libraries (like a file-based routing helper) can now name and reuse the type of the optional config argument passed to the spec constructors instead of reconstructing it. The types keep their existing `@inline`/`@expandType` doc tags, so the constructor docs still expand the config fields inline. No runtime behavior changes; this only adds type-only exports.

Closes #4324.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
