### PR TITLE
Limit e2e snapshot test concurrency to avoid CPU oversubscription

### DIFF
--- a/waspc/e2e-tests/Main.hs
+++ b/waspc/e2e-tests/Main.hs
@@ -1,4 +1,4 @@
-import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent (getNumCapabilities)
 import FileSystem (getWaspcDirPath, waspCliDevToolInWaspcDir)
 import SnapshotTest (testTreeFromSnapshotTest)
 import StrongPath ((</>))
@@ -33,6 +33,8 @@ import Tests.WaspSpecEntityTypesTest (waspSpecEntityTypesTest)
 import Tests.WaspTelemetryTest (waspTelemetryTest)
 import Tests.WaspTsSpecNodeEnvTest (waspTsSpecNodeEnvTest)
 import Tests.WaspVersionTest (waspVersionTest)
+import Text.Read (readMaybe)
+import UnliftIO.Async (pooledMapConcurrentlyN)
 
 main :: IO ()
 main = do
@@ -55,7 +57,7 @@ ensureE2eTestsEnvironment = do
       setEnv "WASP_CLI_CMD" devWaspCliCmd
 
 -- | Builds the dev Wasp CLI once, serially, before the snapshot tests start
--- invoking it concurrently (via 'mapConcurrently' in 'e2eTests').
+-- invoking it concurrently (via 'pooledMapConcurrentlyN' in 'e2eTests').
 --
 -- The dev CLI runs through `cabal run`, and Cabal does not support several
 -- concurrent invocations sharing a single `dist-newstyle`: if the first build
@@ -71,8 +73,11 @@ warmUpWaspCli = callCommand "$WASP_CLI_CMD version 2>&1 >/dev/null" -- We don't 
 --       See: github.com/wasp-lang/wasp/issues/3404
 e2eTests :: IO TestTree
 e2eTests = do
+  maxConcurrentSnapshotBuilds <- getMaxConcurrentSnapshotBuilds
+  putStrLn $ "Preparing snapshot tests with up to " ++ show maxConcurrentSnapshotBuilds ++ " concurrent build(s). Override with WASP_E2E_TEST_MAX_JOBS."
   snapshotTestTrees <-
-    mapConcurrently
+    pooledMapConcurrentlyN
+      maxConcurrentSnapshotBuilds
       testTreeFromSnapshotTest
       [ waspNewSnapshotTest,
         waspCompileSnapshotTest,
@@ -123,3 +128,20 @@ e2eTests = do
         testGroup "Shell tests" shellTestTrees,
         testGroup "Tests" [sdkPackageExportsTestTree]
       ]
+
+-- | How many snapshot tests we prepare concurrently.
+--
+-- Each snapshot test shells out to Node tooling (`npm install`, `tsc`,
+-- `vite build`, ...) that already parallelizes across every core, so preparing
+-- all of them at once oversubscribes the CPU. We therefore cap the fan-out.
+--
+-- The default scales with the number of available cores (a fraction of them,
+-- since each build is itself multi-core). Set @WASP_E2E_TEST_MAX_JOBS@ to a
+-- positive integer to override it (e.g. @1@ for fully serial preparation).
+getMaxConcurrentSnapshotBuilds :: IO Int
+getMaxConcurrentSnapshotBuilds = do
+  numCores <- getNumCapabilities
+  override <- (>>= readMaybe) <$> lookupEnv "WASP_E2E_TEST_MAX_JOBS"
+  return $ case override of
+    Just n | n >= 1 -> n
+    _ -> max 1 (numCores `div` 4)

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -682,7 +682,6 @@ test-suite waspc-e2e-tests
   build-depends:
     aeson,
     aeson-pretty,
-    async,
     base,
     base64-bytestring,
     bytestring,
@@ -699,6 +698,7 @@ test-suite waspc-e2e-tests
     tasty-golden,
     tasty-hspec,
     text,
+    unliftio ^>=0.2.25,
     waspc,
 
   other-modules:


### PR DESCRIPTION
## Description

The waspc e2e snapshot tests prepared every snapshot at once via `mapConcurrently`, and since each one shells out to Node tooling (`npm install`, `tsc`, `vite build`) that already parallelizes across all cores, running them all together oversubscribed the CPU and made the machine unusable during a run. This caps the fan-out using `pooledMapConcurrentlyN` from the already-present `unliftio`, defaulting to a fraction of the available cores and overridable via the `WASP_E2E_TEST_MAX_JOBS` env var (set it to `1` for fully serial preparation). This only touches the e2e test harness, so there is no functional change to Wasp itself and no snapshots need regenerating.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
