### PR TITLE
Migrate blog image captions to ImgWithCaption

### DIFF
--- a/web/blog/2021-04-29-discord-bot-introduction.mdx
+++ b/web/blog/2021-04-29-discord-bot-introduction.mdx
@@ -4,15 +4,13 @@ authors: [martinsos]
 tags: [discord, nodejs]
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
+import { ImgWithCaption } from './components/ImgWithCaption';
 
-<p align="center">
-  <figure>
-    <img alt="Guest introducing themselves and getting full-access." src={useBaseUrl('img/discord-introduction-example.png')} />
-
-    <figcaption>A Guest user getting access by introducing themselves in the "introductions" channel.</figcaption>
-  </figure>
-</p>
+<ImgWithCaption
+  alt="Guest introducing themselves and getting full-access."
+  source="img/discord-introduction-example.png"
+  caption='A Guest user getting access by introducing themselves in the "introductions" channel.'
+/>
 
 At [Wasp](https://wasp.sh), we have a Discord server for our community, where we talk with people interested in and using Wasp - Waspeteers!
 
@@ -32,13 +30,12 @@ We want the following: when a new user comes to our Discord server, they should 
 
 Once they introduced themselves in the `introductions` channel, they would get access to the rest of the channels.
 
-<p align="center">
-  <figure>
-    <img alt="Channels user can see when Guest vs when full member." src={useBaseUrl('img/wasp-guest-vs-waspeteer.png')} height="400px" />
-
-    <figcaption>Left: what Guest sees; Right: what Waspeteer sees.</figcaption>
-  </figure>
-</p>
+<ImgWithCaption
+  alt="Channels user can see when Guest vs when full member."
+  source="img/wasp-guest-vs-waspeteer.png"
+  height="400px"
+  caption="Left: what Guest sees; Right: what Waspeteer sees."
+/>
 
 In Discord, access control is performed via roles. There are two ways to accomplish what we need:
 

--- a/web/blog/2021-11-21-seed-round.mdx
+++ b/web/blog/2021-11-21-seed-round.mdx
@@ -5,9 +5,9 @@ tags: [startup, wasp]
 ---
 
 import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import WaspIntro from './_wasp-intro.md';
+import { ImgWithCaption } from './components/ImgWithCaption';
 import { InBlogCta } from './components/InBlogCta';
 
 After graduating from Y Combinator's Winter 2021 Batch, we are super excited to announce that Wasp raised $1.5m in our first funding round! The round is led by Lunar Ventures and joined by HV Capital. Also [see it in TechCrunch](https://techcrunch.com/2021/10/04/yc-grads-wasp-land-1-5m-seed-to-help-developers-build-web-apps-faster/).
@@ -60,13 +60,11 @@ To date, over 250 projects have been created with Wasp in the last couple of mon
 
 Martin and I have been working on Wasp for the last two years and together with our amazing contributors, who made us believe our vision is possible and made it what it is today. Having led development of several complex web apps in the past and continuously switching to the latest stack, we felt the pain and could also clearly see the patterns that we felt were mature and common enough to be worth extracting into a simpler, higher-level language.
 
-<p align="center">
-  <figure>
-    <img alt="The team" src={useBaseUrl('img/us-at-ycombinator.jpg')} />
-
-    <figcaption>Martin and I during our first YC interview. Read <Link to={useBaseUrl('blog/2021/02/23/journey-to-ycombinator')}>here</Link> for more details on our journey to YC!</figcaption>
-  </figure>
-</p>
+<ImgWithCaption
+  alt="The team"
+  source="img/us-at-ycombinator.jpg"
+  caption={<>Martin and I during our first YC interview. Read <Link to="/blog/2021/02/23/journey-to-ycombinator">here</Link> for more details on our journey to YC!</>}
+/>
 
 In case you couldn't tell from the photo and our identical glasses, we are twins (but not fraternal ones, and I'm a couple of minutes older, which makes me CEO :D)!
 

--- a/web/blog/2021-12-02-waspello.mdx
+++ b/web/blog/2021-12-02-waspello.mdx
@@ -5,7 +5,6 @@ tags: [webdev, wasp]
 ---
 
 import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import WaspIntro from './_wasp-intro.md';
 import { ImgWithCaption } from './components/ImgWithCaption';
@@ -13,9 +12,9 @@ import { InBlogCta } from './components/InBlogCta';
 
 ![Enter Waspello](../static/img/waspello-screenshot.png)
 
-<p align="center">
+<div align="center">
   <Link to={'https://waspello-app-client.fly.dev/'}>Try Waspello here!</Link> | <Link to={'https://github.com/wasp-lang/wasp/blob/release/examples/waspello/main.wasp'}>See the code</Link>
-</p>
+</div>
 
 We've built a Trello clone using Wasp! Read on to learn how it went and how you can contribute.
 
@@ -37,11 +36,11 @@ So let's dig in and see and how it went - what works, what doesn't and, what's m
 
 The good news is all the basic functionality is here - Waspello users can signup/log in which brings them to their project board where they can perform CRUD operations on lists and cards - create them, edit them, move them around, etc. Let's see it in action:
 
-![Waspello in action](../static/img/waspello-in-action.gif)
-
-<p align="center" class="image-caption">
-  Waspello in action!
-</p>
+<ImgWithCaption
+  alt="Waspello in action"
+  source="img/waspello-in-action.gif"
+  caption="Waspello in action!"
+/>
 
 As you can see things work, but not everything is perfect (e.g. there is a delay when creating/moving a card) - we'll examine why is that so a bit later.
 
@@ -49,11 +48,11 @@ As you can see things work, but not everything is perfect (e.g. there is a delay
 
 Here is a simple visual overview of Waspello's code anatomy (which applies to every Wasp app):
 
-![Waspello code anatomy](../static/img/waspello-code-anatomy.png)
-
-<p align="center" class="image-caption">
-  Waspello code anatomy
-</p>
+<ImgWithCaption
+  alt="Waspello code anatomy"
+  source="img/waspello-code-anatomy.png"
+  caption="Waspello code anatomy"
+/>
 
 Let's now dig in a bit deeper and shortly examine each of the concepts Wasp supports (page, query, entity, ...) and learn through code samples how to use it to implement Waspello.
 
@@ -194,13 +193,11 @@ That is why upon dropping on "Done", the card first goes back to the original li
 
 A typical approach for solving this issue is to **make the client a bit more self-confident, in a way that it doesn't wait for the confirmation from the server but rather immediately updates the UI, at the same time or even before the API request is fired**. If it then turns out something went wrong on the server (which typically shouldn't happen), it reverses the change and shows an error message. Thus the name optimistic UI update, since the client assumes in advance that everything will go well to provide a nicer UX.
 
-<p align="center">
-  <figure>
-    <img alt="Waspello - the client being brave" src={useBaseUrl('img/waspello-client-being-brave.gif')} />
-
-    <figcaption class="image-caption">The client when performing an optimistic UI update</figcaption>
-  </figure>
-</p>
+<ImgWithCaption
+  alt="Waspello - the client being brave"
+  source="img/waspello-client-being-brave.gif"
+  caption="The client when performing an optimistic UI update"
+/>
 
 This is one of the most complex and error-prone features when developing web apps today and that is why we are super excited to tackle it in Wasp and make the experience as smooth as possible! We are currently in the "figuring out the solution" stage and you can [track/join the discussion on GitHub](https://github.com/wasp-lang/wasp/issues/63)!
 
@@ -217,13 +214,12 @@ And many more - e.g. support for workspaces (next level of the hierarchy, a coll
 
 ## Become a Waspeller!
 
-<p align="center">
-  <figure style={{width: '55%'}}>
-    <img alt="Waspello propaganda" src={useBaseUrl('img/waspello-propaganda.png')} />
-
-    <figcaption class="image-caption">Lightweight Waspello propaganda</figcaption>
-  </figure>
-</p>
+<ImgWithCaption
+  alt="Waspello propaganda"
+  source="img/waspello-propaganda.png"
+  width="55%"
+  caption="Lightweight Waspello propaganda"
+/>
 
 If you want to get involved with OSS and at the same time familiarize yourself with Wasp, this is a great way to get started - feel free to [choose one of the features listed here or add your own](https://github.com/wasp-lang/wasp/issues/337) and help us make Waspello the best demo productivity app out there!
 

--- a/web/blog/2022-01-27-waspleau.mdx
+++ b/web/blog/2022-01-27-waspleau.mdx
@@ -12,9 +12,9 @@ import { InBlogCta } from './components/InBlogCta';
 
 ![Hello, Waspleau](../static/img/waspleau-screenshot.png)
 
-<p align="center">
+<div align="center">
   <Link to={'https://waspleau-app-client.fly.dev/'}>See Waspleau here!</Link> | <Link to={'https://github.com/wasp-lang/wasp/blob/release/examples/waspleau'}>See the code</Link>
-</p>
+</div>
 
 We've built a dashboard powered by a job queue using Wasp!
 

--- a/web/blog/2022-06-15-jobs-feature-announcement.mdx
+++ b/web/blog/2022-06-15-jobs-feature-announcement.mdx
@@ -8,6 +8,7 @@ tags: [webdev, wasp, feature, jobs]
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import WaspIntro from './_wasp-intro.md';
+import { ImgWithCaption } from './components/ImgWithCaption';
 import { InBlogCta } from './components/InBlogCta';
 
 <p align="center">
@@ -60,13 +61,11 @@ Wasp allows you to write a regular async JavaScript function (like the one above
 
 ## Most jobs have a boss. Our first job executor is a... pg-boss. 😅
 
-<p align="center">
-  <figure>
-    <img alt="Eeek" src={useBaseUrl('img/jobs-eyes.gif')} />
-
-    <figcaption>Me trying to lay off the job-related puns. Ok, ok, I’ll quit. Ahhh!</figcaption>
-  </figure>
-</p>
+<ImgWithCaption
+  alt="Eeek"
+  source="img/jobs-eyes.gif"
+  caption="Me trying to lay off the job-related puns. Ok, ok, I’ll quit. Ahhh!"
+/>
 
 In my prior life as a Ruby on Rails developer, the decision of how to implement jobs was pretty simple. You had Active Job at your disposal, and for backends, you would use something like Sidekiq or Delayed Job. In a similarly paved path, Python developers would have likely looked first to Celery.
 

--- a/web/blog/2022-11-16-alpha-testing-program-post-mortem.mdx
+++ b/web/blog/2022-11-16-alpha-testing-program-post-mortem.mdx
@@ -6,7 +6,6 @@ tags: [webdev, wasp, startups, github]
 ---
 
 import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import WaspIntro from './_wasp-intro.md';
 import { ImgWithCaption } from './components/ImgWithCaption';
@@ -36,13 +35,11 @@ Having realised all that, we understood we needed to give people a reason to try
 
 ## Welcome to Wasp Alpha Testing Program!
 
-<p align="center">
-  <figure>
-    <img alt="The team" src={useBaseUrl('img/atp/welcome-to-atp-notion.png')} />
-
-    <figcaption style={{color: '#808080'}}>I was having a bit too much fun <Link to={useBaseUrl('https://wasp-lang.notion.site/CLOSED-Welcome-to-Wasp-Alpha-Testing-program-f3a8a350802341abac87fb7831bb1e60')}>here</Link>, but Portal fans will understand.</figcaption>
-  </figure>
-</p>
+<ImgWithCaption
+  alt="The team"
+  source="img/atp/welcome-to-atp-notion.png"
+  caption={<span style={{color: '#808080'}}>I was having a bit too much fun <Link to="https://wasp-lang.notion.site/CLOSED-Welcome-to-Wasp-Alpha-Testing-program-f3a8a350802341abac87fb7831bb1e60">here</Link>, but Portal fans will understand.</span>}
+/>
 
 We quickly put together an admissions page for alpha testers in Notion (you can see it [here](https://wasp-lang.notion.site/Wasp-Alpha-Testing-Program-Admissions-dca25649d63849cb8dfc55881e4f6f82)) and started sharing it around. To counter the hurdles we mentioned above, we time-boxed the program (_”this is happening now and you have 48 hours to finish once you start_”) and promised a t-shirt to everyone that goes through the tutorial and fills out the feedback form.
 

--- a/web/blog/components/ImgWithCaption.tsx
+++ b/web/blog/components/ImgWithCaption.tsx
@@ -4,7 +4,8 @@ import type { ReactNode } from "react";
 interface ImgWithCaptionProps {
   source: string;
   caption?: ReactNode;
-  width?: number;
+  width?: number | string;
+  height?: number | string;
   alt: string;
   justifyContent?: "center" | "flex-start" | "flex-end";
   margin?: string;
@@ -32,6 +33,7 @@ export function ImgWithCaption(props: ImgWithCaptionProps) {
     <img
       style={{
         width: props.width,
+        height: props.height,
         display: isFramed ? "block" : undefined,
         border: isFramed
           ? `${frameBorderWidth}px solid ${frameBorderColor}`


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Migrates older blog image/caption markup away from invalid paragraph-wrapped figures and into the shared `ImgWithCaption` component where applicable.
The component now accepts string dimensions and a `height` prop so it can preserve the sizing behavior of the migrated images.
Non-image centered CTA link rows were kept as centered `div`s.
Validated with `git diff --check` and `npm --prefix web run build`.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
