### PR TITLE
Error early on duplicate entities in an operation's entities list

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -30,6 +30,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 - `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4398](https://github.com/wasp-lang/wasp/pull/4398))
 - Improved some prerendering internals for a faster first paint and more accurate lazy-loading of pages. ([#4428](https://github.com/wasp-lang/wasp/pull/4428))
 - The Wasp Spec package now exports the config object types for its constructors from `@wasp.sh/spec`, so libraries built on top of the Spec can reuse the type of a constructor's optional config argument. ([#4447](https://github.com/wasp-lang/wasp/pull/4447))
+- Listing the same entity more than once in a query or action's `entities` now fails with a clear error. ([#3272](https://github.com/wasp-lang/wasp/issues/3272))
 
 ## 0.24.0
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -30,7 +30,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 - `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4398](https://github.com/wasp-lang/wasp/pull/4398))
 - Improved some prerendering internals for a faster first paint and more accurate lazy-loading of pages. ([#4428](https://github.com/wasp-lang/wasp/pull/4428))
 - The Wasp Spec package now exports the config object types for its constructors from `@wasp.sh/spec`, so libraries built on top of the Spec can reuse the type of a constructor's optional config argument. ([#4447](https://github.com/wasp-lang/wasp/pull/4447))
-- Listing the same entity more than once in a query or action's `entities` now fails with a clear error. ([#3272](https://github.com/wasp-lang/wasp/issues/3272))
+- Listing the same entity more than once in a query or action's `entities` now fails with a clear error. ([#4455](https://github.com/wasp-lang/wasp/pull/4455))
 
 ## 0.24.0
 

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -70,6 +70,7 @@ validateAppSpec spec =
           validateApiRoutesAreUnique spec,
           validateApiNamespacePathsAreUnique spec,
           validateCrudOperations spec,
+          validateOperationEntitiesAreUnique spec,
           validateUniqueDeclarationNames spec,
           validateDeclarationNames spec,
           validateWebAppBaseDir spec,
@@ -263,6 +264,28 @@ validateCrudOperations spec =
         maybeIdField = Entity.getIdField entity
         maybeIdBlockAttribute = Entity.getIdBlockAttribute entity
         (entityName, entity) = AS.resolveRef spec (AS.Crud.entity crud)
+
+validateOperationEntitiesAreUnique :: AppSpec -> [ValidationError]
+validateOperationEntitiesAreUnique spec =
+  concatMap validateOperation (AS.getOperations spec)
+  where
+    validateOperation :: AS.Operation.Operation -> [ValidationError]
+    validateOperation operation = case findDuplicateElems entityNames of
+      [] -> []
+      duplicateEntityNames ->
+        [ GenericValidationError $
+            "The "
+              ++ describeOperation operation
+              ++ " lists the same entity more than once in its 'entities' list: "
+              ++ intercalate ", " (map show duplicateEntityNames)
+              ++ ". Please remove the duplicate entity references."
+        ]
+      where
+        entityNames = maybe [] (map AS.refName) (AS.Operation.getEntities operation)
+
+    describeOperation :: AS.Operation.Operation -> String
+    describeOperation (AS.Operation.QueryOp name _) = "query '" ++ name ++ "'"
+    describeOperation (AS.Operation.ActionOp name _) = "action '" ++ name ++ "'"
 
 {- ORMOLU_DISABLE -}
 -- *** MAKE SURE TO UPDATE: Unit tests in `AppSpec.ValidTest` module named "duplicate declarations validation"

--- a/waspc/tests/AppSpec/ValidTest.hs
+++ b/waspc/tests/AppSpec/ValidTest.hs
@@ -456,6 +456,43 @@ spec_AppSpecValid = do
       testDuplicateDecls [basicAppDecl, entityDecl, entityDecl] "entity" "There are duplicate entity declarations with name 'TestEntity'."
       testDuplicateDecls [basicAppDecl, jobDecl, jobDecl] "job" "There are duplicate job declarations with name 'testJob'."
 
+    describe "operation entities uniqueness validation" $ do
+      let makeActionDeclWithEntities name entityNames =
+            AS.Decl.makeDecl
+              name
+              AS.Action.Action
+                { AS.Action.auth = Nothing,
+                  AS.Action.entities = Just $ AS.Core.Ref.Ref <$> entityNames,
+                  AS.Action.fn = dummyExtImport
+                }
+      let makeQueryDeclWithEntities name entityNames =
+            AS.Decl.makeDecl
+              name
+              AS.Query.Query
+                { AS.Query.auth = Nothing,
+                  AS.Query.entities = Just $ AS.Core.Ref.Ref <$> entityNames,
+                  AS.Query.fn = dummyExtImport
+                }
+      let makeSpecWithDecls extraDecls =
+            basicAppSpec {AS.decls = [basicAppDecl, basicRouteDecl] ++ extraDecls}
+
+      it "returns no error when an action's entities are all unique" $ do
+        ASV.validateAppSpec (makeSpecWithDecls [makeActionDeclWithEntities "myAction" ["Task", "User"]])
+          `shouldBe` []
+      it "returns no error when an operation has no entities" $ do
+        ASV.validateAppSpec (makeSpecWithDecls [makeActionDeclWithEntities "myAction" []])
+          `shouldBe` []
+      it "returns an error when an action lists the same entity more than once" $ do
+        ASV.validateAppSpec (makeSpecWithDecls [makeActionDeclWithEntities "myAction" ["Task", "User", "Task"]])
+          `shouldBe` [ Valid.GenericValidationError
+                         "The action 'myAction' lists the same entity more than once in its 'entities' list: \"Task\". Please remove the duplicate entity references."
+                     ]
+      it "returns an error when a query lists the same entity more than once" $ do
+        ASV.validateAppSpec (makeSpecWithDecls [makeQueryDeclWithEntities "myQuery" ["Task", "Task"]])
+          `shouldBe` [ Valid.GenericValidationError
+                         "The query 'myQuery' lists the same entity more than once in its 'entities' list: \"Task\". Please remove the duplicate entity references."
+                     ]
+
     describe "should validate that there's at least one 'route' declaration" $ do
       it "returns no error if there is at least one 'route' declaration" $ do
         ASV.validateAppSpec (basicAppSpec {AS.decls = [basicAppDecl, basicRouteDecl]}) `shouldBe` []


### PR DESCRIPTION
## Description

Fixes [#3272](https://github.com/wasp-lang/wasp/issues/3272). Listing the same entity more than once in a query or action's `entities` (e.g. `entities: [Task, User, Task]`) previously slipped past Wasp validation and only surfaced later as a confusing `TS1117: An object literal cannot have multiple properties with the same name` error during code generation. This adds a `validateOperationEntitiesAreUnique` check to `AppSpec.Valid` that catches duplicates up front and reports a clear Wasp error naming the operation and the repeated entity. I chose the "clearer error sooner" option from the issue over silently deduping, since a repeated entity is almost always a typo the user should see.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [x] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
