### PR TITLE
Add `wasp compile` to CLI usage output for discoverability

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -26,6 +26,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 ### 🔧 Small improvements
 
 - Added a `wasp doctor` command that runs common sanity checks on your setup to check that Wasp can work correctly, and prints a report. ([#4283](https://github.com/wasp-lang/wasp/pull/4283))
+- The `wasp compile` command is now listed in `wasp`'s usage output and bash completion, making it easier to discover. ([#4295](https://github.com/wasp-lang/wasp/issues/4295))
 - `wasp deps` no longer shows internal Wasp packages in its output (by @okxint). ([#4342](https://github.com/wasp-lang/wasp/issues/4342))
 - `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4398](https://github.com/wasp-lang/wasp/pull/4398))
 - Improved some prerendering internals for a faster first paint and more accurate lazy-loading of pages. ([#4428](https://github.com/wasp-lang/wasp/pull/4428))

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -26,7 +26,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
 ### 🔧 Small improvements
 
 - Added a `wasp doctor` command that runs common sanity checks on your setup to check that Wasp can work correctly, and prints a report. ([#4283](https://github.com/wasp-lang/wasp/pull/4283))
-- The `wasp compile` command is now listed in `wasp`'s usage output and bash completion, making it easier to discover. ([#4295](https://github.com/wasp-lang/wasp/issues/4295))
+- The `wasp compile` command is now listed in `wasp`'s usage output and bash completion, making it easier to discover. ([#4456](https://github.com/wasp-lang/wasp/pull/4456))
 - `wasp deps` no longer shows internal Wasp packages in its output (by @okxint). ([#4342](https://github.com/wasp-lang/wasp/issues/4342))
 - `tsconfig.wasp.json`'s `include` now accepts extra globs in addition to the required Wasp entries, so you can keep helpers and libraries used by your `.wasp.ts` files in the same TS project. ([#4398](https://github.com/wasp-lang/wasp/pull/4398))
 - Improved some prerendering internals for a faster first paint and more accurate lazy-loading of pages. ([#4428](https://github.com/wasp-lang/wasp/pull/4428))

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -154,6 +154,7 @@ printUsage =
         cmd   "    install               Sets up all internal Wasp npm dependencies and runs npm install.",
         cmd   "    clean                 Deletes the generated app, all cached artifacts, and the node_modules dir.",
               "                          Wasp equivalent of 'have you tried closing and opening it again?'.",
+        cmd   "    compile               Compiles your Wasp project and reports any errors, without running it.",
         cmd   "    build                 Generates the full web app, ready for deployment.",
         cmd   "    build start [args]    Previews the built production app locally.",
         cmd   "    deploy                Deploys your Wasp app to cloud hosting providers.",

--- a/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
@@ -34,6 +34,7 @@ bashCompletion = do
         "start",
         "db",
         "clean",
+        "compile",
         "build",
         "deploy",
         "telemetry",

--- a/web/docs/general/cli.md
+++ b/web/docs/general/cli.md
@@ -34,6 +34,7 @@ COMMANDS
     install               Sets up all internal Wasp npm dependencies and runs npm install.
     clean                 Deletes the generated app, all cached artifacts, and the node_modules dir.
                           Wasp equivalent of 'have you tried closing and opening it again?'.
+    compile               Compiles your Wasp project and reports any errors, without running it.
     build                 Generates the full web app, ready for deployment.
     build start [args]    Previews the built production app locally.
     deploy                Deploys your Wasp app to cloud hosting providers.
@@ -119,6 +120,8 @@ $ wasp clean
 ✅ --- Deleted the node\_modules/ directory. ---------------------------------------
 
 ```
+
+- `wasp compile` compiles your Wasp project and reports any errors, without running the app. It's a quick way to check that your project is valid, which makes it especially handy in CI or for AI agents.
 
 - `wasp build` generates the complete web app code, which is ready for [deployment](../deployment/intro.md). Use this command when you're deploying or ejecting. The generated code is stored in the `.wasp/out` folder.
 


### PR DESCRIPTION
## Description

The `wasp compile` command already exists but wasn't listed anywhere a user or AI agent would look for it. This exposes it in the `wasp` usage output, in bash completion, and in the CLI reference docs, so it's easy to discover. This is especially useful now that AI agents rely on `wasp compile` to check that a project compiles. Closes #4295.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
