### PR TITLE
Use npm staged publishing for releases

### DIFF
--- a/.github/workflows/release-create.yaml
+++ b/.github/workflows/release-create.yaml
@@ -72,14 +72,29 @@ jobs:
           name: ${{ vars.WASP_NPM_ARTIFACT_NAME }}
           path: packages/
 
-      - name: Publish Wasp npm packages
-        # Tokenless npm publishing requires npm v11.5.1+ so we request it
-        # explicitly.
-        # Read more: https://docs.npmjs.com/trusted-publishers/
+      - name: Stage Wasp npm packages for publishing
+        # Staged publishing uploads the packages to npm's staging queue instead
+        # of publishing them directly. A maintainer then has to approve them (on
+        # npmjs.com or with `npm stage approve`) before they become installable.
+        # Staged publishing requires npm v11.15.0+, so we request it explicitly.
+        # Read more:
+        # - https://docs.npmjs.com/trusted-publishers/
+        # - https://docs.npmjs.com/cli/v11/commands/npm-stage/
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -x # Log each command for debugging
+
+          # Pre-release versions are staged under the "rc" dist-tag so they
+          # don't become "latest" once approved. The dist-tag is fixed at
+          # staging time and can't be changed at approval time.
+          # Per semver, a version containing a "-" character is a pre-release
+          # (e.g. v0.24.1-rc.1), which is what we match on here.
+          case "$REF_NAME" in
+            *-*) DIST_TAG="rc" ;;
+            *) DIST_TAG="latest" ;;
+          esac
+
           for pkg in ./packages/*; do
-            # The tag name has no special meaning, just avoids us
-            # broadly publishing an RC to the "latest" tag.
-            npx npm@^11.5.1 publish --tag rc "$pkg"
+            npx npm@^11.15.0 stage publish --tag "$DIST_TAG" "$pkg"
           done

--- a/.github/workflows/release-create.yaml
+++ b/.github/workflows/release-create.yaml
@@ -85,9 +85,6 @@ jobs:
         run: |
           set -x # Log each command for debugging
 
-          # Pre-release versions are staged under the "rc" dist-tag so they
-          # don't become "latest" once approved. The dist-tag is fixed at
-          # staging time and can't be changed at approval time.
           # Per semver, a version containing a "-" character is a pre-release
           # (e.g. v0.24.1-rc.1), which is what we match on here.
           case "$REF_NAME" in

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -405,7 +405,7 @@ CI runs for any commits on `main` branch, for pull requests, and for any commits
 
 During CI, we build and test Wasp code on Linux, MacOS and Windows.
 
-If commit is tagged with tag starting with `v`, github draft release is created from it containing binary packages.
+If commit is tagged with tag starting with `v`, github draft release is created from it containing binary packages, and the Wasp npm packages are uploaded to npm's staging queue (see [Typical Release Process](#typical-release-process) for how they get approved).
 
 We also have a workflow for deploying example apps to Fly.io (`release-examples-deploy.yaml`). This workflow can be run manually from the GitHub UI and should typically be run from the `release` branch after publishing a new release to ensure the deployed examples are using the latest stable version of Wasp.
 
@@ -447,10 +447,10 @@ Do the non-bold steps when necessary (decide for each step depending on the chan
 - 👉 When you're ready to make the final release, make sure you are on `release` and then run `./new-release 0.x.y`.
   - This script will do some checks, tag the commit with the new release version, and push the tag.
 - 👉 Wait for CI to finish & succeed for the new tag.
-  - This is triggered automatically on tag push. When it's done, it will create a new draft release.
+  - This is triggered automatically on tag push. When it's done, it will create a new draft release on Github and stage the npm packages on npm (staged packages are not published until a maintainer approves them).
 - 👉 Find the new draft release here: https://github.com/wasp-lang/wasp/releases and edit it with your release notes. This usually means copy-pasting the ChangeLog entries for the released version.
 - 👉 Publish the draft release when ready.
-- 👉 Run `npm dist-tag add @wasp.sh/wasp-cli@<version> latest` for users to get the newest version when they install through `npm`.
+- 👉 Approve the staged npm packages. Run `npm stage list` to find the stage IDs, then `npm stage approve <stage-id>` for each. Approval requires 2FA.
 - 👉 Push your local `release` branch to remote.
 - 👉 You will have been tagged in an automated PR to merge `release` back to `main` (you can also find it [here](https://github.com/wasp-lang/wasp/pulls?q=is%3Apr+head%3Arelease+base%3Amain+is%3Aopen)). Make sure to merge that PR (create a merge commit, **don't squash or rebase**). This ensures that `main` is ahead of `release` and we won't have merge conflicts in future releases.
 - Deploy the example apps to Fly.io by running the [release-examples-deploy workflow](https://github.com/wasp-lang/wasp/actions/workflows/release-examples-deploy.yaml) (see "Deployment / CI" section for more details).
@@ -478,13 +478,15 @@ If doing this, steps are the following:
    - Use their UI to mark it as a pre-release and publish it. This will automatically remove the checkmark from "latest release", which is exactly what we want. **This is the crucial step that differentiates test release from the proper release.**
    - Push the `rc-<version>` branch to remote.
 
-4. Since npm installs the latest release by default, it will skip this pre-release (which is what we wanted). You can install it by pasing an explicit version! That way user's don't get in touch with it, but we can install and use it normally:
+4. Approve the staged npm packages. Run `npm stage list` to find the stage IDs, then `npm stage approve <stage-id>` for each. Approval requires 2FA.
+
+5. Install the package by passing an explicit version:
 
    ```sh
    npm i -g @wasp.sh/wasp-cli@0.24.1-rc.1
    ```
 
-5. Create a new checklist [in Notion](https://www.notion.so/wasp-lang/1d018a74854c80d9aa64deb058719000) and go through the "Before the release" section. If you find problems, fix them on the `rc` branch and create a new RC following the same process (e.g., `0.24.1-rc.2`, see step 2).
+6. Create a new checklist [in Notion](https://www.notion.so/wasp-lang/1d018a74854c80d9aa64deb058719000) and go through the "Before the release" section. If you find problems, fix them on the `rc` branch and create a new RC following the same process (e.g., `0.24.1-rc.2`, see step 2).
 
 ## Documentation
 


### PR DESCRIPTION
## Description

- Solves #4207

Instead of publishing to the `rc` channel on npm as a workaround for doing a final approval on what we publish, we use the new [npm Staged Publishing](https://docs.npmjs.com/staged-publishing) system directly.

This means that the release is added to an internal npm queue and needs an `npm stage approve` command run by a maintainer.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->