### PR TITLE
Extract Archive.hs download logic into Wasp.Util.Network.HTTP

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Archive.hs
+++ b/waspc/cli/src/Wasp/Cli/Archive.hs
@@ -6,13 +6,13 @@ import Control.Exception (SomeException, try)
 import qualified Data.ByteString.Lazy as BL
 import Data.Functor ((<&>))
 import Data.Maybe (fromJust)
-import Network.HTTP.Conduit (simpleHttp)
 import Path.IO (copyDirRecur)
 import StrongPath (Abs, Dir, File, Path', Rel, reldir, (</>))
 import qualified StrongPath as SP
 import StrongPath.Path (toPathAbsDir)
 import System.FilePath (takeFileName)
 import Wasp.Cli.FileSystem (withTempDir)
+import Wasp.Util.Network.HTTP (downloadUrlToFile)
 
 fetchArchiveAndCopySubdirToDisk ::
   String ->
@@ -27,7 +27,7 @@ fetchArchiveAndCopySubdirToDisk archiveDownloadUrl targetFolder destinationOnDis
             archiveUnpackPath = tempDir </> extractedContentsDir
             targetFolderInArchivePath = archiveUnpackPath </> targetFolder
 
-        downloadFile archiveDownloadUrl archiveDownloadPath
+        downloadUrlToFile archiveDownloadUrl archiveDownloadPath
         unpackArchive archiveDownloadPath archiveUnpackPath
         copyDirRecur (toPathAbsDir targetFolderInArchivePath) (toPathAbsDir destinationOnDisk)
     )
@@ -35,10 +35,6 @@ fetchArchiveAndCopySubdirToDisk archiveDownloadUrl targetFolder destinationOnDis
   where
     extractedContentsDir :: Path' (Rel tempDir) (Dir extracted)
     extractedContentsDir = [reldir|extracted|]
-
-    downloadFile :: String -> Path' Abs (File f) -> IO ()
-    downloadFile downloadUrl destinationPath =
-      simpleHttp downloadUrl >>= BL.writeFile (SP.fromAbsFile destinationPath)
 
     unpackArchive :: Path' Abs (File f) -> Path' Abs (Dir d) -> IO ()
     unpackArchive sourceFile destinationDir =

--- a/waspc/src/Wasp/Util/Network/HTTP.hs
+++ b/waspc/src/Wasp/Util/Network/HTTP.hs
@@ -3,6 +3,7 @@ module Wasp.Util.Network.HTTP
     getHttpExceptionStatusCode,
     httpJSONThatThrowsIfNot2xx,
     checkUrlExists,
+    downloadUrlToFile,
   )
 where
 
@@ -11,9 +12,12 @@ import Control.Monad (void, when)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as BL
 import qualified Network.HTTP.Conduit as HTTP.C
 import qualified Network.HTTP.Simple as HTTP
 import Network.HTTP.Types.Status (statusIsSuccessful)
+import StrongPath (Abs, File, Path')
+import qualified StrongPath as SP
 import UnliftIO (MonadUnliftIO)
 import UnliftIO.Exception (catch, throwIO)
 
@@ -65,3 +69,8 @@ httpHeadRequest url = do
       <$> HTTP.parseRequest url
 
   HTTP.httpNoBody req
+
+-- | Throws an HttpException if status is not 2xx.
+downloadUrlToFile :: (MonadIO m) => String -> Path' Abs (File f) -> m ()
+downloadUrlToFile url destinationPath =
+  liftIO $ HTTP.C.simpleHttp url >>= BL.writeFile (SP.fromAbsFile destinationPath)


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Closes #3661.

That issue asked to extract duplicated HTTP-fetching logic (across `News/Fetching.hs`, `Archive.hs`, `Telemetry/Project.hs`, `GithubRepo.hs`, and the old `AI/ChatGPT.hs`/`AI/CodeAgent.hs`) into a single `Wasp.Util.Network.HTTP` module. Since it was filed, most of that work already happened organically: the module already exists, `News/Fetching.hs` and `GithubRepo.hs` already use it, and the two AI files were removed entirely when the Wasp AI code-agent feature was dropped.

This PR closes out the one remaining genuine duplicate: `Archive.hs` was still calling `Network.HTTP.Conduit.simpleHttp` directly to download a URL to a file on disk. I added `downloadUrlToFile` to `Wasp.Util.Network.HTTP` (same shape/behavior as the existing `simpleHttp`-based code, just relocated) and migrated `Archive.hs` to use it.

I deliberately did **not** touch `Telemetry/Project.hs`'s `sendTelemetryData`. It's a fire-and-forget POST that intentionally swallows failures (telemetry must never crash the CLI), so it doesn't share the module's "throw if not 2xx" shape, and per [Martinsos's comment on the originating PR](https://github.com/wasp-lang/wasp/pull/3535#discussion), forcing it into the module for the sake of consolidation would be over-engineering for a 3-line function.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.
  <!-- Verified with `cabal build` (clean, -Wall, zero warnings on both changed files) plus ormolu/hlint. Also exercised `downloadUrlToFile` directly against a real URL (downloaded https://raw.githubusercontent.com/wasp-lang/wasp/main/README.md successfully, byte-identical to the source) and confirmed it still throws HttpException on a non-2xx response, matching the pre-refactor behavior of the inlined `simpleHttp` call in Archive.hs. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- No existing tests cover `Wasp.Util.Network.HTTP` or `Archive.hs` (both do real network/file I/O); this PR doesn't change that, it only moves an existing untested code path. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- N/A, not a bug fix. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- N/A, no feature change. -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- N/A -->
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- N/A -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa). <!-- N/A -->

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- N/A, internal refactor only. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- N/A, pure internal code improvement, no user-visible change. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`. <!-- N/A -->
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- N/A per template rules: version bumps are for bug fixes/features/breaking changes, not pure code improvements. -->
