### PR TITLE
Refactor CrudOperations

### DIFF
--- a/waspc/src/Wasp/AppSpec/Crud.hs
+++ b/waspc/src/Wasp/AppSpec/Crud.hs
@@ -1,17 +1,20 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TupleSections #-}
 
 module Wasp.AppSpec.Crud
   ( Crud (..),
     CrudOperations (..),
     CrudOperation (..),
     CrudOperationOptions (..),
+    toOperationList,
   )
 where
 
 import Data.Aeson (FromJSON)
 import Data.Data (Data)
+import Data.Maybe (catMaybes)
 import GHC.Generics (Generic)
 import Wasp.AppSpec.Core.IsDecl (IsDecl)
 import Wasp.AppSpec.Core.Ref (Ref)
@@ -42,4 +45,17 @@ data CrudOperationOptions = CrudOperationOptions
   deriving (Show, Eq, Data, Generic, FromJSON)
 
 data CrudOperation = Get | GetAll | Create | Update | Delete
-  deriving (Show, Eq, Ord, Data, Generic, FromJSON)
+  deriving (Show, Eq, Ord, Data, Generic, FromJSON, Enum, Bounded)
+
+toOperationList :: CrudOperations -> [(CrudOperation, CrudOperationOptions)]
+toOperationList ops =
+  catMaybes
+    [ (operation,) <$> getOptions operation ops
+    | operation <- [minBound ..] :: [CrudOperation]
+    ]
+  where
+    getOptions Get = get
+    getOptions GetAll = getAll
+    getOptions Create = create
+    getOptions Update = update
+    getOptions Delete = delete

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -38,7 +38,6 @@ import qualified Wasp.AppSpec.Operation as AS.Operation
 import qualified Wasp.AppSpec.Page as Page
 import qualified Wasp.AppSpec.Route as Route
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
-import Wasp.Generator.Crud (crudDeclarationToOperationsList)
 import Wasp.Node.Version (oldestWaspSupportedNodeVersion)
 import qualified Wasp.Node.Version as V
 import qualified Wasp.Psl.Ast.Model as Psl.Model
@@ -239,7 +238,7 @@ validateCrudOperations spec =
         then []
         else [GenericValidationError $ "CRUD \"" ++ crudName ++ "\" must have at least one operation defined."]
       where
-        crudOperations = crudDeclarationToOperationsList crud
+        crudOperations = AS.Crud.toOperationList crud.operations
 
     checkIfSimpleIdFieldIsDefinedForEntity :: (String, AS.Crud.Crud) -> [ValidationError]
     checkIfSimpleIdFieldIsDefinedForEntity (crudName, crud) = case (maybeIdField, maybeIdBlockAttribute) of

--- a/waspc/src/Wasp/Generator/Crud.hs
+++ b/waspc/src/Wasp/Generator/Crud.hs
@@ -1,11 +1,9 @@
-{-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module Wasp.Generator.Crud
   ( getCrudOperationJson,
     getCrudFilePath,
     makeCrudOperationKeyAndJsonPair,
-    crudDeclarationToOperationsList,
   )
 where
 
@@ -13,7 +11,7 @@ import Data.Aeson (object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.Types as Aeson.Types
-import Data.Maybe (catMaybes, fromJust, fromMaybe)
+import Data.Maybe (fromJust, fromMaybe)
 import StrongPath (File', Path', Rel)
 import qualified StrongPath as SP
 import qualified Wasp.AppSpec as AS
@@ -36,7 +34,7 @@ getCrudOperationJson crudOperationName crud idField =
   where
     crudEntityName = AS.refName $ AS.Crud.entity crud
 
-    crudOperations = crudDeclarationToOperationsList crud
+    crudOperations = AS.Crud.toOperationList crud.operations
 
     getDataForOperation :: (AS.Crud.CrudOperation, AS.Crud.CrudOperationOptions) -> Aeson.Types.Pair
     getDataForOperation (operation, options) =
@@ -51,16 +49,6 @@ getCrudOperationJson crudOperationName crud idField =
 
 getCrudFilePath :: String -> String -> Path' (Rel r) File'
 getCrudFilePath crudName ext = fromJust (SP.parseRelFile (crudName ++ "." ++ ext))
-
-crudDeclarationToOperationsList :: AS.Crud.Crud -> [(AS.Crud.CrudOperation, AS.Crud.CrudOperationOptions)]
-crudDeclarationToOperationsList crud =
-  catMaybes
-    [ fmap (AS.Crud.Get,) (AS.Crud.get $ AS.Crud.operations crud),
-      fmap (AS.Crud.GetAll,) (AS.Crud.getAll $ AS.Crud.operations crud),
-      fmap (AS.Crud.Create,) (AS.Crud.create $ AS.Crud.operations crud),
-      fmap (AS.Crud.Update,) (AS.Crud.update $ AS.Crud.operations crud),
-      fmap (AS.Crud.Delete,) (AS.Crud.delete $ AS.Crud.operations crud)
-    ]
 
 -- Produces a pair of the operation name and arbitrary json value.
 -- For example, for operation CrudOperation.Get and json value { "route": "get" },

--- a/waspc/src/Wasp/Generator/SdkGenerator/CrudG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/CrudG.hs
@@ -16,7 +16,7 @@ import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.Crud as AS.Crud
 import Wasp.AppSpec.Valid (getApp, getIdFieldFromCrudEntity, isAuthEnabled)
-import Wasp.Generator.Crud (crudDeclarationToOperationsList, getCrudFilePath, getCrudOperationJson, makeCrudOperationKeyAndJsonPair)
+import Wasp.Generator.Crud (getCrudFilePath, getCrudOperationJson, makeCrudOperationKeyAndJsonPair)
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import Wasp.Generator.SdkGenerator.Common (mkTmplFdWithDstAndData)
@@ -63,7 +63,7 @@ genCrudServerOperations spec cruds = return $ map genCrudOperation cruds
         overrides :: [Aeson.Types.Pair]
         overrides = map operationToOverrideImport crudOperations
 
-        crudOperations = crudDeclarationToOperationsList crud
+        crudOperations = AS.Crud.toOperationList crud.operations
 
         operationToOverrideImport :: (AS.Crud.CrudOperation, AS.Crud.CrudOperationOptions) -> Aeson.Types.Pair
         operationToOverrideImport (operation, options) = makeCrudOperationKeyAndJsonPair operation importJson

--- a/waspc/src/Wasp/Generator/ServerGenerator/CrudG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/CrudG.hs
@@ -16,8 +16,7 @@ import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.Crud as AS.Crud
 import Wasp.AppSpec.Valid (getApp, getIdFieldFromCrudEntity, isAuthEnabled)
 import Wasp.Generator.Crud
-  ( crudDeclarationToOperationsList,
-    getCrudFilePath,
+  ( getCrudFilePath,
     getCrudOperationJson,
     makeCrudOperationKeyAndJsonPair,
   )
@@ -111,7 +110,7 @@ genCrudOperations spec cruds = return $ map genCrudOperation cruds
         overrides :: [Aeson.Types.Pair]
         overrides = map operationToOverrideImport crudOperations
 
-        crudOperations = crudDeclarationToOperationsList crud
+        crudOperations = AS.Crud.toOperationList crud.operations
 
         operationToOverrideImport :: (AS.Crud.CrudOperation, AS.Crud.CrudOperationOptions) -> Aeson.Types.Pair
         operationToOverrideImport (operation, options) = makeCrudOperationKeyAndJsonPair operation importJson


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Refactors CRUD operation-list construction by moving `crudDeclarationToOperationsList` out of `Wasp.Generator.Crud` and into `Wasp.AppSpec.Crud` as `toOperationList`, which now operates on `CrudOperations` directly.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
