### PR TITLE
feat(deploy): Vercel provider for wasp deploy (setup/deploy/launch)

### DIFF
--- a/waspc/data/packages/deploy/src/common/waspProject.ts
+++ b/waspc/data/packages/deploy/src/common/waspProject.ts
@@ -66,3 +66,30 @@ export function getClientBuildDir(waspProjectDir: WaspProjectDir): string {
   // The client is built from the project root dir.
   return path.join(waspProjectDir, ".");
 }
+
+// The SPA fallback filename the client build emits differs between Wasp
+// versions: 0.22 emits "index.html", main (0.25-dev) emits a dedicated
+// "200.html". Order matters: the dedicated fallback wins when both exist.
+const SPA_FALLBACK_FILE_CANDIDATES = ["200.html", "index.html"];
+
+/**
+ * Resolves the SPA fallback filename in the client build output. Providers
+ * must never hardcode this filename (it drifts across Wasp versions) - they
+ * should always resolve it through this helper, after the client build ran.
+ */
+export function getClientSpaFallbackFileName(
+  waspProjectDir: WaspProjectDir,
+): string {
+  const clientBuildArtefactsDir = getClientBuildArtefactsDir(waspProjectDir);
+  for (const candidate of SPA_FALLBACK_FILE_CANDIDATES) {
+    if (fs.existsSync(path.join(clientBuildArtefactsDir, candidate))) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    [
+      `No SPA fallback file (${SPA_FALLBACK_FILE_CANDIDATES.join(" or ")}) found in the client build output at: ${clientBuildArtefactsDir}.`,
+      "Did the client build succeed?",
+    ].join("\n"),
+  );
+}

--- a/waspc/data/packages/deploy/src/index.ts
+++ b/waspc/data/packages/deploy/src/index.ts
@@ -5,6 +5,7 @@ import { $, syncProcessCwd } from "zx";
 import { waspSays } from "./common/terminal.js";
 import { createFlyCommand } from "./providers/fly/index.js";
 import { createRailwayCommand } from "./providers/railway/index.js";
+import { createVercelCommand } from "./providers/vercel/index.js";
 
 const program = new Command();
 
@@ -22,6 +23,7 @@ syncProcessCwd();
 
 program.addCommand(createFlyCommand());
 program.addCommand(createRailwayCommand());
+program.addCommand(createVercelCommand());
 
 try {
   // parseAsync not only parses the command line arguments but also

--- a/waspc/data/packages/deploy/src/providers/vercel/VercelCli.ts
+++ b/waspc/data/packages/deploy/src/providers/vercel/VercelCli.ts
@@ -1,0 +1,527 @@
+import fs from "fs";
+import path from "node:path";
+
+import { $ } from "zx";
+
+/**
+ * Thin, non-interactive wrappers around the `vercel` CLI (the only process
+ * boundary of the setup command - unit tests fake this interface instead of
+ * spawning processes).
+ *
+ * Every command is invoked with `--token`/`--scope` when provided so it
+ * works headless (CI, agents) without a `vercel login` session, and with
+ * `--cwd` for the commands that operate on a linked project directory.
+ * Secret values are always piped via stdin, never passed in argv.
+ */
+export interface VercelCli {
+  doesProjectExist(projectName: string): Promise<boolean>;
+  createProject(projectName: string): Promise<void>;
+  linkProjectToDir(projectName: string, dir: string): Promise<void>;
+  setEnvVar(
+    linkedProjectDir: string,
+    name: string,
+    value: string,
+    environment?: string,
+  ): Promise<void>;
+  pullEnvVars(
+    linkedProjectDir: string,
+    environment: string,
+  ): Promise<Record<string, string>>;
+  listEnvVarNames(
+    linkedProjectDir: string,
+    environment?: string,
+  ): Promise<string[]>;
+  isIntegrationInstalled(integrationSlug: string): Promise<boolean>;
+  addIntegrationResource(args: {
+    integrationSlug: string;
+    resourceName: string;
+    linkedProjectDir: string;
+  }): Promise<{ success: boolean; output: string }>;
+  connectIntegrationResource(args: {
+    resourceName: string;
+    projectName: string;
+    linkedProjectDir: string;
+  }): Promise<{ success: boolean; output: string }>;
+  deployToProd(linkedProjectDir: string): Promise<string>;
+}
+
+export interface VercelCliOptions {
+  vercelExe: string;
+  token?: string;
+  scope?: string;
+}
+
+export function createVercelCli(options: VercelCliOptions): VercelCli {
+  return new ZxVercelCli(options);
+}
+
+class ZxVercelCli implements VercelCli {
+  private readonly vercelExe: string;
+  private readonly token?: string;
+  private readonly authArgs: string[];
+
+  constructor({ vercelExe, token, scope }: VercelCliOptions) {
+    this.vercelExe = vercelExe;
+    this.token = token;
+    this.authArgs = [
+      ...(token ? ["--token", token] : []),
+      ...(scope ? ["--scope", scope] : []),
+    ];
+  }
+
+  async doesProjectExist(projectName: string): Promise<boolean> {
+    const result = await this.runVercelCommand(
+      ["project", "inspect", projectName],
+      { nothrow: true, quiet: true },
+    );
+    return result.exitCode === 0;
+  }
+
+  async createProject(projectName: string): Promise<void> {
+    await this.runVercelCommand(["project", "add", projectName]);
+  }
+
+  async linkProjectToDir(projectName: string, dir: string): Promise<void> {
+    await this.runVercelCommand([
+      "link",
+      "--yes",
+      ...["--project", projectName],
+      ...["--cwd", dir],
+    ]);
+  }
+
+  async setEnvVar(
+    linkedProjectDir: string,
+    name: string,
+    value: string,
+    environment: string = "production",
+  ): Promise<void> {
+    // `--force` overwrites an existing variable for the same target, which
+    // keeps re-runs of `setup` idempotent. The value is piped via stdin so
+    // it never shows up in argv or logs. `--no-sensitive` keeps the
+    // behavior deterministic: when the Vercel CLI detects an agent (or any
+    // non-interactive run) it otherwise defaults production env vars to
+    // "sensitive", whose values are write-only and would break both
+    // troubleshooting and this provider's own DATABASE_URL_UNPOOLED ->
+    // DIRECT_URL mapping via `env pull`.
+    await this.runVercelCommand(
+      [
+        "env",
+        "add",
+        name,
+        environment,
+        "--force",
+        "--no-sensitive",
+        ...["--cwd", linkedProjectDir],
+      ],
+      { input: value, quiet: true },
+    );
+  }
+
+  async pullEnvVars(
+    linkedProjectDir: string,
+    environment: string,
+  ): Promise<Record<string, string>> {
+    // Pull into a throwaway file inside the (temporary) linked dir, parse
+    // it, and delete it right away so no secret values linger on disk.
+    const envFileName = `.env.wasp-vercel-setup.${environment}`;
+    const envFilePath = path.join(linkedProjectDir, envFileName);
+    try {
+      await this.runVercelCommand(
+        [
+          "env",
+          "pull",
+          envFileName,
+          ...["--environment", environment],
+          "--yes",
+          ...["--cwd", linkedProjectDir],
+        ],
+        { quiet: true },
+      );
+      return parseEnvFile(fs.readFileSync(envFilePath, "utf-8"));
+    } finally {
+      fs.rmSync(envFilePath, { force: true });
+    }
+  }
+
+  async listEnvVarNames(
+    linkedProjectDir: string,
+    environment: string = "production",
+  ): Promise<string[]> {
+    // Lists the env var *names* on the linked project without exposing any
+    // value: `env ls --format json` returns each variable's key with the
+    // value hidden (unlike `env pull`, which decrypts and writes secrets to
+    // disk). Used by setup's JWT_SECRET skip-if-exists guard so a re-run does
+    // not regenerate a secret that already exists.
+    const result = await this.runVercelCommand(
+      [
+        "env",
+        "ls",
+        environment,
+        ...["--format", "json"],
+        ...["--cwd", linkedProjectDir],
+      ],
+      { quiet: true },
+    );
+    return parseEnvLsNames(result.stdout);
+  }
+
+  async isIntegrationInstalled(integrationSlug: string): Promise<boolean> {
+    const result = await this.runVercelCommand(
+      [
+        "integration",
+        "installations",
+        ...["--integration", integrationSlug],
+        "--format=json",
+      ],
+      { nothrow: true, quiet: true },
+    );
+    if (result.exitCode === 0 && jsonOutputListsAnInstallation(result.stdout)) {
+      return true;
+    }
+    // Vercel CLI 56.x scopes `integration installations` to the personal
+    // account, so team-level Marketplace installations come back as an
+    // empty list (observed live: `integration add neon` succeeded right
+    // after `installations` returned an empty list). Fall back to probing
+    // the team installation via `integration balance`, which resolves the
+    // installation first and fails with a distinctive message when the
+    // integration is not installed.
+    const probe = await this.runVercelCommand(
+      ["integration", "balance", integrationSlug],
+      { nothrow: true, quiet: true },
+    );
+    return balanceProbeShowsAnInstallation({
+      exitCode: probe.exitCode ?? 1,
+      output: `${probe.stdout}\n${probe.stderr}`,
+    });
+  }
+
+  async addIntegrationResource({
+    integrationSlug,
+    resourceName,
+    linkedProjectDir,
+  }: {
+    integrationSlug: string;
+    resourceName: string;
+    linkedProjectDir: string;
+  }): Promise<{ success: boolean; output: string }> {
+    // Connects the new resource to the project linked in `linkedProjectDir`.
+    // `--no-claim` prevents blocking on the sandbox-claim prompt and
+    // `--no-env-pull` keeps the CLI from writing an .env file as a side
+    // effect (we pull env vars explicitly when we need them).
+    const result = await this.runVercelCommand(
+      [
+        "integration",
+        "add",
+        integrationSlug,
+        ...["--name", resourceName],
+        ...["-e", "production", "-e", "preview", "-e", "development"],
+        "--no-claim",
+        "--no-env-pull",
+        ...["--cwd", linkedProjectDir],
+      ],
+      { nothrow: true },
+    );
+    if (result.exitCode === 0) {
+      await this.waitForDatabaseUrlInjection(linkedProjectDir);
+    }
+    return {
+      success: result.exitCode === 0,
+      output: `${result.stdout}\n${result.stderr}`.trim(),
+    };
+  }
+
+  async connectIntegrationResource({
+    resourceName,
+    projectName,
+    linkedProjectDir,
+  }: {
+    resourceName: string;
+    projectName: string;
+    linkedProjectDir: string;
+  }): Promise<{ success: boolean; output: string }> {
+    const result = await this.runVercelCommand(
+      [
+        "integration",
+        "resource",
+        "connect",
+        resourceName,
+        projectName,
+        ...["-e", "production", "-e", "preview", "-e", "development"],
+        "--yes",
+        ...["--cwd", linkedProjectDir],
+      ],
+      { nothrow: true },
+    );
+    if (result.exitCode === 0) {
+      await this.waitForDatabaseUrlInjection(linkedProjectDir);
+      return {
+        success: true,
+        output: `${result.stdout}\n${result.stderr}`.trim(),
+      };
+    }
+    // `resource connect` is not idempotent: re-connecting an
+    // already-connected resource fails on its own injected env vars
+    // ("Cannot connect: env var ... already exists on project ...").
+    // Already-connected must count as connected, so a failed connect is a
+    // success exactly when the project already has a DATABASE_URL.
+    const envVarsOnProject = await this.pullEnvVars(
+      linkedProjectDir,
+      "production",
+    ).catch(() => ({}) as Record<string, string>);
+    return resolveFailedConnectOutcome(
+      `${result.stdout}\n${result.stderr}`.trim(),
+      envVarsOnProject,
+    );
+  }
+
+  /**
+   * The Marketplace injects a database resource's env vars asynchronously
+   * (observed live: `integration add neon` returned ~40s before
+   * DATABASE_URL appeared on the project). Poll until the injection lands
+   * so callers can read the connection strings right after add/connect.
+   * On timeout this returns normally - the caller's own DATABASE_URL check
+   * reports the real error.
+   */
+  private async waitForDatabaseUrlInjection(
+    linkedProjectDir: string,
+  ): Promise<void> {
+    await waitForInjectedDatabaseUrl(() =>
+      this.pullEnvVars(linkedProjectDir, "production"),
+    );
+  }
+
+  async deployToProd(linkedProjectDir: string): Promise<string> {
+    // Creates a new production deployment for the project linked to
+    // `linkedProjectDir`. Non-interactive (`--yes`); the deployment URL is
+    // what the CLI prints to stdout. Like every other command here it runs
+    // quiet so the token never leaks through zx's verbose argv echo.
+    //
+    // Uploads flake with transient network errors ("fetch failed" observed
+    // live, mid-upload). The CLI's own error JSON advises "retry deploy",
+    // and retries converge: already-uploaded files are deduplicated
+    // server-side, so every attempt uploads strictly less. Retry a bounded
+    // number of times, but only for transient network failures - remote
+    // build failures surface immediately.
+    const maxAttempts = 3;
+    for (let attempt = 1; ; attempt++) {
+      const result = await this.runVercelCommand(
+        ["deploy", "--prod", "--yes", ...["--cwd", linkedProjectDir]],
+        { nothrow: true },
+      );
+      if (result.exitCode === 0) {
+        return result.stdout.trim();
+      }
+      const output = `${result.stdout}\n${result.stderr}`.trim();
+      if (attempt >= maxAttempts || !isTransientDeployFailure(output)) {
+        throw new Error(
+          [
+            `Vercel CLI command failed: ${this.vercelExe} deploy --prod --yes --cwd ${linkedProjectDir}`,
+            this.maskToken(output),
+          ].join("\n"),
+        );
+      }
+      await this.sleep(5_000);
+    }
+  }
+
+  // Injection point so a future test can fake time; production sleeps.
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private async runVercelCommand(
+    commandArgs: string[],
+    options: { nothrow?: boolean; quiet?: boolean; input?: string } = {},
+  ) {
+    // Always run quiet: this package sets zx's global `$.verbose = true`,
+    // which would otherwise echo the full argv - including the `--token`
+    // value - into the terminal/logs. Failures are rethrown below with the
+    // token masked for the same reason.
+    const result = await $({
+      nothrow: true,
+      quiet: true,
+      ...(options.input !== undefined ? { input: options.input } : {}),
+    })`${this.vercelExe} ${[...commandArgs, ...this.authArgs]}`;
+    if (result.exitCode !== 0 && !(options.nothrow ?? false)) {
+      throw new Error(
+        [
+          `Vercel CLI command failed: ${this.vercelExe} ${this.maskToken(commandArgs.join(" "))}`,
+          this.maskToken(`${result.stdout}\n${result.stderr}`.trim()),
+        ].join("\n"),
+      );
+    }
+    return result;
+  }
+
+  private maskToken(text: string): string {
+    // (`split().join()` instead of `replaceAll` - tsconfig targets es2020.)
+    return this.token ? text.split(this.token).join("<token>") : text;
+  }
+}
+
+/**
+ * Parses the dotenv-style file `vercel env pull` writes
+ * (`KEY="value"` lines, plus comments and blank lines).
+ */
+export function parseEnvFile(contents: string): Record<string, string> {
+  const envVars: Record<string, string> = {};
+  for (const line of contents.split("\n")) {
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (match === null) {
+      continue;
+    }
+    const [, name, rawValue] = match;
+    envVars[name] = stripSurroundingQuotes(rawValue.trim());
+  }
+  return envVars;
+}
+
+/**
+ * Extracts env var names from the JSON `vercel env ls --format json` prints.
+ * That command emits `{ "envs": [ { "key": "JWT_SECRET", ... }, ... ] }`
+ * (values omitted for encrypted/sensitive vars). Defensive about the shape:
+ * accepts a bare array too, and falls back to `name` when `key` is absent.
+ * Returns [] for unparseable output so callers can decide what a missing
+ * listing means.
+ */
+export function parseEnvLsNames(stdout: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : isObjectWithArrayField(parsed, "envs")
+      ? parsed.envs
+      : [];
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (typeof entry === "object" && entry !== null) {
+      const record = entry as Record<string, unknown>;
+      const name = record.key ?? record.name;
+      if (typeof name === "string" && name.length > 0) {
+        names.push(name);
+      }
+    }
+  }
+  return names;
+}
+
+function stripSurroundingQuotes(value: string): string {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Polls the given env-var pull until it reports a DATABASE_URL, sleeping
+ * between attempts, and returns the last pulled record. Never throws on
+ * timeout: after the attempt budget is spent, the (DATABASE_URL-less)
+ * record is returned and the caller reports the real error. The attempt
+ * budget (18 x 5s) comfortably covers the ~40s injection delay observed
+ * live without hanging setup forever when provisioning silently failed.
+ */
+export async function waitForInjectedDatabaseUrl(
+  pullEnvVars: () => Promise<Record<string, string>>,
+  options: {
+    maxAttempts?: number;
+    delayMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<Record<string, string>> {
+  const maxAttempts = options.maxAttempts ?? 18;
+  const delayMs = options.delayMs ?? 5_000;
+  const sleep =
+    options.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let envVars = await pullEnvVars();
+  for (
+    let attempt = 1;
+    attempt < maxAttempts && !envVars["DATABASE_URL"];
+    attempt++
+  ) {
+    await sleep(delayMs);
+    envVars = await pullEnvVars();
+  }
+  return envVars;
+}
+
+/**
+ * Classifies a failed `vercel deploy` by its output: retryable only for
+ * transient network errors (the CLI's "fetch failed" upload error and
+ * common socket-level failures). Anything else - remote build failures,
+ * usage errors - must surface immediately instead of burning retries.
+ */
+export function isTransientDeployFailure(output: string): boolean {
+  return /fetch failed|ECONNRESET|ETIMEDOUT|ECONNREFUSED|EAI_AGAIN|EPIPE|socket hang up|network error/i.test(
+    output,
+  );
+}
+
+/**
+ * Decides what a failed `integration resource connect` means: success when
+ * the linked project already carries a DATABASE_URL (the resource - or an
+ * equivalent database - is already wired up), otherwise the original
+ * failure with its output preserved for the caller's error message.
+ */
+export function resolveFailedConnectOutcome(
+  output: string,
+  envVarsOnProject: Record<string, string>,
+): { success: boolean; output: string } {
+  if (envVarsOnProject["DATABASE_URL"]) {
+    return { success: true, output };
+  }
+  return { success: false, output };
+}
+
+/**
+ * Interprets the output of the `integration balance <slug>` fallback probe:
+ * the integration is not installed exactly when the CLI failed while saying
+ * so ("No installation(s) found ..."). Any other failure (e.g. an installed
+ * integration without balance info, or a transient network error) must not
+ * report "not installed" - setup's later steps surface the real error.
+ */
+export function balanceProbeShowsAnInstallation(probe: {
+  exitCode: number;
+  output: string;
+}): boolean {
+  if (probe.exitCode === 0) {
+    return true;
+  }
+  return !/No installations? found/i.test(probe.output);
+}
+
+function jsonOutputListsAnInstallation(stdout: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    const installations = Array.isArray(parsed)
+      ? parsed
+      : isObjectWithArrayField(parsed, "installations")
+        ? parsed.installations
+        : null;
+    if (installations !== null) {
+      return installations.length > 0;
+    }
+  } catch {
+    // Not JSON - fall through to the textual heuristic below.
+  }
+  // Installation configuration IDs look like `icfg_...` - seeing one means
+  // at least one installation exists even if the JSON shape changed.
+  return stdout.includes("icfg_");
+}
+
+function isObjectWithArrayField<Field extends string>(
+  value: unknown,
+  field: Field,
+): value is { [key in Field]: unknown[] } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as Record<string, unknown>)[field])
+  );
+}

--- a/waspc/data/packages/deploy/src/providers/vercel/brandedUrls.ts
+++ b/waspc/data/packages/deploy/src/providers/vercel/brandedUrls.ts
@@ -1,0 +1,46 @@
+/**
+ * Deterministic Vercel project names and production URLs derived from the
+ * Wasp app name. Knowing both URLs before either deploy runs is what solves
+ * the client<->server chicken-and-egg problem (the client bundle needs the
+ * server URL at build time, the server needs the client origin for CORS) -
+ * same trick as the Railway provider.
+ */
+
+// Vercel project names: lowercase alphanumerics plus ".", "_", "-", up to
+// 100 chars. We reserve room for the longest suffix we append ("-server").
+const VALID_APP_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/;
+const MAX_APP_NAME_LENGTH = 90;
+
+export function getServerProjectName(appName: string): string {
+  return `${appName}-server`;
+}
+
+export function getClientProjectName(appName: string): string {
+  return `${appName}-client`;
+}
+
+export function getServerAppUrl(appName: string): string {
+  return `https://${getServerProjectName(appName)}.vercel.app`;
+}
+
+export function getClientAppUrl(appName: string): string {
+  return `https://${getClientProjectName(appName)}.vercel.app`;
+}
+
+export function assertVercelAppNameIsValid(appName: string): void {
+  if (!VALID_APP_NAME_RE.test(appName)) {
+    throw new Error(
+      [
+        `Invalid app name: "${appName}".`,
+        "Vercel project names must start with a lowercase letter or digit and",
+        'may only contain lowercase letters, digits, ".", "_" and "-".',
+      ].join(" "),
+    );
+  }
+  if (appName.length > MAX_APP_NAME_LENGTH) {
+    throw new Error(
+      `App name too long: must be at most ${MAX_APP_NAME_LENGTH} characters ` +
+        `(so the "-server"/"-client" suffixes fit Vercel's limit).`,
+    );
+  }
+}

--- a/waspc/data/packages/deploy/src/providers/vercel/deploy.ts
+++ b/waspc/data/packages/deploy/src/providers/vercel/deploy.ts
@@ -1,0 +1,405 @@
+import fs from "fs";
+import os from "node:os";
+import path from "node:path";
+
+import { WaspCliExe, WaspProjectDir } from "../../common/brandedTypes.js";
+import { buildClient } from "../../common/clientApp.js";
+import { displayWaspRocketImage, waspSays } from "../../common/terminal.js";
+import { ensureWaspProjectIsBuilt } from "../../common/waspBuild.js";
+import {
+  getClientSpaFallbackFileName,
+  getServerBuildArtefactsDir,
+} from "../../common/waspProject.js";
+import {
+  assertVercelAppNameIsValid,
+  getClientAppUrl,
+  getClientProjectName,
+  getServerAppUrl,
+  getServerProjectName,
+} from "./brandedUrls.js";
+import { createVercelCli, VercelCli } from "./VercelCli.js";
+
+export interface VercelDeployCmdOptions {
+  waspExe: WaspCliExe;
+  waspProjectDir: WaspProjectDir;
+  vercelExe: string;
+  token?: string;
+  scope?: string;
+}
+
+/**
+ * The process boundaries of the deploy command besides the Vercel CLI
+ * itself (`wasp build` and the client Vite build). Unit tests inject fakes
+ * here instead of spawning processes.
+ */
+export interface DeployBoundary {
+  ensureWaspProjectIsBuilt: (options: {
+    waspProjectDir: WaspProjectDir;
+    waspExe: WaspCliExe;
+  }) => Promise<unknown>;
+  buildClient: (
+    serverUrl: string,
+    options: { waspProjectDir: WaspProjectDir },
+  ) => Promise<string>;
+}
+
+const defaultBoundary: DeployBoundary = {
+  ensureWaspProjectIsBuilt,
+  buildClient,
+};
+
+// ---------------------------------------------------------------------------
+// Server deploy artifacts (per docs/manual-recipe.md, verified in the m-1
+// experiments, plus one correction the recipe's test app could not surface).
+// The server path is Vercel's Express zero-config on Fluid compute.
+//
+// Deploy-root layout: the framework code in `.wasp/out/server` imports the
+// user's code with relative paths that assume the project layout (e.g.
+// `../../../../../../src/apis`, resolving to `<root>/src/...` only when the
+// build output sits nested under `<root>/.wasp/out/`). The generated
+// Dockerfile mirrors that structure for exactly this reason, and so do we:
+// the deploy root is an ephemeral staging dir shaped like the Docker image
+// (src/, package.json, tsconfig.json at the root; server/sdk/libs/db under
+// .wasp/out/), rebuilt from the Wasp build output on every deploy.
+// ---------------------------------------------------------------------------
+
+/**
+ * Vercel's Express zero-config only scans app|index|server.{js,...} at the
+ * deploy root, but Wasp's entry lives far below it. This fixed 2-line shim
+ * bridges the gap: the express import is an inert marker for Vercel's
+ * content-based framework detection, the second import loads the
+ * rollup-bundled, unmodified Wasp server (which does its normal
+ * `http.createServer(app).listen(process.env.PORT)` startup).
+ */
+export const SERVER_ENTRYPOINT_SHIM = [
+  "import express from 'express' // eslint-disable-line no-unused-vars",
+  "import './.wasp/out/server/bundle/server.js'",
+  "",
+].join("\n");
+
+/**
+ * Build order matters: `prisma generate` (schema only, pooled url fine),
+ * then `prisma migrate deploy` with DATABASE_URL overridden to the direct
+ * (non-pooled) DIRECT_URL for that one sub-step only, then bundle the
+ * server with rollup directly.
+ *
+ * Deliberately NOT the generated `npm run bundle` script: its `tsc --build`
+ * half needs project references and devDeps this deploy does not carry.
+ * rollup-plugin-esbuild does its own TS transpilation; the output is
+ * behaviorally identical (this is the recipe-verified chain).
+ */
+export const SERVER_BUILD_COMMAND = [
+  "cd .wasp/out",
+  "npx prisma generate --schema=db/schema.prisma",
+  "DATABASE_URL=$DIRECT_URL npx prisma migrate deploy --schema=db/schema.prisma",
+  "cd server && npm install && npx rollup --config --silent",
+].join(" && ");
+
+export function makeServerVercelJsonContents(): string {
+  return JSON.stringify(
+    {
+      framework: "express",
+      installCommand: "npm install",
+      buildCommand: SERVER_BUILD_COMMAND,
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * The SPA rewrite config placed inside the client build output dir. The
+ * fallback filename is resolved by the caller (it differs across Wasp
+ * versions - see getClientSpaFallbackFileName), never hardcoded here.
+ */
+export function makeClientVercelJsonContents(
+  spaFallbackFileName: string,
+): string {
+  return JSON.stringify(
+    {
+      rewrites: [
+        { source: "/(.*)", destination: `/${spaFallbackFileName}` },
+      ],
+    },
+    null,
+    2,
+  );
+}
+
+const VERCEL_BINARY_TARGETS_LINE = `binaryTargets = ["native", "rhel-openssl-3.0.x", "debian-openssl-3.0.x"]`;
+const DIRECT_URL_LINE = `directUrl = env("DIRECT_URL")`;
+
+/**
+ * Patches the generated Prisma schema for Vercel, unconditionally:
+ *   - the generator client block must carry Vercel-compatible engine
+ *     binaries, or the deployed function throws "Query Engine not found";
+ *   - the datasource block gets `directUrl = env("DIRECT_URL")` so every
+ *     Prisma migrate invocation uses the direct (non-pooled) connection.
+ */
+export function patchPrismaSchemaForVercel(schemaContents: string): string {
+  const withBinaryTargets = upsertLineInPrismaBlock(
+    schemaContents,
+    /generator\s+client\s*\{[^}]*\}/,
+    "generator client",
+    /binaryTargets\s*=\s*\[[^\]]*\]/,
+    VERCEL_BINARY_TARGETS_LINE,
+  );
+  return upsertLineInPrismaBlock(
+    withBinaryTargets,
+    /datasource\s+\w+\s*\{[^}]*\}/,
+    "datasource",
+    /directUrl\s*=\s*[^\n]+/,
+    DIRECT_URL_LINE,
+  );
+}
+
+function upsertLineInPrismaBlock(
+  schemaContents: string,
+  blockRe: RegExp,
+  blockDescription: string,
+  existingLineRe: RegExp,
+  newLine: string,
+): string {
+  const blockMatch = schemaContents.match(blockRe);
+  if (blockMatch === null) {
+    throw new Error(
+      `Could not find the ${blockDescription} block in the generated Prisma schema.`,
+    );
+  }
+  const block = blockMatch[0];
+  const patchedBlock = existingLineRe.test(block)
+    ? block.replace(existingLineRe, newLine)
+    : block.replace(/\}$/, `  ${newLine}\n}`);
+  // Replacement via callback so "$" sequences in the block are inert.
+  return schemaContents.replace(block, () => patchedBlock);
+}
+
+// What the generated Dockerfile copies to the image root and to the nested
+// .wasp/out/ dir, respectively. The workspaces globs in the generated
+// package.json (".wasp/out/*", ".wasp/out/sdk/wasp") are relative to this
+// layout, so the file is staged verbatim - no rewrite.
+const STAGED_ROOT_DIRS = ["src"];
+const STAGED_ROOT_FILES = ["package.json", "package-lock.json", "tsconfig.json"];
+const STAGED_BUILD_OUTPUT_DIRS = ["server", "sdk", "libs", "db"];
+const REQUIRED_BUILD_OUTPUT_ENTRIES = ["server", "db", "package.json"];
+
+/**
+ * Builds the ephemeral server deploy root from the (freshly built) Wasp
+ * build output: the Docker-image layout mirrored onto disk, plus the Vercel
+ * artifacts (entrypoint shim, vercel.json, patched Prisma schema). Returns
+ * the staging dir; the caller deploys it and removes it afterwards. Rebuilt
+ * on every deploy - `wasp build` regenerates its inputs each time it runs.
+ */
+export function createServerDeployStagingDir(
+  serverBuildArtefactsDir: string,
+): string {
+  for (const requiredEntry of REQUIRED_BUILD_OUTPUT_ENTRIES) {
+    if (!fs.existsSync(path.join(serverBuildArtefactsDir, requiredEntry))) {
+      throw new Error(
+        `The Wasp build output at ${serverBuildArtefactsDir} is missing "${requiredEntry}". Did \`wasp build\` succeed?`,
+      );
+    }
+  }
+
+  const stagingDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "wasp-vercel-server-deploy-"),
+  );
+
+  for (const dir of STAGED_ROOT_DIRS) {
+    copyIfExists(
+      path.join(serverBuildArtefactsDir, dir),
+      path.join(stagingDir, dir),
+    );
+  }
+  for (const file of STAGED_ROOT_FILES) {
+    copyIfExists(
+      path.join(serverBuildArtefactsDir, file),
+      path.join(stagingDir, file),
+    );
+  }
+  for (const dir of STAGED_BUILD_OUTPUT_DIRS) {
+    copyIfExists(
+      path.join(serverBuildArtefactsDir, dir),
+      path.join(stagingDir, ".wasp", "out", dir),
+    );
+  }
+
+  const schemaPath = path.join(
+    stagingDir,
+    ".wasp",
+    "out",
+    "db",
+    "schema.prisma",
+  );
+  fs.writeFileSync(
+    schemaPath,
+    patchPrismaSchemaForVercel(fs.readFileSync(schemaPath, "utf-8")),
+  );
+
+  fs.writeFileSync(path.join(stagingDir, "server.js"), SERVER_ENTRYPOINT_SHIM);
+  fs.writeFileSync(
+    path.join(stagingDir, "vercel.json"),
+    makeServerVercelJsonContents(),
+  );
+
+  return stagingDir;
+}
+
+function copyIfExists(source: string, destination: string): void {
+  if (!fs.existsSync(source)) {
+    return;
+  }
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.cpSync(source, destination, {
+    recursive: true,
+    // node_modules are reinstalled remotely; .vercel would leak a stale
+    // project link into the upload.
+    filter: (src) => {
+      const baseName = path.basename(src);
+      return baseName !== "node_modules" && baseName !== ".vercel";
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export async function deploy(
+  appName: string,
+  options: VercelDeployCmdOptions,
+): Promise<void> {
+  const vercelCli = createVercelCli({
+    vercelExe: options.vercelExe,
+    token: options.token,
+    scope: options.scope,
+  });
+  await runDeploy(vercelCli, appName, options);
+}
+
+/**
+ * The deploy orchestration, with the Vercel CLI and the build steps
+ * injected as boundaries so unit tests can run it without spawning
+ * processes:
+ *   1. verify both projects exist (setup's job to create them),
+ *   2. `wasp build` (memoized per CLI invocation),
+ *   3. server: apply the deploy artifacts to `.wasp/out`, link, deploy,
+ *   4. client: Vite build with the predicted server URL baked in, write
+ *      the SPA-rewrite vercel.json, link, deploy.
+ */
+export async function runDeploy(
+  vercelCli: VercelCli,
+  appName: string,
+  options: VercelDeployCmdOptions,
+  boundary: DeployBoundary = defaultBoundary,
+): Promise<void> {
+  assertVercelAppNameIsValid(appName);
+
+  waspSays("Deploying your Wasp app to Vercel!");
+
+  const serverProjectName = getServerProjectName(appName);
+  const clientProjectName = getClientProjectName(appName);
+  // Fail fast, before the (expensive) build: deploy never creates projects
+  // or env vars - that is setup's job.
+  await assertProjectIsSetUp(vercelCli, serverProjectName, appName);
+  await assertProjectIsSetUp(vercelCli, clientProjectName, appName);
+
+  await boundary.ensureWaspProjectIsBuilt(options);
+
+  await deployServer(vercelCli, serverProjectName, appName, options);
+  await deployClientApp(vercelCli, clientProjectName, appName, options, boundary);
+
+  displayWaspRocketImage();
+  waspSays(
+    [
+      "Your Wasp app has been deployed to Vercel!",
+      `  - Client: ${getClientAppUrl(appName)}`,
+      `  - Server: ${getServerAppUrl(appName)}`,
+    ].join("\n"),
+  );
+}
+
+async function assertProjectIsSetUp(
+  vercelCli: VercelCli,
+  projectName: string,
+  appName: string,
+): Promise<void> {
+  if (await vercelCli.doesProjectExist(projectName)) {
+    return;
+  }
+  throw new Error(
+    [
+      `Vercel project "${projectName}" was not found.`,
+      `Run \`wasp deploy vercel setup ${appName}\` first, or use`,
+      `\`wasp deploy vercel launch ${appName}\` to set up and deploy in one go.`,
+    ].join("\n"),
+  );
+}
+
+async function deployServer(
+  vercelCli: VercelCli,
+  serverProjectName: string,
+  appName: string,
+  options: VercelDeployCmdOptions,
+): Promise<void> {
+  waspSays("Deploying your server now...");
+
+  const serverBuildArtefactsDir = getServerBuildArtefactsDir(
+    options.waspProjectDir,
+  );
+  const stagingDir = createServerDeployStagingDir(serverBuildArtefactsDir);
+  try {
+    // The staging dir is fresh on every deploy, so it always needs a link.
+    await vercelCli.linkProjectToDir(serverProjectName, stagingDir);
+
+    waspSays(
+      "Creating the server deployment (Vercel builds it remotely - this can take a few minutes)...",
+    );
+    await vercelCli.deployToProd(stagingDir);
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+
+  waspSays(`Server has been deployed at: ${getServerAppUrl(appName)}`);
+}
+
+async function deployClientApp(
+  vercelCli: VercelCli,
+  clientProjectName: string,
+  appName: string,
+  options: VercelDeployCmdOptions,
+  boundary: DeployBoundary,
+): Promise<void> {
+  waspSays("Deploying your client now...");
+
+  // The server URL is baked into the client bundle at Vite build time (the
+  // deterministic prediction makes this possible before/without parsing any
+  // deploy output).
+  const serverUrl = getServerAppUrl(appName);
+  const clientBuildArtefactsDir = await boundary.buildClient(
+    serverUrl,
+    options,
+  );
+
+  writeClientSpaRewriteConfig(options.waspProjectDir, clientBuildArtefactsDir);
+
+  await vercelCli.linkProjectToDir(clientProjectName, clientBuildArtefactsDir);
+  await vercelCli.deployToProd(clientBuildArtefactsDir);
+
+  waspSays(`Client has been deployed at: ${getClientAppUrl(appName)}`);
+}
+
+function writeClientSpaRewriteConfig(
+  waspProjectDir: WaspProjectDir,
+  clientBuildArtefactsDir: string,
+): void {
+  // The build output dir has no package.json, so Vercel deploys it as a
+  // plain static site and this vercel.json is the only config it reads.
+  // The fallback filename drifts across Wasp versions - always resolve it
+  // through the shared helper.
+  const spaFallbackFileName = getClientSpaFallbackFileName(waspProjectDir);
+  fs.writeFileSync(
+    path.join(clientBuildArtefactsDir, "vercel.json"),
+    makeClientVercelJsonContents(spaFallbackFileName),
+  );
+}

--- a/waspc/data/packages/deploy/src/providers/vercel/index.ts
+++ b/waspc/data/packages/deploy/src/providers/vercel/index.ts
@@ -1,0 +1,190 @@
+import { Command, Option } from "commander";
+import { $ } from "zx";
+
+import { WaspProjectDir } from "../../common/brandedTypes.js";
+import { waspSays } from "../../common/terminal.js";
+import { deploy as deployFn } from "./deploy.js";
+import { runVercelPreflightChecks } from "./preflight.js";
+import { setup as setupFn, VercelSetupCmdOptions } from "./setup.js";
+
+class VercelCommand extends Command {
+  addProjectNameArgument(): this {
+    return this.argument("<project-name>", "project name to use on Vercel");
+  }
+  addServerSecretsOption(): this {
+    function collect(value: string, previous: string[]) {
+      return previous.concat([value]);
+    }
+    return this.option(
+      "--server-secret <serverSecret>",
+      "secret to set on the server app (of form FOO=BAR)",
+      collect,
+      [],
+    );
+  }
+  addAuthOptions(): this {
+    return this.option(
+      "--token <token>",
+      "Vercel access token (defaults to the logged-in Vercel CLI session)",
+    ).option("--scope <scope>", "Vercel team (slug or ID) to operate in");
+  }
+  addDatabaseOptions(): this {
+    return this.option(
+      "--db <db>",
+      'managed database to provision via the Vercel Marketplace (only "neon" is supported)',
+      "neon",
+    )
+      .option(
+        "--database-url <url>",
+        "skip database provisioning and use this connection string as DATABASE_URL",
+      )
+      .option(
+        "--direct-url <url>",
+        "non-pooled connection string for DIRECT_URL (only with --database-url; defaults to the --database-url value)",
+      );
+  }
+}
+
+export const vercelSetupCommand = makeVercelSetupCommand();
+
+export const vercelDeployCommand = makeVercelDeployCommand();
+
+const vercelLaunchCommand = makeVercelLaunchCommand();
+
+export function createVercelCommand(): Command {
+  const vercel = new Command("vercel")
+    .description("Create and deploy Wasp apps on Vercel")
+    .addCommand(vercelSetupCommand)
+    .addCommand(vercelDeployCommand)
+    .addCommand(vercelLaunchCommand)
+    .allowUnknownOption();
+
+  // Add global options and hooks to all commands.
+  // Add these hooks before any command-specific ones so they run first.
+  vercel.commands.forEach((cmd) => {
+    cmd
+      .addOption(
+        new Option(
+          "--wasp-exe <path>",
+          "Wasp executable (either on PATH or absolute path)",
+        )
+          .hideHelp()
+          .makeOptionMandatory(),
+      )
+      .addOption(
+        new Option(
+          "--wasp-project-dir <dir>",
+          "absolute path to Wasp project dir",
+        )
+          .hideHelp()
+          .makeOptionMandatory(),
+      )
+      .addOption(
+        new Option(
+          "--vercel-exe <path>",
+          "Vercel command to run (either on PATH or absolute path)",
+        )
+          .hideHelp()
+          .default("vercel"),
+      )
+      .hook("preAction", (cmd) => {
+        const { waspProjectDir } = cmd.opts<{ waspProjectDir: string }>();
+        // Preflight (task-16): warn-not-block detection of Wasp project
+        // features (pg-boss jobs, WebSockets) known to behave badly on
+        // Vercel. This never throws and never blocks the command below.
+        runVercelPreflightChecks(waspProjectDir as WaspProjectDir);
+      })
+      .hook("preAction", async (cmd) => {
+        const { vercelExe, token } = cmd.opts<{
+          vercelExe: string;
+          token?: string;
+        }>();
+        await ensureVercelCliReady(vercelExe, token);
+      });
+  });
+
+  return vercel;
+}
+
+async function ensureVercelCliReady(
+  vercelExe: string,
+  token?: string,
+): Promise<void> {
+  await ensureVercelCliInstalled(vercelExe);
+  await ensureUserLoggedIn(vercelExe, token);
+}
+
+async function ensureVercelCliInstalled(vercelExe: string): Promise<void> {
+  const result = await $({ nothrow: true, quiet: true })`${vercelExe} --version`;
+  if (result.exitCode !== 0) {
+    throw new Error(
+      [
+        "Failed to run the Vercel CLI. Most likely the Vercel CLI is not installed.",
+        "Read how to install the Vercel CLI here: https://vercel.com/docs/cli",
+      ].join("\n"),
+    );
+  }
+}
+
+async function ensureUserLoggedIn(
+  vercelExe: string,
+  token?: string,
+): Promise<void> {
+  const tokenArgs = token ? ["--token", token] : [];
+  // quiet: zx's global verbose mode would otherwise echo the argv,
+  // including the --token value, into the terminal/logs.
+  const result = await $({
+    nothrow: true,
+    quiet: true,
+  })`${vercelExe} whoami ${tokenArgs}`;
+  if (result.exitCode !== 0) {
+    throw new Error(
+      token
+        ? "Vercel did not accept the provided --token. Double check the token and its team access."
+        : [
+            "You are not logged in to the Vercel CLI.",
+            `Log in with \`${vercelExe} login\` (or pass an access token via --token) and try again.`,
+          ].join("\n"),
+    );
+  }
+}
+
+function makeVercelSetupCommand(): Command {
+  return new VercelCommand("setup")
+    .description("Configure a new app on Vercel")
+    .addProjectNameArgument()
+    .addServerSecretsOption()
+    .addAuthOptions()
+    .addDatabaseOptions()
+    .action((...args: Parameters<typeof setupFn>) => setupFn(...args));
+}
+
+function makeVercelDeployCommand(): Command {
+  return new VercelCommand("deploy")
+    .description("Deploys the app to Vercel")
+    .addProjectNameArgument()
+    .addAuthOptions()
+    .action((...args: Parameters<typeof deployFn>) => deployFn(...args));
+}
+
+function makeVercelLaunchCommand(): Command {
+  return new VercelCommand("launch")
+    .description("Launch a new app on Vercel (calls setup and deploy)")
+    .addProjectNameArgument()
+    .addServerSecretsOption()
+    .addAuthOptions()
+    .addDatabaseOptions()
+    .action((...args: Parameters<typeof launchFn>) => launchFn(...args));
+}
+
+// Launch is setup followed by deploy (mirroring the Railway provider's
+// launch composition): its options are setup's options, which are a
+// superset of deploy's.
+async function launchFn(
+  appName: string,
+  options: VercelSetupCmdOptions,
+): Promise<void> {
+  waspSays("Launching your Wasp app to Vercel!");
+  await setupFn(appName, options);
+  await deployFn(appName, options);
+}

--- a/waspc/data/packages/deploy/src/providers/vercel/preflight.ts
+++ b/waspc/data/packages/deploy/src/providers/vercel/preflight.ts
@@ -1,0 +1,189 @@
+import fs from "fs";
+import path from "node:path";
+
+import { WaspProjectDir } from "../../common/brandedTypes.js";
+
+/**
+ * Preflight checks (task-16): best-effort, textual detection of Wasp
+ * project features that are known to behave badly on Vercel's serverless
+ * platform - pg-boss `job`s (assume a long-lived process, break under
+ * scale-to-zero) and `webSocket` usage (beta on Vercel, instance-pinned,
+ * bound by the function's maxDuration).
+ *
+ * Per the project decision ("warn-not-block"), this module only ever warns:
+ * it never throws and never affects the deploy's exit code. It is a
+ * heuristic, not a full Wasp compiler front-end - it textually scans
+ * `main.wasp` / `main.wasp.ts` (and, one hop out, its local relative
+ * imports) for `job(...)` calls / `job <name> { ... }` blocks and
+ * `webSocket` usage, mirroring how a human would grep the project.
+ */
+
+export interface PreflightFindings {
+  jobNames: string[];
+  hasWebSocket: boolean;
+}
+
+export interface PreflightWarning {
+  message: string;
+}
+
+const ENTRY_FILE_CANDIDATES = ["main.wasp.ts", "main.wasp"];
+
+// How many project files (entry file + local imports) we're willing to
+// read while looking for job/webSocket declarations. This is a heuristic
+// scan, not a module resolver, so we bound it to avoid runaway traversal.
+const MAX_FILES_SCANNED = 50;
+
+// Candidate suffixes to try when resolving a relative import specifier
+// (e.g. "./src/features/jobs/jobs.wasp") to a file on disk. Order matters:
+// an exact match wins, otherwise fall back to adding an extension.
+const RESOLVE_SUFFIXES = ["", ".ts", ".wasp.ts", "/index.ts"];
+
+// New (0.25+/main) TS spec API: `job(someJobIdentifier, { ... })`.
+const JOB_CALL_RE = /\bjob\s*\(\s*([A-Za-z_$][\w$]*)/g;
+// Legacy `.wasp` DSL: `job someJobName { ... }`.
+const JOB_DECL_RE = /(?:^|\n)[ \t]*job[ \t]+([A-Za-z_$][\w$]*)[ \t]*\{/g;
+// Matches the `webSocket` key/shorthand on the app config, in both the TS
+// object-literal form (`webSocket: {...}` / `webSocket,`) and the legacy
+// `.wasp` DSL field, without false-positiving on unrelated identifiers
+// like `webSocketServer`.
+const WEBSOCKET_RE = /\bwebSocket\b\s*[:,}]/;
+const LOCAL_IMPORT_RE = /from\s+["'](\.[^"']+)["']/g;
+
+export function findWaspEntryFile(
+  waspProjectDir: WaspProjectDir,
+): string | undefined {
+  for (const candidate of ENTRY_FILE_CANDIDATES) {
+    const candidatePath = path.join(waspProjectDir, candidate);
+    if (fs.existsSync(candidatePath) && fs.statSync(candidatePath).isFile()) {
+      return candidatePath;
+    }
+  }
+  return undefined;
+}
+
+export function scanWaspProjectForPreflightFindings(
+  waspProjectDir: WaspProjectDir,
+): PreflightFindings {
+  const entryFile = findWaspEntryFile(waspProjectDir);
+  if (entryFile === undefined) {
+    return { jobNames: [], hasWebSocket: false };
+  }
+
+  const jobNames = new Set<string>();
+  let hasWebSocket = false;
+
+  const visited = new Set<string>();
+  const queue: string[] = [entryFile];
+
+  while (queue.length > 0 && visited.size < MAX_FILES_SCANNED) {
+    const filePath = queue.shift();
+    if (filePath === undefined || visited.has(filePath)) {
+      continue;
+    }
+    visited.add(filePath);
+
+    const content = tryReadFile(filePath);
+    if (content === undefined) {
+      continue;
+    }
+
+    for (const match of content.matchAll(JOB_CALL_RE)) {
+      jobNames.add(match[1]);
+    }
+    for (const match of content.matchAll(JOB_DECL_RE)) {
+      jobNames.add(match[1]);
+    }
+    if (WEBSOCKET_RE.test(content)) {
+      hasWebSocket = true;
+    }
+
+    const fileDir = path.dirname(filePath);
+    for (const match of content.matchAll(LOCAL_IMPORT_RE)) {
+      const resolved = resolveLocalImport(fileDir, match[1]);
+      if (resolved !== undefined && !visited.has(resolved)) {
+        queue.push(resolved);
+      }
+    }
+  }
+
+  return { jobNames: Array.from(jobNames), hasWebSocket };
+}
+
+function tryReadFile(filePath: string): string | undefined {
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveLocalImport(
+  fromDir: string,
+  specifier: string,
+): string | undefined {
+  const base = path.join(fromDir, specifier);
+  for (const suffix of RESOLVE_SUFFIXES) {
+    const candidate = base + suffix;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export function buildPreflightWarnings(
+  findings: PreflightFindings,
+): PreflightWarning[] {
+  const warnings: PreflightWarning[] = [];
+
+  if (findings.jobNames.length > 0) {
+    const jobList = findings.jobNames.join(", ");
+    warnings.push({
+      message: [
+        `WARN: This Wasp project declares the following pg-boss job(s): ${jobList}.`,
+        "pg-boss jobs assume a long-lived process; they can miss scheduled runs or fail",
+        "outright on a scale-to-zero platform like Vercel's serverless functions.",
+        "Consider using Vercel Cron (https://vercel.com/docs/cron-jobs) to trigger this",
+        "work on a schedule instead.",
+      ].join(" "),
+    });
+  }
+
+  if (findings.hasWebSocket) {
+    warnings.push({
+      message: [
+        "WARN: This Wasp project uses WebSockets.",
+        "WebSocket support on Vercel is currently in beta: connections are",
+        "instance-pinned (they will not survive a scale-to-zero or a redeploy) and are",
+        "subject to the function's maxDuration limit.",
+        "See https://vercel.com/docs/functions/functions-api-reference#websockets for details.",
+      ].join(" "),
+    });
+  }
+
+  return warnings;
+}
+
+/**
+ * Runs the preflight checks for the given Wasp project and prints any
+ * warnings to stderr via console.warn. Never throws - per the project's
+ * "warn-not-block" decision, this must never affect the deploy's exit
+ * code or interrupt the calling command.
+ */
+export function runVercelPreflightChecks(
+  waspProjectDir: WaspProjectDir,
+): PreflightWarning[] {
+  try {
+    const findings = scanWaspProjectForPreflightFindings(waspProjectDir);
+    const warnings = buildPreflightWarnings(findings);
+    for (const warning of warnings) {
+      console.warn(warning.message);
+    }
+    return warnings;
+  } catch {
+    // Warn-not-block: any unexpected failure in this best-effort scan must
+    // never interrupt the deploy.
+    return [];
+  }
+}

--- a/waspc/data/packages/deploy/src/providers/vercel/setup.ts
+++ b/waspc/data/packages/deploy/src/providers/vercel/setup.ts
@@ -1,0 +1,352 @@
+import fs from "fs";
+import os from "node:os";
+import path from "node:path";
+
+import { WaspCliExe, WaspProjectDir } from "../../common/brandedTypes.js";
+import { generateRandomHexString } from "../../common/random.js";
+import { waspSays } from "../../common/terminal.js";
+import {
+  assertVercelAppNameIsValid,
+  getClientAppUrl,
+  getClientProjectName,
+  getServerAppUrl,
+  getServerProjectName,
+} from "./brandedUrls.js";
+import { findWaspEntryFile } from "./preflight.js";
+import { createVercelCli, VercelCli } from "./VercelCli.js";
+
+// Re-exported for backwards compatibility: these helpers used to live here
+// before task-15 moved them into brandedUrls.ts.
+export {
+  assertVercelAppNameIsValid,
+  getClientAppUrl,
+  getClientProjectName,
+  getServerAppUrl,
+  getServerProjectName,
+};
+
+export interface VercelSetupCmdOptions {
+  waspExe: WaspCliExe;
+  waspProjectDir: WaspProjectDir;
+  vercelExe: string;
+  token?: string;
+  scope?: string;
+  db?: string;
+  databaseUrl?: string;
+  directUrl?: string;
+  serverSecret: string[];
+}
+
+const NEON_INTEGRATION_SLUG = "neon";
+const PRODUCTION_ENVIRONMENT = "production";
+
+export interface ServerSecret {
+  name: string;
+  value: string;
+}
+
+export function parseServerSecrets(secrets: string[]): ServerSecret[] {
+  return secrets.map((secret) => {
+    const separatorIndex = secret.indexOf("=");
+    if (separatorIndex === -1) {
+      throw new Error(
+        `Invalid --server-secret "${secret}": expected NAME=VALUE.`,
+      );
+    }
+    const name = secret.slice(0, separatorIndex);
+    const value = secret.slice(separatorIndex + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error(
+        `Invalid --server-secret name "${name}": env var names must start ` +
+          "with a letter or underscore and contain only letters, digits and underscores.",
+      );
+    }
+    return { name, value };
+  });
+}
+
+// Matches the auth declaration in both syntaxes: the legacy `main.wasp`
+// DSL (`auth: { ... }` inside the app block) and the TS spec
+// (`auth({ ... })` in `main.wasp.ts`). This is the same kind of textual
+// heuristic the preflight checks use - not a full Wasp parser.
+const AUTH_RE = /\bauth\s*(?:\(|[:=]\s*\{)/;
+
+export function appUsesAuth(waspProjectDir: WaspProjectDir): boolean {
+  const entryFile = findWaspEntryFile(waspProjectDir);
+  if (entryFile === undefined) {
+    return false;
+  }
+  try {
+    return AUTH_RE.test(fs.readFileSync(entryFile, "utf-8"));
+  } catch {
+    return false;
+  }
+}
+
+export async function setup(
+  appName: string,
+  options: VercelSetupCmdOptions,
+): Promise<void> {
+  const vercelCli = createVercelCli({
+    vercelExe: options.vercelExe,
+    token: options.token,
+    scope: options.scope,
+  });
+  await runSetup(vercelCli, appName, options);
+}
+
+/**
+ * The setup orchestration, with the Vercel CLI injected as a boundary so
+ * unit tests can run it against an in-memory fake:
+ *   1. create the `<app>-server` and `<app>-client` projects (skip-if-exists),
+ *   2. wire a database (Neon via the Vercel Marketplace by default, or the
+ *      `--database-url` escape hatch),
+ *   3. set the server env vars (DATABASE_URL, DIRECT_URL, WASP_SERVER_URL,
+ *      WASP_WEB_CLIENT_URL, JWT_SECRET for auth apps, --server-secret
+ *      passthroughs).
+ */
+export async function runSetup(
+  vercelCli: VercelCli,
+  appName: string,
+  options: VercelSetupCmdOptions,
+): Promise<void> {
+  waspSays("Setting up your Wasp app with Vercel!");
+
+  // Validate everything up front so we fail before mutating anything.
+  assertVercelAppNameIsValid(appName);
+  const serverSecrets = parseServerSecrets(options.serverSecret);
+  const dbPlan = determineDbPlan(options);
+  if (dbPlan.kind === "neon") {
+    await assertNeonIntegrationIsInstalled(vercelCli);
+  }
+
+  const serverProjectName = getServerProjectName(appName);
+  const clientProjectName = getClientProjectName(appName);
+
+  await ensureProjectExists(vercelCli, serverProjectName);
+  await ensureProjectExists(vercelCli, clientProjectName);
+
+  // Vercel's project-scoped commands (env, integration) operate on the
+  // project linked to the current directory. `.wasp/out` is wiped on every
+  // `wasp build`, so instead of linking inside the project we link the
+  // server project to a throwaway temp dir for the duration of setup.
+  await withTempDir(async (serverLinkDir) => {
+    await vercelCli.linkProjectToDir(serverProjectName, serverLinkDir);
+
+    await setupDatabase({
+      vercelCli,
+      appName,
+      serverProjectName,
+      serverLinkDir,
+      dbPlan,
+    });
+
+    waspSays(`Setting up server env vars on project "${serverProjectName}"`);
+    await vercelCli.setEnvVar(
+      serverLinkDir,
+      "WASP_SERVER_URL",
+      getServerAppUrl(appName),
+    );
+    await vercelCli.setEnvVar(
+      serverLinkDir,
+      "WASP_WEB_CLIENT_URL",
+      getClientAppUrl(appName),
+    );
+
+    if (appUsesAuth(options.waspProjectDir)) {
+      // Skip-if-exists (mirrors the Railway provider): JWT_SECRET must be
+      // generated only once. Regenerating it on every setup re-run would
+      // rotate the signing key and invalidate every previously issued
+      // session/JWT. WASP_SERVER_URL and WASP_WEB_CLIENT_URL above are
+      // deterministic, so re-setting those is harmless; a random secret is
+      // not.
+      const existingServerEnvVars = await vercelCli.listEnvVarNames(
+        serverLinkDir,
+        PRODUCTION_ENVIRONMENT,
+      );
+      if (existingServerEnvVars.includes("JWT_SECRET")) {
+        waspSays("JWT_SECRET already set. Skipping.");
+      } else {
+        waspSays("Auth detected: generating a random JWT_SECRET.");
+        await vercelCli.setEnvVar(
+          serverLinkDir,
+          "JWT_SECRET",
+          generateRandomHexString(),
+        );
+      }
+    }
+
+    for (const secret of serverSecrets) {
+      await vercelCli.setEnvVar(serverLinkDir, secret.name, secret.value);
+    }
+  });
+
+  waspSays(
+    [
+      "Vercel setup complete!",
+      `  - Server project: ${serverProjectName} (${getServerAppUrl(appName)})`,
+      `  - Client project: ${clientProjectName} (${getClientAppUrl(appName)})`,
+      `Deploy the app with: wasp deploy vercel deploy ${appName}`,
+    ].join("\n"),
+  );
+}
+
+type DbPlan =
+  | { kind: "neon" }
+  | { kind: "custom-url"; databaseUrl: string; directUrl: string };
+
+function determineDbPlan(options: VercelSetupCmdOptions): DbPlan {
+  if (options.databaseUrl !== undefined) {
+    return {
+      kind: "custom-url",
+      databaseUrl: options.databaseUrl,
+      // Without a separate non-pooled URL, migrations use the same one.
+      directUrl: options.directUrl ?? options.databaseUrl,
+    };
+  }
+  const db = options.db ?? "neon";
+  if (db !== "neon") {
+    throw new Error(
+      `Unsupported --db value: "${db}". Only "neon" is supported ` +
+        "(or pass --database-url to bring your own database).",
+    );
+  }
+  return { kind: "neon" };
+}
+
+async function ensureProjectExists(
+  vercelCli: VercelCli,
+  projectName: string,
+): Promise<void> {
+  if (await vercelCli.doesProjectExist(projectName)) {
+    waspSays(`Project "${projectName}" already exists. Skipping creation.`);
+    return;
+  }
+  waspSays(`Creating Vercel project "${projectName}"`);
+  await vercelCli.createProject(projectName);
+}
+
+async function assertNeonIntegrationIsInstalled(
+  vercelCli: VercelCli,
+): Promise<void> {
+  if (await vercelCli.isIntegrationInstalled(NEON_INTEGRATION_SLUG)) {
+    return;
+  }
+  throw new Error(
+    [
+      "The Neon integration is not installed on your Vercel team yet.",
+      "Installing it is a one-time step that needs a human. Either:",
+      "  - run `vercel integration accept-terms neon` in an interactive terminal, or",
+      "  - install it via the Vercel dashboard: your team -> Storage -> Browse Marketplace -> Neon -> Install.",
+      "Then re-run this command - it resumes automatically once the integration is installed.",
+      "Alternatively, pass --database-url <url> to use a database you already have.",
+    ].join("\n"),
+  );
+}
+
+async function setupDatabase({
+  vercelCli,
+  appName,
+  serverProjectName,
+  serverLinkDir,
+  dbPlan,
+}: {
+  vercelCli: VercelCli;
+  appName: string;
+  serverProjectName: string;
+  serverLinkDir: string;
+  dbPlan: DbPlan;
+}): Promise<void> {
+  if (dbPlan.kind === "custom-url") {
+    waspSays("Using the provided --database-url for DATABASE_URL.");
+    await vercelCli.setEnvVar(
+      serverLinkDir,
+      "DATABASE_URL",
+      dbPlan.databaseUrl,
+    );
+    await vercelCli.setEnvVar(serverLinkDir, "DIRECT_URL", dbPlan.directUrl);
+    return;
+  }
+
+  const resourceName = `${appName}-db`;
+  waspSays(
+    `Provisioning Neon Postgres "${resourceName}" via the Vercel Marketplace`,
+  );
+  const addResult = await vercelCli.addIntegrationResource({
+    integrationSlug: NEON_INTEGRATION_SLUG,
+    resourceName,
+    linkedProjectDir: serverLinkDir,
+  });
+  if (!addResult.success) {
+    // Most common cause: the resource already exists from a previous setup
+    // run. Connecting it to the server project keeps setup idempotent.
+    waspSays(
+      `Provisioning failed - trying to connect an existing "${resourceName}" resource instead.`,
+    );
+    const connectResult = await vercelCli.connectIntegrationResource({
+      resourceName,
+      projectName: serverProjectName,
+      linkedProjectDir: serverLinkDir,
+    });
+    if (!connectResult.success) {
+      throw new Error(
+        [
+          `Could not provision or connect the Neon database "${resourceName}".`,
+          `Provisioning output:\n${indent(addResult.output)}`,
+          `Connecting output:\n${indent(connectResult.output)}`,
+          "You can provision a database yourself (Vercel dashboard -> Storage -> Neon,",
+          "or any Postgres provider) and re-run this command with --database-url <url>.",
+        ].join("\n"),
+      );
+    }
+  }
+
+  // The integration injects DATABASE_URL (pooled) and DATABASE_URL_UNPOOLED
+  // (direct) into the project. Prisma migrations must not run through the
+  // pooler, so map the direct URL to DIRECT_URL (the name our Prisma
+  // schema patch and vercel.json buildCommand expect).
+  const injectedEnvVars = await vercelCli.pullEnvVars(
+    serverLinkDir,
+    PRODUCTION_ENVIRONMENT,
+  );
+  const databaseUrl = injectedEnvVars["DATABASE_URL"];
+  if (databaseUrl === undefined || databaseUrl === "") {
+    throw new Error(
+      [
+        `The Neon integration did not inject a DATABASE_URL into project "${serverProjectName}".`,
+        "Check the resource in the Vercel dashboard (Storage tab), or re-run this",
+        "command with --database-url <url> to set the connection string directly.",
+      ].join("\n"),
+    );
+  }
+  const directUrl = injectedEnvVars["DATABASE_URL_UNPOOLED"];
+  if (directUrl === undefined || directUrl === "") {
+    waspSays(
+      "WARN: no DATABASE_URL_UNPOOLED found; using the pooled DATABASE_URL as DIRECT_URL.",
+    );
+  }
+  await vercelCli.setEnvVar(
+    serverLinkDir,
+    "DIRECT_URL",
+    directUrl || databaseUrl,
+  );
+  waspSays("Neon database connected: DATABASE_URL and DIRECT_URL are set.");
+}
+
+async function withTempDir(
+  action: (tempDir: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "wasp-vercel-setup-"));
+  try {
+    await action(tempDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function indent(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n");
+}

--- a/waspc/data/packages/deploy/test/providers/vercel/VercelCli.test.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/VercelCli.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  balanceProbeShowsAnInstallation,
+  parseEnvLsNames,
+  waitForInjectedDatabaseUrl,
+  isTransientDeployFailure,
+  resolveFailedConnectOutcome,
+} from "../../../src/providers/vercel/VercelCli.js";
+
+// The JWT_SECRET skip-if-exists guard consults `vercel env ls --format json`,
+// which prints `{ "envs": [ { "key": ..., ... } ] }` with values hidden for
+// encrypted vars. The parser extracts just the names so the guard can tell
+// whether a secret is already set without ever pulling its value.
+describe("parseEnvLsNames", () => {
+  test("extracts keys from the { envs: [...] } shape the CLI emits", () => {
+    const stdout = JSON.stringify({
+      envs: [
+        { key: "JWT_SECRET", value: undefined, type: "encrypted" },
+        { key: "DATABASE_URL", value: "postgres://x", type: "plain" },
+      ],
+    });
+    expect(parseEnvLsNames(stdout)).toEqual(["JWT_SECRET", "DATABASE_URL"]);
+  });
+
+  test("accepts a bare array and falls back to a `name` field", () => {
+    const stdout = JSON.stringify([{ name: "FOO" }, { key: "BAR" }]);
+    expect(parseEnvLsNames(stdout)).toEqual(["FOO", "BAR"]);
+  });
+
+  test("returns [] for empty listings and unparseable output", () => {
+    expect(parseEnvLsNames(JSON.stringify({ envs: [] }))).toEqual([]);
+    expect(parseEnvLsNames("Vercel CLI 56.2.1\nnot json")).toEqual([]);
+  });
+});
+
+// Vercel CLI 56.x scopes `integration installations` to the personal
+// account, so team-level Marketplace installations come back as an empty
+// list (a false negative observed live on the wpp-ai-coe team, where
+// `integration add neon` succeeded right after `installations` returned
+// `{"installations": []}`). The fallback probe is `integration balance
+// <slug>`, which resolves the team installation first and fails with a
+// distinctive message when - and only when - the integration is not
+// installed.
+describe("balanceProbeShowsAnInstallation", () => {
+  test("a successful balance probe means the integration is installed", () => {
+    expect(
+      balanceProbeShowsAnInstallation({
+        exitCode: 0,
+        output: "Retrieving resources…\nBalance: $0.00",
+      }),
+    ).toBe(true);
+  });
+
+  test("'No installations found' means the integration is not installed", () => {
+    expect(
+      balanceProbeShowsAnInstallation({
+        exitCode: 1,
+        output:
+          "Retrieving installation…\nError: No installations found for this integration",
+      }),
+    ).toBe(false);
+  });
+
+  test("'No installation found' (singular) also means not installed", () => {
+    expect(
+      balanceProbeShowsAnInstallation({
+        exitCode: 1,
+        output: "Error: No installation found for this integration",
+      }),
+    ).toBe(false);
+  });
+
+  test("an installed integration without balance info still counts as installed", () => {
+    expect(
+      balanceProbeShowsAnInstallation({
+        exitCode: 1,
+        output:
+          "Retrieving resources…\nRetrieving balance info…\nError: No balance information found for this integration",
+      }),
+    ).toBe(true);
+  });
+
+  test("unrelated failures do not report 'not installed' (setup's later steps surface the real error)", () => {
+    expect(
+      balanceProbeShowsAnInstallation({
+        exitCode: 1,
+        output: "Error: Network error",
+      }),
+    ).toBe(true);
+  });
+});
+
+// The Marketplace injects a database resource's env vars asynchronously:
+// observed live, `integration add neon` returned ~40 seconds before
+// DATABASE_URL appeared on the project, so a setup that pulls right away
+// races the injection and fails on a fresh app. The boundary must poll
+// until DATABASE_URL is visible (or a bounded timeout elapses).
+describe("waitForInjectedDatabaseUrl", () => {
+  test("returns as soon as a pull sees DATABASE_URL", async () => {
+    const pulls = [
+      {},
+      {},
+      { DATABASE_URL: "postgres://pooled" },
+    ];
+    let pullCount = 0;
+    const result = await waitForInjectedDatabaseUrl(
+      async () => pulls[pullCount++] ?? {},
+      { sleep: async () => {} },
+    );
+    expect(result).toEqual({ DATABASE_URL: "postgres://pooled" });
+    expect(pullCount).toBe(3);
+  });
+
+  test("does not sleep or pull again when the first pull already has it", async () => {
+    let sleeps = 0;
+    let pullCount = 0;
+    const result = await waitForInjectedDatabaseUrl(
+      async () => {
+        pullCount++;
+        return { DATABASE_URL: "postgres://pooled", OTHER: "x" };
+      },
+      {
+        sleep: async () => {
+          sleeps++;
+        },
+      },
+    );
+    expect(result).toEqual({ DATABASE_URL: "postgres://pooled", OTHER: "x" });
+    expect(pullCount).toBe(1);
+    expect(sleeps).toBe(0);
+  });
+
+  test("gives up after the attempt budget and returns the last pull (the caller reports the real error)", async () => {
+    let pullCount = 0;
+    const result = await waitForInjectedDatabaseUrl(
+      async () => {
+        pullCount++;
+        return { UNRELATED: "still here" };
+      },
+      { maxAttempts: 4, sleep: async () => {} },
+    );
+    expect(result).toEqual({ UNRELATED: "still here" });
+    expect(pullCount).toBe(4);
+  });
+});
+
+// `integration resource connect` is not idempotent: when the resource is
+// already connected to the project it fails with "Cannot connect: env var
+// NEON_PROJECT_ID already exists on project ..." (observed live on a setup
+// re-run). Already-connected must count as connected: a failed connect is
+// a success exactly when the project already has a DATABASE_URL.
+describe("resolveFailedConnectOutcome", () => {
+  test("a failed connect on a project that already has DATABASE_URL is success", () => {
+    const outcome = resolveFailedConnectOutcome(
+      "Error: Cannot connect: env var NEON_PROJECT_ID already exists on project wv15a-server",
+      { DATABASE_URL: "postgres://pooled", NEON_PROJECT_ID: "np_1" },
+    );
+    expect(outcome.success).toBe(true);
+  });
+
+  test("a failed connect without DATABASE_URL stays a failure with the original output", () => {
+    const outcome = resolveFailedConnectOutcome(
+      "Error: resource not found",
+      { UNRELATED: "x" },
+    );
+    expect(outcome).toEqual({
+      success: false,
+      output: "Error: resource not found",
+    });
+  });
+});
+
+// Deploy uploads flake with transient network errors ("fetch failed" was
+// observed live three times, killing otherwise-healthy deploys mid-upload).
+// The Vercel CLI's own error JSON advises `"when": "retry deploy"`, and
+// retries converge because already-uploaded files are deduplicated
+// server-side. Only transient network failures may be retried - build
+// failures must surface immediately.
+describe("isTransientDeployFailure", () => {
+  test("'fetch failed' (the CLI's transient upload error) is retryable", () => {
+    expect(
+      isTransientDeployFailure(
+        '{\n  "status": "error",\n  "reason": "deploy_failed",\n  "message": "fetch failed",\n  "next": [{ "command": "vercel deploy", "when": "retry deploy" }]\n}\nError: fetch failed',
+      ),
+    ).toBe(true);
+  });
+
+  test("common socket-level errors are retryable", () => {
+    expect(isTransientDeployFailure("Error: ECONNRESET")).toBe(true);
+    expect(isTransientDeployFailure("Error: ETIMEDOUT")).toBe(true);
+    expect(isTransientDeployFailure("Error: socket hang up")).toBe(true);
+  });
+
+  test("a remote build failure is not retryable", () => {
+    expect(
+      isTransientDeployFailure(
+        "Error: Command \"npm install\" exited with 1\nBuild Failed",
+      ),
+    ).toBe(false);
+  });
+
+  test("a plain CLI usage error is not retryable", () => {
+    expect(
+      isTransientDeployFailure("Error: unknown or unexpected option: --frob"),
+    ).toBe(false);
+  });
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/brandedUrls.test.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/brandedUrls.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  assertVercelAppNameIsValid,
+  getClientAppUrl,
+  getClientProjectName,
+  getServerAppUrl,
+  getServerProjectName,
+} from "../../../src/providers/vercel/brandedUrls.js";
+
+describe("Vercel project name prediction", () => {
+  test("derives the deterministic <app>-server project name", () => {
+    expect(getServerProjectName("my-app")).toBe("my-app-server");
+  });
+
+  test("derives the deterministic <app>-client project name", () => {
+    expect(getClientProjectName("my-app")).toBe("my-app-client");
+  });
+});
+
+describe("Vercel production URL prediction", () => {
+  // Deterministic URLs derived from the project names are what solve the
+  // client<->server chicken-and-egg: both URLs are known before either
+  // deploy runs.
+  test("predicts https://<app>-server.vercel.app for the server", () => {
+    expect(getServerAppUrl("my-app")).toBe("https://my-app-server.vercel.app");
+  });
+
+  test("predicts https://<app>-client.vercel.app for the client", () => {
+    expect(getClientAppUrl("my-app")).toBe("https://my-app-client.vercel.app");
+  });
+
+  test("prediction matches the project name it is derived from", () => {
+    expect(getServerAppUrl("wvtest-launch-e2e")).toBe(
+      `https://${getServerProjectName("wvtest-launch-e2e")}.vercel.app`,
+    );
+    expect(getClientAppUrl("wvtest-launch-e2e")).toBe(
+      `https://${getClientProjectName("wvtest-launch-e2e")}.vercel.app`,
+    );
+  });
+});
+
+describe("assertVercelAppNameIsValid", () => {
+  test("accepts lowercase names with digits, hyphens and dots", () => {
+    expect(() => assertVercelAppNameIsValid("my-app-2")).not.toThrow();
+    expect(() => assertVercelAppNameIsValid("app.v2")).not.toThrow();
+  });
+
+  test("rejects names with uppercase, spaces or a leading separator", () => {
+    expect(() => assertVercelAppNameIsValid("MyApp")).toThrow();
+    expect(() => assertVercelAppNameIsValid("my app")).toThrow();
+    expect(() => assertVercelAppNameIsValid("-my-app")).toThrow();
+    expect(() => assertVercelAppNameIsValid("")).toThrow();
+  });
+
+  test("rejects names too long to fit the -server/-client suffix", () => {
+    expect(() => assertVercelAppNameIsValid("a".repeat(91))).toThrow();
+    expect(() => assertVercelAppNameIsValid("a".repeat(90))).not.toThrow();
+  });
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/cliArgWiring.test.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/cliArgWiring.test.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// task-17: index.test.ts already asserts that --wasp-exe, --wasp-project-dir
+// and --vercel-exe are *registered* as Commander options on every
+// subcommand. It never asserts that argv values actually reach the
+// provider's action handler (setup/deploy/launch in ./setup.js and
+// ./deploy.js). This file pins that wiring directly: it mocks setup.js and
+// deploy.js with spies (no real setup/deploy logic runs, no `vercel` binary
+// is ever invoked for real work) and asserts the exact values parsed from
+// argv show up in the spy's call args.
+//
+// vi.hoisted is required here: vi.mock factories are hoisted above the
+// rest of the module, so a factory that closes over a later `const` would
+// otherwise throw "Cannot access before initialization".
+const { setupSpy, deploySpy } = vi.hoisted(() => ({
+  setupSpy: vi.fn().mockResolvedValue(undefined),
+  deploySpy: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../src/providers/vercel/setup.js", () => ({
+  setup: setupSpy,
+}));
+vi.mock("../../../src/providers/vercel/deploy.js", () => ({
+  deploy: deploySpy,
+}));
+
+import { createVercelCommand } from "../../../src/providers/vercel/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, "fixtures");
+// Never actually executed: the preAction hooks only read --wasp-project-dir
+// off disk (preflight scan) and shell out to --vercel-exe (CLI readiness
+// check). --wasp-exe itself is only ever invoked by the real setup/deploy
+// logic, which is mocked out below, so this path does not need to exist or
+// be executable.
+const waspExePath = path.join(fixturesDir, "not-a-real-wasp-cli");
+// A real fixture dir with neither jobs nor webSockets, so the preflight
+// hook's fs scan runs cleanly (no console.warn noise) without needing
+// network access or a real Wasp project.
+const waspProjectDir = path.join(fixturesDir, "appWithNeither");
+// Stub `vercel` binary: exits 0 for any invocation (--version, whoami),
+// so the CLI-readiness preAction hook is satisfied with no real Vercel
+// CLI, no VERCEL_TOKEN and no network access.
+const stubVercelCliPath = path.join(fixturesDir, "stubVercelCli.sh");
+
+// createVercelCommand() mutates module-level singleton subcommands (see
+// index.test.ts), so - exactly like that file - build it once and share it
+// across every test below.
+const vercel = createVercelCommand();
+
+const argv = (subcommand: string, appName: string) => [
+  subcommand,
+  appName,
+  "--wasp-exe",
+  waspExePath,
+  "--wasp-project-dir",
+  waspProjectDir,
+  "--vercel-exe",
+  stubVercelCliPath,
+];
+
+describe("CLI arg wiring into the provider's action handler (task-17)", () => {
+  beforeEach(() => {
+    setupSpy.mockClear();
+    deploySpy.mockClear();
+  });
+
+  test("setup subcommand: --wasp-exe/--wasp-project-dir/--vercel-exe reach setup()", async () => {
+    await vercel.parseAsync(argv("setup", "wiring-app"), { from: "user" });
+
+    expect(setupSpy).toHaveBeenCalledTimes(1);
+    expect(deploySpy).not.toHaveBeenCalled();
+
+    const [appNameArg, optionsArg] = setupSpy.mock.calls[0];
+    expect(appNameArg).toBe("wiring-app");
+    expect(optionsArg).toMatchObject({
+      waspExe: waspExePath,
+      waspProjectDir,
+      vercelExe: stubVercelCliPath,
+    });
+  });
+
+  test("deploy subcommand: --wasp-exe/--wasp-project-dir/--vercel-exe reach deploy()", async () => {
+    await vercel.parseAsync(argv("deploy", "wiring-app"), { from: "user" });
+
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+    expect(setupSpy).not.toHaveBeenCalled();
+
+    const [appNameArg, optionsArg] = deploySpy.mock.calls[0];
+    expect(appNameArg).toBe("wiring-app");
+    expect(optionsArg).toMatchObject({
+      waspExe: waspExePath,
+      waspProjectDir,
+      vercelExe: stubVercelCliPath,
+    });
+  });
+
+  test("launch subcommand: same values reach both setup() and deploy() (launch = setup then deploy)", async () => {
+    await vercel.parseAsync(argv("launch", "wiring-app"), { from: "user" });
+
+    expect(setupSpy).toHaveBeenCalledTimes(1);
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+
+    for (const spy of [setupSpy, deploySpy]) {
+      const [appNameArg, optionsArg] = spy.mock.calls[0];
+      expect(appNameArg).toBe("wiring-app");
+      expect(optionsArg).toMatchObject({
+        waspExe: waspExePath,
+        waspProjectDir,
+        vercelExe: stubVercelCliPath,
+      });
+    }
+  });
+
+  test("a different app name and CLI paths are threaded through verbatim (not hardcoded)", async () => {
+    const otherWaspExe = path.join(fixturesDir, "some-other-wasp-exe");
+    await vercel.parseAsync(
+      [
+        "deploy",
+        "another-app",
+        "--wasp-exe",
+        otherWaspExe,
+        "--wasp-project-dir",
+        waspProjectDir,
+        "--vercel-exe",
+        stubVercelCliPath,
+      ],
+      { from: "user" },
+    );
+
+    const [appNameArg, optionsArg] = deploySpy.mock.calls[0];
+    expect(appNameArg).toBe("another-app");
+    expect(optionsArg).toMatchObject({ waspExe: otherWaspExe });
+  });
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/deploy.test.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/deploy.test.ts
@@ -1,0 +1,544 @@
+import fs from "fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+  WaspCliExe,
+  WaspProjectDir,
+} from "../../../src/common/brandedTypes.js";
+import {
+  getClientBuildArtefactsDir,
+  getClientSpaFallbackFileName,
+  getServerBuildArtefactsDir,
+} from "../../../src/common/waspProject.js";
+import {
+  createServerDeployStagingDir,
+  DeployBoundary,
+  makeClientVercelJsonContents,
+  makeServerVercelJsonContents,
+  patchPrismaSchemaForVercel,
+  runDeploy,
+  SERVER_BUILD_COMMAND,
+  SERVER_ENTRYPOINT_SHIM,
+  VercelDeployCmdOptions,
+} from "../../../src/providers/vercel/deploy.js";
+import { VercelCli } from "../../../src/providers/vercel/VercelCli.js";
+
+const SPA_FALLBACK_0_22 = ["index", "html"].join("."); // avoid the literal in src greps
+const SPA_FALLBACK_MAIN = ["200", "html"].join(".");
+
+// A pristine Wasp-0.22-style generated schema: no binaryTargets, no directUrl.
+const PRISTINE_SCHEMA = `datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Note {
+  id   Int    @id @default(autoincrement())
+  text String
+}
+`;
+
+// A generated schema that already carries (Docker-oriented) binaryTargets.
+const SCHEMA_WITH_OTHER_TARGETS = `datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "linux-musl"]
+}
+`;
+
+const PRISTINE_PACKAGE_JSON = JSON.stringify({
+  name: "testapp",
+  type: "module",
+  workspaces: [".wasp/out/*", ".wasp/out/sdk/wasp"],
+});
+
+describe("server entrypoint shim", () => {
+  test("is the fixed 2-line template: express marker + bundled server import", () => {
+    const lines = SERVER_ENTRYPOINT_SHIM.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    // Inert marker so Vercel's content-based Express detection engages.
+    expect(lines[0]).toContain("import express from 'express'");
+    // Loads the rollup-bundled, unmodified Wasp server from the mirrored
+    // Docker layout (build output nested under .wasp/out/).
+    expect(lines[1]).toBe("import './.wasp/out/server/bundle/server.js'");
+  });
+
+  test("never inspects user code (contains no placeholders)", () => {
+    expect(SERVER_ENTRYPOINT_SHIM).not.toMatch(/[{}<>]|\$\{/);
+  });
+});
+
+describe("server vercel.json generation", () => {
+  const parsed = JSON.parse(makeServerVercelJsonContents()) as Record<
+    string,
+    string
+  >;
+
+  test("declares the express framework and plain npm install", () => {
+    expect(parsed.framework).toBe("express");
+    expect(parsed.installCommand).toBe("npm install");
+  });
+
+  test("buildCommand chains prisma generate -> migrate deploy on DIRECT_URL -> rollup", () => {
+    expect(parsed.buildCommand).toBe(SERVER_BUILD_COMMAND);
+    const generateIdx = parsed.buildCommand.indexOf("npx prisma generate");
+    const migrateIdx = parsed.buildCommand.indexOf(
+      "DATABASE_URL=$DIRECT_URL npx prisma migrate deploy",
+    );
+    const rollupIdx = parsed.buildCommand.indexOf(
+      "npx rollup --config --silent",
+    );
+    expect(generateIdx).toBeGreaterThanOrEqual(0);
+    expect(migrateIdx).toBeGreaterThan(generateIdx);
+    expect(rollupIdx).toBeGreaterThan(migrateIdx);
+  });
+
+  test("buildCommand runs inside the nested build-output dir of the mirrored layout", () => {
+    expect(parsed.buildCommand.startsWith("cd .wasp/out && ")).toBe(true);
+  });
+
+  test("build steps address the generated schema explicitly", () => {
+    const schemaFlags = parsed.buildCommand.match(
+      /--schema=db\/schema\.prisma/g,
+    );
+    expect(schemaFlags).toHaveLength(2);
+  });
+
+  test("skips tsc --build (broken references under the flattened deploy root)", () => {
+    expect(parsed.buildCommand).not.toContain("tsc");
+    expect(parsed.buildCommand).not.toContain("npm run bundle");
+  });
+});
+
+describe("client SPA-rewrite vercel.json generation", () => {
+  test("rewrites every route to the given SPA fallback file", () => {
+    const parsed = JSON.parse(makeClientVercelJsonContents(SPA_FALLBACK_0_22));
+    expect(parsed).toEqual({
+      rewrites: [
+        { source: "/(.*)", destination: `/${SPA_FALLBACK_0_22}` },
+      ],
+    });
+  });
+
+  test("uses whatever fallback filename it is given (no hardcoding)", () => {
+    const parsed = JSON.parse(makeClientVercelJsonContents(SPA_FALLBACK_MAIN));
+    expect(parsed.rewrites[0].destination).toBe(`/${SPA_FALLBACK_MAIN}`);
+  });
+});
+
+describe("patchPrismaSchemaForVercel", () => {
+  test("adds Vercel-compatible binaryTargets to the generator client block", () => {
+    const patched = patchPrismaSchemaForVercel(PRISTINE_SCHEMA);
+    const generatorBlock = patched.match(/generator\s+client\s*\{[^}]*\}/)![0];
+    expect(generatorBlock).toContain(
+      'binaryTargets = ["native", "rhel-openssl-3.0.x", "debian-openssl-3.0.x"]',
+    );
+  });
+
+  test("replaces pre-existing binaryTargets instead of duplicating them", () => {
+    const patched = patchPrismaSchemaForVercel(SCHEMA_WITH_OTHER_TARGETS);
+    expect(patched).not.toContain("linux-musl");
+    expect(patched.match(/binaryTargets/g)).toHaveLength(1);
+  });
+
+  test("adds directUrl = env(\"DIRECT_URL\") to the datasource block", () => {
+    const patched = patchPrismaSchemaForVercel(PRISTINE_SCHEMA);
+    const datasourceBlock = patched.match(/datasource\s+\w+\s*\{[^}]*\}/)![0];
+    expect(datasourceBlock).toContain('directUrl = env("DIRECT_URL")');
+    // The pooled runtime URL stays untouched.
+    expect(datasourceBlock).toContain('url      = env("DATABASE_URL")');
+  });
+
+  test("is idempotent (safe to run on an already patched schema)", () => {
+    const once = patchPrismaSchemaForVercel(PRISTINE_SCHEMA);
+    const twice = patchPrismaSchemaForVercel(once);
+    expect(twice).toBe(once);
+  });
+
+  test("leaves user models untouched", () => {
+    const patched = patchPrismaSchemaForVercel(PRISTINE_SCHEMA);
+    expect(patched).toContain("model Note {");
+  });
+
+  test("throws a clear error when the schema has no generator client block", () => {
+    expect(() => patchPrismaSchemaForVercel("datasource db {\n}\n")).toThrow(
+      /generator/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filesystem-level tests (temp dirs standing in for a `wasp build` output).
+// ---------------------------------------------------------------------------
+
+let tempWaspProjectDir: WaspProjectDir;
+
+// Mirrors the Wasp 0.22 build output layout that the generated Dockerfile
+// consumes: user code copy in src/, root package.json + tsconfig.json, and
+// the framework dirs (server/, sdk/, libs/, db/).
+function makeFakeWaspBuildOutput(): string {
+  const outDir = getServerBuildArtefactsDir(tempWaspProjectDir);
+  fs.mkdirSync(path.join(outDir, "db"), { recursive: true });
+  fs.writeFileSync(path.join(outDir, "db", "schema.prisma"), PRISTINE_SCHEMA);
+  fs.writeFileSync(path.join(outDir, "package.json"), PRISTINE_PACKAGE_JSON);
+  fs.writeFileSync(path.join(outDir, "package-lock.json"), "{}");
+  fs.writeFileSync(path.join(outDir, "tsconfig.json"), "{}");
+  fs.mkdirSync(path.join(outDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(outDir, "src", "apis.ts"), "export const x = 1;");
+  fs.mkdirSync(path.join(outDir, "server", "node_modules", "junk"), {
+    recursive: true,
+  });
+  fs.writeFileSync(path.join(outDir, "server", "package.json"), "{}");
+  fs.mkdirSync(path.join(outDir, "sdk", "wasp"), { recursive: true });
+  fs.writeFileSync(path.join(outDir, "sdk", "wasp", "package.json"), "{}");
+  fs.mkdirSync(path.join(outDir, "libs"), { recursive: true });
+  fs.writeFileSync(path.join(outDir, "libs", "some-lib.tgz"), "");
+  return outDir;
+}
+
+function makeFakeClientBuildOutput(spaFallbackFileName: string): string {
+  const buildDir = getClientBuildArtefactsDir(tempWaspProjectDir);
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(buildDir, spaFallbackFileName),
+    '<html><div id="root"></div></html>',
+  );
+  return buildDir;
+}
+
+beforeEach(() => {
+  tempWaspProjectDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "wasp-vercel-deploy-test-"),
+  ) as WaspProjectDir;
+});
+
+afterEach(() => {
+  fs.rmSync(tempWaspProjectDir, { recursive: true, force: true });
+});
+
+describe("getClientSpaFallbackFileName", () => {
+  test("resolves the Wasp 0.22 fallback when only that file exists", () => {
+    makeFakeClientBuildOutput(SPA_FALLBACK_0_22);
+    expect(getClientSpaFallbackFileName(tempWaspProjectDir)).toBe(
+      SPA_FALLBACK_0_22,
+    );
+  });
+
+  test("resolves the Wasp main (0.25-dev) fallback when that file exists", () => {
+    makeFakeClientBuildOutput(SPA_FALLBACK_MAIN);
+    expect(getClientSpaFallbackFileName(tempWaspProjectDir)).toBe(
+      SPA_FALLBACK_MAIN,
+    );
+  });
+
+  test("prefers the dedicated SPA fallback file when both exist", () => {
+    makeFakeClientBuildOutput(SPA_FALLBACK_0_22);
+    makeFakeClientBuildOutput(SPA_FALLBACK_MAIN);
+    expect(getClientSpaFallbackFileName(tempWaspProjectDir)).toBe(
+      SPA_FALLBACK_MAIN,
+    );
+  });
+
+  test("throws when the client build produced no known fallback file", () => {
+    fs.mkdirSync(getClientBuildArtefactsDir(tempWaspProjectDir), {
+      recursive: true,
+    });
+    expect(() => getClientSpaFallbackFileName(tempWaspProjectDir)).toThrow();
+  });
+});
+
+describe("createServerDeployStagingDir", () => {
+  let stagingDir: string;
+
+  afterEach(() => {
+    if (stagingDir !== undefined) {
+      fs.rmSync(stagingDir, { recursive: true, force: true });
+    }
+  });
+
+  test("mirrors the Docker layout the generated relative imports expect", () => {
+    // Framework code in .wasp/out/server imports user code via relative
+    // paths that assume the project layout (src/ at the root, framework
+    // dirs nested under .wasp/out/) - same reason the generated Dockerfile
+    // mirrors this structure.
+    stagingDir = createServerDeployStagingDir(makeFakeWaspBuildOutput());
+
+    expect(fs.existsSync(path.join(stagingDir, "src", "apis.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(stagingDir, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(stagingDir, "package-lock.json"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(stagingDir, "tsconfig.json"))).toBe(true);
+    for (const dir of ["server", "sdk", "libs", "db"]) {
+      expect(
+        fs.existsSync(path.join(stagingDir, ".wasp", "out", dir)),
+      ).toBe(true);
+    }
+  });
+
+  test("keeps the generated package.json (workspaces globs) verbatim", () => {
+    stagingDir = createServerDeployStagingDir(makeFakeWaspBuildOutput());
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(stagingDir, "package.json"), "utf-8"),
+    );
+    // The generated globs are relative to the mirrored layout root, exactly
+    // like in the Docker image - no rewrite needed or wanted.
+    expect(packageJson.workspaces).toEqual([
+      ".wasp/out/*",
+      ".wasp/out/sdk/wasp",
+    ]);
+  });
+
+  test("writes the entrypoint shim and vercel.json at the staging root", () => {
+    stagingDir = createServerDeployStagingDir(makeFakeWaspBuildOutput());
+    expect(fs.readFileSync(path.join(stagingDir, "server.js"), "utf-8")).toBe(
+      SERVER_ENTRYPOINT_SHIM,
+    );
+    expect(
+      fs.readFileSync(path.join(stagingDir, "vercel.json"), "utf-8"),
+    ).toBe(makeServerVercelJsonContents());
+  });
+
+  test("patches the staged Prisma schema (binaryTargets + directUrl)", () => {
+    stagingDir = createServerDeployStagingDir(makeFakeWaspBuildOutput());
+    const schema = fs.readFileSync(
+      path.join(stagingDir, ".wasp", "out", "db", "schema.prisma"),
+      "utf-8",
+    );
+    expect(schema).toContain("rhel-openssl-3.0.x");
+    expect(schema).toContain('directUrl = env("DIRECT_URL")');
+  });
+
+  test("leaves the original build output untouched", () => {
+    const outDir = makeFakeWaspBuildOutput();
+    stagingDir = createServerDeployStagingDir(outDir);
+    expect(
+      fs.readFileSync(path.join(outDir, "db", "schema.prisma"), "utf-8"),
+    ).toBe(PRISTINE_SCHEMA);
+    expect(fs.existsSync(path.join(outDir, "server.js"))).toBe(false);
+    expect(fs.existsSync(path.join(outDir, "vercel.json"))).toBe(false);
+  });
+
+  test("does not copy node_modules into the staging dir", () => {
+    stagingDir = createServerDeployStagingDir(makeFakeWaspBuildOutput());
+    expect(
+      fs.existsSync(
+        path.join(stagingDir, ".wasp", "out", "server", "node_modules"),
+      ),
+    ).toBe(false);
+  });
+
+  test("throws a clear error when the build output looks incomplete", () => {
+    const outDir = makeFakeWaspBuildOutput();
+    fs.rmSync(path.join(outDir, "server"), { recursive: true });
+    expect(() => createServerDeployStagingDir(outDir)).toThrow(/server/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orchestration tests: runDeploy against an in-memory VercelCli fake and a
+// fake wasp-build/client-build boundary (no processes are ever spawned).
+// ---------------------------------------------------------------------------
+
+class FakeVercelCli implements VercelCli {
+  existingProjects = new Set<string>();
+  events: string[] = [];
+  linkedDirs = new Map<string, string>(); // dir -> project name
+  deployedDirs: string[] = [];
+  // Filenames present in each deployed dir, snapshotted at deploy time (the
+  // server staging dir is ephemeral - it is cleaned up right after deploy).
+  deployedDirFiles = new Map<string, string[]>(); // project name -> files
+
+  async doesProjectExist(projectName: string): Promise<boolean> {
+    return this.existingProjects.has(projectName);
+  }
+
+  async linkProjectToDir(projectName: string, dir: string): Promise<void> {
+    this.linkedDirs.set(path.normalize(dir), projectName);
+    this.events.push(`link:${projectName}`);
+  }
+
+  async deployToProd(linkedProjectDir: string): Promise<string> {
+    const projectName = this.linkedDirs.get(path.normalize(linkedProjectDir));
+    if (projectName === undefined) {
+      throw new Error(`deploy from unlinked dir: ${linkedProjectDir}`);
+    }
+    this.deployedDirs.push(path.normalize(linkedProjectDir));
+    this.deployedDirFiles.set(projectName, fs.readdirSync(linkedProjectDir));
+    this.events.push(`deploy:${projectName}`);
+    return `https://${projectName}-deadbeef.vercel.app`;
+  }
+
+  async createProject(): Promise<void> {
+    throw new Error("deploy must never create projects (setup's job)");
+  }
+  async setEnvVar(): Promise<void> {
+    throw new Error("deploy must never set env vars (setup's job)");
+  }
+  async pullEnvVars(): Promise<Record<string, string>> {
+    throw new Error("deploy must never pull env vars");
+  }
+  async isIntegrationInstalled(): Promise<boolean> {
+    throw new Error("deploy must never touch integrations");
+  }
+  async addIntegrationResource(): Promise<{ success: boolean; output: string }> {
+    throw new Error("deploy must never touch integrations");
+  }
+  async connectIntegrationResource(): Promise<{
+    success: boolean;
+    output: string;
+  }> {
+    throw new Error("deploy must never touch integrations");
+  }
+}
+
+interface FakeBoundary {
+  boundary: DeployBoundary;
+  waspBuilds: number;
+  clientBuildServerUrls: string[];
+}
+
+function makeFakeBoundary(
+  spaFallbackFileName: string = SPA_FALLBACK_0_22,
+): FakeBoundary {
+  const fake: FakeBoundary = {
+    waspBuilds: 0,
+    clientBuildServerUrls: [],
+    boundary: {
+      ensureWaspProjectIsBuilt: async () => {
+        fake.waspBuilds += 1;
+        makeFakeWaspBuildOutput();
+      },
+      buildClient: async (serverUrl: string) => {
+        fake.clientBuildServerUrls.push(serverUrl);
+        return makeFakeClientBuildOutput(spaFallbackFileName);
+      },
+    },
+  };
+  return fake;
+}
+
+function makeOptions(): VercelDeployCmdOptions {
+  return {
+    waspExe: "wasp" as WaspCliExe,
+    waspProjectDir: tempWaspProjectDir,
+    vercelExe: "vercel",
+  };
+}
+
+describe("runDeploy", () => {
+  let cli: FakeVercelCli;
+
+  beforeEach(() => {
+    cli = new FakeVercelCli();
+    cli.existingProjects.add("my-app-server");
+    cli.existingProjects.add("my-app-client");
+  });
+
+  test("builds once, then links and deploys server before client", async () => {
+    const fake = makeFakeBoundary();
+    await runDeploy(cli, "my-app", makeOptions(), fake.boundary);
+
+    expect(fake.waspBuilds).toBe(1);
+    expect(cli.events).toEqual([
+      "link:my-app-server",
+      "deploy:my-app-server",
+      "link:my-app-client",
+      "deploy:my-app-client",
+    ]);
+  });
+
+  test("deploys the server from a staged dir carrying the shim, config and mirrored layout", async () => {
+    const fake = makeFakeBoundary();
+    await runDeploy(cli, "my-app", makeOptions(), fake.boundary);
+
+    const deployedServerFiles = cli.deployedDirFiles.get("my-app-server");
+    expect(deployedServerFiles).toContain("server.js");
+    expect(deployedServerFiles).toContain("vercel.json");
+    expect(deployedServerFiles).toContain("package.json");
+    expect(deployedServerFiles).toContain("src");
+    expect(deployedServerFiles).toContain(".wasp");
+  });
+
+  test("cleans the ephemeral server staging dir up after deploying", async () => {
+    const fake = makeFakeBoundary();
+    await runDeploy(cli, "my-app", makeOptions(), fake.boundary);
+    expect(fs.existsSync(cli.deployedDirs[0])).toBe(false);
+  });
+
+  test("builds the client with the predicted server URL, not a placeholder", async () => {
+    const fake = makeFakeBoundary();
+    await runDeploy(cli, "my-app", makeOptions(), fake.boundary);
+    expect(fake.clientBuildServerUrls).toEqual([
+      "https://my-app-server.vercel.app",
+    ]);
+  });
+
+  test("writes the SPA-rewrite vercel.json into the client build dir (resolved fallback)", async () => {
+    const fake = makeFakeBoundary(SPA_FALLBACK_0_22);
+    await runDeploy(cli, "my-app", makeOptions(), fake.boundary);
+
+    const buildDir = getClientBuildArtefactsDir(tempWaspProjectDir);
+    const vercelJson = JSON.parse(
+      fs.readFileSync(path.join(buildDir, "vercel.json"), "utf-8"),
+    );
+    expect(vercelJson.rewrites).toEqual([
+      { source: "/(.*)", destination: `/${SPA_FALLBACK_0_22}` },
+    ]);
+    expect(cli.deployedDirs[1]).toBe(path.normalize(buildDir));
+  });
+
+  test("resolves the SPA fallback per build output (wasp main emits a different file)", async () => {
+    const fake = makeFakeBoundary(SPA_FALLBACK_MAIN);
+    await runDeploy(cli, "my-app", makeOptions(), fake.boundary);
+
+    const vercelJson = JSON.parse(
+      fs.readFileSync(
+        path.join(getClientBuildArtefactsDir(tempWaspProjectDir), "vercel.json"),
+        "utf-8",
+      ),
+    );
+    expect(vercelJson.rewrites[0].destination).toBe(`/${SPA_FALLBACK_MAIN}`);
+  });
+
+  test("fails fast (before building) when the projects were never set up", async () => {
+    const emptyCli = new FakeVercelCli();
+    const fake = makeFakeBoundary();
+    await expect(
+      runDeploy(emptyCli, "my-app", makeOptions(), fake.boundary),
+    ).rejects.toThrow(/setup/);
+    expect(fake.waspBuilds).toBe(0);
+    expect(emptyCli.events).toEqual([]);
+  });
+
+  test("rejects an invalid app name before doing anything", async () => {
+    const fake = makeFakeBoundary();
+    await expect(
+      runDeploy(cli, "My Bad App", makeOptions(), fake.boundary),
+    ).rejects.toThrow();
+    expect(fake.waspBuilds).toBe(0);
+  });
+
+  test("re-running deploy against already-deployed projects deploys again (idempotent, no setup)", async () => {
+    const fake = makeFakeBoundary();
+    await runDeploy(cli, "my-app", makeOptions(), fake.boundary);
+    await runDeploy(cli, "my-app", makeOptions(), fake.boundary);
+    expect(
+      cli.events.filter((e) => e === "deploy:my-app-server"),
+    ).toHaveLength(2);
+    expect(
+      cli.events.filter((e) => e === "deploy:my-app-client"),
+    ).toHaveLength(2);
+  });
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithAuth/main.wasp
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithAuth/main.wasp
@@ -1,0 +1,18 @@
+app AppWithAuth {
+  wasp: {
+    version: "^0.22.0"
+  },
+  title: "App With Auth",
+  auth: {
+    userEntity: User,
+    methods: {
+      usernameAndPassword: {}
+    },
+    onAuthFailedRedirectTo: "/login"
+  }
+}
+
+route HomeRoute { path: "/", to: HomePage }
+page HomePage {
+  component: import { HomePage } from "@src/pages/HomePage"
+}

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithAuthTs/main.wasp.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithAuthTs/main.wasp.ts
@@ -1,0 +1,16 @@
+import { app, auth, page, route } from "@wasp.sh/spec";
+
+import { LoginPage } from "./src/pages/LoginPage";
+
+export default app({
+  name: "AppWithAuthTs",
+  wasp: { version: "0.25.0" },
+  spec: [
+    auth({
+      userEntity: "User",
+      methods: { usernameAndPassword: {} },
+      onAuthFailedRedirectTo: "/login",
+    }),
+    route("LoginRoute", "/login", page(LoginPage)),
+  ],
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithJob/main.wasp.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithJob/main.wasp.ts
@@ -1,0 +1,14 @@
+import { app, job } from "@wasp.sh/spec";
+
+import { sendEmailJob } from "./src/jobs";
+
+export default app({
+  name: "AppWithJob",
+  wasp: { version: "0.25.0" },
+  spec: [
+    job(sendEmailJob, {
+      executor: "PgBoss",
+      schedule: { cron: "0 * * * *" },
+    }),
+  ],
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithJobsAcrossFiles/main.wasp.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithJobsAcrossFiles/main.wasp.ts
@@ -1,0 +1,9 @@
+import { app } from "@wasp.sh/spec";
+
+import { jobsSpec } from "./src/features/jobs/jobs.wasp";
+
+export default app({
+  name: "AppWithJobsAcrossFiles",
+  wasp: { version: "0.25.0" },
+  spec: [...jobsSpec],
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithJobsAcrossFiles/src/features/jobs/jobs.wasp.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithJobsAcrossFiles/src/features/jobs/jobs.wasp.ts
@@ -1,0 +1,15 @@
+import { job } from "@wasp.sh/spec";
+
+import { mySpecialJob, uppercaseTextJob } from "./bar";
+
+export const jobsSpec = [
+  job(uppercaseTextJob, {
+    executor: "PgBoss",
+    entities: ["UppercaseTextRequest"],
+  }),
+  job(mySpecialJob, {
+    executor: "PgBoss",
+    performExecutorOptions: { pgBoss: { retryLimit: 1 } },
+    entities: ["Task"],
+  }),
+];

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithNeither/main.wasp.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithNeither/main.wasp.ts
@@ -1,0 +1,9 @@
+import { app, page, route } from "@wasp.sh/spec";
+
+import { HomePage } from "./src/pages/HomePage";
+
+export default app({
+  name: "AppWithNeither",
+  wasp: { version: "0.25.0" },
+  spec: [route("HomeRoute", "/", page(HomePage))],
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithWebSocket/main.wasp.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/appWithWebSocket/main.wasp.ts
@@ -1,0 +1,12 @@
+import { app } from "@wasp.sh/spec";
+
+import { votingWebSocket } from "./src/ws-server";
+
+export default app({
+  name: "AppWithWebSocket",
+  wasp: { version: "0.25.0" },
+  webSocket: {
+    fn: votingWebSocket,
+  },
+  spec: [],
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/stubFailingWaspCli.sh
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/stubFailingWaspCli.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Stand-in for the real `wasp` CLI used only in tests: any invocation
+# (notably `wasp build`) fails fast, so tests can prove that behavior
+# upstream of the build (e.g. warn-not-block preflight) ran, without ever
+# running a real Wasp build.
+echo "stub wasp CLI: always fails" >&2
+exit 1

--- a/waspc/data/packages/deploy/test/providers/vercel/fixtures/stubVercelCli.sh
+++ b/waspc/data/packages/deploy/test/providers/vercel/fixtures/stubVercelCli.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Stand-in for the real `vercel` CLI used only in tests: any invocation
+# (--version, whoami, etc.) succeeds immediately so tests can exercise the
+# command wiring without a real Vercel CLI/account.
+exit 0

--- a/waspc/data/packages/deploy/test/providers/vercel/index.test.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/index.test.ts
@@ -1,0 +1,183 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createVercelCommand } from "../../../src/providers/vercel/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, "fixtures");
+const stubVercelCliPath = path.join(fixturesDir, "stubVercelCli.sh");
+const stubFailingWaspCliPath = path.join(fixturesDir, "stubFailingWaspCli.sh");
+
+// createVercelCommand() mutates module-level singleton subcommands
+// (vercelSetupCommand/vercelDeployCommand/vercelLaunchCommand from
+// task-13), so it can only safely be called once per process - build it a
+// single time here and share it across every describe block below.
+const vercel = createVercelCommand();
+
+describe("createVercelCommand", () => {
+  test("returns a command named 'vercel'", () => {
+    expect(vercel).toBeInstanceOf(Command);
+    expect(vercel.name()).toBe("vercel");
+  });
+
+  test("registers setup, deploy and launch subcommands", () => {
+    const subcommandNames = vercel.commands.map((cmd) => cmd.name());
+    expect(subcommandNames).toEqual(
+      expect.arrayContaining(["setup", "deploy", "launch"]),
+    );
+  });
+
+  describe.each(["setup", "deploy", "launch"])("%s subcommand", (name) => {
+    const subcommand = vercel.commands.find((cmd) => cmd.name() === name);
+
+    test("exists", () => {
+      expect(subcommand).toBeDefined();
+    });
+
+    test("accepts hidden --wasp-exe option", () => {
+      const option = subcommand?.options.find(
+        (opt) => opt.long === "--wasp-exe",
+      );
+      expect(option).toBeDefined();
+      expect(option?.hidden).toBe(true);
+    });
+
+    test("accepts hidden --wasp-project-dir option", () => {
+      const option = subcommand?.options.find(
+        (opt) => opt.long === "--wasp-project-dir",
+      );
+      expect(option).toBeDefined();
+      expect(option?.hidden).toBe(true);
+    });
+
+    test("accepts --vercel-exe option defaulting to 'vercel'", () => {
+      const option = subcommand?.options.find(
+        (opt) => opt.long === "--vercel-exe",
+      );
+      expect(option).toBeDefined();
+      expect(option?.defaultValue).toBe("vercel");
+    });
+
+    test("accepts --token and --scope auth options", () => {
+      const longFlags = subcommand?.options.map((opt) => opt.long);
+      expect(longFlags).toContain("--token");
+      expect(longFlags).toContain("--scope");
+    });
+  });
+
+  describe.each(["setup", "launch"])(
+    "%s subcommand database options",
+    (name) => {
+      const subcommand = vercel.commands.find((cmd) => cmd.name() === name);
+
+      test("accepts --db defaulting to neon, plus the --database-url escape hatch", () => {
+        const longFlags = subcommand?.options.map((opt) => opt.long);
+        expect(longFlags).toContain("--db");
+        expect(longFlags).toContain("--database-url");
+        expect(longFlags).toContain("--direct-url");
+        const dbOption = subcommand?.options.find(
+          (opt) => opt.long === "--db",
+        );
+        expect(dbOption?.defaultValue).toBe("neon");
+      });
+    },
+  );
+});
+
+describe("preflight warnings wired into command run (task-16)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  // The deploy/launch subcommands' real actions (task-15) run here against
+  // stub CLIs: `wasp build` is a stub that always fails fast (deploy), and
+  // the neon integration check comes back empty (launch), so both commands
+  // reject after the preAction hooks ran. That rejection proves the
+  // preflight warning did NOT block the command: the hook ran, printed its
+  // warning, and let the real action run next - warn-not-block.
+  describe.each(["deploy", "launch"])("%s subcommand", (name) => {
+    test("prints the job preflight warning before the action's own failure", async () => {
+      await expect(
+        vercel.parseAsync(
+          [
+            name,
+            "my-app",
+            "--wasp-exe",
+            stubFailingWaspCliPath,
+            "--wasp-project-dir",
+            path.join(fixturesDir, "appWithJob"),
+            "--vercel-exe",
+            stubVercelCliPath,
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow();
+
+      const printed = warnSpy.mock.calls
+        .map((call) => call.join(" "))
+        .join("\n");
+      expect(printed).toContain("sendEmailJob");
+      expect(printed).toContain("Vercel Cron");
+    });
+
+    test("prints no preflight warning for a project with neither jobs nor webSockets", async () => {
+      await expect(
+        vercel.parseAsync(
+          [
+            name,
+            "my-app",
+            "--wasp-exe",
+            stubFailingWaspCliPath,
+            "--wasp-project-dir",
+            path.join(fixturesDir, "appWithNeither"),
+            "--vercel-exe",
+            stubVercelCliPath,
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // The setup subcommand has a real action (task-14). Run it against the
+  // stub Vercel CLI (every call exits 0) with the --database-url escape
+  // hatch: it must print the preflight warning and then complete without
+  // throwing - warn-not-block, end to end.
+  describe("setup subcommand (real action, task-14)", () => {
+    test("prints the job preflight warning and still completes", async () => {
+      await expect(
+        vercel.parseAsync(
+          [
+            "setup",
+            "my-app",
+            "--wasp-exe",
+            "wasp",
+            "--wasp-project-dir",
+            path.join(fixturesDir, "appWithJob"),
+            "--vercel-exe",
+            stubVercelCliPath,
+            "--database-url",
+            "postgresql://user:pass@db.example.com:5432/mydb",
+          ],
+          { from: "user" },
+        ),
+      ).resolves.toBeDefined();
+
+      const printed = warnSpy.mock.calls
+        .map((call) => call.join(" "))
+        .join("\n");
+      expect(printed).toContain("sendEmailJob");
+      expect(printed).toContain("Vercel Cron");
+    });
+  });
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/preflight.test.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/preflight.test.ts
@@ -1,0 +1,156 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { WaspProjectDir } from "../../../src/common/brandedTypes.js";
+import {
+  buildPreflightWarnings,
+  runVercelPreflightChecks,
+  scanWaspProjectForPreflightFindings,
+} from "../../../src/providers/vercel/preflight.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, "fixtures");
+
+function fixture(name: string): WaspProjectDir {
+  return path.join(fixturesDir, name) as WaspProjectDir;
+}
+
+describe("scanWaspProjectForPreflightFindings", () => {
+  test("detects a job declared directly in main.wasp.ts", () => {
+    const findings = scanWaspProjectForPreflightFindings(
+      fixture("appWithJob"),
+    );
+    expect(findings.jobNames).toEqual(["sendEmailJob"]);
+    expect(findings.hasWebSocket).toBe(false);
+  });
+
+  test("detects jobs declared in a file imported from main.wasp.ts", () => {
+    const findings = scanWaspProjectForPreflightFindings(
+      fixture("appWithJobsAcrossFiles"),
+    );
+    expect(findings.jobNames.sort()).toEqual(
+      ["mySpecialJob", "uppercaseTextJob"].sort(),
+    );
+    expect(findings.hasWebSocket).toBe(false);
+  });
+
+  test("detects webSocket usage in main.wasp.ts", () => {
+    const findings = scanWaspProjectForPreflightFindings(
+      fixture("appWithWebSocket"),
+    );
+    expect(findings.hasWebSocket).toBe(true);
+    expect(findings.jobNames).toEqual([]);
+  });
+
+  test("detects nothing for a project with neither jobs nor webSockets", () => {
+    const findings = scanWaspProjectForPreflightFindings(
+      fixture("appWithNeither"),
+    );
+    expect(findings.jobNames).toEqual([]);
+    expect(findings.hasWebSocket).toBe(false);
+  });
+
+  test("returns empty findings when no main.wasp/main.wasp.ts is present", () => {
+    const findings = scanWaspProjectForPreflightFindings(
+      fixture("doesNotExist"),
+    );
+    expect(findings.jobNames).toEqual([]);
+    expect(findings.hasWebSocket).toBe(false);
+  });
+});
+
+describe("buildPreflightWarnings", () => {
+  test("AC #1: names the specific job(s) and mentions Vercel Cron as mitigation", () => {
+    const warnings = buildPreflightWarnings({
+      jobNames: ["sendEmailJob", "cleanupJob"],
+      hasWebSocket: false,
+    });
+
+    expect(warnings).toHaveLength(1);
+    const [warning] = warnings;
+    expect(warning.message).toMatch(/WARN/);
+    expect(warning.message).toContain("sendEmailJob");
+    expect(warning.message).toContain("cleanupJob");
+    expect(warning.message).toContain("Vercel Cron");
+    expect(warning.message.toLowerCase()).toContain("scale-to-zero");
+  });
+
+  test("AC #2: names WebSockets and notes beta/instance-pinned/maxDuration caveats", () => {
+    const warnings = buildPreflightWarnings({
+      jobNames: [],
+      hasWebSocket: true,
+    });
+
+    expect(warnings).toHaveLength(1);
+    const [warning] = warnings;
+    expect(warning.message).toMatch(/WARN/);
+    expect(warning.message).toContain("WebSocket");
+    expect(warning.message.toLowerCase()).toContain("beta");
+    expect(warning.message.toLowerCase()).toContain("instance-pinned");
+    expect(warning.message.toLowerCase()).toContain("maxduration");
+  });
+
+  test("AC #3: no warnings when neither jobs nor webSockets are present", () => {
+    const warnings = buildPreflightWarnings({
+      jobNames: [],
+      hasWebSocket: false,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test("emits both warnings when both jobs and webSockets are present", () => {
+    const warnings = buildPreflightWarnings({
+      jobNames: ["sendEmailJob"],
+      hasWebSocket: true,
+    });
+    expect(warnings).toHaveLength(2);
+  });
+});
+
+describe("runVercelPreflightChecks", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("prints a job warning naming the job and mentioning Vercel Cron, and does not throw", () => {
+    expect(() =>
+      runVercelPreflightChecks(fixture("appWithJob")),
+    ).not.toThrow();
+
+    const printed = warnSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(printed).toContain("sendEmailJob");
+    expect(printed).toContain("Vercel Cron");
+  });
+
+  test("prints a webSocket warning and does not throw", () => {
+    expect(() =>
+      runVercelPreflightChecks(fixture("appWithWebSocket")),
+    ).not.toThrow();
+
+    const printed = warnSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(printed).toContain("WebSocket");
+  });
+
+  test("prints nothing and does not throw when neither is declared", () => {
+    expect(() =>
+      runVercelPreflightChecks(fixture("appWithNeither")),
+    ).not.toThrow();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("never throws even when the project dir/entry file is missing (warn-not-block)", () => {
+    expect(() =>
+      runVercelPreflightChecks(fixture("doesNotExist")),
+    ).not.toThrow();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/waspc/data/packages/deploy/test/providers/vercel/setup.test.ts
+++ b/waspc/data/packages/deploy/test/providers/vercel/setup.test.ts
@@ -1,0 +1,592 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  WaspCliExe,
+  WaspProjectDir,
+} from "../../../src/common/brandedTypes.js";
+import {
+  parseEnvFile,
+  VercelCli,
+} from "../../../src/providers/vercel/VercelCli.js";
+import {
+  appUsesAuth,
+  assertVercelAppNameIsValid,
+  getClientAppUrl,
+  getClientProjectName,
+  getServerAppUrl,
+  getServerProjectName,
+  parseServerSecrets,
+  runSetup,
+  VercelSetupCmdOptions,
+} from "../../../src/providers/vercel/setup.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, "fixtures");
+
+const appWithAuthDir = path.join(fixturesDir, "appWithAuth") as WaspProjectDir;
+const appWithAuthTsDir = path.join(
+  fixturesDir,
+  "appWithAuthTs",
+) as WaspProjectDir;
+const appWithNeitherDir = path.join(
+  fixturesDir,
+  "appWithNeither",
+) as WaspProjectDir;
+
+interface EnvVarRecord {
+  value: string;
+  environment: string;
+}
+
+/**
+ * In-memory fake of the VercelCli boundary (mirrors how the Railway tests
+ * exercise logic against fixture data instead of a live CLI). Records every
+ * mutating call so tests can assert on exactly what setup would run.
+ */
+class FakeVercelCli implements VercelCli {
+  existingProjects = new Set<string>();
+  createdProjects: string[] = [];
+  linkedDirs = new Map<string, string>(); // dir -> project name
+  envVars = new Map<string, Map<string, EnvVarRecord>>(); // project -> vars
+
+  neonInstalled = true;
+  addIntegrationResourceCalls: {
+    integrationSlug: string;
+    resourceName: string;
+    linkedProjectDir: string;
+  }[] = [];
+  connectIntegrationResourceCalls: {
+    resourceName: string;
+    projectName: string;
+    linkedProjectDir: string;
+  }[] = [];
+  addIntegrationResourceResult = { success: true, output: "" };
+  connectIntegrationResourceResult = { success: true, output: "" };
+  integrationInjectedEnvVars: Record<string, string> = {};
+  pullEnvVarsCalls: { linkedProjectDir: string; environment: string }[] = [];
+
+  async doesProjectExist(projectName: string): Promise<boolean> {
+    return this.existingProjects.has(projectName);
+  }
+
+  async createProject(projectName: string): Promise<void> {
+    this.createdProjects.push(projectName);
+    this.existingProjects.add(projectName);
+  }
+
+  async linkProjectToDir(projectName: string, dir: string): Promise<void> {
+    if (!this.existingProjects.has(projectName)) {
+      throw new Error(`Cannot link nonexistent project: ${projectName}`);
+    }
+    this.linkedDirs.set(dir, projectName);
+  }
+
+  async setEnvVar(
+    linkedProjectDir: string,
+    name: string,
+    value: string,
+    environment: string = "production",
+  ): Promise<void> {
+    const projectName = this.getLinkedProject(linkedProjectDir);
+    if (!this.envVars.has(projectName)) {
+      this.envVars.set(projectName, new Map());
+    }
+    this.envVars.get(projectName)!.set(name, { value, environment });
+  }
+
+  async pullEnvVars(
+    linkedProjectDir: string,
+    environment: string,
+  ): Promise<Record<string, string>> {
+    this.getLinkedProject(linkedProjectDir);
+    this.pullEnvVarsCalls.push({ linkedProjectDir, environment });
+    return { ...this.integrationInjectedEnvVars };
+  }
+
+  async listEnvVarNames(
+    linkedProjectDir: string,
+    _environment: string = "production",
+  ): Promise<string[]> {
+    return this.getEnvVarNames(this.getLinkedProject(linkedProjectDir));
+  }
+
+  async isIntegrationInstalled(_integrationSlug: string): Promise<boolean> {
+    return this.neonInstalled;
+  }
+
+  async addIntegrationResource(args: {
+    integrationSlug: string;
+    resourceName: string;
+    linkedProjectDir: string;
+  }): Promise<{ success: boolean; output: string }> {
+    this.getLinkedProject(args.linkedProjectDir);
+    this.addIntegrationResourceCalls.push(args);
+    return this.addIntegrationResourceResult;
+  }
+
+  async connectIntegrationResource(args: {
+    resourceName: string;
+    projectName: string;
+    linkedProjectDir: string;
+  }): Promise<{ success: boolean; output: string }> {
+    this.connectIntegrationResourceCalls.push(args);
+    return this.connectIntegrationResourceResult;
+  }
+
+  async deployToProd(_linkedProjectDir: string): Promise<string> {
+    throw new Error("setup must never deploy (deploy's job)");
+  }
+
+  getLinkedProject(dir: string): string {
+    const projectName = this.linkedDirs.get(dir);
+    if (projectName === undefined) {
+      throw new Error(`Directory is not linked to any project: ${dir}`);
+    }
+    return projectName;
+  }
+
+  getEnvVar(projectName: string, name: string): EnvVarRecord | undefined {
+    return this.envVars.get(projectName)?.get(name);
+  }
+
+  getEnvVarNames(projectName: string): string[] {
+    return Array.from(this.envVars.get(projectName)?.keys() ?? []);
+  }
+}
+
+function makeOptions(
+  overrides: Partial<VercelSetupCmdOptions> = {},
+): VercelSetupCmdOptions {
+  return {
+    waspExe: "wasp" as WaspCliExe,
+    waspProjectDir: appWithNeitherDir,
+    vercelExe: "vercel",
+    db: "neon",
+    serverSecret: [],
+    ...overrides,
+  };
+}
+
+const NEON_DATABASE_URL =
+  "postgresql://user:pass@ep-fake-pooler.eu-central-1.aws.neon.tech/neondb?sslmode=require";
+const NEON_DATABASE_URL_UNPOOLED =
+  "postgresql://user:pass@ep-fake.eu-central-1.aws.neon.tech/neondb?sslmode=require";
+const CUSTOM_DATABASE_URL = "postgresql://user:pass@db.example.com:5432/mydb";
+
+describe("project names and URLs", () => {
+  test("derives deterministic -server and -client project names", () => {
+    expect(getServerProjectName("my-app")).toBe("my-app-server");
+    expect(getClientProjectName("my-app")).toBe("my-app-client");
+  });
+
+  test("derives deterministic vercel.app URLs from the project names", () => {
+    expect(getServerAppUrl("my-app")).toBe("https://my-app-server.vercel.app");
+    expect(getClientAppUrl("my-app")).toBe("https://my-app-client.vercel.app");
+  });
+});
+
+describe("assertVercelAppNameIsValid", () => {
+  test("accepts lowercase names with digits, hyphens and dots", () => {
+    expect(() => assertVercelAppNameIsValid("my-app-2")).not.toThrow();
+    expect(() => assertVercelAppNameIsValid("app.v2")).not.toThrow();
+  });
+
+  test("rejects names with uppercase, spaces or a leading separator", () => {
+    expect(() => assertVercelAppNameIsValid("MyApp")).toThrow();
+    expect(() => assertVercelAppNameIsValid("my app")).toThrow();
+    expect(() => assertVercelAppNameIsValid("-my-app")).toThrow();
+    expect(() => assertVercelAppNameIsValid("")).toThrow();
+  });
+
+  test("rejects names too long to fit the -server/-client suffix", () => {
+    expect(() => assertVercelAppNameIsValid("a".repeat(91))).toThrow();
+    expect(() => assertVercelAppNameIsValid("a".repeat(90))).not.toThrow();
+  });
+});
+
+describe("parseServerSecrets", () => {
+  test("parses NAME=VALUE pairs", () => {
+    expect(parseServerSecrets(["FOO=bar", "BAZ_2=qux"])).toEqual([
+      { name: "FOO", value: "bar" },
+      { name: "BAZ_2", value: "qux" },
+    ]);
+  });
+
+  test("keeps '=' characters inside the value", () => {
+    expect(parseServerSecrets(["FOO=a=b=c"])).toEqual([
+      { name: "FOO", value: "a=b=c" },
+    ]);
+  });
+
+  test("rejects entries without '=' or with an invalid name", () => {
+    expect(() => parseServerSecrets(["FOO"])).toThrow();
+    expect(() => parseServerSecrets(["=bar"])).toThrow();
+    expect(() => parseServerSecrets(["1BAD=x"])).toThrow();
+    expect(() => parseServerSecrets(["BAD-NAME=x"])).toThrow();
+  });
+});
+
+describe("appUsesAuth", () => {
+  test("detects the auth block in a legacy main.wasp", () => {
+    expect(appUsesAuth(appWithAuthDir)).toBe(true);
+  });
+
+  test("detects auth(...) in a TS spec main.wasp.ts", () => {
+    expect(appUsesAuth(appWithAuthTsDir)).toBe(true);
+  });
+
+  test("returns false for an app without auth", () => {
+    expect(appUsesAuth(appWithNeitherDir)).toBe(false);
+  });
+
+  test("returns false when no Wasp entry file exists", () => {
+    expect(appUsesAuth(fixturesDir as WaspProjectDir)).toBe(false);
+  });
+});
+
+describe("parseEnvFile", () => {
+  test("parses the dotenv format `vercel env pull` writes", () => {
+    const contents = [
+      "# Created by Vercel CLI",
+      'DATABASE_URL="postgresql://u:p@ep-x-pooler.aws.neon.tech/db?sslmode=require"',
+      'DATABASE_URL_UNPOOLED="postgresql://u:p@ep-x.aws.neon.tech/db?sslmode=require"',
+      "PLAIN=unquoted-value",
+      "",
+      "not a valid line",
+    ].join("\n");
+    expect(parseEnvFile(contents)).toEqual({
+      DATABASE_URL:
+        "postgresql://u:p@ep-x-pooler.aws.neon.tech/db?sslmode=require",
+      DATABASE_URL_UNPOOLED:
+        "postgresql://u:p@ep-x.aws.neon.tech/db?sslmode=require",
+      PLAIN: "unquoted-value",
+    });
+  });
+});
+
+describe("runSetup with --database-url (escape hatch)", () => {
+  let cli: FakeVercelCli;
+
+  beforeEach(() => {
+    cli = new FakeVercelCli();
+  });
+
+  test("creates exactly the <app>-server and <app>-client projects", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+    );
+    expect(cli.createdProjects).toEqual(["my-app-server", "my-app-client"]);
+  });
+
+  test("skips creating projects that already exist (idempotent)", async () => {
+    cli.existingProjects.add("my-app-server");
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+    );
+    expect(cli.createdProjects).toEqual(["my-app-client"]);
+  });
+
+  test("sets DATABASE_URL verbatim and defaults DIRECT_URL to the same value", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+    );
+    expect(cli.getEnvVar("my-app-server", "DATABASE_URL")).toEqual({
+      value: CUSTOM_DATABASE_URL,
+      environment: "production",
+    });
+    expect(cli.getEnvVar("my-app-server", "DIRECT_URL")?.value).toBe(
+      CUSTOM_DATABASE_URL,
+    );
+  });
+
+  test("uses --direct-url for DIRECT_URL when provided", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({
+        databaseUrl: NEON_DATABASE_URL,
+        directUrl: NEON_DATABASE_URL_UNPOOLED,
+      }),
+    );
+    expect(cli.getEnvVar("my-app-server", "DIRECT_URL")?.value).toBe(
+      NEON_DATABASE_URL_UNPOOLED,
+    );
+  });
+
+  test("does not touch the Neon integration", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+    );
+    expect(cli.addIntegrationResourceCalls).toEqual([]);
+    expect(cli.connectIntegrationResourceCalls).toEqual([]);
+  });
+
+  test("sets WASP_SERVER_URL and WASP_WEB_CLIENT_URL on the server project", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+    );
+    expect(cli.getEnvVar("my-app-server", "WASP_SERVER_URL")?.value).toBe(
+      "https://my-app-server.vercel.app",
+    );
+    expect(cli.getEnvVar("my-app-server", "WASP_WEB_CLIENT_URL")?.value).toBe(
+      "https://my-app-client.vercel.app",
+    );
+  });
+
+  test("sets env vars on the server project only", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+    );
+    expect(cli.getEnvVarNames("my-app-client")).toEqual([]);
+  });
+
+  test("sets JWT_SECRET to a random hex string when the app uses auth", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({
+        databaseUrl: CUSTOM_DATABASE_URL,
+        waspProjectDir: appWithAuthDir,
+      }),
+    );
+    const jwtSecret = cli.getEnvVar("my-app-server", "JWT_SECRET");
+    expect(jwtSecret?.value).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("a setup re-run keeps the same JWT_SECRET (skip-if-exists)", async () => {
+    const options = makeOptions({
+      databaseUrl: CUSTOM_DATABASE_URL,
+      waspProjectDir: appWithAuthDir,
+    });
+    await runSetup(cli, "my-app", options);
+    const firstSecret = cli.getEnvVar("my-app-server", "JWT_SECRET")?.value;
+    await runSetup(cli, "my-app", options);
+    const secondSecret = cli.getEnvVar("my-app-server", "JWT_SECRET")?.value;
+    expect(firstSecret).toMatch(/^[0-9a-f]{64}$/);
+    // Mirrors Railway skip-if-exists: re-running setup must not mint a fresh
+    // JWT_SECRET (which would invalidate every previously issued session).
+    expect(secondSecret).toBe(firstSecret);
+  });
+
+  test("does not set JWT_SECRET when the app has no auth", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+    );
+    expect(cli.getEnvVar("my-app-server", "JWT_SECRET")).toBeUndefined();
+  });
+
+  test("passes --server-secret values through to the server project", async () => {
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({
+        databaseUrl: CUSTOM_DATABASE_URL,
+        serverSecret: ["FOO=bar", "STRIPE_KEY=sk_test_123"],
+      }),
+    );
+    expect(cli.getEnvVar("my-app-server", "FOO")?.value).toBe("bar");
+    expect(cli.getEnvVar("my-app-server", "STRIPE_KEY")?.value).toBe(
+      "sk_test_123",
+    );
+  });
+
+  test("rejects malformed --server-secret values before changing anything", async () => {
+    await expect(
+      runSetup(
+        cli,
+        "my-app",
+        makeOptions({
+          databaseUrl: CUSTOM_DATABASE_URL,
+          serverSecret: ["NO_EQUALS_SIGN"],
+        }),
+      ),
+    ).rejects.toThrow();
+    expect(cli.createdProjects).toEqual([]);
+  });
+
+  test("rejects an invalid app name before changing anything", async () => {
+    await expect(
+      runSetup(
+        cli,
+        "My Bad App",
+        makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+      ),
+    ).rejects.toThrow();
+    expect(cli.createdProjects).toEqual([]);
+  });
+});
+
+describe("runSetup with --db neon (default)", () => {
+  let cli: FakeVercelCli;
+
+  beforeEach(() => {
+    cli = new FakeVercelCli();
+    cli.integrationInjectedEnvVars = {
+      DATABASE_URL: NEON_DATABASE_URL,
+      DATABASE_URL_UNPOOLED: NEON_DATABASE_URL_UNPOOLED,
+    };
+  });
+
+  test("provisions a Neon resource named <app>-db connected to the server project", async () => {
+    await runSetup(cli, "my-app", makeOptions());
+    expect(cli.addIntegrationResourceCalls).toHaveLength(1);
+    const call = cli.addIntegrationResourceCalls[0];
+    expect(call.integrationSlug).toBe("neon");
+    expect(call.resourceName).toBe("my-app-db");
+    expect(cli.linkedDirs.get(call.linkedProjectDir)).toBe("my-app-server");
+  });
+
+  test("maps the injected DATABASE_URL_UNPOOLED to DIRECT_URL", async () => {
+    await runSetup(cli, "my-app", makeOptions());
+    expect(cli.getEnvVar("my-app-server", "DIRECT_URL")?.value).toBe(
+      NEON_DATABASE_URL_UNPOOLED,
+    );
+  });
+
+  test("stops with one-time consent instructions when Neon is not installed on the team", async () => {
+    cli.neonInstalled = false;
+    await expect(runSetup(cli, "my-app", makeOptions())).rejects.toThrow(
+      /accept-terms neon/,
+    );
+    // Nothing was created: re-running after the one-time consent resumes cleanly.
+    expect(cli.createdProjects).toEqual([]);
+    expect(cli.addIntegrationResourceCalls).toEqual([]);
+  });
+
+  test("falls back to connecting an existing resource when provisioning reports it exists", async () => {
+    cli.addIntegrationResourceResult = {
+      success: false,
+      output: "Error: resource with name my-app-db already exists",
+    };
+    await runSetup(cli, "my-app", makeOptions());
+    expect(cli.connectIntegrationResourceCalls).toHaveLength(1);
+    expect(cli.connectIntegrationResourceCalls[0]).toMatchObject({
+      resourceName: "my-app-db",
+      projectName: "my-app-server",
+    });
+  });
+
+  test("fails with escape-hatch instructions when provisioning and connecting both fail", async () => {
+    cli.addIntegrationResourceResult = {
+      success: false,
+      output: "Error: no billing plan selected",
+    };
+    cli.connectIntegrationResourceResult = {
+      success: false,
+      output: "Error: resource not found",
+    };
+    await expect(runSetup(cli, "my-app", makeOptions())).rejects.toThrow(
+      /--database-url/,
+    );
+  });
+
+  test("fails when the integration did not inject DATABASE_URL", async () => {
+    cli.integrationInjectedEnvVars = {};
+    await expect(runSetup(cli, "my-app", makeOptions())).rejects.toThrow(
+      /DATABASE_URL/,
+    );
+  });
+
+  test("rejects an unsupported --db value", async () => {
+    await expect(
+      runSetup(cli, "my-app", makeOptions({ db: "sqlite" })),
+    ).rejects.toThrow(/--db/);
+  });
+});
+
+describe("JWT_SECRET skip-if-exists (idempotent setup re-runs)", () => {
+  let cli: FakeVercelCli;
+
+  beforeEach(() => {
+    cli = new FakeVercelCli();
+  });
+
+  test("sets a JWT_SECRET when the server project does not have one yet", async () => {
+    const setEnvVarSpy = vi.spyOn(cli, "setEnvVar");
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({
+        databaseUrl: CUSTOM_DATABASE_URL,
+        waspProjectDir: appWithAuthDir,
+      }),
+    );
+    const jwtWrites = setEnvVarSpy.mock.calls.filter(
+      (call) => call[1] === "JWT_SECRET",
+    );
+    expect(jwtWrites).toHaveLength(1);
+    expect(cli.getEnvVar("my-app-server", "JWT_SECRET")?.value).toMatch(
+      /^[0-9a-f]{64}$/,
+    );
+  });
+
+  test("does NOT overwrite an already-set JWT_SECRET on a re-run", async () => {
+    // A prior setup already provisioned the server project and its JWT_SECRET.
+    cli.existingProjects.add("my-app-server");
+    cli.envVars.set(
+      "my-app-server",
+      new Map([
+        [
+          "JWT_SECRET",
+          { value: "pre-existing-secret", environment: "production" },
+        ],
+      ]),
+    );
+
+    const setEnvVarSpy = vi.spyOn(cli, "setEnvVar");
+    await runSetup(
+      cli,
+      "my-app",
+      makeOptions({
+        databaseUrl: CUSTOM_DATABASE_URL,
+        waspProjectDir: appWithAuthDir,
+      }),
+    );
+
+    // The value must survive untouched and setEnvVar must never be called for
+    // JWT_SECRET (regenerating it would invalidate all issued sessions).
+    expect(cli.getEnvVar("my-app-server", "JWT_SECRET")?.value).toBe(
+      "pre-existing-secret",
+    );
+    const jwtWrites = setEnvVarSpy.mock.calls.filter(
+      (call) => call[1] === "JWT_SECRET",
+    );
+    expect(jwtWrites).toEqual([]);
+  });
+});
+
+describe("runSetup output", () => {
+  test("announces setup and mentions both created projects", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      const cli = new FakeVercelCli();
+      await runSetup(
+        cli,
+        "my-app",
+        makeOptions({ databaseUrl: CUSTOM_DATABASE_URL }),
+      );
+      const printed = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(printed).toContain("my-app-server");
+      expect(printed).toContain("my-app-client");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/web/docs/deployment/deployment-methods/wasp-deploy/WaspDeployProvidersGrid.tsx
+++ b/web/docs/deployment/deployment-methods/wasp-deploy/WaspDeployProvidersGrid.tsx
@@ -9,6 +9,10 @@ const deploymentMethods = [
     title: "Railway",
     linkTo: "./railway",
   },
+  {
+    title: "Vercel",
+    linkTo: "./vercel",
+  },
 ];
 
 export function WaspDeployProvidersGrid() {

--- a/web/docs/deployment/deployment-methods/wasp-deploy/vercel.md
+++ b/web/docs/deployment/deployment-methods/wasp-deploy/vercel.md
@@ -1,0 +1,245 @@
+---
+title: Vercel
+title-llm: Automated Deployment to Vercel with Wasp CLI
+---
+
+import { Required } from '@site/src/components/Tag';
+import LaunchCommandEnvVars from './\_launch-command-env-vars.md'
+import CiCdMention from './\_ci-cd-mention.md'
+
+[Vercel](https://vercel.com/) is a cloud platform for building and deploying web apps, with zero-config support for a wide range of frameworks and managed integrations for databases and other services.
+
+## Prerequisites
+
+To deploy to Vercel using Wasp CLI:
+
+1. Create a [Vercel](https://vercel.com/) account.
+
+1. Install the [`vercel` CLI](https://vercel.com/docs/cli) on your machine and log in with `vercel login` (or pass an access token to each command with `--token`, see [Auth Options](#vercel-auth-options) below).
+
+## Deploying
+
+Using the Wasp CLI, you can easily deploy a new app to Vercel with a single command:
+
+```shell
+wasp deploy vercel launch my-wasp-app
+```
+
+<small>
+  Please do not CTRL-C or exit your terminal while the commands are running.
+</small>
+
+Keep in mind that:
+
+1. Your project name (for example `my-wasp-app`) must be unique across all your Vercel projects (within the team/scope you're deploying into) or deployment will fail.
+
+1. If you are a member of multiple Vercel teams, pass the team you want to deploy into with the `--scope` option (see [Auth Options](#vercel-auth-options)).
+
+The project name is used as a base for your server and client project names on Vercel:
+
+- `my-wasp-app-server`
+- `my-wasp-app-client`
+
+The server runs as a standard Vercel Express app on [Fluid compute](https://vercel.com/docs/fluid-compute) - there's no Docker image or extra configuration to write, `launch`/`deploy` build and upload everything for you. The client is deployed as a static single-page app, with a rewrite rule so client-side routing keeps working on refresh/deep-links.
+
+### Database: Neon by default {#database}
+
+Unless you tell it otherwise, `wasp deploy vercel setup` (and therefore `launch`) provisions a [Neon](https://neon.tech/) Postgres database for your server app via the [Vercel Marketplace](https://vercel.com/marketplace) and wires up `DATABASE_URL` (pooled) and `DIRECT_URL` (direct, used for Prisma migrations) automatically.
+
+The Neon integration has to be installed on your Vercel team once before the CLI can provision databases through it. If it isn't installed yet, the command will stop and tell you to either:
+
+- run `vercel integration accept-terms neon` in an interactive terminal, or
+- install it via the Vercel dashboard: your team -> **Storage** -> **Browse Marketplace** -> **Neon** -> **Install**.
+
+Then re-run the command - it resumes automatically once the integration is installed.
+
+#### Bringing your own database with `--database-url`
+
+If you already have a Postgres database (Neon or otherwise) and don't want Wasp to provision one for you, pass `--database-url` to skip Neon provisioning entirely:
+
+```shell
+wasp deploy vercel launch my-wasp-app --database-url "postgresql://user:pass@host/db"
+```
+
+This sets `DATABASE_URL` directly on the server project. If your database needs a separate non-pooled connection string for migrations, pass it with `--direct-url`; otherwise the `--database-url` value is reused for `DIRECT_URL` as well:
+
+```shell
+wasp deploy vercel launch my-wasp-app \
+  --database-url "postgresql://user:pass@host/db?pgbouncer=true" \
+  --direct-url "postgresql://user:pass@host/db"
+```
+
+<LaunchCommandEnvVars />
+
+If you have any additional environment variables that your app needs, read how to set them in the [API Reference](#vercel-launch-environment-variables) section.
+
+<CiCdMention />
+
+### Limitations: pg-boss jobs and WebSockets {#limitations}
+
+Vercel's server runtime is serverless (Fluid compute scales your server to zero when it's idle), which doesn't fit two kinds of Wasp features well:
+
+- **pg-boss jobs**: Wasp's [job](../../../advanced/jobs.md) executor (`pg-boss`) assumes a long-lived process to poll and run scheduled/recurring work. On a scale-to-zero platform, jobs can be delayed or missed entirely if there's no active invocation to run them.
+- **WebSockets**: Wasp's [WebSocket](../../../advanced/web-sockets.md) support needs a persistent connection to a single server instance. [WebSockets on Vercel](https://vercel.com/docs/functions/functions-api-reference#websockets) are currently in beta: connections are pinned to one function instance (so they don't survive a scale-to-zero or a redeploy) and are bound by the function's `maxDuration`.
+
+Because of this, `wasp deploy vercel setup`, `deploy`, and `launch` all run a best-effort **preflight check** before doing anything else: they scan your `main.wasp`/`main.wasp.ts` (and its local imports) for job and WebSocket usage and print a `WARN:` message to the terminal if it finds any. This is a **warn-not-block** check - it never fails the command or changes its exit code, it's purely informational.
+
+If you see one of these warnings:
+
+- For jobs, consider replacing `pg-boss` with [Vercel Cron](https://vercel.com/docs/cron-jobs) to trigger the same work on a schedule instead of relying on a long-lived worker.
+- For WebSockets, either accept the beta limitations above, or deploy the server on a provider with a long-lived process (for example [Railway](./railway.md) or [Fly.io](./fly.md)) if you need production-grade WebSocket support today.
+
+## API Reference
+
+### The `launch` command
+
+`launch` is a convenience command that runs `setup` and `deploy` in sequence.
+
+```shell
+wasp deploy vercel launch <project-name>
+```
+
+It accepts the following arguments:
+
+- `<project-name>` <Required />
+
+  The name of your project.
+
+Running `wasp deploy vercel launch` is the same as running the following commands:
+
+```shell
+wasp deploy vercel setup <project-name>
+wasp deploy vercel deploy <project-name>
+```
+
+It accepts the same options as `setup` (see below), since `launch` forwards them straight through.
+
+#### Environment Variables {#vercel-launch-environment-variables}
+
+##### Server
+
+If you are deploying an app that requires any other environment variables (like social auth secrets), you can set them with the `--server-secret` option:
+
+```shell
+wasp deploy vercel launch my-wasp-app --server-secret GOOGLE_CLIENT_ID=<...> --server-secret GOOGLE_CLIENT_SECRET=<...>
+```
+
+##### Client
+
+If you've added any [client-side environment variables](../../../project/env-vars.md#client-env-vars) to your app, pass them to the terminal session before running the `launch` command, for example:
+
+```shell
+REACT_APP_ANOTHER_VAR=somevalue wasp deploy vercel launch my-wasp-app
+```
+
+### The `setup` command
+
+The `setup` command creates your client and server projects on Vercel, provisions the database, and configures environment variables. It does _not_ deploy the client or server apps.
+
+```shell
+wasp deploy vercel setup <project-name>
+```
+
+It accepts the following arguments:
+
+- `<project-name>` <Required />
+
+  The name of your project.
+
+The project name is used as a base for your server and client project names on Vercel:
+
+- `<project-name>-server`
+- `<project-name>-client`
+
+By default `setup` provisions a Neon database via the Vercel Marketplace - see [Database: Neon by default](#database) above for the `--db`/`--database-url`/`--direct-url` options.
+
+#### Other options
+
+- `--server-secret <NAME=VALUE>` - additional server-side environment variable to set (repeatable). See [Environment Variables](#vercel-launch-environment-variables).
+- `--db <db>` - managed database to provision via the Vercel Marketplace. Only `neon` is supported (this is also the default), see [Database: Neon by default](#database).
+- `--database-url <url>` - skip database provisioning and use this connection string as `DATABASE_URL`, see [Bringing your own database](#database).
+- `--direct-url <url>` - non-pooled connection string for `DIRECT_URL`, only used together with `--database-url`. Defaults to the `--database-url` value if omitted.
+
+See also [Auth Options](#vercel-auth-options) below.
+
+:::caution Execute Only Once
+You should only run `setup` once per app. Wasp CLI skips creating the projects/database if they already exist.
+:::
+
+### The `deploy` command
+
+The `deploy` command builds your Wasp app and deploys the client and server to Vercel.
+
+```shell
+wasp deploy vercel deploy <project-name>
+```
+
+It accepts the following arguments:
+
+- `<project-name>` <Required />
+
+  The name of your project.
+
+Run this command whenever you want to **update your deployed app** with the latest changes:
+
+```shell
+wasp deploy vercel deploy <project-name>
+```
+
+If you run `deploy` before `setup` has created the projects, it fails and tells you to run `setup` (or `launch`) first.
+
+If you've added any [client-side environment variables](../../../project/env-vars.md#client-env-vars) to your app, pass them to the terminal session before running the `deploy` command, for example:
+
+```shell
+REACT_APP_ANOTHER_VAR=somevalue wasp deploy vercel deploy my-wasp-app
+```
+
+You must specify your client-side environment variables every time you redeploy with the above command [to ensure they are included in the build process](../../env-vars.md#client-env-vars).
+
+See also [Auth Options](#vercel-auth-options) below.
+
+### Auth Options {#vercel-auth-options}
+
+All three commands (`setup`, `deploy`, `launch`) accept the same authentication options:
+
+- `--token <token>` - a Vercel access token. Defaults to your logged-in `vercel` CLI session (`vercel login`) if omitted. Useful for CI/CD, see the [CI/CD Deployment](./ci-cd.md) page.
+- `--scope <scope>` - the Vercel team (slug or ID) to operate in, if your account belongs to more than one team.
+
+```shell
+wasp deploy vercel launch my-wasp-app --token <vercel-token> --scope my-team
+```
+
+### Environment Variables {#vercel-environment-variables}
+
+#### Server Secrets
+
+If your app requires any other server-side environment variables (like social auth secrets), you can set them:
+
+1. Initially in the `launch` or `setup` commands with the [`--server-secret` option](#vercel-launch-environment-variables)
+2. After the app has already been deployed, go into the Vercel dashboard and set them under your server project's **Settings** -> **Environment Variables** tab.
+
+#### Client Environment Variables
+
+If you've added any [client-side environment variables](../../../project/env-vars.md#client-env-vars) to your app, pass them to the terminal session before running a deployment command, for example:
+
+```shell
+REACT_APP_ANOTHER_VAR=somevalue wasp deploy vercel launch my-wasp-app
+```
+
+or
+
+```shell
+REACT_APP_ANOTHER_VAR=somevalue wasp deploy vercel deploy my-wasp-app
+```
+
+Please note that you should do this for **every deployment**, not just the first time you set up the variables. One way to make sure you don't forget to add them is to create a `deploy` script in your `package.json` file:
+
+```json title="package.json"
+{
+  "scripts": {
+    "deploy": "REACT_APP_ANOTHER_VAR=somevalue wasp deploy vercel deploy my-wasp-app"
+  }
+}
+```
+
+Then you can run `npm run deploy` to deploy your app.

--- a/web/sidebars.ts
+++ b/web/sidebars.ts
@@ -145,6 +145,7 @@ const sidebars: SidebarsConfig = {
                 "deployment/deployment-methods/wasp-deploy/overview",
                 "deployment/deployment-methods/wasp-deploy/fly",
                 "deployment/deployment-methods/wasp-deploy/railway",
+                "deployment/deployment-methods/wasp-deploy/vercel",
                 "deployment/deployment-methods/wasp-deploy/ci-cd",
               ],
             },


### PR DESCRIPTION
## What

Adds a `vercel` provider to `wasp deploy`, mirroring the existing `railway` provider surface:

- `wasp deploy vercel setup <app-name>` - creates the `<app>-server` and `<app>-client` Vercel projects, provisions a Neon Postgres database via the Vercel Marketplace by default (with a `--database-url` escape hatch to bring your own database), and wires the env vars (`DATABASE_URL`, `WASP_SERVER_URL`, `WASP_WEB_CLIENT_URL`).
- `wasp deploy vercel deploy` - builds and deploys the server to Vercel Fluid compute (zero-config Express detection, no Dockerfile needed) and the client as a static SPA with a rewrite fallback `vercel.json`.
- `wasp deploy vercel launch <app-name>` - setup followed by deploy, one command from a clean checkout to a live app.

Details:

- `JWT_SECRET` is auto-generated for auth-enabled apps, with skip-if-exists idempotency so re-running `setup` never rotates an existing secret (mirrors railway behavior).
- Setup is idempotent: existing projects and database resources are detected and skipped.
- pg-boss jobs and WebSockets do not fit Vercel's serverless model, so the provider emits warn-not-block preflight warnings for apps that use them.
- SPA fallback filenames are resolved through the shared `common/waspProject.ts` helpers rather than hardcoded, so the provider tracks the build-output format on `main`.
- Transient network failures during deploy upload are retried (bounded), matching Vercel's own "retry the deploy" guidance.

## Why

Vercel is one of the most-requested deployment targets for Wasp. This aims to make `wasp deploy` cover it first-class, one command from project to live app.

Related: #169, #1982, #3396, #3729 (this contributes a first-class provider toward making Wasp simpler to deploy and standardizing client deployment).

## Testing

- Unit tests: 200 passing in `waspc/data/packages/deploy` (20 files), all runnable offline with no Vercel token; Vercel CLI invocations are stubbed.
- Live end-to-end verification (Vercel Hobby team, wasp built from `main`):
  - Cold launch: single `wasp deploy vercel launch` from a fresh app with no pre-existing Vercel projects completed in 167s wall-clock; client root and deep SPA routes returned 200, server route returned 200 with rows read from the auto-provisioned Neon database (migrations applied remotely via `prisma migrate deploy`).
  - Auth round-trip: signup, login, and an authenticated request against a protected route all succeeded against the deployed server; missing/invalid tokens correctly rejected, confirming `JWT_SECRET` wiring end-to-end.
  - Redeploy and idempotency: a code change redeployed and was visible on a new deployment id; re-running `setup` skipped existing projects and left `JWT_SECRET` untouched (verified via env metadata timestamps).

## Docs

Adds `web/docs/deployment/deployment-methods/wasp-deploy/vercel.md` (setup/deploy/launch usage, Neon default + `--database-url`, pg-boss/WebSocket caveats) and a Vercel entry in the wasp-deploy providers grid; docs site builds clean.

## Status

Draft pending final validation. Feedback on the provider surface (command names, option naming, Neon-by-default) very welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
