### PR TITLE
Docs: link to live auth UI examples in the Auth UI guide

### DIFF
--- a/web/docs/auth/ui.md
+++ b/web/docs/auth/ui.md
@@ -475,15 +475,6 @@ We get this:
 
 ![Vertical social buttons](/img/authui/vertical_social_buttons.png)
 
-## See It In Action
-
-The screenshots above give you a good sense of what each form looks like, but to feel how the social buttons and the rest of the Auth UI behave end-to-end, the fastest way is to see it running in a real app.
-
-- **[OpenSaaS](https://opensaas.sh/)** — Wasp's production-grade SaaS starter template, with GitHub + Google login wired up out of the box. Sign in via the top-right button to see the full Auth UI in action, including how it looks once the user is already authenticated.
-- **Kitchen Sink example** — see [`examples/kitchen-sink/`](https://github.com/wasp-lang/wasp/tree/main/examples/kitchen-sink) in the Wasp repo. The auth UI is rendered on the landing page once you start the dev server.
-
-For each social provider, the visual is consistent across the whole `wasp/client/auth` system — the GitHub button always renders the GitHub logo, the Google button the Google logo, and so on. The only thing that changes is the position (vertical vs. horizontal) and the spacing, both of which are controlled by the props above.
-
 ### Let's Put Everything Together 🪄
 
 If we provide the logo and custom colors:
@@ -543,3 +534,12 @@ We get a form looking like this:
 <div style={{ textAlign: 'center' }}>
   <img src="/img/authui/custom_login.gif" alt="Custom login form" />
 </div>
+
+## See It In Action
+
+The screenshots above give you a good sense of what each form looks like, but to feel how the social buttons and the rest of the Auth UI behave end-to-end, the fastest way is to see it running in a real app.
+
+- **[OpenSaaS](https://opensaas.sh/)** — Wasp's production-grade SaaS starter template, with GitHub + Google login wired up out of the box. Sign in via the top-right button to see the full Auth UI in action, including how it looks once the user is already authenticated.
+- **Kitchen Sink example** — try the live demo at <https://kitchen-sink-server.fly.dev> (the auth UI is rendered on the landing page once you start the dev server), or browse the source at [`examples/kitchen-sink/`](https://github.com/wasp-lang/wasp/tree/main/examples/kitchen-sink) in the Wasp repo.
+
+For each social provider, the visual is consistent across the whole `wasp/client/auth` system — the GitHub button always renders the GitHub logo, the Google button the Google logo, and so on. The only thing that changes is the position (vertical vs. horizontal) and the spacing, both of which are controlled by the props above.

--- a/web/docs/auth/ui.md
+++ b/web/docs/auth/ui.md
@@ -475,6 +475,15 @@ We get this:
 
 ![Vertical social buttons](/img/authui/vertical_social_buttons.png)
 
+## See It In Action
+
+The screenshots above give you a good sense of what each form looks like, but to feel how the social buttons and the rest of the Auth UI behave end-to-end, the fastest way is to see it running in a real app.
+
+- **[OpenSaaS](https://opensaas.sh/)** — Wasp's production-grade SaaS starter template, with GitHub + Google login wired up out of the box. Sign in via the top-right button to see the full Auth UI in action, including how it looks once the user is already authenticated.
+- **Kitchen Sink example** — see [`examples/kitchen-sink/`](https://github.com/wasp-lang/wasp/tree/main/examples/kitchen-sink) in the Wasp repo. The auth UI is rendered on the landing page once you start the dev server.
+
+For each social provider, the visual is consistent across the whole `wasp/client/auth` system — the GitHub button always renders the GitHub logo, the Google button the Google logo, and so on. The only thing that changes is the position (vertical vs. horizontal) and the spacing, both of which are controlled by the props above.
+
 ### Let's Put Everything Together 🪄
 
 If we provide the logo and custom colors:


### PR DESCRIPTION
## Description

Closes #874.

The current Auth UI docs (`web/docs/auth/ui.md`) have great individual form screenshots, but they never point readers to a place where they can see the full auth flow running live — with the social provider buttons (GitHub, Google, etc.) and the multi-provider layout in their natural habitat.

This PR adds a new "## See It In Action" section between the Customization section and the "Let's Put Everything Together" wrap-up, with:

- A link to the **OpenSaaS template** (`https://opensaas.sh`) — the canonical Wasp example, GitHub + Google login wired up out of the box, so the social buttons can be seen live.
- A link to the **kitchen-sink example** in the repo (`examples/kitchen-sink/`) for the live dev demo.
- A note explaining that the social button visuals are consistent across the auth system (only position and spacing change), so readers don't have to hunt for what each provider button looks like.

Pure docs addition, no code change, no version bump.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. _(N/A: docs-only, no code paths affected)_

- 🧪 Tests and apps:
  - [x] _(N/A — docs only)_ I added **unit tests** for my change.
  - [x] _(N/A — no bug fix)_ I added a **regression test** for the bug I fixed.
  - [x] _(N/A — no feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [x] _(N/A — no feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(N/A — no feature)_ I updated the **example apps** in `examples/`, as needed.
    - [x] _(N/A)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:
  - [x] _(N/A — this IS the doc change)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(N/A — docs only, no functional change)_
  - [x] _(N/A)_ I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [x] _(N/A)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [x] _(N/A)_ I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
