### PR TITLE
Docs: fix Todo tutorial grammar and gif alt text

### DIFF
--- a/web/docs/tutorial/01-create.md
+++ b/web/docs/tutorial/01-create.md
@@ -11,7 +11,7 @@ You'll need to have the latest version of Wasp installed locally to follow this 
 
 In this section, we'll guide you through the process of creating a simple Todo app with Wasp. In the process, we'll take you through the most important and useful features of Wasp.
 
-<img alt="How Todo App will work once it is done" src={useBaseUrl('img/todo-app-tutorial-intro.gif')} className="tutorial-image" />
+<img alt="How the Todo App will work once it is finished" src={useBaseUrl('img/todo-app-tutorial-intro.gif')} className="tutorial-image" />
 
 <br />
 

--- a/web/docs/tutorial/06-actions.md
+++ b/web/docs/tutorial/06-actions.md
@@ -122,7 +122,7 @@ const NewTaskForm = () => {
 Unlike Queries, you can call Actions directly (without wrapping them in a hook) because they don't need reactivity. The rest is just regular React code.
 
 <ShowForTs>
-  Finally, because we've previously annotated the Action's server implementation with the correct type, Wasp knows that the `createTask` Action expects a value of type `{ description: string }` (try changing the argument and reading the error message). Wasp also knows that a call to the `createTask` Action returns a `Task` but are not using it in this example.
+  Finally, because we've previously annotated the Action's server implementation with the correct type, Wasp knows that the `createTask` Action expects a value of type `{ description: string }` (try changing the argument and reading the error message). Wasp also knows that a call to the `createTask` Action returns a `Task` but we are not using it in this example.
 </ShowForTs>
 
 All that's left now is adding this form to the page component:


### PR DESCRIPTION
## Description

Closes (partial) #1065.

The Todo app tutorial is the entry-point doc for new Wasp users, and #1065 tracks a broader polish pass. This PR is the easy first slice of that — two small corrections found while reading the tutorial end-to-end:

- `web/docs/tutorial/06-actions.md:125` — "returns a `Task` but are not using it" → "returns a `Task` but we are not using it". The subject of the original clause is ambiguous (the `are` was a stranded verb with no agent); the fix makes the agent explicit. This is a long-standing grammatical error.
- `web/docs/tutorial/01-create.md:14` — the intro gif's alt text "How Todo App will work once it is done" → "How the Todo App will work once it is finished". The original was missing the article and used "is done" where "is finished" is clearer for a screen reader.

No new content, no behavior change, no version bump. The remaining #1065 work (removing the clocks, proper CSS styling, reorganization) is a larger pass that deserves its own PR.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. _(N/A: docs-only)_

- 🧪 Tests and apps:
  - [x] _(N/A — docs only)_ I added **unit tests** for my change.
  - [x] _(N/A — no bug fix)_ I added a **regression test** for the bug I fixed.
  - [x] _(N/A — no feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [x] _(N/A — no feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(N/A — no feature)_ I updated the **example apps** in `examples/`, as needed.
    - [x] _(N/A)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:
  - [x] _(N/A — this IS the doc change)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(N/A — docs only, no functional change)_
  - [x] _(N/A)_ I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [x] _(N/A)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [x] _(N/A)_ I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
