### PR TITLE
Add shared glob construction utilities

### DIFF
--- a/waspc/src/Wasp/Project/Waspignore.hs
+++ b/waspc/src/Wasp/Project/Waspignore.hs
@@ -11,16 +11,16 @@ where
 import StrongPath (Abs, Dir, File', Path', Rel)
 import qualified StrongPath as SP
 import StrongPath.TH (relfile)
-import System.FilePath.Glob (Pattern, compile, match)
 import System.IO.Error (isDoesNotExistError)
 import UnliftIO.Exception (catch, throwIO)
 import Wasp.AppSpec.ExternalFiles (SourceExternalCodeDir)
 import Wasp.Project.Common
+import Wasp.Util.Glob (GlobPatterns, compileGlobPatterns, matchesAnyGlob)
 import qualified Wasp.Util.IO as IOUtil
 
 class AffectedByWaspignoreFile a
 
-newtype WaspignoreFile = WaspignoreFile [Pattern]
+newtype WaspignoreFile = WaspignoreFile GlobPatterns
 
 instance AffectedByWaspignoreFile SourceExternalCodeDir
 
@@ -37,8 +37,8 @@ waspIgnorePathInWaspProjectDir :: Path' (Rel WaspProjectDir) File'
 waspIgnorePathInWaspProjectDir = [relfile|.waspignore|]
 
 -- | These patterns are ignored by every 'WaspignoreFile'
-defaultIgnorePatterns :: [Pattern]
-defaultIgnorePatterns = map compile [".waspignore"]
+defaultIgnorePatterns :: [String]
+defaultIgnorePatterns = [".waspignore"]
 
 -- | Parses a string to a 'WaspignoreFile'.
 --
@@ -60,8 +60,8 @@ defaultIgnorePatterns = map compile [".waspignore"]
 parseWaspignoreFile :: String -> WaspignoreFile
 parseWaspignoreFile =
   WaspignoreFile
+    . compileGlobPatterns
     . (defaultIgnorePatterns ++)
-    . map compile
     . filter isPatternLine
     . lines
   where
@@ -96,4 +96,4 @@ readWaspignoreFile file = do
 --   ignoreFile `ignores` "src/a.js" -- False
 --   @
 ignores :: WaspignoreFile -> FilePath -> Bool
-ignores (WaspignoreFile pats) fp = any (`match` fp) pats
+ignores (WaspignoreFile patterns) fp = patterns `matchesAnyGlob` fp

--- a/waspc/src/Wasp/Project/Waspignore.hs
+++ b/waspc/src/Wasp/Project/Waspignore.hs
@@ -15,12 +15,12 @@ import System.IO.Error (isDoesNotExistError)
 import UnliftIO.Exception (catch, throwIO)
 import Wasp.AppSpec.ExternalFiles (SourceExternalCodeDir)
 import Wasp.Project.Common
-import Wasp.Util.Glob (GlobPatterns, compileGlobPatterns, matchesAnyGlob)
+import Wasp.Util.Glob (Pattern, compile, match)
 import qualified Wasp.Util.IO as IOUtil
 
 class AffectedByWaspignoreFile a
 
-newtype WaspignoreFile = WaspignoreFile GlobPatterns
+newtype WaspignoreFile = WaspignoreFile [Pattern]
 
 instance AffectedByWaspignoreFile SourceExternalCodeDir
 
@@ -37,7 +37,7 @@ waspIgnorePathInWaspProjectDir :: Path' (Rel WaspProjectDir) File'
 waspIgnorePathInWaspProjectDir = [relfile|.waspignore|]
 
 -- | These patterns are ignored by every 'WaspignoreFile'
-defaultIgnorePatterns :: [String]
+defaultIgnorePatterns :: [Pattern]
 defaultIgnorePatterns = [".waspignore"]
 
 -- | Parses a string to a 'WaspignoreFile'.
@@ -60,8 +60,8 @@ defaultIgnorePatterns = [".waspignore"]
 parseWaspignoreFile :: String -> WaspignoreFile
 parseWaspignoreFile =
   WaspignoreFile
-    . compileGlobPatterns
     . (defaultIgnorePatterns ++)
+    . map compile
     . filter isPatternLine
     . lines
   where
@@ -96,4 +96,4 @@ readWaspignoreFile file = do
 --   ignoreFile `ignores` "src/a.js" -- False
 --   @
 ignores :: WaspignoreFile -> FilePath -> Bool
-ignores (WaspignoreFile patterns) fp = patterns `matchesAnyGlob` fp
+ignores (WaspignoreFile patterns) fp = any (`match` fp) patterns

--- a/waspc/src/Wasp/Util/Glob.hs
+++ b/waspc/src/Wasp/Util/Glob.hs
@@ -1,0 +1,16 @@
+module Wasp.Util.Glob
+  ( GlobPatterns,
+    compileGlobPatterns,
+    matchesAnyGlob,
+  )
+where
+
+import qualified System.FilePath.Glob as Glob
+
+type GlobPatterns = [Glob.Pattern]
+
+compileGlobPatterns :: [String] -> GlobPatterns
+compileGlobPatterns = map Glob.compile
+
+matchesAnyGlob :: GlobPatterns -> FilePath -> Bool
+matchesAnyGlob patterns path = any (`Glob.match` path) patterns

--- a/waspc/src/Wasp/Util/Glob.hs
+++ b/waspc/src/Wasp/Util/Glob.hs
@@ -1,16 +1,21 @@
 module Wasp.Util.Glob
-  ( GlobPatterns,
-    compileGlobPatterns,
-    matchesAnyGlob,
+  ( Pattern,
+    compile,
+    match,
+    recursiveFileGlobsWithExtensions,
+    dirAndDescendantsGlobs,
   )
 where
 
-import qualified System.FilePath.Glob as Glob
+import qualified System.FilePath as FP
+import System.FilePath.Glob (Pattern, compile, match)
 
-type GlobPatterns = [Glob.Pattern]
+recursiveFileGlobsWithExtensions :: FilePath -> [String] -> [String]
+recursiveFileGlobsWithExtensions dir extensions =
+  (\ext -> dir FP.</> "**" FP.</> "*" ++ ext) <$> extensions
 
-compileGlobPatterns :: [String] -> GlobPatterns
-compileGlobPatterns = map Glob.compile
-
-matchesAnyGlob :: GlobPatterns -> FilePath -> Bool
-matchesAnyGlob patterns path = any (`Glob.match` path) patterns
+dirAndDescendantsGlobs :: FilePath -> [String]
+dirAndDescendantsGlobs dir =
+  [ dir,
+    dir FP.</> "**" FP.</> "*"
+  ]

--- a/waspc/tests/Util/GlobTest.hs
+++ b/waspc/tests/Util/GlobTest.hs
@@ -2,35 +2,16 @@ module Util.GlobTest where
 
 import qualified System.FilePath as FP
 import Test.Hspec (Spec, describe, it, shouldBe)
-import Wasp.Util.Glob (compileGlobPatterns, matchesAnyGlob)
+import Wasp.Util.Glob (dirAndDescendantsGlobs, recursiveFileGlobsWithExtensions)
 
-spec_GlobPatterns :: Spec
-spec_GlobPatterns =
-  describe "GlobPatterns" $ do
-    it "matches files directly inside a directory" $ do
-      let patterns = compileGlobPatterns ["src" FP.</> "**" FP.</> "*.ts"]
-      patterns `matchesAnyGlob` ("src" FP.</> "foo.ts") `shouldBe` True
+spec_globConstruction :: Spec
+spec_globConstruction =
+  describe "glob construction" $ do
+    it "builds recursive file globs for extensions" $ do
+      recursiveFileGlobsWithExtensions "src" [".ts", ".js"]
+        `shouldBe` ["src" FP.</> "**" FP.</> "*.ts", "src" FP.</> "**" FP.</> "*.js"]
 
-    it "matches files nested inside a directory" $ do
-      let patterns = compileGlobPatterns ["src" FP.</> "**" FP.</> "*.ts"]
-      patterns `matchesAnyGlob` ("src" FP.</> "actions" FP.</> "foo.ts") `shouldBe` True
-
-    it "does not match a different file extension" $ do
-      let patterns = compileGlobPatterns ["src" FP.</> "**" FP.</> "*.ts"]
-      patterns `matchesAnyGlob` ("src" FP.</> "actions" FP.</> "foo.css") `shouldBe` False
-
-    it "matches if any pattern matches" $ do
-      let patterns = compileGlobPatterns ["src" FP.</> "**" FP.</> "*.ts", "src" FP.</> "**" FP.</> "*.js"]
-      patterns `matchesAnyGlob` ("src" FP.</> "actions" FP.</> "foo.js") `shouldBe` True
-
-    it "matches exact file patterns" $ do
-      let patterns = compileGlobPatterns ["server" FP.</> ".env"]
-      patterns `matchesAnyGlob` ("server" FP.</> ".env") `shouldBe` True
-      patterns `matchesAnyGlob` ("server" FP.</> "src" FP.</> ".env") `shouldBe` False
-
-    it "matches exact and nested directory paths" $ do
-      let patterns = compileGlobPatterns ["server" FP.</> "src", "server" FP.</> "src" FP.</> "**" FP.</> "*"]
-      patterns `matchesAnyGlob` ("server" FP.</> "src") `shouldBe` True
-      patterns `matchesAnyGlob` ("server" FP.</> "src" FP.</> "routes") `shouldBe` True
-      patterns `matchesAnyGlob` ("server" FP.</> "src" FP.</> "routes" FP.</> "auth") `shouldBe` True
-      patterns `matchesAnyGlob` "server" `shouldBe` False
+    it "builds exact and nested directory globs" $ do
+      let serverSrc = "server" FP.</> "src"
+      dirAndDescendantsGlobs serverSrc
+        `shouldBe` [serverSrc, serverSrc FP.</> "**" FP.</> "*"]

--- a/waspc/tests/Util/GlobTest.hs
+++ b/waspc/tests/Util/GlobTest.hs
@@ -1,0 +1,36 @@
+module Util.GlobTest where
+
+import qualified System.FilePath as FP
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Wasp.Util.Glob (compileGlobPatterns, matchesAnyGlob)
+
+spec_GlobPatterns :: Spec
+spec_GlobPatterns =
+  describe "GlobPatterns" $ do
+    it "matches files directly inside a directory" $ do
+      let patterns = compileGlobPatterns ["src" FP.</> "**" FP.</> "*.ts"]
+      patterns `matchesAnyGlob` ("src" FP.</> "foo.ts") `shouldBe` True
+
+    it "matches files nested inside a directory" $ do
+      let patterns = compileGlobPatterns ["src" FP.</> "**" FP.</> "*.ts"]
+      patterns `matchesAnyGlob` ("src" FP.</> "actions" FP.</> "foo.ts") `shouldBe` True
+
+    it "does not match a different file extension" $ do
+      let patterns = compileGlobPatterns ["src" FP.</> "**" FP.</> "*.ts"]
+      patterns `matchesAnyGlob` ("src" FP.</> "actions" FP.</> "foo.css") `shouldBe` False
+
+    it "matches if any pattern matches" $ do
+      let patterns = compileGlobPatterns ["src" FP.</> "**" FP.</> "*.ts", "src" FP.</> "**" FP.</> "*.js"]
+      patterns `matchesAnyGlob` ("src" FP.</> "actions" FP.</> "foo.js") `shouldBe` True
+
+    it "matches exact file patterns" $ do
+      let patterns = compileGlobPatterns ["server" FP.</> ".env"]
+      patterns `matchesAnyGlob` ("server" FP.</> ".env") `shouldBe` True
+      patterns `matchesAnyGlob` ("server" FP.</> "src" FP.</> ".env") `shouldBe` False
+
+    it "matches exact and nested directory paths" $ do
+      let patterns = compileGlobPatterns ["server" FP.</> "src", "server" FP.</> "src" FP.</> "**" FP.</> "*"]
+      patterns `matchesAnyGlob` ("server" FP.</> "src") `shouldBe` True
+      patterns `matchesAnyGlob` ("server" FP.</> "src" FP.</> "routes") `shouldBe` True
+      patterns `matchesAnyGlob` ("server" FP.</> "src" FP.</> "routes" FP.</> "auth") `shouldBe` True
+      patterns `matchesAnyGlob` "server" `shouldBe` False

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -423,6 +423,7 @@ library
     Wasp.Util.Fib
     Wasp.Util.FilePath
     Wasp.Util.GitRev
+    Wasp.Util.Glob
     Wasp.Util.HashMap
     Wasp.Util.InstallMethod
     Wasp.Util.IO
@@ -641,6 +642,7 @@ test-suite waspc-tests
     Util.Diff
     Util.FibTest
     Util.FilePathTest
+    Util.GlobTest
     Util.IO.RetryTest
     Util.Prisma
     Util.StrongPathTest


### PR DESCRIPTION
## Description

Split from #4407, stacked on #4500. Pure refactor, no behavior change.

- Add `Wasp.Util.Glob` as a narrow re-export of `Pattern`, `compile`, and `match`.
- Add reusable builders for recursive extension globs and directory-descendant globs.
- Keep `WaspignoreFile` as `[Pattern]` and use `Pattern` string literals directly.
- #4407 consumes the construction helpers for watched-path classification.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->