### PR TITLE
Add `defer` to the CLI `Command` monad for cleanup actions

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command.hs
+++ b/waspc/cli/src/Wasp/Cli/Command.hs
@@ -6,6 +6,9 @@ module Wasp.Cli.Command
     runCommand,
     CommandError (..),
 
+    -- * Cleanup
+    defer,
+
     -- * Requirements
 
     -- See "Wasp.Cli.Command.Requires" for documentation.
@@ -18,18 +21,31 @@ import Control.Monad.Error.Class (MonadError)
 import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.State.Strict (StateT, evalStateT, gets, modify)
+import Control.Monad.Writer (WriterT, runWriterT, tell)
 import Data.Data (Typeable, cast)
 import Data.Maybe (mapMaybe)
 import System.Exit (exitFailure)
 import Wasp.Cli.Message (cliSendMessage)
 import qualified Wasp.Message as Msg
 
-newtype Command a = Command {_runCommand :: StateT [Requirement] (ExceptT CommandError IO) a}
+newtype Command a = Command
+  { _runCommand :: HasRequirementsT (HasCommandErrorT (HasCleanupT IO)) a
+  }
   deriving (Functor, Applicative, Monad, MonadIO, MonadError CommandError)
+
+type HasCleanupT m = WriterT [m ()] m
+
+type HasCommandErrorT = ExceptT CommandError
+
+type HasRequirementsT = StateT [Requirement]
 
 runCommand :: Command a -> IO ()
 runCommand cmd = do
-  runExceptT (flip evalStateT [] $ _runCommand cmd) >>= \case
+  (result, cleanups) <- runWriterT $ runExceptT $ (`evalStateT` mempty) $ _runCommand cmd
+
+  sequence_ $ reverse cleanups
+
+  case result of
     Left cmdError -> do
       cliSendMessage $ Msg.Failure (_errorTitle cmdError) (_errorMsg cmdError)
       exitFailure
@@ -68,3 +84,6 @@ require =
       req <- checkRequirement
       Command $ modify (Requirement req :)
       return req
+
+defer :: IO () -> Command ()
+defer cleanup = Command $ tell [cleanup]

--- a/waspc/cli/src/Wasp/Cli/Command.hs
+++ b/waspc/cli/src/Wasp/Cli/Command.hs
@@ -29,20 +29,21 @@ import Wasp.Cli.Message (cliSendMessage)
 import qualified Wasp.Message as Msg
 
 newtype Command a = Command
-  { _runCommand :: HasRequirementsT (HasCommandErrorT (HasCleanupT IO)) a
+  { _runCommand :: RequirerT (ExceptT CommandError (CleanupT IO)) a
   }
   deriving (Functor, Applicative, Monad, MonadIO, MonadError CommandError)
 
-type HasCleanupT m = WriterT [m ()] m
+type CleanupT m = WriterT [m ()] m
 
-type HasCommandErrorT = ExceptT CommandError
-
-type HasRequirementsT = StateT [Requirement]
+type RequirerT = StateT [Requirement]
 
 runCommand :: Command a -> IO ()
 runCommand cmd = do
   (result, cleanups) <- runWriterT $ runExceptT $ (`evalStateT` mempty) $ _runCommand cmd
 
+  -- We reverse the cleanups so they behave like a FILO queue.
+  -- e.g. `mkdir folder >> defer (rmdir folder) >> mkdir (folder </> file) >> defer (rm $ folder </> file)`
+  -- Should first cleanup the file and then the folder.
   sequence_ $ reverse cleanups
 
   case result of

--- a/waspc/cli/tests/Wasp/Cli/CommandTest.hs
+++ b/waspc/cli/tests/Wasp/Cli/CommandTest.hs
@@ -1,0 +1,51 @@
+module Wasp.Cli.CommandTest where
+
+import Control.Exception (try)
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
+import System.Exit (ExitCode (ExitFailure))
+import Test.Hspec
+import Wasp.Cli.Command (Command, CommandError (..), defer, runCommand)
+
+spec_defer :: Spec
+spec_defer = do
+  describe "defer" $ do
+    it "runs deferred cleanups only after the command finishes" $ do
+      markers <- newIORef []
+      runCommand $ do
+        defer $ addMarker markers "cleanup"
+        liftIO $ addMarker markers "body"
+      readIORef markers `shouldReturn` ["body", "cleanup"]
+
+    it "runs deferred cleanups in reverse order of registration" $ do
+      markers <- newIORef []
+      runCommand $ do
+        defer $ addMarker markers "cleanup 1"
+        defer $ addMarker markers "cleanup 2"
+        defer $ addMarker markers "cleanup 3"
+      readIORef markers `shouldReturn` ["cleanup 3", "cleanup 2", "cleanup 1"]
+
+    it "runs only the cleanups registered before a command error" $ do
+      markers <- newIORef []
+      _ <- tryRunCommand $ do
+        defer $ addMarker markers "cleanup before error"
+        _ <- throwError $ CommandError "Test error" "Error message"
+        defer $ addMarker markers "cleanup after error"
+      readIORef markers `shouldReturn` ["cleanup before error"]
+
+    it "runs cleanups before exiting with failure on a command error" $ do
+      markers <- newIORef []
+      result <- tryRunCommand $ do
+        defer $ addMarker markers "cleanup"
+        throwError $ CommandError "Test error" "Error message"
+      readIORef markers `shouldReturn` ["cleanup"]
+      result `shouldBe` Left (ExitFailure 1)
+  where
+    addMarker :: IORef [String] -> String -> IO ()
+    addMarker markers marker = modifyIORef markers (++ [marker])
+
+    -- On error, 'runCommand' exits the process, which we catch as an
+    -- 'ExitCode' exception to keep the test process alive.
+    tryRunCommand :: Command () -> IO (Either ExitCode ())
+    tryRunCommand = try . runCommand

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -659,6 +659,7 @@ test-suite wasp-cli-tests
     base,
     cli-lib,
     hspec,
+    mtl,
     QuickCheck,
     tasty,
     tasty-hspec,
@@ -671,6 +672,7 @@ test-suite wasp-cli-tests
     TerminalTest
     Wasp.Cli.Command.News.ListingTest
     Wasp.Cli.Command.News.LocalNewsStateTest
+    Wasp.Cli.CommandTest
     Wasp.Cli.Util.EnvVarArgumentTest
 
 test-suite waspc-e2e-tests


### PR DESCRIPTION
## Description

Adds a `defer` primitive to the CLI `Command` monad, giving commands a way to register cleanup actions that always run once the command finishes, in the spirit of Go's `defer`.

**Motivation:** Commands often create temporary resources (files, directories, processes) that must be torn down whether the command succeeds or fails. Until now there was no uniform mechanism for this, so cleanup had to be threaded manually and was easy to get wrong on the error path.

**How it works:**

- The `Command` monad transformer stack gains a `WriterT [IO ()]` layer (`CleanupT`) at the base, below `ExceptT`. Registered cleanups are collected regardless of whether the command errors out.
- `defer :: IO () -> Command ()` appends a cleanup action to that writer.
- `runCommand` collects all deferred actions and runs them **after** the command body completes, in **reverse order of registration** (FILO), so nested setup/teardown pairs unwind correctly:
  ```
  mkdir folder >> defer (rmdir folder) >> touch file >> defer (rm file)
  -- cleans up: rm file, then rmdir folder
  ```
- On a `CommandError`, only the cleanups registered before the error are run, and they run **before** the process exits with failure.

No command uses `defer` yet; this PR only introduces the mechanism and its tests.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended. <!-- Internal Command-monad utility with no user-facing behavior; covered by unit tests instead. -->

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- New `Wasp.Cli.CommandTest` covering ordering, error paths, and exit behavior. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Not a bug fix. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- No user-facing feature. -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- N/A -->
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- N/A -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa). <!-- N/A -->

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- Internal API, not user-facing. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- Code-only improvement, no user-facing change. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
