### PR TITLE
Remove duplicated either/maybe helpers in favor of Data.Either.Extra

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Doctor.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Doctor.hs
@@ -6,6 +6,7 @@ where
 import Control.Monad (forM_, when)
 import Control.Monad.Except (ExceptT (ExceptT), runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
+import Data.Either.Extra (eitherToMaybe)
 import Data.Functor ((<&>))
 import Data.Maybe (catMaybes)
 import System.Directory (findExecutable)
@@ -18,7 +19,7 @@ import qualified Wasp.Generator.WebAppGenerator.Common as WebApp
 import qualified Wasp.Node.Version as NodeVersion
 import qualified Wasp.Project.Db.Dev.Postgres as Dev.Postgres
 import qualified Wasp.SemanticVersion as SV
-import Wasp.Util (eitherToMaybe, trim)
+import Wasp.Util (trim)
 import Wasp.Util.GitRev (gitRevDescription)
 import qualified Wasp.Util.Network.Socket as Socket
 import qualified Wasp.Util.Terminal as Term

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -35,8 +35,6 @@ module Wasp.Util
     orIfNothing,
     orIfNothingM,
     kebabToCamelCase,
-    maybeToEither,
-    eitherToMaybe,
     orElse,
     whenM,
     naiveTrimJSON,
@@ -283,13 +281,6 @@ orIfNothing = flip fromMaybe
 
 orIfNothingM :: (Monad m) => m (Maybe a) -> m a -> m a
 orIfNothingM = flip fromMaybeM
-
-maybeToEither :: a -> Maybe b -> Either a b
-maybeToEither leftValue = maybe (Left leftValue) Right
-
-eitherToMaybe :: Either e a -> Maybe a
-eitherToMaybe (Right x) = Just x
-eitherToMaybe (Left _) = Nothing
 
 orElse :: Maybe a -> a -> a
 orElse = flip fromMaybe

--- a/waspc/src/Wasp/Util/GitRev.hs
+++ b/waspc/src/Wasp/Util/GitRev.hs
@@ -3,8 +3,8 @@ module Wasp.Util.GitRev
   )
 where
 
+import Data.Either.Extra (eitherToMaybe)
 import qualified GitHash
-import Wasp.Util (eitherToMaybe)
 
 -- | The `git describe` of the Wasp source tree this binary was built from, or
 -- `Nothing` if it couldn't be determined (e.g. building outside of a git

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -450,6 +450,7 @@ library cli-lib
     cryptonite ^>=0.30,
     directory,
     exceptions,
+    extra,
     filepath,
     fsnotify ^>=0.4.2,
     http-conduit,


### PR DESCRIPTION
## Description

`Wasp.Util` defined its own `maybeToEither` and `eitherToMaybe`, but the rest of the codebase already imports these from `Data.Either.Extra` (from the `extra` package). This removes the duplicated definitions and points the two remaining callers (`Doctor.hs` and `GitRev.hs`) at `Data.Either.Extra` instead. The `extra` dependency is added to the `cli-lib` component for `Doctor.hs`; the main library already depended on it. No functional change.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
