### PR TITLE
Fix: use stable id as React key in 2 more example apps

### DIFF
--- a/examples/kitchen-sink/src/features/operations/components/Todo.tsx
+++ b/examples/kitchen-sink/src/features/operations/components/Todo.tsx
@@ -97,7 +97,7 @@ const Footer = ({ tasks }: { tasks: NonEmptyArray<TaskWithUser> }) => {
 const Tasks = ({ tasks }: { tasks: NonEmptyArray<TaskWithUser> }) => {
   return (
     <div>
-      {tasks.map((task, idx) => (
+      {tasks.map((task) => (
         <TaskView task={task} key={task.id} />
       ))}
     </div>

--- a/examples/kitchen-sink/src/features/operations/components/Todo.tsx
+++ b/examples/kitchen-sink/src/features/operations/components/Todo.tsx
@@ -98,7 +98,7 @@ const Tasks = ({ tasks }: { tasks: NonEmptyArray<TaskWithUser> }) => {
   return (
     <div>
       {tasks.map((task, idx) => (
-        <TaskView task={task} key={idx} />
+        <TaskView task={task} key={task.id} />
       ))}
     </div>
   );

--- a/examples/tutorials/TodoAppTs/src/MainPage.tsx
+++ b/examples/tutorials/TodoAppTs/src/MainPage.tsx
@@ -55,7 +55,7 @@ const TasksList = ({ tasks }: { tasks: Task[] }) => {
   return (
     <div>
       {tasks.map((task, idx) => (
-        <TaskView task={task} key={idx} />
+        <TaskView task={task} key={task.id} />
       ))}
     </div>
   );

--- a/examples/tutorials/TodoAppTs/src/MainPage.tsx
+++ b/examples/tutorials/TodoAppTs/src/MainPage.tsx
@@ -54,7 +54,7 @@ const TasksList = ({ tasks }: { tasks: Task[] }) => {
 
   return (
     <div>
-      {tasks.map((task, idx) => (
+      {tasks.map((task) => (
         <TaskView task={task} key={task.id} />
       ))}
     </div>


### PR DESCRIPTION
﻿## Description

Follow-up to #4515, which fixed the same anti-pattern in the JS tutorial app. The same anti-pattern was present in two more files:

- `examples/tutorials/TodoAppTs/src/MainPage.tsx:58` — the TypeScript flavor of the tutorial
- `examples/kitchen-sink/src/features/operations/components/Todo.tsx:101` — the canonical "demonstrates every Wasp feature" example

Both got the same one-character fix. Now ALL three call sites of this pattern in the repo use a stable id as the React key.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. _(Verified by reading the surrounding code and matching the same fix pattern as the previous tutorial key PR.)_

- 🧪 Tests and apps:
  - [x] _(N/A — example app cosmetic)_ I added **unit tests** for my change.
  - [x] _(N/A — typo fix, not a real bug fix)_ I added a **regression test** for the bug I fixed.
  - [x] _(N/A — no feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [x] _(N/A — no feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(N/A — no feature)_ I updated the **example apps** in `examples/`, as needed.
    - [x] _(N/A)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:
  - [x] _(N/A)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(N/A — example app only)_
  - [x] _(N/A)_ I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [x] _(N/A)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [x] _(N/A)_ I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
