### PR TITLE
Docs: fix 'ommited' and 'neccessary' typos in docs + blog

### DIFF
--- a/web/blog/2021-04-29-discord-bot-introduction.mdx
+++ b/web/blog/2021-04-29-discord-bot-introduction.mdx
@@ -73,7 +73,7 @@ I will describe how to create it step by step below, but [here is the final code
 
 ### Defining bot on Discord and adding it to your server.
 
-Before we even start implementing the bot, we will tell Discord about it first, in order to obtain the neccessary credentials that we will use in our code, and we will add the bot to our server.
+Before we even start implementing the bot, we will tell Discord about it first, in order to obtain the necessary credentials that we will use in our code, and we will add the bot to our server.
 There are many tutorials already on how to do this, so I will keep it short.
 
 1. Go to Discord Developer Portal, create a new Application -> I named it `Wasp`.

--- a/web/blog/2021-09-01-haskell-forall-tutorial.mdx
+++ b/web/blog/2021-09-01-haskell-forall-tutorial.mdx
@@ -138,7 +138,7 @@ bar :: forall a. ((a -> a) -> (Char, Bool))  -- This is usual stuff, we don't ne
 ```
 
 In `foo`, `forall` is applied only to the first argument of `foo`, which is `a -> a`, and not to the rest of the `f`'s type signature. This can be done only with `RankNTypes` extension.
-`bar` on the other hand has `forall` applied to the whole signature, and we could have even ommited this `forall` since it would be there implicitly anyway.
+`bar` on the other hand has `forall` applied to the whole signature, and we could have even omitted this `forall` since it would be there implicitly anyway.
 
 Now, what does this mean? If we now have `specificFunc :: Int -> Int` and `polymorphicFunc :: a -> a`, `foo polymorphicFunc` will compile, while `foo specificFunc` will not! On the other hand both `bar specificFunc` and `bar polymorphicFunc` will compile.
 

--- a/web/docs/telemetry.md
+++ b/web/docs/telemetry.md
@@ -25,7 +25,7 @@ Our telemetry implementation is anonymized and very limited in its scope, focuse
     // True if command was `wasp build`, false otherwise.
     "is_build": true,
     // Captures `wasp deploy ...` args, but only those from the limited, pre-defined list of keywords.
-    // Those are "fly", "railway", "setup", "create-db", "deploy", "cmd", and "launch". Everything else is ommited.
+    // Those are "fly", "railway", "setup", "create-db", "deploy", "cmd", and "launch". Everything else is omitted.
     "deploy_cmd_args": "fly;deploy",
     "wasp_version": "0.1.9.1",
     "os": "linux",


### PR DESCRIPTION
## Description

Small batch of long-standing typos found by a one-pass `grep` over `web/docs/` and `web/blog/`. Pure typo fixes, no content/meaning changes.

- `web/docs/telemetry.md:28` — `ommited` → `omitted`
- `web/blog/2021-09-01-haskell-forall-tutorial.mdx:141` — `ommited` → `omitted`
- `web/blog/2021-04-29-discord-bot-introduction.mdx:79` — `neccessary` → `necessary`

No version bump, no changelog entry (per Wasp's PR template: code/docs improvement).

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. _(N/A: docs-only, no code paths affected)_

- 🧪 Tests and apps:
  - [x] _(N/A — docs only)_ I added **unit tests** for my change.
  - [x] _(N/A — no bug fix)_ I added a **regression test** for the bug I fixed.
  - [x] _(N/A — no feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [x] _(N/A — no feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(N/A — no feature)_ I updated the **example apps** in `examples/`, as needed.
    - [x] _(N/A)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:
  - [x] _(N/A — this IS the doc change)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(N/A — typo fixes, no functional change)_
  - [x] _(N/A)_ I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [x] _(N/A)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [x] _(N/A)_ I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.