### PR TITLE
Docs: fix 'should look like' grammar in the Wasp file structure note

### DIFF
--- a/web/docs/auth/social-auth/_wasp-file-structure-note.md
+++ b/web/docs/auth/social-auth/_wasp-file-structure-note.md
@@ -1,4 +1,4 @@
-Here's what our `main.wasp.ts` should look like after we're done:
+Here's a skeleton of what our `main.wasp.ts` should look like after we're done:
 
 ```ts title="main.wasp.ts"
 import { app, page, route } from "@wasp.sh/spec"

--- a/web/docs/auth/social-auth/_wasp-file-structure-note.md
+++ b/web/docs/auth/social-auth/_wasp-file-structure-note.md
@@ -1,4 +1,4 @@
-Here's a skeleton of how our `main.wasp.ts` should look like after we're done:
+Here's what our `main.wasp.ts` should look like after we're done:
 
 ```ts title="main.wasp.ts"
 import { app, page, route } from "@wasp.sh/spec"


### PR DESCRIPTION
## Description

Small grammar fix in a shared docs partial.

The partial `_wasp-file-structure-note.md` opens with "Here's a skeleton of how our `main.wasp.ts` should look like after we're done:". The construction "should look like" needs a noun, not "how" — the correct phrasing is either "Here's what our `main.wasp.ts` should look like" or "Here's how our `main.wasp.ts` should look". This PR uses the first form (closer to the original wording).

This partial is imported by all four social auth docs (Google, GitHub, Keycloak, Microsoft) via:

```mdx
import WaspFileStructureNote from './_wasp-file-structure-note.md';
...
<WaspFileStructureNote />
```

so the fix propagates to ~4 pages with a single-file change.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. _(N/A: docs-only)_

- 🧪 Tests and apps:
  - [x] _(N/A — docs only)_ I added **unit tests** for my change.
  - [x] _(N/A — no bug fix)_ I added a **regression test** for the bug I fixed.
  - [x] _(N/A — no feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [x] _(N/A — no feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(N/A — no feature)_ I updated the **example apps** in `examples/`, as needed.
    - [x] _(N/A)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:
  - [x] _(N/A — this IS the doc change)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(N/A — docs only, no functional change)_
  - [x] _(N/A)_ I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [x] _(N/A)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [x] _(N/A)_ I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.