### PR TITLE
Fix: 'recieved' typo in Watch.hs comment

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Watch.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Watch.hs
@@ -89,7 +89,7 @@ watch waspProjectDir outDir ongoingCompilationResultMVar = FSN.withManager $ \mg
         >> tryPutMVar ongoingCompilationResultMVar (warnings, errors)
         >> return ()
 
-    -- Blocks until no new events are recieved for a duration of `secondsToDelay`.
+    -- Blocks until no new events are received for a duration of `secondsToDelay`.
     -- Consumes any new events during an active timer window and then restarts wait.
     -- If a stale event comes in during an active timer window, we immediately
     -- return control to the caller.


### PR DESCRIPTION
## Description

One English typo in a comment in `waspc/cli/src/Wasp/Cli/Command/Watch.hs:92`. The function `waitForCompilation` is described as:

```haskell
-- Blocks until no new events are recieved for a duration of `secondsToDelay`.
```

`recieved` should be `received`. Comment-only, no code change, no behavior change.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. _(N/A: comment typo, no logic change.)_

- 🧪 Tests and apps:
  - [x] _(N/A — typo only)_ I added **unit tests** for my change.
  - [x] _(N/A — typo only)_ I added a **regression test** for the bug I fixed.
  - [x] _(N/A — no feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [x] _(N/A — no feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(N/A — no feature)_ I updated the **example apps** in `examples/`, as needed.
    - [x] _(N/A)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:
  - [x] _(N/A)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(N/A — comment typo, no functional change)_
  - [x] _(N/A)_ I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [x] _(N/A)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [x] _(N/A)_ I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.