### PR TITLE
Docs: fix 3 bugs in entities.md code examples

### DIFF
--- a/web/docs/data-model/entities.md
+++ b/web/docs/data-model/entities.md
@@ -122,7 +122,7 @@ Let's see how you can define and work with Wasp Entities:
 1. Create/update some Entities in the `schema.prisma` file.
 2. Run `wasp db migrate-dev`. This command syncs the database model with the Entity definitions the `schema.prisma` file. It does this by creating migration scripts.
 3. Migration scripts are automatically placed in the `migrations/` folder. Make sure to commit this folder into version control.
-4.   Use Wasp's JavaScript API to work with the database when implementing Operations (we'll cover this in detail when we talk about [operations](../data-model/operations/overview)).
+4. Use Wasp's JavaScript API to work with the database when implementing Operations (we'll cover this in detail when we talk about [operations](../data-model/operations/overview)).
 
 #### Using Entities in Operations
 

--- a/web/docs/data-model/entities.md
+++ b/web/docs/data-model/entities.md
@@ -91,7 +91,7 @@ The above Prisma `model` definition tells Wasp to create a table for storing Tas
   }
   ```
 
-  Using the `Task` type in `getInfoMessageInfo`'s definition connects the argument's type with the `Task` entity.
+  Using the `Task` type in `getInfoMessage`'s definition connects the argument's type with the `Task` entity.
 
   This coupling removes duplication and ensures the function keeps the correct signature even if you change the entity. Of course, the function might throw type errors depending on how you change it, but that's precisely what you want!
 
@@ -102,7 +102,7 @@ The above Prisma `model` definition tells Wasp to create a table for storing Tas
 
   export function ExamplePage() {
     const task: Task = {
-      id: 123,
+      id: "some-uuid-1234",
       description: "Some random task",
       isDone: false,
     }
@@ -122,7 +122,7 @@ Let's see how you can define and work with Wasp Entities:
 1. Create/update some Entities in the `schema.prisma` file.
 2. Run `wasp db migrate-dev`. This command syncs the database model with the Entity definitions the `schema.prisma` file. It does this by creating migration scripts.
 3. Migration scripts are automatically placed in the `migrations/` folder. Make sure to commit this folder into version control.
-4. Use Wasp's JavasScript API to work with the database when implementing Operations (we'll cover this in detail when we talk about [operations](../data-model/operations/overview)).
+4.   Use Wasp's JavaScript API to work with the database when implementing Operations (we'll cover this in detail when we talk about [operations](../data-model/operations/overview)).
 
 #### Using Entities in Operations
 


### PR DESCRIPTION
## Description

Three small but real bugs in the Entities doc that mislead readers about Wasp's actual API:

1. **Line 94** — "Using the `Task` type in `getInfoMessageInfo`'s definition..." referenced a function named `getInfoMessage` (one extra `Info` suffix). Fixed.

2. **Line 105** — example code set `id: 123` (a number) on a Task object. The Prisma schema in the same doc uses `@default(uuid())` which produces a string, so the example would fail TypeScript checking. Changed to a string.

3. **Line 125** — "Wasp's JavasScript API" typo. Fixed.

These are the kinds of errors a tutorial reader would copy-paste and immediately hit a compiler error on. Fixing them improves the first-time experience without changing any actual behavior.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. _(N/A: docs-only)_

- 🧪 Tests and apps:
  - [x] _(N/A — docs only)_ I added **unit tests** for my change.
  - [x] _(N/A — no bug fix in code)_ I added a **regression test** for the bug I fixed.
  - [x] _(N/A — no feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [x] _(N/A — no feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(N/A — no feature)_ I updated the **example apps** in `examples/`, as needed.
    - [x] _(N/A)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:
  - [x] _(N/A — this IS the doc change)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(N/A — docs only)_
  - [x] _(N/A)_ I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [x] _(N/A)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [x] _(N/A)_ I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.