### PR TITLE
Fix docs titles sidebar scrolling

### DIFF
--- a/web/src/theme/TOC/index.tsx
+++ b/web/src/theme/TOC/index.tsx
@@ -1,0 +1,72 @@
+import type { Props } from "@theme/TOC";
+import TOCItems from "@theme/TOCItems";
+import clsx from "clsx";
+import { useEffect, useRef, type ReactNode } from "react";
+
+import styles from "./styles.module.css";
+
+const LINK_CLASS_NAME = "table-of-contents__link toc-highlight";
+const LINK_ACTIVE_CLASS_NAME = "table-of-contents__link--active";
+const SCROLL_PADDING_PX = 1;
+
+function scrollActiveLinkIntoView(container: HTMLDivElement): void {
+  const activeLink = container.querySelector<HTMLElement>(
+    `.${LINK_ACTIVE_CLASS_NAME}`,
+  );
+
+  if (!activeLink) {
+    return;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const activeLinkRect = activeLink.getBoundingClientRect();
+
+  if (activeLinkRect.top < containerRect.top) {
+    container.scrollTop +=
+      Math.floor(activeLinkRect.top - containerRect.top) - SCROLL_PADDING_PX;
+  } else if (activeLinkRect.bottom > containerRect.bottom) {
+    container.scrollTop +=
+      Math.ceil(activeLinkRect.bottom - containerRect.bottom) +
+      SCROLL_PADDING_PX;
+  }
+}
+
+export default function TOC({ className, ...props }: Props): ReactNode {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return undefined;
+    }
+
+    const observer = new MutationObserver(() => {
+      scrollActiveLinkIntoView(container);
+    });
+
+    observer.observe(container, {
+      attributes: true,
+      attributeFilter: ["class"],
+      childList: true,
+      subtree: true,
+    });
+
+    scrollActiveLinkIntoView(container);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className={clsx(styles.tableOfContents, "thin-scrollbar", className)}
+    >
+      <TOCItems
+        {...props}
+        linkClassName={LINK_CLASS_NAME}
+        linkActiveClassName={LINK_ACTIVE_CLASS_NAME}
+      />
+    </div>
+  );
+}

--- a/web/src/theme/TOC/index.tsx
+++ b/web/src/theme/TOC/index.tsx
@@ -9,28 +9,6 @@ const LINK_CLASS_NAME = "table-of-contents__link toc-highlight";
 const LINK_ACTIVE_CLASS_NAME = "table-of-contents__link--active";
 const SCROLL_PADDING_PX = 1;
 
-function scrollActiveLinkIntoView(container: HTMLDivElement): void {
-  const activeLink = container.querySelector<HTMLElement>(
-    `.${LINK_ACTIVE_CLASS_NAME}`,
-  );
-
-  if (!activeLink) {
-    return;
-  }
-
-  const containerRect = container.getBoundingClientRect();
-  const activeLinkRect = activeLink.getBoundingClientRect();
-
-  if (activeLinkRect.top < containerRect.top) {
-    container.scrollTop +=
-      Math.floor(activeLinkRect.top - containerRect.top) - SCROLL_PADDING_PX;
-  } else if (activeLinkRect.bottom > containerRect.bottom) {
-    container.scrollTop +=
-      Math.ceil(activeLinkRect.bottom - containerRect.bottom) +
-      SCROLL_PADDING_PX;
-  }
-}
-
 export default function TOC({ className, ...props }: Props): ReactNode {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -44,7 +22,6 @@ export default function TOC({ className, ...props }: Props): ReactNode {
     const observer = new MutationObserver(() => {
       scrollActiveLinkIntoView(container);
     });
-
     observer.observe(container, {
       attributes: true,
       attributeFilter: ["class"],
@@ -69,4 +46,26 @@ export default function TOC({ className, ...props }: Props): ReactNode {
       />
     </div>
   );
+}
+
+function scrollActiveLinkIntoView(container: HTMLDivElement): void {
+  const activeLink = container.querySelector<HTMLElement>(
+    `.${LINK_ACTIVE_CLASS_NAME}`,
+  );
+
+  if (!activeLink) {
+    return;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const activeLinkRect = activeLink.getBoundingClientRect();
+
+  if (activeLinkRect.top < containerRect.top) {
+    container.scrollTop +=
+      Math.floor(activeLinkRect.top - containerRect.top) - SCROLL_PADDING_PX;
+  } else if (activeLinkRect.bottom > containerRect.bottom) {
+    container.scrollTop +=
+      Math.ceil(activeLinkRect.bottom - containerRect.bottom) +
+      SCROLL_PADDING_PX;
+  }
 }

--- a/web/src/theme/TOC/styles.module.css
+++ b/web/src/theme/TOC/styles.module.css
@@ -1,0 +1,12 @@
+.tableOfContents {
+  max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
+  overflow-y: auto;
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 1rem);
+}
+
+@media (max-width: 996px) {
+  .tableOfContents {
+    display: none;
+  }
+}

--- a/web/src/theme/TOC/styles.module.css
+++ b/web/src/theme/TOC/styles.module.css
@@ -9,4 +9,8 @@
   .tableOfContents {
     display: none;
   }
+
+  .docItemContainer {
+    padding: 0 0.3rem;
+  }
 }


### PR DESCRIPTION
## Description

Fixes #4507.

The docs' titles sidebar now scrolls independently to reveal the active heading. This works both when loading a URL with a fragment and when navigating to a heading client-side.

This overrides Docusaurus' `TOC` theme component and watches the active-link class managed by Docusaurus. It adjusts only the TOC container's `scrollTop`, so revealing the title never causes the document itself to scroll.

Manual verification used the production docs build with a deliberately short desktop viewport and a long table of contents:

- Direct load of `/docs/guides/optimization/seo#good-content` revealed the active `Good content` title while preserving the fragment scroll position.
- Client-side navigation to `#good-content` revealed the same active title.
- The browser console reported no errors.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The docs currently have no testing setup; the maintainer confirmed manual testing is sufficient for this issue. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- The docs currently have no testing setup; the maintainer confirmed manual testing is sufficient for this issue. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
