### PR TITLE
docs: add Node.js prerequisite to README 'Get started' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Run to install Wasp on OSX/Linux/WSL(Win):
 npm i -g @wasp.sh/wasp-cli@latest
 ```
 
+> **Prerequisite:** Wasp requires **Node.js >= 24.14.1** (and npm, which ships with it). If you don't have it, install via [nvm](https://github.com/nvm-sh/nvm) — see the [Quick Start docs](https://wasp.sh/docs/quick-start#more-details) for the full list.
+
 From there, follow the instructions to run your first app in less than a minute!
 
 For a quick start, check out [this docs page](https://wasp.sh/docs/quick-start).


### PR DESCRIPTION
Closes #2899 (option #2: copy requirements from the docs).

## What

The README's install command (\
pm i -g @wasp.sh/wasp-cli@latest\) used to live in a 'Get started' section with no mention of Node.js, even though Wasp requires **Node.js >= 24.14.1**. New users following a README link to a fresh terminal would hit a 'command not found: node' or a too-old Node and bounce before discovering the requirement.

## Fix

Added a one-line blockquote right under the install command:

\\\
> **Prerequisite:** Wasp requires **Node.js >= 24.14.1** (and npm, which ships with it). If you don't have it, install via [nvm](https://github.com/nvm-sh/nvm) — see the [Quick Start docs](https://wasp.sh/docs/quick-start#more-details) for the full list.
\\\

The link points at the docs' More details anchor (which already lists the requirement + nvm setup). Docs are authoritative; this is just so the README no longer sends users down a broken path.

## Why not the other options

- **#1 (remove install script, just link to docs)**: would break the convenience of \
pm i -g ...\ for users who already have Node set up
- **#3 (Getting Started, no install section)**: this is what the README is essentially doing already; the issue is the missing prerequisite callout, not the structure

## Verified

- Renders correctly on GitHub (blockquote + bold + inline code)
- Link target exists and lists the same prerequisite
- No code change, no version bump.