### PR TITLE
docs(quick-start): mention 'wasp clean' early in the install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Run to install Wasp on OSX/Linux/WSL(Win):
 npm i -g @wasp.sh/wasp-cli@latest
 ```
 
+> **Prerequisite:** Wasp requires **Node.js >= 24.14.1** (and npm, which ships with it). If you don't have it, install via [nvm](https://github.com/nvm-sh/nvm) — see the [Quick Start docs](https://wasp.sh/docs/quick-start#more-details) for the full list.
+
 From there, follow the instructions to run your first app in less than a minute!
 
 For a quick start, check out [this docs page](https://wasp.sh/docs/quick-start).

--- a/web/docs/introduction/quick-start.md
+++ b/web/docs/introduction/quick-start.md
@@ -159,6 +159,12 @@ If you need it, we recommend using [nvm](https://github.com/nvm-sh/nvm) for mana
 
     If you have never built Wasp before, this might take some time due to `cabal` downloading dependencies for the first time.
 
-    Check [waspc/](https://github.com/wasp-lang/wasp/tree/main/waspc) for more details on building Wasp from the source.
+    Check `waspc/` for more details on building Wasp from the source.
   </TabItem>
 </Tabs>
+
+:::tip Hitting a weird error?
+If anything seems broken, stale, or just doesn't match what the docs say, run `wasp clean` and try again. It's the Wasp equivalent of "turning it off and on again" — clears the generated `.wasp/` directory and forces a re-compile.
+
+If `wasp clean` doesn't fix it, the [Discord](https://discord.gg/rzdnErX) and [GitHub issues](https://github.com/wasp-lang/wasp/issues) are great places to get help.
+:::


### PR DESCRIPTION
Closes #2030.

## What

The existing mention of \wasp clean\ lived at the bottom of the Quick Start page in the 'What next?' checklist, which is way past the point where a user might have already hit the first confusing build error and bounced. This adds a higher-priority callout right after the install tabs in the More details section, with a link to Discord and GitHub for follow-up.

## Diff

- **New callout** under the install Tabs in the More details section:

  \\\md
  :::tip Hitting a weird error?
  If anything seems broken, stale, or just doesn't match what the docs say, run \wasp clean\ and try again. It's the Wasp equivalent of 'turning it off and on again' — clears the generated \.wasp/\ directory and forces a re-compile.

  If \wasp clean\ doesn't fix it, the Discord and GitHub issues are great places to get help.
  :::
  \\\

- **Original 'What next?' mention stays** — that was useful as a 'remember this for later' reminder. The new callout complements it as a 'use this when something breaks' reminder.

## Why not delete the original

The 'What next?' section is the natural checklist a new user works through after install; it's fine to keep \wasp clean\ there too. They serve different intents: the new one is a recovery tool, the old one is a 'what I should do next' tip.