### PR TITLE
docs(social-auth): add 'server-side code only' caution for userSignupFields/configFn

### DIFF
--- a/web/docs/auth/social-auth/overview.md
+++ b/web/docs/auth/social-auth/overview.md
@@ -71,6 +71,12 @@ If you wish to store more information about the user, you can override the defau
 
 You can create custom signup setups, such as allowing users to define a custom username after they sign up with a social provider.
 
+:::caution Server-side code only
+The `userSignupFields` and `configFn` implementations run **on the server** — they execute during the OAuth handshake, before the user is redirected back to the client. Define them in a **TypeScript** file (`.ts` or `.tsx`); a `.jsx` file will fail to compile against the `wasp/server/auth` import.
+
+If your project mixes `.js`/`.jsx`/`.ts`/`.tsx`, keep the auth files in `.ts`/`.tsx` even if everything else is JavaScript.
+:::
+
 ### Example: Allowing User to Set Their Username
 
 If you want to modify the signup flow (e.g., let users choose their own usernames), you will need to go through three steps:


### PR DESCRIPTION
Closes #2342.

## What

The docs showed \userSignupFields\ and \configFn\ being imported from \wasp/server/auth\, but didn't explicitly call out that these implementations are server-side code and must live in a TypeScript file. A user following the Google Auth docs in a mixed .jsx/.tsx project hit a compile error (reported on Discord) and didn't know why.

## Fix

Added a one-paragraph caution right under the 'Overrides' heading in the social-auth overview, in front of every provider-specific example (Google, GitHub, Discord, Slack, Microsoft, Keycloak all inherit the warning):

\\\md
:::caution Server-side code only
The \userSignupFields\ and \configFn\ implementations run **on the server** — they execute during the OAuth handshake, before the user is redirected back to the client. Define them in a TypeScript file (\.ts\ or \.tsx\); a \.jsx\ file will fail to compile against the \wasp/server/auth\ import.

If your project mixes \.js\/\.jsx\/\.ts\/\.tsx\, keep the auth files in \.ts\/\.tsx\ even if everything else is JavaScript.
:::
\\\

## Why not per-provider

Adding it once in the overview (right where the \userSignupFields\ and \configFn\ fields are introduced) means every provider's docs (Google, GitHub, Discord, Slack, Microsoft, Keycloak) inherits the warning. The provider-specific pages already link back to this section.

The user's original report is in the linked Discord thread — a one-paragraph caution would have saved them the round trip.