### PR TITLE
fix(docs): keep active sidebar item visible

### DIFF
--- a/web/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/web/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -1,0 +1,96 @@
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import {
+  useAnnouncementBar,
+  useScrollPosition,
+} from "@docusaurus/theme-common/internal";
+import { translate } from "@docusaurus/Translate";
+import type { Props } from "@theme/DocSidebar/Desktop/Content";
+import DocSidebarItems from "@theme/DocSidebarItems";
+import clsx from "clsx";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import styles from "./styles.module.css";
+
+const ACTIVE_LINK_SELECTOR = "a.menu__link--active";
+const SCROLL_PADDING_PX = 8;
+
+function useShowAnnouncementBar() {
+  const { isActive } = useAnnouncementBar();
+  const [showAnnouncementBar, setShowAnnouncementBar] = useState(isActive);
+
+  useScrollPosition(
+    ({ scrollY }) => {
+      if (isActive) {
+        setShowAnnouncementBar(scrollY === 0);
+      }
+    },
+    [isActive],
+  );
+
+  return isActive && showAnnouncementBar;
+}
+
+export default function DocSidebarDesktopContent({
+  path,
+  sidebar,
+  className,
+}: Props): ReactNode {
+  const showAnnouncementBar = useShowAnnouncementBar();
+  const containerRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return undefined;
+    }
+
+    const animationFrameId = window.requestAnimationFrame(() => {
+      scrollActiveLinkIntoView(container);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+    };
+  }, [path]);
+
+  return (
+    <nav
+      ref={containerRef}
+      aria-label={translate({
+        id: "theme.docs.sidebar.navAriaLabel",
+        message: "Docs sidebar",
+        description: "The ARIA label for the sidebar navigation",
+      })}
+      className={clsx(
+        "menu thin-scrollbar",
+        styles.menu,
+        showAnnouncementBar && styles.menuWithAnnouncementBar,
+        className,
+      )}
+    >
+      <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, "menu__list")}>
+        <DocSidebarItems items={sidebar} activePath={path} level={1} />
+      </ul>
+    </nav>
+  );
+}
+
+function scrollActiveLinkIntoView(container: HTMLElement): void {
+  const activeLink = container.querySelector<HTMLElement>(ACTIVE_LINK_SELECTOR);
+
+  if (!activeLink) {
+    return;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const activeLinkRect = activeLink.getBoundingClientRect();
+
+  if (activeLinkRect.top < containerRect.top) {
+    container.scrollTop +=
+      Math.floor(activeLinkRect.top - containerRect.top) - SCROLL_PADDING_PX;
+  } else if (activeLinkRect.bottom > containerRect.bottom) {
+    container.scrollTop +=
+      Math.ceil(activeLinkRect.bottom - containerRect.bottom) +
+      SCROLL_PADDING_PX;
+  }
+}

--- a/web/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/web/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -10,24 +10,8 @@ import clsx from "clsx";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import styles from "./styles.module.css";
 
-const ACTIVE_LINK_SELECTOR = "a.menu__link--active";
+const ACTIVE_LINK_SELECTOR = 'a[aria-current="page"]';
 const SCROLL_PADDING_PX = 8;
-
-function useShowAnnouncementBar() {
-  const { isActive } = useAnnouncementBar();
-  const [showAnnouncementBar, setShowAnnouncementBar] = useState(isActive);
-
-  useScrollPosition(
-    ({ scrollY }) => {
-      if (isActive) {
-        setShowAnnouncementBar(scrollY === 0);
-      }
-    },
-    [isActive],
-  );
-
-  return isActive && showAnnouncementBar;
-}
 
 export default function DocSidebarDesktopContent({
   path,
@@ -41,7 +25,7 @@ export default function DocSidebarDesktopContent({
     const container = containerRef.current;
 
     if (!container) {
-      return undefined;
+      return;
     }
 
     const animationFrameId = window.requestAnimationFrame(() => {
@@ -75,6 +59,22 @@ export default function DocSidebarDesktopContent({
   );
 }
 
+function useShowAnnouncementBar() {
+  const { isActive } = useAnnouncementBar();
+  const [showAnnouncementBar, setShowAnnouncementBar] = useState(isActive);
+
+  useScrollPosition(
+    ({ scrollY }) => {
+      if (isActive) {
+        setShowAnnouncementBar(scrollY === 0);
+      }
+    },
+    [isActive],
+  );
+
+  return isActive && showAnnouncementBar;
+}
+
 function scrollActiveLinkIntoView(container: HTMLElement): void {
   const activeLink = container.querySelector<HTMLElement>(ACTIVE_LINK_SELECTOR);
 
@@ -87,10 +87,9 @@ function scrollActiveLinkIntoView(container: HTMLElement): void {
 
   if (activeLinkRect.top < containerRect.top) {
     container.scrollTop +=
-      Math.floor(activeLinkRect.top - containerRect.top) - SCROLL_PADDING_PX;
+      activeLinkRect.top - containerRect.top - SCROLL_PADDING_PX;
   } else if (activeLinkRect.bottom > containerRect.bottom) {
     container.scrollTop +=
-      Math.ceil(activeLinkRect.bottom - containerRect.bottom) +
-      SCROLL_PADDING_PX;
+      activeLinkRect.bottom - containerRect.bottom + SCROLL_PADDING_PX;
   }
 }

--- a/web/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/web/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 @media (min-width: 997px) {
   .menu {
     flex-grow: 1;

--- a/web/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/web/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@media (min-width: 997px) {
+  .menu {
+    flex-grow: 1;
+    padding: 0.5rem;
+  }
+
+  @supports (scrollbar-gutter: stable) {
+    .menu {
+      padding: 0.5rem 0 0.5rem 0.5rem;
+      scrollbar-gutter: stable;
+    }
+  }
+
+  .menuWithAnnouncementBar {
+    margin-bottom: var(--docusaurus-announcement-bar-height);
+  }
+}


### PR DESCRIPTION
## Description

Closes #4507.

Automatically scrolls the desktop documentation sidebar when the active
document link is outside the sidebar's visible area.

The implementation adjusts only the sidebar's scroll position, avoiding
changes to the main document's scroll position.

## Type of change

- [ ] Just code/docs improvement
- [x] Bug fix
- [ ] New/improved feature
- [ ] Breaking change

## Testing

- Opened `/docs/advanced/email` directly
- Tested a hard refresh
- Tested client-side navigation between documentation pages
- Tested active links near the top and bottom of the sidebar
- Confirmed already-visible links do not cause unnecessary scrolling
- Confirmed the main document does not jump
- Confirmed there are no browser console errors
- Ran `npm run build` successfully