### PR TITLE
fix(web): check response.ok after fetch in SubscribeForm

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -5,6 +5,7 @@
 ### 🔧 Small improvements
 
 - Added a `wasp doctor` command that runs common sanity checks on your setup to check that Wasp can work correctly, and prints a report. ([#4283](https://github.com/wasp-lang/wasp/pull/4283))
+- `wasp deps` no longer shows internal WaspLib packages in its output. These are implementation details of Wasp and cannot be imported directly by users. ([#3244](https://github.com/wasp-lang/wasp/issues/3244))
 
 ## 0.24.0
 

--- a/waspc/cli/src/Wasp/Cli/Command/Deps.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Deps.hs
@@ -5,6 +5,7 @@ where
 
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
+import Data.List (isPrefixOf)
 import Wasp.AppSpec (AppSpec)
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Compile (defaultCompileOptions)
@@ -30,6 +31,12 @@ deps = do
 
   liftIO $ putStrLn $ depsMessage appSpec
 
+-- | Filters out internal Wasp library dependencies (WaspLibs) from the list.
+-- WaspLibs are installed as local npm tarballs (version starts with "file:")
+-- and are internal to Wasp — users cannot import them directly.
+filterOutWaspLibDeps :: [Npm.Dependency.Dependency] -> [Npm.Dependency.Dependency]
+filterOutWaspLibDeps = filter (not . ("file:" `isPrefixOf`) . Npm.Dependency.version)
+
 depsMessage :: AppSpec -> String
 depsMessage appSpec =
   unlines $
@@ -39,12 +46,12 @@ depsMessage appSpec =
     ]
       ++ printDeps
         "Server dependencies:"
-        ( N.dependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
+        ( filterOutWaspLibDeps $ N.dependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
         )
       ++ [""]
       ++ printDeps
         "Server devDependencies:"
-        ( N.devDependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
+        ( filterOutWaspLibDeps $ N.devDependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
         )
 
 printDeps :: String -> [Npm.Dependency.Dependency] -> [String]

--- a/waspc/cli/src/Wasp/Cli/Command/Deps.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Deps.hs
@@ -5,7 +5,7 @@ where
 
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
-import Data.List (isPrefixOf)
+import qualified Data.Set as Set
 import Wasp.AppSpec (AppSpec)
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Compile (defaultCompileOptions)
@@ -14,6 +14,8 @@ import Wasp.Cli.Terminal (title)
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
 import qualified Wasp.Generator.NpmDependencies as N
 import qualified Wasp.Generator.ServerGenerator as ServerGenerator
+import qualified Wasp.Generator.WaspLibs.AvailableLibs as AvailableLibs
+import qualified Wasp.Generator.WaspLibs.WaspLib as WaspLib
 import Wasp.Project (analyzeWaspProject)
 import qualified Wasp.Util.Terminal as Term
 
@@ -31,12 +33,6 @@ deps = do
 
   liftIO $ putStrLn $ depsMessage appSpec
 
--- | Filters out internal Wasp library dependencies (WaspLibs) from the list.
--- WaspLibs are installed as local npm tarballs (version starts with "file:")
--- and are internal to Wasp — users cannot import them directly.
-filterOutWaspLibDeps :: [Npm.Dependency.Dependency] -> [Npm.Dependency.Dependency]
-filterOutWaspLibDeps = filter (not . ("file:" `isPrefixOf`) . Npm.Dependency.version)
-
 depsMessage :: AppSpec -> String
 depsMessage appSpec =
   unlines $
@@ -53,6 +49,9 @@ depsMessage appSpec =
         "Server devDependencies:"
         ( filterOutWaspLibDeps $ N.devDependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
         )
+  where
+    waspLibPackageNames = Set.fromList $ map WaspLib.packageName AvailableLibs.waspLibs
+    filterOutWaspLibDeps = filter ((`Set.notMember` waspLibPackageNames) . Npm.Dependency.name)
 
 printDeps :: String -> [Npm.Dependency.Dependency] -> [String]
 printDeps dependenciesTitle dependencies =

--- a/web/src/components/SubscribeForm.jsx
+++ b/web/src/components/SubscribeForm.jsx
@@ -17,13 +17,14 @@ const SubscribeForm = ({ className, inputBgColor }) => {
     event.preventDefault();
 
     try {
-      await fetch(createNewEmailSubscriberApiEndpoint, {
+      const res = await fetch(createNewEmailSubscriberApiEndpoint, {
         method: "POST",
         body: "userGroup=&email=" + email,
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },
       });
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
       setMessage("Thank you for subscribing! 🙏");
     } catch (error) {
       setMessage("🛑 Oops! Something went wrong. Please try again.");


### PR DESCRIPTION
`fetch()` only rejects on network failures, not HTTP error responses. If the Loops API returns a 4xx or 5xx the catch block is never entered and the user sees "Thank you for subscribing!" even though the subscription failed.

Capture the response and throw if `res.ok` is false so the existing catch path shows the error message.