### PR TITLE
Capture Fly logs and test artifacts in deploy test

### DIFF
--- a/.github/workflows/ci-deploy-test.yaml
+++ b/.github/workflows/ci-deploy-test.yaml
@@ -74,6 +74,33 @@ jobs:
           echo "server=$SERVER_HOSTNAME" >> "$GITHUB_OUTPUT"
           echo "client=$CLIENT_HOSTNAME" >> "$GITHUB_OUTPUT"
 
+      # NOTE: Temporary diagnostics for flaky e2e tests: the deployed server
+      # briefly stops responding a few minutes after deploy (suspected
+      # postgres-flex 18.1 hiccup or Fly proxy machine downscaling). Capture
+      # machine logs and states during the test run so we can see what the
+      # infrastructure did when a test fails. The background processes are
+      # cleaned up automatically when the job ends.
+      - name: Capture Fly logs and machine states during tests
+        run: |
+          mkdir -p fly-debug-logs
+          for app_suffix in server db client; do
+            app="$APP_PREFIX-$app_suffix"
+            flyctl logs -a "$app" > "fly-debug-logs/$app_suffix.log" 2>&1 &
+          done
+          (
+            while true; do
+              {
+                date -u
+                for app_suffix in server db client; do
+                  app="$APP_PREFIX-$app_suffix"
+                  flyctl machine list -a "$app" --json \
+                    | jq -r --arg app "$app" '.[] | "\($app) \(.id) state=\(.state)"'
+                done
+              } >> fly-debug-logs/machine-states.log 2>&1
+              sleep 15
+            done
+          ) &
+
       - name: Run E2E tests against deployed app
         working-directory: ${{ env.APP_TO_DEPLOY }}
         env:
@@ -81,6 +108,16 @@ jobs:
           PLAYWRIGHT_BASE_URL: "https://${{ steps.get-hostnames.outputs.client }}"
           PLAYWRIGHT_SERVER_URL: "https://${{ steps.get-hostnames.outputs.server }}"
         run: npm test
+
+      - name: Upload Fly debug logs and test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fly-deploy-test-debug-${{ github.run_attempt }}
+          path: |
+            fly-debug-logs/
+            ${{ env.APP_TO_DEPLOY }}/e2e-tests/test-results/
+          if-no-files-found: ignore
 
   cleanup_fly_deploy_test:
     name: Clean up Fly deployment test apps


### PR DESCRIPTION
## Description

The Fly deploy test has been flaky since mid-July (runs on Jul 17, 20, 23, 28): always `custom-signup.spec.ts` in the Mobile Chrome project, always a ~15-20s window where server API requests hang and then recover on their own, ~2-3 minutes after deploy. The flakiness started right after Fly silently flipped the default image for `fly postgres create` from `postgres-flex:17.2` to `postgres-flex:18.1` (visible in our CI logs between Jul 10 and Jul 13). Suspects: the PG 18 image struggling on the 256MB dev VM, or Fly proxy downscaling the extra HA server machine.

The job currently uploads no artifacts, so every flake is a dead end. This PR adds temporary diagnostics to the Fly deploy test:

- tails `flyctl logs` for the server, db, and client apps in the background during the e2e tests,
- snapshots machine states every 15s (to catch autostop downscaling in the act),
- uploads those logs plus Playwright `test-results/` (error contexts, traces) as an artifact, on success and failure.

Next time the flake hits we get the infrastructure-side story instead of guessing. Meant to be reverted (or slimmed down) once the root cause is confirmed.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
