### PR TITLE
Discover dev db port from Docker at compile time

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -8,6 +8,7 @@
 
 ### 🔧 Small improvements
 
+- `wasp start` now finds the managed dev database by asking Docker where the project's database container is running, instead of assuming `localhost:5432`. This means Wasp will no longer accidentally connect to an unrelated database that happens to be listening on port 5432. ([#4567](https://github.com/wasp-lang/wasp/pull/4567))
 - Newly created projects no longer open the browser automatically on `wasp start`. ([#4553](https://github.com/wasp-lang/wasp/pull/4553))
 - Upgraded internal `morgan` to 1.11, which fixes ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Wasp's usage was unaffected by the vulnerability. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
 - The `<region>` argument of `wasp deploy fly` is now case-insensitive, so e.g. `MIA` is accepted instead of being rejected as an invalid region. ([#4588](https://github.com/wasp-lang/wasp/pull/4588))

--- a/waspc/e2e-tests/Tests/WaspDbMigrateDevTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDbMigrateDevTest.hs
@@ -3,7 +3,7 @@ module Tests.WaspDbMigrateDevTest (waspDbMigrateDevTest) where
 import Control.Monad.Reader (MonadReader (ask))
 import qualified Data.Text as T
 import NeatInterpolation (trimming)
-import ShellCommands (ShellCommand, ShellCommandBuilder, WaspProjectContext (..), appendToPrismaFile, createTestWaspProject, inTestWaspProjectDir, waspCliDbMigrateDev, (~&&))
+import ShellCommands (ShellCommand, ShellCommandBuilder, WaspProjectContext (..), appendToPrismaFile, assertCommandOutputContains, createTestWaspProject, inTestWaspProjectDir, setWaspDbToPSQL, waspCliDbMigrateDev, (~&&))
 import StrongPath (fromAbsDir, (</>))
 import Test (Test (..), TestCase (..))
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
@@ -25,6 +25,18 @@ waspDbMigrateDevTest =
     [ TestCase
         "fail-outside-project"
         (return [waspCliDbMigrateDevFails]),
+      TestCase
+        "fail-postgresql-project-when-dev-db-not-running"
+        ( sequence
+            [ createTestWaspProject minimalStarterTemplate,
+              inTestWaspProjectDir
+                [ setWaspDbToPSQL,
+                  assertCommandOutputContains
+                    (return waspCliDbMigrateDevFails)
+                    "The database needs to be running"
+                ]
+            ]
+        ),
       TestCase
         "succeed-migrations-up-to-date"
         ( sequence

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -7,6 +7,9 @@ module Wasp.Generator.ServerGenerator
   ( genServer,
     operationsRouteInRootRouter,
     npmDepsFromWasp,
+
+    -- * Exported for testing only
+    genDotEnv,
   )
 where
 
@@ -105,8 +108,8 @@ genDotEnv spec =
     ]
   where
     envVars = waspEnvVars ++ userEnvVars
-    userEnvVars = AS.devEnvVarsServer spec
-    waspEnvVars = case AS.devDatabaseUrl spec of
+    userEnvVars = spec.devEnvVarsServer
+    waspEnvVars = case spec.devDatabaseUrl of
       Just url | not isThereCustomDbUrl -> [(databaseUrlEnvVarName, url)]
       _ -> []
     isThereCustomDbUrl = any ((== databaseUrlEnvVarName) . fst) userEnvVars

--- a/waspc/src/Wasp/Project/Analyze.hs
+++ b/waspc/src/Wasp/Project/Analyze.hs
@@ -86,7 +86,7 @@ constructAppSpec waspDir compileOptions externalConfigs parsedPrismaSchema decls
   maybeMigrationsDir <- findMigrationsDir waspDir
   maybeUserDockerfileContents <- loadUserDockerfileContents waspDir
   let dbSystem = getValidDbSystemFromPrismaSchema parsedPrismaSchema
-  let devDbUrl = makeDevDatabaseUrl waspDir dbSystem decls
+  devDbUrl <- makeDevDatabaseUrl waspDir dbSystem decls
   serverEnvVars <- readDotEnvServer waspDir
   clientEnvVars <- readDotEnvClient waspDir
 

--- a/waspc/src/Wasp/Project/Db.hs
+++ b/waspc/src/Wasp/Project/Db.hs
@@ -27,12 +27,13 @@ makeDevDatabaseUrl ::
   Path' Abs (Dir WaspProjectDir) ->
   AS.Db.DbSystem ->
   [AS.Decl] ->
-  Maybe String
-makeDevDatabaseUrl waspProjectDir dbSystem decls = do
-  (appName, _) <- AS.getApp decls
-  case dbSystem of
-    AS.Db.PostgreSQL -> Just $ DevPostgres.makeDevConnectionUrl waspProjectDir appName
-    AS.Db.SQLite -> Just DevSqlite.defaultDevDbFile
+  IO (Maybe String)
+makeDevDatabaseUrl waspProjectDir dbSystem decls =
+  case AS.getApp decls of
+    Nothing -> return Nothing
+    Just (appName, _) -> case dbSystem of
+      AS.Db.SQLite -> return $ Just DevSqlite.defaultDevDbFile
+      AS.Db.PostgreSQL -> DevPostgres.discoverDevConnectionUrl waspProjectDir appName
 
 databaseUrlEnvVarName :: String
 databaseUrlEnvVarName = "DATABASE_URL"

--- a/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
+++ b/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
@@ -1,6 +1,7 @@
 -- | This module captures how Wasp runs a PostgreSQL dev database.
 module Wasp.Project.Db.Dev.Postgres
-  ( defaultDevUser,
+  ( discoverDevConnectionUrl,
+    defaultDevUser,
     makeDevDbName,
     defaultDevPass,
     defaultDevPort,
@@ -8,12 +9,50 @@ module Wasp.Project.Db.Dev.Postgres
     makeWaspDevDbDockerContainerName,
     makeWaspDevDbDockerVolumeName,
     waspDevDbDockerVolumePrefix,
+
+    -- * Exported for testing only
+    parseDockerPortOutput,
   )
 where
 
+import Control.Exception (SomeException, try)
+import Data.List.Extra (takeWhileEnd)
 import StrongPath (Abs, Dir, Path')
+import System.Exit (ExitCode (..))
+import System.Process (readProcessWithExitCode)
+import Text.Read (readMaybe)
 import Wasp.Db.Postgres (makeConnectionUrl, postgresMaxDbNameLength)
 import Wasp.Project.Common (WaspProjectDir, makeAppUniqueId)
+
+-- | Returns the connection URL of this Wasp project's dev db, on the host port
+-- the dev db container is currently published on. Returns Nothing if the
+-- container is not running or docker is not available.
+discoverDevConnectionUrl :: Path' Abs (Dir WaspProjectDir) -> String -> IO (Maybe String)
+discoverDevConnectionUrl waspProjectDir appName =
+  fmap makeUrlForPort <$> discoverDevDbPort waspProjectDir appName
+  where
+    makeUrlForPort port = makeConnectionUrl defaultDevUser defaultDevPass port $ makeDevDbName waspProjectDir appName
+
+-- | Asks Docker for the host port on which this Wasp project's dev db container
+-- is currently published. Returns Nothing if the container is not running or
+-- docker is not available.
+discoverDevDbPort :: Path' Abs (Dir WaspProjectDir) -> String -> IO (Maybe Int)
+discoverDevDbPort waspProjectDir appName = do
+  result <-
+    try $ readProcessWithExitCode "docker" ["port", containerName, "5432"] ""
+  return $ case result of
+    Right (ExitSuccess, stdout, _stderr) -> parseDockerPortOutput stdout
+    Right (ExitFailure _, _stdout, _stderr) -> Nothing
+    Left (_ :: SomeException) -> Nothing
+  where
+    containerName = makeWaspDevDbDockerContainerName waspProjectDir appName
+
+-- | Parses the output of @docker port \<container\> \<port\>@ into the host port.
+-- The output has a line per network interface, e.g. "0.0.0.0:5433\n[::]:5433\n".
+parseDockerPortOutput :: String -> Maybe Int
+parseDockerPortOutput output = case lines output of
+  (firstLine : _) -> readMaybe $ takeWhileEnd (/= ':') firstLine
+  [] -> Nothing
 
 defaultDevUser :: String
 defaultDevUser = "postgresWaspDevUser"

--- a/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
+++ b/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
@@ -9,50 +9,24 @@ module Wasp.Project.Db.Dev.Postgres
     makeWaspDevDbDockerContainerName,
     makeWaspDevDbDockerVolumeName,
     waspDevDbDockerVolumePrefix,
-
-    -- * Exported for testing only
-    parseDockerPortOutput,
   )
 where
 
-import Control.Exception (SomeException, try)
-import Data.List.Extra (takeWhileEnd)
 import StrongPath (Abs, Dir, Path')
-import System.Exit (ExitCode (..))
-import System.Process (readProcessWithExitCode)
-import Text.Read (readMaybe)
 import Wasp.Db.Postgres (makeConnectionUrl, postgresMaxDbNameLength)
 import Wasp.Project.Common (WaspProjectDir, makeAppUniqueId)
+import Wasp.Util.Docker (getDockerContainerHostPort)
 
--- | Returns the connection URL of this Wasp project's dev db, on the host port
--- the dev db container is currently published on. Returns Nothing if the
--- container is not running or docker is not available.
+-- | Returns the connection URL of this Wasp project's dev db if it is up and
+-- operational, Nothing otherwise.
 discoverDevConnectionUrl :: Path' Abs (Dir WaspProjectDir) -> String -> IO (Maybe String)
-discoverDevConnectionUrl waspProjectDir appName =
-  fmap makeUrlForPort <$> discoverDevDbPort waspProjectDir appName
+discoverDevConnectionUrl waspProjectDir appName = do
+  exposedContainerPort <- getDockerContainerHostPort devDbContainerName 5432
+  return $ makeUrlOnPort <$> exposedContainerPort
   where
-    makeUrlForPort port = makeConnectionUrl defaultDevUser defaultDevPass port $ makeDevDbName waspProjectDir appName
-
--- | Asks Docker for the host port on which this Wasp project's dev db container
--- is currently published. Returns Nothing if the container is not running or
--- docker is not available.
-discoverDevDbPort :: Path' Abs (Dir WaspProjectDir) -> String -> IO (Maybe Int)
-discoverDevDbPort waspProjectDir appName = do
-  result <-
-    try $ readProcessWithExitCode "docker" ["port", containerName, "5432"] ""
-  return $ case result of
-    Right (ExitSuccess, stdout, _stderr) -> parseDockerPortOutput stdout
-    Right (ExitFailure _, _stdout, _stderr) -> Nothing
-    Left (_ :: SomeException) -> Nothing
-  where
-    containerName = makeWaspDevDbDockerContainerName waspProjectDir appName
-
--- | Parses the output of @docker port \<container\> \<port\>@ into the host port.
--- The output has a line per network interface, e.g. "0.0.0.0:5433\n[::]:5433\n".
-parseDockerPortOutput :: String -> Maybe Int
-parseDockerPortOutput output = case lines output of
-  (firstLine : _) -> readMaybe $ takeWhileEnd (/= ':') firstLine
-  [] -> Nothing
+    makeUrlOnPort port = makeConnectionUrl defaultDevUser defaultDevPass port devDbName
+    devDbName = makeDevDbName waspProjectDir appName
+    devDbContainerName = makeWaspDevDbDockerContainerName waspProjectDir appName
 
 defaultDevUser :: String
 defaultDevUser = "postgresWaspDevUser"

--- a/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
+++ b/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
@@ -17,12 +17,12 @@ import Wasp.Db.Postgres (makeConnectionUrl, postgresMaxDbNameLength)
 import Wasp.Project.Common (WaspProjectDir, makeAppUniqueId)
 import Wasp.Util.Docker (getDockerContainerHostPort)
 
--- | Returns the connection URL of this Wasp project's dev db if it is up and
--- operational, Nothing otherwise.
+-- | Returns the connection URL of this Wasp project's dev db if it is up,
+-- 'Nothing' otherwise.
 discoverDevConnectionUrl :: Path' Abs (Dir WaspProjectDir) -> String -> IO (Maybe String)
 discoverDevConnectionUrl waspProjectDir appName = do
-  exposedContainerPort <- getDockerContainerHostPort devDbContainerName 5432
-  return $ makeUrlOnPort <$> exposedContainerPort
+  devDbPort <- getDockerContainerHostPort devDbContainerName 5432
+  return $ makeUrlOnPort <$> devDbPort
   where
     makeUrlOnPort port = makeConnectionUrl defaultDevUser defaultDevPass port devDbName
     devDbName = makeDevDbName waspProjectDir appName

--- a/waspc/src/Wasp/Util/Docker.hs
+++ b/waspc/src/Wasp/Util/Docker.hs
@@ -1,9 +1,38 @@
 module Wasp.Util.Docker
-  ( DockerImageName,
+  ( DockerContainerName,
+    DockerImageName,
     DockerVolumeMountPath,
+    getDockerContainerHostPort,
+
+    -- * Exported for testing only
+    parseDockerPortOutput,
   )
 where
+
+import Control.Exception (SomeException, try)
+import Data.List.Extra (takeWhileEnd)
+import System.Exit (ExitCode (..))
+import System.Process (readProcessWithExitCode)
+import Text.Read (readMaybe)
+
+type DockerContainerName = String
 
 type DockerImageName = String
 
 type DockerVolumeMountPath = String
+
+getDockerContainerHostPort :: DockerContainerName -> Int -> IO (Maybe Int)
+getDockerContainerHostPort containerName containerPort = do
+  result <-
+    try $ readProcessWithExitCode "docker" ["port", containerName, show containerPort] ""
+  return $ case result of
+    Right (ExitSuccess, stdout, _stderr) -> parseDockerPortOutput stdout
+    Right (ExitFailure _, _stdout, _stderr) -> Nothing
+    Left (_ :: SomeException) -> Nothing
+
+-- | Parses the output of @docker port \<container\> \<port\>@ into the host port.
+-- The output has a line per network interface, e.g. "0.0.0.0:5433\n[::]:5433\n".
+parseDockerPortOutput :: String -> Maybe Int
+parseDockerPortOutput output = case lines output of
+  (firstLine : _) -> readMaybe $ takeWhileEnd (/= ':') firstLine
+  [] -> Nothing

--- a/waspc/tests/Generator/ServerGeneratorTest.hs
+++ b/waspc/tests/Generator/ServerGeneratorTest.hs
@@ -1,0 +1,84 @@
+module Generator.ServerGeneratorTest where
+
+import qualified Data.Map as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import Fixtures (systemSPRoot)
+import NeatInterpolation (trimming)
+import StrongPath (relfile)
+import qualified StrongPath as SP
+import Test.Hspec
+import qualified Util.Prisma as Util
+import qualified Wasp.AppSpec as AS
+import qualified Wasp.ExternalConfig.Npm.PackageJson as Npm.PackageJson
+import Wasp.Generator.FileDraft (FileDraft (FileDraftTextFd))
+import Wasp.Generator.FileDraft.TextFileDraft (TextFileDraft (_content))
+import Wasp.Generator.Monad (runGenerator)
+import qualified Wasp.Generator.NpmWorkspaces as NW
+import Wasp.Generator.ServerGenerator (genDotEnv)
+import qualified Wasp.Project.BuildType as BuildType
+
+spec_genDotEnv :: Spec
+spec_genDotEnv = do
+  describe "genDotEnv" $ do
+    it "writes DATABASE_URL when the dev database url is known" $ do
+      genDotEnvContent basicAppSpec {AS.devDatabaseUrl = Just devDbUrl}
+        `shouldBe` Just (T.pack $ "DATABASE_URL=" <> devDbUrl)
+
+    it "omits DATABASE_URL when the dev database url is not known" $ do
+      genDotEnvContent basicAppSpec {AS.devDatabaseUrl = Nothing}
+        `shouldBe` Just ""
+
+    it "prefers the user-provided DATABASE_URL over the dev database one" $ do
+      genDotEnvContent
+        basicAppSpec
+          { AS.devDatabaseUrl = Just devDbUrl,
+            AS.devEnvVarsServer = [("DATABASE_URL", userDbUrl)]
+          }
+        `shouldBe` Just (T.pack $ "DATABASE_URL=" <> userDbUrl)
+
+    it "generates no .env for production builds" $ do
+      case runGenerator $ genDotEnv basicAppSpec {AS.buildType = BuildType.Production, AS.devDatabaseUrl = Just devDbUrl} of
+        (_, Right drafts) -> length drafts `shouldBe` 0
+        (_, Left _) -> expectationFailure "genDotEnv failed"
+  where
+    devDbUrl = "postgresql://devUser:devPass@localhost:5432/devDb"
+    userDbUrl = "postgresql://userUser:userPass@localhost:9999/userDb"
+
+    genDotEnvContent :: AS.AppSpec -> Maybe T.Text
+    genDotEnvContent spec = case runGenerator $ genDotEnv spec of
+      (_, Right [FileDraftTextFd draft]) -> Just draft._content
+      _ -> Nothing
+
+    basicAppSpec =
+      AS.AppSpec
+        { AS.decls = [],
+          AS.prismaSchema = basicPrismaSchema,
+          AS.waspProjectDir = systemSPRoot SP.</> [SP.reldir|test/|],
+          AS.externalCodeFiles = [],
+          AS.packageJson =
+            Npm.PackageJson.PackageJson
+              { Npm.PackageJson.name = "testApp",
+                Npm.PackageJson.version = Nothing,
+                Npm.PackageJson.dependencies = M.empty,
+                Npm.PackageJson.devDependencies = M.empty,
+                Npm.PackageJson.workspaces = Just $ S.toList NW.requiredWorkspaceGlobs,
+                Npm.PackageJson.wasp = Nothing
+              },
+          AS.buildType = BuildType.Development,
+          AS.migrationsDir = Nothing,
+          AS.devEnvVarsClient = [],
+          AS.devEnvVarsServer = [],
+          AS.userDockerfileContents = Nothing,
+          AS.devDatabaseUrl = Nothing,
+          AS.srcTsConfigPath = [relfile|tsconfig.json|]
+        }
+
+    basicPrismaSchema =
+      Util.getPrismaSchema
+        [trimming|
+          datasource db {
+            provider = "postgresql"
+            url = env("DATABASE_URL")
+          }
+        |]

--- a/waspc/tests/Generator/ServerGeneratorTest.hs
+++ b/waspc/tests/Generator/ServerGeneratorTest.hs
@@ -17,25 +17,26 @@ import Wasp.Generator.Monad (runGenerator)
 import qualified Wasp.Generator.NpmWorkspaces as NW
 import Wasp.Generator.ServerGenerator (genDotEnv)
 import qualified Wasp.Project.BuildType as BuildType
+import Wasp.Project.Db (databaseUrlEnvVarName)
 
 spec_genDotEnv :: Spec
 spec_genDotEnv = do
   describe "genDotEnv" $ do
-    it "writes DATABASE_URL when the dev database url is known" $ do
+    it ("writes " <> databaseUrlEnvVarName <> " when the dev database url is known") $ do
       genDotEnvContent basicAppSpec {AS.devDatabaseUrl = Just devDbUrl}
-        `shouldBe` Just (T.pack $ "DATABASE_URL=" <> devDbUrl)
+        `shouldBe` Just (T.pack $ databaseUrlEnvVarName <> "=" <> devDbUrl)
 
-    it "omits DATABASE_URL when the dev database url is not known" $ do
+    it ("omits " <> databaseUrlEnvVarName <> " when the dev database url is not known") $ do
       genDotEnvContent basicAppSpec {AS.devDatabaseUrl = Nothing}
         `shouldBe` Just ""
 
-    it "prefers the user-provided DATABASE_URL over the dev database one" $ do
+    it ("prefers the user-provided " <> databaseUrlEnvVarName <> " over the dev database one") $ do
       genDotEnvContent
         basicAppSpec
           { AS.devDatabaseUrl = Just devDbUrl,
-            AS.devEnvVarsServer = [("DATABASE_URL", userDbUrl)]
+            AS.devEnvVarsServer = [(databaseUrlEnvVarName, userDbUrl)]
           }
-        `shouldBe` Just (T.pack $ "DATABASE_URL=" <> userDbUrl)
+        `shouldBe` Just (T.pack $ databaseUrlEnvVarName <> "=" <> userDbUrl)
 
     it "generates no .env for production builds" $ do
       case runGenerator $ genDotEnv basicAppSpec {AS.buildType = BuildType.Production, AS.devDatabaseUrl = Just devDbUrl} of

--- a/waspc/tests/Project/Db/Dev/PostgresTest.hs
+++ b/waspc/tests/Project/Db/Dev/PostgresTest.hs
@@ -1,0 +1,22 @@
+module Project.Db.Dev.PostgresTest where
+
+import Test.Hspec
+import Wasp.Project.Db.Dev.Postgres (parseDockerPortOutput)
+
+spec_parseDockerPortOutput :: Spec
+spec_parseDockerPortOutput = do
+  describe "parseDockerPortOutput" $ do
+    it "parses single-line output" $ do
+      parseDockerPortOutput "0.0.0.0:5432\n" `shouldBe` Just 5432
+
+    it "parses multi-line output by using the first line" $ do
+      parseDockerPortOutput "0.0.0.0:5433\n[::]:5434\n" `shouldBe` Just 5433
+
+    it "parses an IPv6 first line" $ do
+      parseDockerPortOutput "[::]:5433\n0.0.0.0:5433\n" `shouldBe` Just 5433
+
+    it "returns Nothing on empty output" $ do
+      parseDockerPortOutput "" `shouldBe` Nothing
+
+    it "returns Nothing on output without a port" $ do
+      parseDockerPortOutput "no port mapping found\n" `shouldBe` Nothing

--- a/waspc/tests/Util/DockerTest.hs
+++ b/waspc/tests/Util/DockerTest.hs
@@ -1,7 +1,7 @@
-module Project.Db.Dev.PostgresTest where
+module Util.DockerTest where
 
 import Test.Hspec
-import Wasp.Project.Db.Dev.Postgres (parseDockerPortOutput)
+import Wasp.Util.Docker (parseDockerPortOutput)
 
 spec_parseDockerPortOutput :: Spec
 spec_parseDockerPortOutput = do

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -611,6 +611,7 @@ test-suite waspc-tests
     JsImportTest
     Node.InternalTest
     Paths_waspc
+    Project.Db.Dev.PostgresTest
     Project.DbTest
     Project.ExternalConfig.PackageJsonTest
     Project.ExternalConfig.RootTsConfigTest

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -607,6 +607,7 @@ test-suite waspc-tests
     Generator.FileDraft.TemplateFileDraftTest
     Generator.JsImportTest
     Generator.MockWriteableMonad
+    Generator.ServerGeneratorTest
     Generator.WriteFileDraftsTest
     JsImportTest
     Node.InternalTest

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -611,7 +611,6 @@ test-suite waspc-tests
     JsImportTest
     Node.InternalTest
     Paths_waspc
-    Project.Db.Dev.PostgresTest
     Project.DbTest
     Project.ExternalConfig.PackageJsonTest
     Project.ExternalConfig.RootTsConfigTest
@@ -642,6 +641,7 @@ test-suite waspc-tests
     Test.Util
     Util.Control.MonadTest
     Util.Diff
+    Util.DockerTest
     Util.FibTest
     Util.FilePathTest
     Util.IO.RetryTest


### PR DESCRIPTION
## Description

Part of #4529 (running multiple dev databases in parallel). Stacked on #4568.

Before this PR:
1. `wasp start db` always starts the database on port 5432.
2. `wasp start` always looks for the dev database on port 5432.
3. Since `wasp start` looks for the DB on `localhost:5432`:
    - If `wasp start db` is running, all good.
    - If there's no database on `localhost:5432`, it fails using the `DbConnectionEstablished` requirement. The user gets a nice error. 
    - If there's a different on `localhost:5432`, `wasp start` will attempt to connect to it. It will either fail during compilation thanks to incorrect credentials or make it all the way to application code and hijack another app's database.

After this PR:
1. `wasp start` always starts the database on port 5432, this is unchanged and coming in the next PR.
2. `wasp start` discovers the dev database port by asking docker. It relies on the container's name, which is the project's path-based unique ID.
3. Since `wasp start` looks for the DB on the output of `docker port uniqueContainerName`:
    - If `wasp start db` is running, `docker port` returns the correct port, and all good.
    - If `wasp start db` isn't running, the user gets a nice error. `wasp start` will no longer connect to whatever is running on 5432, wich means no more database hijacking (at least not until runtime).
  

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.