### PR TITLE
Move dev db Docker naming from CLI into Wasp.Project.Db.Dev.Postgres

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Start/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start/Db.hs
@@ -1,6 +1,5 @@
 module Wasp.Cli.Command.Start.Db
   ( start,
-    waspDevDbDockerVolumePrefix,
   )
 where
 
@@ -26,7 +25,7 @@ import Wasp.Cli.Command.Require.WaspSpecAvailable (WaspSpecAvailable (WaspSpecAv
 import Wasp.Cli.Util.Parser (withArguments)
 import Wasp.Db.Postgres (defaultPostgresDockerImageSpec)
 import qualified Wasp.Message as Msg
-import Wasp.Project.Common (WaspProjectDir, makeAppUniqueId)
+import Wasp.Project.Common (WaspProjectDir)
 import Wasp.Project.Db (databaseUrlEnvVarName)
 import qualified Wasp.Project.Db.Dev.Postgres as Dev.Postgres
 import Wasp.Project.Env (dotEnvServer)
@@ -158,8 +157,8 @@ startPostgresDevDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath 
           ]
   liftIO $ callCommand command
   where
-    dockerVolumeName = makeWaspDevDbDockerVolumeName waspProjectDir appName
-    dockerContainerName = makeWaspDevDbDockerContainerName waspProjectDir appName
+    dockerVolumeName = Dev.Postgres.makeWaspDevDbDockerVolumeName waspProjectDir appName
+    dockerContainerName = Dev.Postgres.makeWaspDevDbDockerContainerName waspProjectDir appName
     dbName = Dev.Postgres.makeDevDbName waspProjectDir appName
     connectionUrl = Dev.Postgres.makeDevConnectionUrl waspProjectDir appName
 
@@ -180,24 +179,3 @@ startPostgresDevDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath 
                   "Wasp can't run PostgreSQL dev database for you since port %d is already in use."
                   Dev.Postgres.defaultDevPort
               )
-
--- | Docker volume name unique for the Wasp project with specified path and name.
-makeWaspDevDbDockerVolumeName :: Path' Abs (Dir WaspProjectDir) -> String -> String
-makeWaspDevDbDockerVolumeName waspProjectDir appName =
-  take maxDockerVolumeNameLength $
-    waspDevDbDockerVolumePrefix <> "-" <> makeAppUniqueId waspProjectDir appName
-
-waspDevDbDockerVolumePrefix :: String
-waspDevDbDockerVolumePrefix = "wasp-dev-db"
-
-maxDockerVolumeNameLength :: Int
-maxDockerVolumeNameLength = 255
-
--- | Docker container name unique for the Wasp project with specified path and name.
-makeWaspDevDbDockerContainerName :: Path' Abs (Dir WaspProjectDir) -> String -> String
-makeWaspDevDbDockerContainerName waspProjectDir appName =
-  take maxDockerContainerNameLength $
-    waspDevDbDockerVolumePrefix <> "-" <> makeAppUniqueId waspProjectDir appName
-
-maxDockerContainerNameLength :: Int
-maxDockerContainerNameLength = 63

--- a/waspc/cli/src/Wasp/Cli/Command/Uninstall.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Uninstall.hs
@@ -10,7 +10,6 @@ import qualified StrongPath as SP
 import System.Exit (die)
 import Wasp.Cli.Command (Command)
 import Wasp.Cli.Command.Message (cliSendMessageC)
-import Wasp.Cli.Command.Start.Db (waspDevDbDockerVolumePrefix)
 import Wasp.Cli.FileSystem
   ( getHomeDir,
     getUserCacheDir,
@@ -19,6 +18,7 @@ import Wasp.Cli.FileSystem
     waspInstallationDirInHomeDir,
   )
 import Wasp.Message (Message)
+import Wasp.Project.Db.Dev.Postgres (waspDevDbDockerVolumePrefix)
 import qualified Wasp.Message as Msg
 import Wasp.Util (indent)
 import Wasp.Util.IO

--- a/waspc/cli/src/Wasp/Cli/Command/Uninstall.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Uninstall.hs
@@ -18,8 +18,8 @@ import Wasp.Cli.FileSystem
     waspInstallationDirInHomeDir,
   )
 import Wasp.Message (Message)
-import Wasp.Project.Db.Dev.Postgres (waspDevDbDockerVolumePrefix)
 import qualified Wasp.Message as Msg
+import Wasp.Project.Db.Dev.Postgres (waspDevDbDockerVolumePrefix)
 import Wasp.Util (indent)
 import Wasp.Util.IO
   ( deleteDirectoryIfExists,

--- a/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
+++ b/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
@@ -5,6 +5,9 @@ module Wasp.Project.Db.Dev.Postgres
     defaultDevPass,
     defaultDevPort,
     makeDevConnectionUrl,
+    makeWaspDevDbDockerContainerName,
+    makeWaspDevDbDockerVolumeName,
+    waspDevDbDockerVolumePrefix,
   )
 where
 
@@ -35,3 +38,24 @@ defaultDevPort = 5432 -- 5432 is default port for PostgreSQL db.
 makeDevConnectionUrl :: Path' Abs (Dir WaspProjectDir) -> String -> String
 makeDevConnectionUrl waspProjectDir appName =
   makeConnectionUrl defaultDevUser defaultDevPass defaultDevPort $ makeDevDbName waspProjectDir appName
+
+-- | Docker volume name unique for the Wasp project with specified path and name.
+makeWaspDevDbDockerVolumeName :: Path' Abs (Dir WaspProjectDir) -> String -> String
+makeWaspDevDbDockerVolumeName waspProjectDir appName =
+  take maxDockerVolumeNameLength $
+    waspDevDbDockerVolumePrefix <> "-" <> makeAppUniqueId waspProjectDir appName
+
+waspDevDbDockerVolumePrefix :: String
+waspDevDbDockerVolumePrefix = "wasp-dev-db"
+
+maxDockerVolumeNameLength :: Int
+maxDockerVolumeNameLength = 255
+
+-- | Docker container name unique for the Wasp project with specified path and name.
+makeWaspDevDbDockerContainerName :: Path' Abs (Dir WaspProjectDir) -> String -> String
+makeWaspDevDbDockerContainerName waspProjectDir appName =
+  take maxDockerContainerNameLength $
+    waspDevDbDockerVolumePrefix <> "-" <> makeAppUniqueId waspProjectDir appName
+
+maxDockerContainerNameLength :: Int
+maxDockerContainerNameLength = 63


### PR DESCRIPTION
## Description

Pure code move, no behavior change.

The dev db container/volume name derivation (and the `wasp-dev-db` prefix) moves from the CLI's `Start/Db.hs` into `Wasp.Project.Db.Dev.Postgres`, so the whole managed-dev-db naming scheme (db name, container name, volume name) lives in one lib module. This also cleans up `Uninstall.hs` importing a naming constant from another CLI command module.

Groundwork for #4529: the compiler will need the container name to discover the dev db's port from Docker (follow-up PR: #4567).

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.