### PR TITLE
Remove license-file field from waspc.cabal

### DIFF
--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -13,7 +13,6 @@ author: Wasp Team
 maintainer: team@wasp-lang.dev
 copyright: Wasp, Inc.
 license: MIT
-license-file: LICENSE
 build-type: Simple
 extra-source-files:
   ChangeLog.md


### PR DESCRIPTION
## Description

`./run install` fails on `main` with `./LICENSE: withBinaryFile: does not exist`.

`waspc/LICENSE` was deleted in e22dda5c3 (the license now lives at the repo root), but `waspc.cabal` still declared `license-file: LICENSE`, and `cabal install` tries to copy that file. Nobody noticed because `cabal build` never touches it.

Since waspc isn't published to Hackage, the field is not important for us and we can remove it.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.