### PR TITLE
Upgrade morgan to 1.11

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -9,6 +9,7 @@
 ### 🔧 Small improvements
 
 - Newly created projects no longer open the browser automatically on `wasp start`. ([#4553](https://github.com/wasp-lang/wasp/pull/4553))
+- Upgraded the `morgan` request logger in your app's server to 1.11, which brings in a fix for a log injection vulnerability ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Your app's logs are unaffected, since Wasp's default log format doesn't use the vulnerable token. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
 
 ## 0.25.0
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -9,7 +9,7 @@
 ### 🔧 Small improvements
 
 - Newly created projects no longer open the browser automatically on `wasp start`. ([#4553](https://github.com/wasp-lang/wasp/pull/4553))
-- Upgraded the `morgan` request logger in your app's server to 1.11, which brings in a fix for a log injection vulnerability ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Your app's logs are unaffected, since Wasp's default log format doesn't use the vulnerable token. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
+- Upgraded internal `morgan` to 1.11, which fixes ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Wasp's usage was unaffected by the vulnerability. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
 
 ## 0.25.0
 

--- a/waspc/data/packages/studio/package-lock.json
+++ b/waspc/data/packages/studio/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "^14.0.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "morgan": "^1.10.0",
+        "morgan": "^1.11.0",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -1300,19 +1300,23 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-finished": "~2.4.1",
+        "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/morgan/node_modules/debug": {
@@ -1329,18 +1333,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1391,9 +1383,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"

--- a/waspc/data/packages/studio/package.json
+++ b/waspc/data/packages/studio/package.json
@@ -19,7 +19,7 @@
     "commander": "^14.0.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "morgan": "^1.10.0",
+    "morgan": "^1.11.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1887,7 +1887,7 @@
             "file",
             "server/package.json"
         ],
-        "0e56c15eff0c79be54a91fb06ab7b4833920384d135e0cf6d7083c88e5c635b8"
+        "91c935f3dc70f466c41f4071f70912ba46cbe622103e10033cec3ac8b7a2f2e2"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
@@ -295,7 +295,7 @@
             },
             {
                 "name": "morgan",
-                "version": "~1.10.0"
+                "version": "~1.11.0"
             },
             {
                 "name": "socket.io",

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/package.json
@@ -9,7 +9,7 @@
     "dotenv": "^16.6.1",
     "express": "~5.1.0",
     "helmet": "^6.0.0",
-    "morgan": "~1.10.0",
+    "morgan": "~1.11.0",
     "socket.io": "^4.6.1",
     "superjson": "^2.2.1"
   },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -669,7 +669,7 @@
             "file",
             "server/package.json"
         ],
-        "63f567149e2c88e030530507cb6699f546f387fe02baeb6bcedcf28d8aa56271"
+        "6762dea4fe86ea61bd6f78bb924b0ccd56c1ad7cd2fad2ff885faf3cb1622cd4"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
@@ -199,7 +199,7 @@
             },
             {
                 "name": "morgan",
-                "version": "~1.10.0"
+                "version": "~1.11.0"
             },
             {
                 "name": "superjson",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/server/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/server/package.json
@@ -8,7 +8,7 @@
     "dotenv": "^16.6.1",
     "express": "~5.1.0",
     "helmet": "^6.0.0",
-    "morgan": "~1.10.0",
+    "morgan": "~1.11.0",
     "superjson": "^2.2.1"
   },
   "devDependencies": {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -669,7 +669,7 @@
             "file",
             "server/package.json"
         ],
-        "63f567149e2c88e030530507cb6699f546f387fe02baeb6bcedcf28d8aa56271"
+        "6762dea4fe86ea61bd6f78bb924b0ccd56c1ad7cd2fad2ff885faf3cb1622cd4"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
@@ -199,7 +199,7 @@
             },
             {
                 "name": "morgan",
-                "version": "~1.10.0"
+                "version": "~1.11.0"
             },
             {
                 "name": "superjson",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/server/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/server/package.json
@@ -8,7 +8,7 @@
     "dotenv": "^16.6.1",
     "express": "~5.1.0",
     "helmet": "^6.0.0",
-    "morgan": "~1.10.0",
+    "morgan": "~1.11.0",
     "superjson": "^2.2.1"
   },
   "devDependencies": {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -676,7 +676,7 @@
             "file",
             "server/package.json"
         ],
-        "2fd7bb4a0a7d34c3634e2a1056e638f2b6316d3cf2219f1e50b522b79d31be20"
+        "88eb4a7854d1734ac115c8e7a6f3dfd6c58684b67e7f905cb73d022a11a54cb9"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/installedNpmDepsLog.json
@@ -199,7 +199,7 @@
             },
             {
                 "name": "morgan",
-                "version": "~1.10.0"
+                "version": "~1.11.0"
             },
             {
                 "name": "superjson",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/server/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/server/package.json
@@ -8,7 +8,7 @@
     "dotenv": "^16.6.1",
     "express": "~5.1.0",
     "helmet": "^6.0.0",
-    "morgan": "~1.10.0",
+    "morgan": "~1.11.0",
     "superjson": "^2.2.1"
   },
   "devDependencies": {

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -168,7 +168,7 @@ npmDepsFromWasp spec =
             [ ("cookie-parser", "~1.4.6"),
               ("cors", "^2.8.5"),
               ("express", show expressVersionRange),
-              ("morgan", "~1.10.0"),
+              ("morgan", "~1.11.0"),
               ("dotenv", show dotenvVersionRange),
               ("helmet", "^6.0.0"),
               ("superjson", show superjsonVersionRange)


### PR DESCRIPTION
## Description

Bumps `morgan` from 1.10 to 1.11 in both places it is declared: the generated app's server dependencies (`ServerGenerator.hs`) and the `studio` package. Morgan 1.11.0 adds a `:pid` token and escapes control characters in the `:remote-user` token ([CVE-2026-5078](https://github.com/expressjs/morgan/security/advisories/GHSA-4vj7-5mj6-jm8m)) — neither affects us, since both call sites use the `dev` format, which includes neither token, so log output is unchanged. Refreshing the studio lockfile also picks up `on-headers` 1.1.0 ([CVE-2025-7339](https://github.com/expressjs/on-headers/security/advisories/GHSA-76c9-3jph-rj3q)), which was still pinned to 1.0.2 there. There are no API, `engines`, or type changes, and `@types/morgan@1.9.10` is still current. E2E snapshots were regenerated and the suite passes in comparison mode (980/980).

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended. <!-- Covered by the e2e snapshot suite, which compiles and builds apps; I did not run one by hand. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- Not applicable: dependency version bump, covered by the e2e snapshots. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Already bumped to 0.26.0 on main since the last release. -->
