### PR TITLE
Add explanatory hints to the forced Vite config options error

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,7 +1,7 @@
 {{={= =}=}}
 /// <reference types="vitest/config" />
 import { type PluginOption } from "vite";
-import { defaultExclude } from "vitest/config"
+import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -17,27 +17,25 @@ import { defaultExclude } from "vitest/config"
 //    appends them to whatever the user already has.
 
 const forcedOptions = {
-  'base': "{= baseDir =}",
-  'envPrefix': "REACT_APP_",
-  'build.outDir': "{= clientBuildDirPath =}",
+  base: "{= baseDir =}",
+  envPrefix: "REACT_APP_",
+  "build.outDir": "{= clientBuildDirPath =}",
 } as const;
 
-const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
-  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
-  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
-  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+const forcedOptionHints: Partial<Record<keyof typeof forcedOptions, string>> = {
+  base: "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config.",
 };
 
 export function waspConfig(): PluginOption {
   return {
     name: "wasp:config",
-    enforce: 'pre',
+    enforce: "pre",
     config(config) {
       throwIfOverridingForcedOptions(config);
 
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
-        base: forcedOptions['base'],
+        base: forcedOptions["base"],
         optimizeDeps: {
           exclude: {=& depsExcludedFromOptimization =}
         },
@@ -45,15 +43,20 @@ export function waspConfig(): PluginOption {
           port: useUserValue(config.server?.port, {= defaultClientPort =}),
           host: useUserValue(config.server?.host, "0.0.0.0"),
         },
-        envPrefix: forcedOptions['envPrefix'],
+        envPrefix: forcedOptions["envPrefix"],
         build: {
-          outDir: forcedOptions['build.outDir'],
+          outDir: forcedOptions["build.outDir"],
         },
         resolve: {
           // These packages rely on a single instance per page. Not deduping them
           // causes runtime errors (e.g., hook rule violation in react, QueryClient
           // instance error in react-query, Invariant Error in react-router).
-          dedupe: ["react", "react-dom", "@tanstack/react-query", "react-router"],
+          dedupe: [
+            "react",
+            "react-dom",
+            "@tanstack/react-query",
+            "react-router",
+          ],
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -76,10 +79,10 @@ export function waspConfig(): PluginOption {
           exclude: [
             ...defaultExclude,
             "{= vitest.excludeWaspArtefactsPattern =}",
-          ]
+          ],
         },
       };
-    }
+    },
   };
 }
 
@@ -94,17 +97,18 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
     if (userValue !== undefined && userValue !== forcedValue) {
       const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}` +
+          (hint ? `\n    ${hint}` : ""),
       );
     }
   }
   if (conflicts.length > 0) {
     throw new Error(
-      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join('\n')}\n\nRemove these from your Vite config, Wasp sets them automatically.`
+      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join("\n")}\n\nRemove these from your Vite config, Wasp sets them automatically.`,
     );
   }
 }
 
 function getByPath(obj: Record<string, any>, path: string): unknown {
-  return path.split('.').reduce<any>((node, segment) => node?.[segment], obj);
+  return path.split(".").reduce<any>((node, segment) => node?.[segment], obj);
 }

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -8,8 +8,9 @@ import { defaultExclude } from "vitest/config"
 // arrays are concatenated.
 //
 // This allows us to treat config values differently:
-//  - Forced: hardcoded in the return object so they always win. If the
-//    user set one of these in their vite.config.ts, we throw an error.
+//  - Forced: taken from `forcedOptions` in the return object so they
+//    always win. If the user set one of these in their vite.config.ts,
+//    we throw an error.
 //  - Overridable: we read the user's value and use it or fall back to
 //    our default.
 //  - Additive (arrays): we only return Wasp's entries; Vite's merge
@@ -20,6 +21,12 @@ const forcedOptions = {
   'envPrefix': "REACT_APP_",
   'build.outDir': "{= clientBuildDirPath =}",
 } as const;
+
+const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
+  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
+  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
+  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+};
 
 export function waspConfig(): PluginOption {
   return {
@@ -85,8 +92,9 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
   for (const [path, forcedValue] of Object.entries(forcedOptions)) {
     const userValue = getByPath(config, path);
     if (userValue !== undefined && userValue !== forcedValue) {
+      const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
       );
     }
   }

--- a/waspc/e2e-tests/Tests/ViteConfigTest.hs
+++ b/waspc/e2e-tests/Tests/ViteConfigTest.hs
@@ -6,6 +6,7 @@ import ShellCommands
   ( ShellCommand,
     ShellCommandBuilder,
     WaspProjectContext (..),
+    assertCommandOutputContains,
     createTestWaspProject,
     inTestWaspProjectDir,
     waspCliCompile,
@@ -38,6 +39,22 @@ viteConfigTest =
                   expectCommandFailure <$> waspCliCompile
                 ]
             ]
+        ),
+      TestCase
+        "fail-on-overriding-forced-options"
+        ( sequence
+            [ createTestWaspProject minimalStarterTemplate,
+              inTestWaspProjectDir
+                [ writeViteConfigOverridingForcedOptions,
+                  waspCliCompile,
+                  -- Wasp's Vite plugin throws while Vite resolves the config, so
+                  -- we assert on the hint to make sure the build failed for that
+                  -- reason and not for an unrelated one.
+                  assertCommandOutputContains
+                    (expectCommandFailure <$> viteBuild)
+                    "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config."
+                ]
+            ]
         )
     ]
 
@@ -54,6 +71,28 @@ writeViteConfigWithoutPlugin = do
 
       export default defineConfig({});
     |]
+
+writeViteConfigOverridingForcedOptions :: ShellCommandBuilder WaspProjectContext ShellCommand
+writeViteConfigOverridingForcedOptions = do
+  context <- ask
+  writeToFile
+    (context.waspProjectDir </> [relfile|vite.config.ts|])
+    [trimming|
+      import { defineConfig } from "vite";
+      import { wasp } from "wasp/client/vite";
+
+      export default defineConfig({
+        plugins: [wasp()],
+        base: "/my-subdir/",
+        envPrefix: "MY_APP_",
+        build: {
+          outDir: "dist",
+        },
+      });
+    |]
+
+viteBuild :: ShellCommandBuilder WaspProjectContext ShellCommand
+viteBuild = return "npx vite build"
 
 expectCommandFailure :: ShellCommand -> ShellCommand
 expectCommandFailure command = "! " ++ command

--- a/waspc/e2e-tests/Tests/ViteConfigTest.hs
+++ b/waspc/e2e-tests/Tests/ViteConfigTest.hs
@@ -47,9 +47,6 @@ viteConfigTest =
               inTestWaspProjectDir
                 [ writeViteConfigOverridingForcedOptions,
                   waspCliCompile,
-                  -- Wasp's Vite plugin throws while Vite resolves the config, so
-                  -- we assert on the hint to make sure the build failed for that
-                  -- reason and not for an unrelated one.
                   assertCommandOutputContains
                     (expectCommandFailure <$> viteBuild)
                     "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config."

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -746,7 +746,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "74359d2f3ae68c2f015beb4b126280907bd8418afc2dea1854f42f0426eea06e"
+        "a8e6a5cbffb010d02729e3cb4046de73ede1844b773417b8f394f60bdd9312cc"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -746,7 +746,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "b5db741e0d7b953cd7f6f70ace2172c35c8123bd4ff60c9d43a14bbb7a5bd03c"
+        "74359d2f3ae68c2f015beb4b126280907bd8418afc2dea1854f42f0426eea06e"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest/config" />
 import { type PluginOption } from "vite";
-import { defaultExclude } from "vitest/config"
+import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -16,27 +16,25 @@ import { defaultExclude } from "vitest/config"
 //    appends them to whatever the user already has.
 
 const forcedOptions = {
-  'base': "/",
-  'envPrefix': "REACT_APP_",
-  'build.outDir': ".wasp/out/web-app/build/",
+  base: "/",
+  envPrefix: "REACT_APP_",
+  "build.outDir": ".wasp/out/web-app/build/",
 } as const;
 
-const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
-  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
-  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
-  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+const forcedOptionHints: Partial<Record<keyof typeof forcedOptions, string>> = {
+  base: "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config.",
 };
 
 export function waspConfig(): PluginOption {
   return {
     name: "wasp:config",
-    enforce: 'pre',
+    enforce: "pre",
     config(config) {
       throwIfOverridingForcedOptions(config);
 
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
-        base: forcedOptions['base'],
+        base: forcedOptions["base"],
         optimizeDeps: {
           exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
         },
@@ -44,15 +42,20 @@ export function waspConfig(): PluginOption {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
         },
-        envPrefix: forcedOptions['envPrefix'],
+        envPrefix: forcedOptions["envPrefix"],
         build: {
-          outDir: forcedOptions['build.outDir'],
+          outDir: forcedOptions["build.outDir"],
         },
         resolve: {
           // These packages rely on a single instance per page. Not deduping them
           // causes runtime errors (e.g., hook rule violation in react, QueryClient
           // instance error in react-query, Invariant Error in react-router).
-          dedupe: ["react", "react-dom", "@tanstack/react-query", "react-router"],
+          dedupe: [
+            "react",
+            "react-dom",
+            "@tanstack/react-query",
+            "react-router",
+          ],
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -75,10 +78,10 @@ export function waspConfig(): PluginOption {
           exclude: [
             ...defaultExclude,
             ".wasp/**/*",
-          ]
+          ],
         },
       };
-    }
+    },
   };
 }
 
@@ -93,17 +96,18 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
     if (userValue !== undefined && userValue !== forcedValue) {
       const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}` +
+          (hint ? `\n    ${hint}` : ""),
       );
     }
   }
   if (conflicts.length > 0) {
     throw new Error(
-      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join('\n')}\n\nRemove these from your Vite config, Wasp sets them automatically.`
+      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join("\n")}\n\nRemove these from your Vite config, Wasp sets them automatically.`,
     );
   }
 }
 
 function getByPath(obj: Record<string, any>, path: string): unknown {
-  return path.split('.').reduce<any>((node, segment) => node?.[segment], obj);
+  return path.split(".").reduce<any>((node, segment) => node?.[segment], obj);
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -7,8 +7,9 @@ import { defaultExclude } from "vitest/config"
 // arrays are concatenated.
 //
 // This allows us to treat config values differently:
-//  - Forced: hardcoded in the return object so they always win. If the
-//    user set one of these in their vite.config.ts, we throw an error.
+//  - Forced: taken from `forcedOptions` in the return object so they
+//    always win. If the user set one of these in their vite.config.ts,
+//    we throw an error.
 //  - Overridable: we read the user's value and use it or fall back to
 //    our default.
 //  - Additive (arrays): we only return Wasp's entries; Vite's merge
@@ -19,6 +20,12 @@ const forcedOptions = {
   'envPrefix': "REACT_APP_",
   'build.outDir': ".wasp/out/web-app/build/",
 } as const;
+
+const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
+  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
+  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
+  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+};
 
 export function waspConfig(): PluginOption {
   return {
@@ -84,8 +91,9 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
   for (const [path, forcedValue] of Object.entries(forcedOptions)) {
     const userValue = getByPath(config, path);
     if (userValue !== undefined && userValue !== forcedValue) {
+      const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
       );
     }
   }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "74359d2f3ae68c2f015beb4b126280907bd8418afc2dea1854f42f0426eea06e"
+        "a8e6a5cbffb010d02729e3cb4046de73ede1844b773417b8f394f60bdd9312cc"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "b5db741e0d7b953cd7f6f70ace2172c35c8123bd4ff60c9d43a14bbb7a5bd03c"
+        "74359d2f3ae68c2f015beb4b126280907bd8418afc2dea1854f42f0426eea06e"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest/config" />
 import { type PluginOption } from "vite";
-import { defaultExclude } from "vitest/config"
+import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -16,27 +16,25 @@ import { defaultExclude } from "vitest/config"
 //    appends them to whatever the user already has.
 
 const forcedOptions = {
-  'base': "/",
-  'envPrefix': "REACT_APP_",
-  'build.outDir': ".wasp/out/web-app/build/",
+  base: "/",
+  envPrefix: "REACT_APP_",
+  "build.outDir": ".wasp/out/web-app/build/",
 } as const;
 
-const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
-  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
-  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
-  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+const forcedOptionHints: Partial<Record<keyof typeof forcedOptions, string>> = {
+  base: "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config.",
 };
 
 export function waspConfig(): PluginOption {
   return {
     name: "wasp:config",
-    enforce: 'pre',
+    enforce: "pre",
     config(config) {
       throwIfOverridingForcedOptions(config);
 
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
-        base: forcedOptions['base'],
+        base: forcedOptions["base"],
         optimizeDeps: {
           exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
         },
@@ -44,15 +42,20 @@ export function waspConfig(): PluginOption {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
         },
-        envPrefix: forcedOptions['envPrefix'],
+        envPrefix: forcedOptions["envPrefix"],
         build: {
-          outDir: forcedOptions['build.outDir'],
+          outDir: forcedOptions["build.outDir"],
         },
         resolve: {
           // These packages rely on a single instance per page. Not deduping them
           // causes runtime errors (e.g., hook rule violation in react, QueryClient
           // instance error in react-query, Invariant Error in react-router).
-          dedupe: ["react", "react-dom", "@tanstack/react-query", "react-router"],
+          dedupe: [
+            "react",
+            "react-dom",
+            "@tanstack/react-query",
+            "react-router",
+          ],
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -75,10 +78,10 @@ export function waspConfig(): PluginOption {
           exclude: [
             ...defaultExclude,
             ".wasp/**/*",
-          ]
+          ],
         },
       };
-    }
+    },
   };
 }
 
@@ -93,17 +96,18 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
     if (userValue !== undefined && userValue !== forcedValue) {
       const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}` +
+          (hint ? `\n    ${hint}` : ""),
       );
     }
   }
   if (conflicts.length > 0) {
     throw new Error(
-      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join('\n')}\n\nRemove these from your Vite config, Wasp sets them automatically.`
+      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join("\n")}\n\nRemove these from your Vite config, Wasp sets them automatically.`,
     );
   }
 }
 
 function getByPath(obj: Record<string, any>, path: string): unknown {
-  return path.split('.').reduce<any>((node, segment) => node?.[segment], obj);
+  return path.split(".").reduce<any>((node, segment) => node?.[segment], obj);
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -7,8 +7,9 @@ import { defaultExclude } from "vitest/config"
 // arrays are concatenated.
 //
 // This allows us to treat config values differently:
-//  - Forced: hardcoded in the return object so they always win. If the
-//    user set one of these in their vite.config.ts, we throw an error.
+//  - Forced: taken from `forcedOptions` in the return object so they
+//    always win. If the user set one of these in their vite.config.ts,
+//    we throw an error.
 //  - Overridable: we read the user's value and use it or fall back to
 //    our default.
 //  - Additive (arrays): we only return Wasp's entries; Vite's merge
@@ -19,6 +20,12 @@ const forcedOptions = {
   'envPrefix': "REACT_APP_",
   'build.outDir': ".wasp/out/web-app/build/",
 } as const;
+
+const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
+  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
+  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
+  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+};
 
 export function waspConfig(): PluginOption {
   return {
@@ -84,8 +91,9 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
   for (const [path, forcedValue] of Object.entries(forcedOptions)) {
     const userValue = getByPath(config, path);
     if (userValue !== undefined && userValue !== forcedValue) {
+      const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
       );
     }
   }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "74359d2f3ae68c2f015beb4b126280907bd8418afc2dea1854f42f0426eea06e"
+        "a8e6a5cbffb010d02729e3cb4046de73ede1844b773417b8f394f60bdd9312cc"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "b5db741e0d7b953cd7f6f70ace2172c35c8123bd4ff60c9d43a14bbb7a5bd03c"
+        "74359d2f3ae68c2f015beb4b126280907bd8418afc2dea1854f42f0426eea06e"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest/config" />
 import { type PluginOption } from "vite";
-import { defaultExclude } from "vitest/config"
+import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -16,27 +16,25 @@ import { defaultExclude } from "vitest/config"
 //    appends them to whatever the user already has.
 
 const forcedOptions = {
-  'base': "/",
-  'envPrefix': "REACT_APP_",
-  'build.outDir': ".wasp/out/web-app/build/",
+  base: "/",
+  envPrefix: "REACT_APP_",
+  "build.outDir": ".wasp/out/web-app/build/",
 } as const;
 
-const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
-  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
-  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
-  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+const forcedOptionHints: Partial<Record<keyof typeof forcedOptions, string>> = {
+  base: "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config.",
 };
 
 export function waspConfig(): PluginOption {
   return {
     name: "wasp:config",
-    enforce: 'pre',
+    enforce: "pre",
     config(config) {
       throwIfOverridingForcedOptions(config);
 
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
-        base: forcedOptions['base'],
+        base: forcedOptions["base"],
         optimizeDeps: {
           exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
         },
@@ -44,15 +42,20 @@ export function waspConfig(): PluginOption {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
         },
-        envPrefix: forcedOptions['envPrefix'],
+        envPrefix: forcedOptions["envPrefix"],
         build: {
-          outDir: forcedOptions['build.outDir'],
+          outDir: forcedOptions["build.outDir"],
         },
         resolve: {
           // These packages rely on a single instance per page. Not deduping them
           // causes runtime errors (e.g., hook rule violation in react, QueryClient
           // instance error in react-query, Invariant Error in react-router).
-          dedupe: ["react", "react-dom", "@tanstack/react-query", "react-router"],
+          dedupe: [
+            "react",
+            "react-dom",
+            "@tanstack/react-query",
+            "react-router",
+          ],
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -75,10 +78,10 @@ export function waspConfig(): PluginOption {
           exclude: [
             ...defaultExclude,
             ".wasp/**/*",
-          ]
+          ],
         },
       };
-    }
+    },
   };
 }
 
@@ -93,17 +96,18 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
     if (userValue !== undefined && userValue !== forcedValue) {
       const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}` +
+          (hint ? `\n    ${hint}` : ""),
       );
     }
   }
   if (conflicts.length > 0) {
     throw new Error(
-      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join('\n')}\n\nRemove these from your Vite config, Wasp sets them automatically.`
+      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join("\n")}\n\nRemove these from your Vite config, Wasp sets them automatically.`,
     );
   }
 }
 
 function getByPath(obj: Record<string, any>, path: string): unknown {
-  return path.split('.').reduce<any>((node, segment) => node?.[segment], obj);
+  return path.split(".").reduce<any>((node, segment) => node?.[segment], obj);
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -7,8 +7,9 @@ import { defaultExclude } from "vitest/config"
 // arrays are concatenated.
 //
 // This allows us to treat config values differently:
-//  - Forced: hardcoded in the return object so they always win. If the
-//    user set one of these in their vite.config.ts, we throw an error.
+//  - Forced: taken from `forcedOptions` in the return object so they
+//    always win. If the user set one of these in their vite.config.ts,
+//    we throw an error.
 //  - Overridable: we read the user's value and use it or fall back to
 //    our default.
 //  - Additive (arrays): we only return Wasp's entries; Vite's merge
@@ -19,6 +20,12 @@ const forcedOptions = {
   'envPrefix': "REACT_APP_",
   'build.outDir': ".wasp/out/web-app/build/",
 } as const;
+
+const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
+  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
+  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
+  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+};
 
 export function waspConfig(): PluginOption {
   return {
@@ -84,8 +91,9 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
   for (const [path, forcedValue] of Object.entries(forcedOptions)) {
     const userValue = getByPath(config, path);
     if (userValue !== undefined && userValue !== forcedValue) {
+      const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
       );
     }
   }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "74359d2f3ae68c2f015beb4b126280907bd8418afc2dea1854f42f0426eea06e"
+        "a8e6a5cbffb010d02729e3cb4046de73ede1844b773417b8f394f60bdd9312cc"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -333,7 +333,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "b5db741e0d7b953cd7f6f70ace2172c35c8123bd4ff60c9d43a14bbb7a5bd03c"
+        "74359d2f3ae68c2f015beb4b126280907bd8418afc2dea1854f42f0426eea06e"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest/config" />
 import { type PluginOption } from "vite";
-import { defaultExclude } from "vitest/config"
+import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -16,27 +16,25 @@ import { defaultExclude } from "vitest/config"
 //    appends them to whatever the user already has.
 
 const forcedOptions = {
-  'base': "/",
-  'envPrefix': "REACT_APP_",
-  'build.outDir': ".wasp/out/web-app/build/",
+  base: "/",
+  envPrefix: "REACT_APP_",
+  "build.outDir": ".wasp/out/web-app/build/",
 } as const;
 
-const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
-  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
-  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
-  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+const forcedOptionHints: Partial<Record<keyof typeof forcedOptions, string>> = {
+  base: "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config.",
 };
 
 export function waspConfig(): PluginOption {
   return {
     name: "wasp:config",
-    enforce: 'pre',
+    enforce: "pre",
     config(config) {
       throwIfOverridingForcedOptions(config);
 
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
-        base: forcedOptions['base'],
+        base: forcedOptions["base"],
         optimizeDeps: {
           exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
         },
@@ -44,15 +42,20 @@ export function waspConfig(): PluginOption {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
         },
-        envPrefix: forcedOptions['envPrefix'],
+        envPrefix: forcedOptions["envPrefix"],
         build: {
-          outDir: forcedOptions['build.outDir'],
+          outDir: forcedOptions["build.outDir"],
         },
         resolve: {
           // These packages rely on a single instance per page. Not deduping them
           // causes runtime errors (e.g., hook rule violation in react, QueryClient
           // instance error in react-query, Invariant Error in react-router).
-          dedupe: ["react", "react-dom", "@tanstack/react-query", "react-router"],
+          dedupe: [
+            "react",
+            "react-dom",
+            "@tanstack/react-query",
+            "react-router",
+          ],
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -75,10 +78,10 @@ export function waspConfig(): PluginOption {
           exclude: [
             ...defaultExclude,
             ".wasp/**/*",
-          ]
+          ],
         },
       };
-    }
+    },
   };
 }
 
@@ -93,17 +96,18 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
     if (userValue !== undefined && userValue !== forcedValue) {
       const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}` +
+          (hint ? `\n    ${hint}` : ""),
       );
     }
   }
   if (conflicts.length > 0) {
     throw new Error(
-      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join('\n')}\n\nRemove these from your Vite config, Wasp sets them automatically.`
+      `Your vite.config.ts sets options that Wasp controls:\n${conflicts.join("\n")}\n\nRemove these from your Vite config, Wasp sets them automatically.`,
     );
   }
 }
 
 function getByPath(obj: Record<string, any>, path: string): unknown {
-  return path.split('.').reduce<any>((node, segment) => node?.[segment], obj);
+  return path.split(".").reduce<any>((node, segment) => node?.[segment], obj);
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -7,8 +7,9 @@ import { defaultExclude } from "vitest/config"
 // arrays are concatenated.
 //
 // This allows us to treat config values differently:
-//  - Forced: hardcoded in the return object so they always win. If the
-//    user set one of these in their vite.config.ts, we throw an error.
+//  - Forced: taken from `forcedOptions` in the return object so they
+//    always win. If the user set one of these in their vite.config.ts,
+//    we throw an error.
 //  - Overridable: we read the user's value and use it or fall back to
 //    our default.
 //  - Additive (arrays): we only return Wasp's entries; Vite's merge
@@ -19,6 +20,12 @@ const forcedOptions = {
   'envPrefix': "REACT_APP_",
   'build.outDir': ".wasp/out/web-app/build/",
 } as const;
+
+const forcedOptionHints: Record<keyof typeof forcedOptions, string> = {
+  'base': "To serve your app from a subdirectory, set `client.baseDir` in your Wasp config. Wasp gives the router the same value.",
+  'envPrefix': "Wasp only exposes client env vars with this prefix, and validates them by it.",
+  'build.outDir': "Wasp looks for the built client here when you deploy it.",
+};
 
 export function waspConfig(): PluginOption {
   return {
@@ -84,8 +91,9 @@ function throwIfOverridingForcedOptions(config: Record<string, any>): void {
   for (const [path, forcedValue] of Object.entries(forcedOptions)) {
     const userValue = getByPath(config, path);
     if (userValue !== undefined && userValue !== forcedValue) {
+      const hint = forcedOptionHints[path as keyof typeof forcedOptions];
       conflicts.push(
-        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}`
+        `  - "${path}" is set to ${JSON.stringify(userValue)}, but Wasp requires ${JSON.stringify(forcedValue)}\n    ${hint}`
       );
     }
   }


### PR DESCRIPTION
## Description

When your `vite.config.ts` sets an option Wasp controls (`base`, `envPrefix`, `build.outDir`), the error message now points at the Wasp-level way to do the same thing, next to the offending value. Only `base` has a hint for now (`client.baseDir`); `forcedOptionHints` is the place to add more.

<img width="828" height="459" alt="image" src="https://github.com/user-attachments/assets/2380f57f-7990-4670-8595-a35c0b7fa7ac" />

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- New waspc e2e case `vite-config-validation/fail-on-overriding-forced-options`: writes a vite.config.ts overriding all three forced options, runs `vite build`, and asserts the failure output contains the `base` hint. There was no runtime coverage of this error before. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.


