### PR TITLE
Lowercase the region argument in wasp deploy fly commands

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -10,7 +10,7 @@
 
 - Newly created projects no longer open the browser automatically on `wasp start`. ([#4553](https://github.com/wasp-lang/wasp/pull/4553))
 - Upgraded internal `morgan` to 1.11, which fixes ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Wasp's usage was unaffected by the vulnerability. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
-- The `<region>` argument of `wasp deploy fly` is now case-insensitive, so e.g. `MIA` is accepted instead of being rejected as an invalid region.
+- The `<region>` argument of `wasp deploy fly` is now case-insensitive, so e.g. `MIA` is accepted instead of being rejected as an invalid region. ([#4588](https://github.com/wasp-lang/wasp/pull/4588))
 
 ## 0.25.0
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -10,6 +10,7 @@
 
 - Newly created projects no longer open the browser automatically on `wasp start`. ([#4553](https://github.com/wasp-lang/wasp/pull/4553))
 - Upgraded internal `morgan` to 1.11, which fixes ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Wasp's usage was unaffected by the vulnerability. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
+- The `<region>` argument of `wasp deploy fly` is now case-insensitive, so e.g. `MIA` is accepted instead of being rejected as an invalid region.
 
 ## 0.25.0
 

--- a/waspc/data/packages/deploy/src/providers/fly/index.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/index.ts
@@ -24,6 +24,7 @@ class FlyCommand extends Command {
     return this.argument(
       "<region>",
       "3 letter deployment region to use on Fly.io",
+      (region) => region.toLowerCase(),
     );
   }
   addDbOptions(): this {
@@ -144,13 +145,13 @@ export function createFlyCommand(): Command {
 
   // Add command-specific hooks.
   flyLaunchCommand.hook("preAction", (_thisCommand, actionCommand) =>
-    assertRegionIsValid(actionCommand.args[1]),
+    assertRegionIsValid(actionCommand.processedArgs[1]),
   );
   flySetupCommand.hook("preAction", (_thisCommand, actionCommand) =>
-    assertRegionIsValid(actionCommand.args[1]),
+    assertRegionIsValid(actionCommand.processedArgs[1]),
   );
   createFlyDbCommand.hook("preAction", (_thisCommand, actionCommand) =>
-    assertRegionIsValid(actionCommand.args[0]),
+    assertRegionIsValid(actionCommand.processedArgs[0]),
   );
 
   return fly;


### PR DESCRIPTION
## Description

`wasp deploy fly launch|setup|create-db` validate `<region>` against `flyctl platform regions`, which is an exact, case-sensitive match, so a region typed as `MIA` was rejected as invalid even though it is a real region. This lowercases the argument in `addRegionArgument` — the single helper all three commands share — so the normalized value reaches both `assertRegionIsValid` and the `--region` flag passed to `flyctl`. The validation hooks also had to switch from `actionCommand.args` to `actionCommand.processedArgs`, because Commander keeps `args` as the raw operands and only exposes parser output on `processedArgs`; I verified against commander 13.1.0 that `processedArgs` is populated before `preAction` hooks run.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended. <!-- Not run against a real Fly.io deploy; verified by driving the Commander command directly and asserting the lowercased region reaches the validator and the action, plus tsc and the package's test suite. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- Intentionally left out, as the CLI wiring is not otherwise unit tested in this package. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- See above. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- Not applicable: kitchen-sink does not exercise wasp deploy fly. -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- Not applicable. -->
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- Not applicable. -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- The Fly docs already document lowercase region codes, which stay correct; this only makes the CLI more forgiving. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Already at 0.26.0 on main since the v0.25.0 release, so no bump needed. -->
