### PR TITLE
Smoke check: run waspc e2e tests on Windows via bash (#3404 spike)

### DIFF
--- a/.github/workflows/ci-waspc-test.yaml
+++ b/.github/workflows/ci-waspc-test.yaml
@@ -23,12 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          # TEMPORARY (Windows e2e smoke check): only windows-latest.
+          # Restore the full matrix before un-drafting the PR.
           # We are using a fixed Ubuntu version instead of 'ubuntu-latest' to
           # prevent the version from changing on its own.
-          - ubuntu-22.04
-          - ubuntu-24.04-arm
-          - macos-15-intel
-          - macos-15 # Apple Silicon
+          # - ubuntu-22.04
+          # - ubuntu-24.04-arm
+          # - macos-15-intel
+          # - macos-15 # Apple Silicon
           - windows-latest
         extra-tools:
           - node@latest
@@ -37,10 +39,10 @@ jobs:
         # additional Node.js versions, to make sure that Wasp works with them.
         # To reduce the number of jobs, we only test the Node.js versions on
         # Ubuntu 22.04.
-        include:
-          - # No extra tool here, so we use our default Node.js version, which
-            # comes from mise and is equal to our lowest supported one.
-            os: ubuntu-22.04
+        # include:
+        #   - # No extra tool here, so we use our default Node.js version, which
+        #     # comes from mise and is equal to our lowest supported one.
+        #     os: ubuntu-22.04
 
     steps:
       - # For waspc parser tests, we need to make sure git doesn't convert line
@@ -75,12 +77,28 @@ jobs:
       - name: Build wasp code
         run: cabal build all
 
-      - name: Run unit tests
-        run: cabal test wasp-cli-tests waspc-tests
+      # TEMPORARY (Windows e2e smoke check): unit tests are skipped to get to
+      # the e2e tests quicker. Restore before un-drafting the PR.
+      # - name: Run unit tests
+      #   run: cabal test wasp-cli-tests waspc-tests
+
+      - # Git Bash (which our e2e shell commands run under on Windows) ships
+        # most POSIX tools but not rsync, which the kitchen-sink snapshot test
+        # uses. We borrow rsync from the runner's preinstalled MSYS2.
+        name: Install rsync (Windows)
+        if: runner.os == 'Windows'
+        run: /c/msys64/usr/bin/pacman.exe -S --noconfirm rsync
 
       - name: Run `waspc` e2e tests
         env:
-          WASP_E2E_TESTS_SKIP_DOCKER: ${{ runner.os == 'macOS' && '1' || '' }}
+          # GitHub's Windows runners can't run the Linux Docker containers our
+          # Docker steps need, and macOS runners don't have Docker at all.
+          WASP_E2E_TESTS_SKIP_DOCKER: ${{ (runner.os == 'macOS' || runner.os == 'Windows') && '1' || '' }}
           EXTRA_TOOLS: ${{ matrix.extra-tools }}
         run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # Appended (not prepended) so Git Bash's own tools stay first and
+            # only rsync gets picked up from MSYS2.
+            export PATH="$PATH:/c/msys64/usr/bin"
+          fi
           mise x "${EXTRA_TOOLS[@]}" -- bash ./run test:waspc:e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,68 +39,72 @@ concurrency:
 # by zizmor separately, so it is moderately safe to ignore the warnings here.
 
 jobs:
-  deploy-test: # zizmor: ignore[excessive-permissions]
-    needs: waspc-build
-    uses: ./.github/workflows/ci-deploy-test.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # TEMPORARY (Windows e2e smoke check): all jobs except waspc-test are
+  # commented out so the Windows e2e run gets runners and finishes quickly.
+  # Restore before un-drafting the PR.
 
-  examples-test: # zizmor: ignore[excessive-permissions]
-    needs: waspc-build
-    uses: ./.github/workflows/ci-examples-test.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # deploy-test: # zizmor: ignore[excessive-permissions]
+  #   needs: waspc-build
+  #   uses: ./.github/workflows/ci-deploy-test.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  formatting: # zizmor: ignore[excessive-permissions]
-    uses: ./.github/workflows/ci-formatting.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # examples-test: # zizmor: ignore[excessive-permissions]
+  #   needs: waspc-build
+  #   uses: ./.github/workflows/ci-examples-test.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  starters-test: # zizmor: ignore[excessive-permissions]
-    needs: waspc-build
-    uses: ./.github/workflows/ci-starters-test.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # formatting: # zizmor: ignore[excessive-permissions]
+  #   uses: ./.github/workflows/ci-formatting.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  tsspec-test: # zizmor: ignore[excessive-permissions]
-    uses: ./.github/workflows/ci-tsspec-test.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # starters-test: # zizmor: ignore[excessive-permissions]
+  #   needs: waspc-build
+  #   uses: ./.github/workflows/ci-starters-test.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  libs-test: # zizmor: ignore[excessive-permissions]
-    uses: ./.github/workflows/ci-libs-test.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # tsspec-test: # zizmor: ignore[excessive-permissions]
+  #   uses: ./.github/workflows/ci-tsspec-test.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  packages-test: # zizmor: ignore[excessive-permissions]
-    uses: ./.github/workflows/ci-packages-test.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # libs-test: # zizmor: ignore[excessive-permissions]
+  #   uses: ./.github/workflows/ci-libs-test.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  waspc-build: # zizmor: ignore[excessive-permissions]
-    uses: ./.github/workflows/ci-waspc-build.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # packages-test: # zizmor: ignore[excessive-permissions]
+  #   uses: ./.github/workflows/ci-packages-test.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  npm-package-build: # zizmor: ignore[excessive-permissions]
-    needs: waspc-build
-    uses: ./.github/workflows/ci-npm-package-build.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    with:
-      build-outputs-json: ${{ toJson(needs.waspc-build.outputs) }}
-      override-npm-package-version: ${{ inputs.override-npm-package-version }}
+  # waspc-build: # zizmor: ignore[excessive-permissions]
+  #   uses: ./.github/workflows/ci-waspc-build.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  npm-package-publish: # zizmor: ignore[excessive-permissions]
-    needs: npm-package-build
-    uses: ./.github/workflows/ci-npm-package-publish.yaml
+  # npm-package-build: # zizmor: ignore[excessive-permissions]
+  #   needs: waspc-build
+  #   uses: ./.github/workflows/ci-npm-package-build.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   with:
+  #     build-outputs-json: ${{ toJson(needs.waspc-build.outputs) }}
+  #     override-npm-package-version: ${{ inputs.override-npm-package-version }}
 
-  npm-package-test: # zizmor: ignore[excessive-permissions]
-    needs: [npm-package-publish, waspc-build]
-    uses: ./.github/workflows/ci-npm-package-test.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    with:
-      data-files-list: ${{ needs.waspc-build.outputs.data_files_list }}
+  # npm-package-publish: # zizmor: ignore[excessive-permissions]
+  #   needs: npm-package-build
+  #   uses: ./.github/workflows/ci-npm-package-publish.yaml
+
+  # npm-package-test: # zizmor: ignore[excessive-permissions]
+  #   needs: [npm-package-publish, waspc-build]
+  #   uses: ./.github/workflows/ci-npm-package-test.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   with:
+  #     data-files-list: ${{ needs.waspc-build.outputs.data_files_list }}
 
   waspc-test: # zizmor: ignore[excessive-permissions]
     uses: ./.github/workflows/ci-waspc-test.yaml
     secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  actions-check: # zizmor: ignore[excessive-permissions]
-    uses: ./.github/workflows/ci-actions-check.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # actions-check: # zizmor: ignore[excessive-permissions]
+  #   uses: ./.github/workflows/ci-actions-check.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  web-check: # zizmor: ignore[excessive-permissions]
-    uses: ./.github/workflows/ci-web-check.yaml
-    secrets: inherit # zizmor: ignore[secrets-inherit]
+  # web-check: # zizmor: ignore[excessive-permissions]
+  #   uses: ./.github/workflows/ci-web-check.yaml
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/waspc/e2e-tests/Main.hs
+++ b/waspc/e2e-tests/Main.hs
@@ -1,11 +1,12 @@
 import Control.Concurrent (getNumCapabilities)
 import FileSystem (getWaspcDirPath, waspCliDevToolInWaspcDir)
+import ShellCommands (bashProc, toShellPath)
 import SnapshotTest (testTreeFromSnapshotTest)
 import StrongPath ((</>))
 import qualified StrongPath as SP
 import System.Environment (lookupEnv, setEnv)
-import System.Info (os)
-import System.Process (callCommand)
+import System.Exit (ExitCode (..))
+import System.Process (waitForProcess, withCreateProcess)
 import Test (testTreeFromTest)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Tests.SdkPackageExportsTest (makeSdkPackageExportsTestTree)
@@ -38,12 +39,9 @@ import UnliftIO.Async (pooledMapConcurrentlyN)
 
 main :: IO ()
 main = do
-  if os == "mingw32"
-    then putStrLn "Skipping end-to-end tests on Windows due to tests using *nix-only commands"
-    else do
-      ensureE2eTestsEnvironment
-      warmUpWaspCli
-      e2eTests >>= defaultMain
+  ensureE2eTestsEnvironment
+  warmUpWaspCli
+  e2eTests >>= defaultMain
 
 ensureE2eTestsEnvironment :: IO ()
 ensureE2eTestsEnvironment = do
@@ -53,7 +51,7 @@ ensureE2eTestsEnvironment = do
     Nothing -> do
       -- Runs the tests using the current state of the `waspc` project.
       waspcDir <- getWaspcDirPath
-      let devWaspCliCmd = SP.fromAbsFile (waspcDir </> waspCliDevToolInWaspcDir)
+      let devWaspCliCmd = toShellPath $ SP.fromAbsFile (waspcDir </> waspCliDevToolInWaspcDir)
       setEnv "WASP_CLI_CMD" devWaspCliCmd
 
 -- | Builds the dev Wasp CLI once, serially, before the snapshot tests start
@@ -66,7 +64,13 @@ ensureE2eTestsEnvironment = do
 -- invocation here forces that build to complete first, so the concurrent
 -- invocations only ever run the already-built CLI.
 warmUpWaspCli :: IO ()
-warmUpWaspCli = callCommand "$WASP_CLI_CMD version 2>&1 >/dev/null" -- We don't need any output.
+warmUpWaspCli =
+  -- We don't need any output.
+  withCreateProcess (bashProc "$WASP_CLI_CMD version 2>&1 >/dev/null") $ \_ _ _ ph -> do
+    exitCode <- waitForProcess ph
+    case exitCode of
+      ExitSuccess -> return ()
+      ExitFailure code -> fail $ "Warming up the Wasp CLI failed with exit code " ++ show code
 
 -- TODO: Investigate automatically discovering the tests.
 -- TODO: Refactor tests DSL so it does not depend on bash commands. Use pure Haskell instead.

--- a/waspc/e2e-tests/Main.hs
+++ b/waspc/e2e-tests/Main.hs
@@ -64,9 +64,10 @@ ensureE2eTestsEnvironment = do
 -- invocation here forces that build to complete first, so the concurrent
 -- invocations only ever run the already-built CLI.
 warmUpWaspCli :: IO ()
-warmUpWaspCli =
+warmUpWaspCli = do
   -- We don't need any output.
-  withCreateProcess (bashProc "$WASP_CLI_CMD version 2>&1 >/dev/null") $ \_ _ _ ph -> do
+  warmUpProcess <- bashProc "$WASP_CLI_CMD version 2>&1 >/dev/null"
+  withCreateProcess warmUpProcess $ \_ _ _ ph -> do
     exitCode <- waitForProcess ph
     case exitCode of
       ExitSuccess -> return ()

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -5,6 +5,8 @@ module ShellCommands
   ( ShellCommand,
     ShellCommandBuilder (..),
     buildShellCommand,
+    bashProc,
+    toShellPath,
     (~|),
     (~&&),
     (~?),
@@ -58,8 +60,10 @@ import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.Text as T
 import FileSystem (GitRootDir, SnapshotDir, TestCaseDir, gitRootFromSnapshotDir, seedsDirInWaspProjectDir, seedsFileInSeedsDir)
-import StrongPath (Abs, Dir, File, Path', Rel, fromAbsDir, fromAbsFile, fromRelDir, parent, (</>))
+import StrongPath (Abs, Dir, File, Path', Rel, parent, (</>))
+import qualified StrongPath as SP
 import System.FilePath (joinPath)
+import System.Process (CreateProcess, proc)
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates (StarterTemplate)
 import Wasp.Generator.DbGenerator.Common (dbMigrationsDirInDbRootDir, dbRootDirInGeneratedAppDir)
@@ -78,6 +82,34 @@ newtype ShellCommandBuilder context a = ShellCommandBuilder (Reader context a)
 
 buildShellCommand :: context -> ShellCommandBuilder context a -> a
 buildShellCommand context (ShellCommandBuilder reader) = runReader reader context
+
+-- | Runs a built shell command through bash on all platforms. We can't use
+-- 'System.Process.shell' because on Windows it runs commands through cmd.exe,
+-- which can't execute our POSIX commands. Bash is a requirement for developing
+-- Wasp on Windows, so we can rely on it being present.
+bashProc :: ShellCommand -> CreateProcess
+bashProc command = proc "bash" ["-c", command]
+
+-- | Makes a path safe for embedding into a bash command. On Windows, paths are
+-- backslash-separated, but bash interprets backslashes as escape characters.
+-- Bash on Windows accepts forward-slash-separated Windows paths (@C:/foo/bar@).
+toShellPath :: FilePath -> FilePath
+toShellPath = map toForwardSlash
+  where
+    toForwardSlash '\\' = '/'
+    toForwardSlash c = c
+
+-- The wrappers below shadow StrongPath's functions of the same name so that
+-- every path embedded into a shell command in this module is bash-safe.
+
+fromAbsDir :: Path' Abs (Dir a) -> FilePath
+fromAbsDir = toShellPath . SP.fromAbsDir
+
+fromAbsFile :: Path' Abs (File a) -> FilePath
+fromAbsFile = toShellPath . SP.fromAbsFile
+
+fromRelDir :: Path' (Rel a) (Dir b) -> FilePath
+fromRelDir = toShellPath . SP.fromRelDir
 
 -- Command utilities
 

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -62,7 +62,8 @@ import qualified Data.Text as T
 import FileSystem (GitRootDir, SnapshotDir, TestCaseDir, gitRootFromSnapshotDir, seedsDirInWaspProjectDir, seedsFileInSeedsDir)
 import StrongPath (Abs, Dir, File, Path', Rel, parent, (</>))
 import qualified StrongPath as SP
-import System.FilePath (joinPath)
+import System.Directory (findExecutablesInDirectories)
+import System.FilePath (getSearchPath, joinPath)
 import System.Process (CreateProcess, proc)
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 import Wasp.Cli.Command.CreateNewProject.StarterTemplates (StarterTemplate)
@@ -87,8 +88,22 @@ buildShellCommand context (ShellCommandBuilder reader) = runReader reader contex
 -- 'System.Process.shell' because on Windows it runs commands through cmd.exe,
 -- which can't execute our POSIX commands. Bash is a requirement for developing
 -- Wasp on Windows, so we can rely on it being present.
-bashProc :: ShellCommand -> CreateProcess
-bashProc command = proc "bash" ["-c", command]
+bashProc :: ShellCommand -> IO CreateProcess
+bashProc command = do
+  bashExe <- findBashExe
+  return $ proc bashExe ["-c", command]
+
+-- | Finds the bash executable by searching PATH.
+-- We can't just pass @"bash"@ to 'proc': on Windows, CreateProcess searches
+-- System32 before PATH, and System32 contains WSL's bash stub, which would
+-- shadow the real bash (e.g. Git Bash) from PATH.
+findBashExe :: IO FilePath
+findBashExe = do
+  searchPathDirs <- getSearchPath
+  bashExes <- findExecutablesInDirectories searchPathDirs "bash"
+  case bashExes of
+    bashExe : _ -> return bashExe
+    [] -> fail "Could not find bash on PATH. Bash is required to run the e2e tests."
 
 -- | Makes a path safe for embedding into a bash command. On Windows, paths are
 -- backslash-separated, but bash interprets backslashes as escape characters.

--- a/waspc/e2e-tests/SnapshotTest.hs
+++ b/waspc/e2e-tests/SnapshotTest.hs
@@ -197,15 +197,19 @@ getNormalizedSnapshotFilesForContentCheck snapshotDir = do
     formatPackageJsonFiles = mapM_ formatPackageJsonFile . filter isPackageJsonFile
       where
         formatPackageJsonFile :: Path' Abs (File file) -> IO ()
-        formatPackageJsonFile packageJsonFile =
-          BS.readFile (SP.fromAbsFile packageJsonFile)
-            >>= BSL.writeFile (SP.fromAbsFile packageJsonFile) . formatJson . unsafeDecodeJson
+        formatPackageJsonFile packageJsonFile = do
+          fileContents <- BS.readFile (SP.fromAbsFile packageJsonFile)
+          case Aeson.decodeStrict fileContents of
+            Just json -> BSL.writeFile (SP.fromAbsFile packageJsonFile) $ formatJson json
+            Nothing ->
+              fail $
+                "Failed to decode JSON in "
+                  ++ SP.fromAbsFile packageJsonFile
+                  ++ ", which starts with: "
+                  ++ show (BS.take 100 fileContents)
 
         isPackageJsonFile :: Path' Abs (File file) -> Bool
         isPackageJsonFile = equalFilePath "package.json" . takeFileName . SP.fromAbsFile
-
-        unsafeDecodeJson :: BS.ByteString -> Aeson.Value
-        unsafeDecodeJson = fromJust . Aeson.decodeStrict
 
         formatJson :: Aeson.Value -> BSL.ByteString
         formatJson =

--- a/waspc/e2e-tests/SnapshotTest.hs
+++ b/waspc/e2e-tests/SnapshotTest.hs
@@ -257,9 +257,10 @@ isSubpathOf subPath filePath = splitDirectories subPath `isInfixOf` splitDirecto
 callCommandInProcessGroup :: String -> Path' Abs (File TestLogFile) -> String -> IO ()
 callCommandInProcessGroup cmd logFile testName = do
   (logOut, logErr) <- openLogForCommand logFile testName cmd
+  cmdProcess <- bashProc cmd
   bracket
     ( createProcess
-        (bashProc cmd)
+        cmdProcess
           { create_group = True,
             std_out = UseHandle logOut,
             std_err = UseHandle logErr

--- a/waspc/e2e-tests/SnapshotTest.hs
+++ b/waspc/e2e-tests/SnapshotTest.hs
@@ -26,14 +26,14 @@ import FileSystem
     snapshotFileListManifestFileInSnapshotDir,
     snapshotLogFileInSnapshotsDir,
   )
-import ShellCommands (ShellCommand, ShellCommandBuilder, SnapshotTestContext (..), WaspProjectContext (..), buildShellCommand, (~&&))
+import ShellCommands (ShellCommand, ShellCommandBuilder, SnapshotTestContext (..), WaspProjectContext (..), bashProc, buildShellCommand, toShellPath, (~&&))
 import StrongPath (Abs, Dir, File, Path', parseRelDir, (</>))
 import qualified StrongPath as SP
-import System.Directory (doesFileExist)
+import System.Directory (createDirectoryIfMissing, doesFileExist, removePathForcibly)
 import System.Directory.Recursive (getDirFiltered)
 import System.Exit (ExitCode (..))
 import System.FilePath (equalFilePath, isExtensionOf, makeRelative, splitDirectories, takeFileName)
-import System.Process (CreateProcess (..), StdStream (..), callCommand, createProcess, interruptProcessGroupOf, shell, waitForProcess)
+import System.Process (CreateProcess (..), StdStream (..), createProcess, interruptProcessGroupOf, waitForProcess)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden (goldenVsFileDiff)
 import TestLogging (formatCommandFailure, openLogForCommand)
@@ -99,17 +99,17 @@ createSnapshotTestTree snapshotTestData =
 -- 2. Ensuring the current and golden snapshot directories exist.
 setupSnapshotTestEnvironment :: Path' Abs (Dir SnapshotDir) -> Path' Abs (Dir SnapshotDir) -> IO ()
 setupSnapshotTestEnvironment currentSnapshotDir goldenSnapshotDir = do
-  callCommand $ "rm -rf " ++ SP.fromAbsDir currentSnapshotDir
+  removePathForcibly $ SP.fromAbsDir currentSnapshotDir
 
-  callCommand $ "mkdir " ++ SP.fromAbsDir currentSnapshotDir
-  callCommand $ "mkdir -p " ++ SP.fromAbsDir goldenSnapshotDir
+  createDirectoryIfMissing False $ SP.fromAbsDir currentSnapshotDir
+  createDirectoryIfMissing True $ SP.fromAbsDir goldenSnapshotDir
 
 executeSnapshotTestCommand :: SnapshotTest -> Path' Abs (Dir SnapshotDir) -> Path' Abs (File TestLogFile) -> IO ()
 executeSnapshotTestCommand snapshotTest snapshotDir logFile =
   callCommandInProcessGroup fullCommand logFile snapshotTest.name
   where
     fullCommand :: ShellCommand
-    fullCommand = "cd " ++ SP.fromAbsDir snapshotDir ~&& snapshotTestCommand
+    fullCommand = "cd " ++ toShellPath (SP.fromAbsDir snapshotDir) ~&& snapshotTestCommand
 
     snapshotTestCommand :: ShellCommand
     snapshotTestCommand = foldr1 (~&&) $ buildShellCommand snapshotTestContext snapshotTest.shellCommandBuilder
@@ -259,7 +259,7 @@ callCommandInProcessGroup cmd logFile testName = do
   (logOut, logErr) <- openLogForCommand logFile testName cmd
   bracket
     ( createProcess
-        (shell cmd)
+        (bashProc cmd)
           { create_group = True,
             std_out = UseHandle logOut,
             std_err = UseHandle logErr

--- a/waspc/e2e-tests/Test.hs
+++ b/waspc/e2e-tests/Test.hs
@@ -9,10 +9,11 @@ where
 
 import Data.Maybe (fromJust)
 import FileSystem (TestCaseDir, TestLogFile, getTestCaseDir, testCaseLogFileInTestCaseDir)
-import ShellCommands (ShellCommand, ShellCommandBuilder, TestContext (..), WaspProjectContext (..), buildShellCommand, (~&&))
+import ShellCommands (ShellCommand, ShellCommandBuilder, TestContext (..), WaspProjectContext (..), bashProc, buildShellCommand, (~&&))
 import StrongPath (Abs, Dir, File, Path', fromAbsDir, parseRelDir, (</>))
+import System.Directory (createDirectoryIfMissing, removePathForcibly)
 import System.Exit (ExitCode (..))
-import System.Process (CreateProcess (..), StdStream (..), callCommand, createProcess, shell, waitForProcess)
+import System.Process (CreateProcess (..), StdStream (..), createProcess, waitForProcess)
 import Test.Hspec (Spec, expectationFailure, it)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec)
@@ -60,8 +61,8 @@ createTestCaseCommand testCaseDir testCase =
 
 setupTestCase :: Path' Abs (Dir TestCaseDir) -> IO ()
 setupTestCase testCaseDir = do
-  callCommand $ "rm -rf " ++ fromAbsDir testCaseDir
-  callCommand $ "mkdir -p " ++ fromAbsDir testCaseDir
+  removePathForcibly $ fromAbsDir testCaseDir
+  createDirectoryIfMissing True $ fromAbsDir testCaseDir
 
 executeTestCaseCommand :: Path' Abs (Dir TestCaseDir) -> ShellCommand -> String -> IO (ExitCode, Path' Abs (File TestLogFile))
 executeTestCaseCommand testCaseDir testCaseCommand testName = do
@@ -69,7 +70,7 @@ executeTestCaseCommand testCaseDir testCaseCommand testName = do
   (logOut, logErr) <- openLogForCommand logFile testName testCaseCommand
   (_, _, _, processHandle) <-
     createProcess
-      (shell testCaseCommand)
+      (bashProc testCaseCommand)
         { cwd = Just $ fromAbsDir testCaseDir,
           std_in = Inherit,
           std_out = UseHandle logOut,

--- a/waspc/e2e-tests/Test.hs
+++ b/waspc/e2e-tests/Test.hs
@@ -68,9 +68,10 @@ executeTestCaseCommand :: Path' Abs (Dir TestCaseDir) -> ShellCommand -> String 
 executeTestCaseCommand testCaseDir testCaseCommand testName = do
   let logFile = testCaseDir </> testCaseLogFileInTestCaseDir
   (logOut, logErr) <- openLogForCommand logFile testName testCaseCommand
+  testCaseProcess <- bashProc testCaseCommand
   (_, _, _, processHandle) <-
     createProcess
-      (bashProc testCaseCommand)
+      testCaseProcess
         { cwd = Just $ fromAbsDir testCaseDir,
           std_in = Inherit,
           std_out = UseHandle logOut,

--- a/waspc/e2e-tests/Tests/ViteBuildTest.hs
+++ b/waspc/e2e-tests/Tests/ViteBuildTest.hs
@@ -12,6 +12,7 @@ import ShellCommands
     createTestWaspProject,
     inTestWaspProjectDir,
     setWaspDbToPSQL,
+    toShellPath,
     waspCliBuild,
     writeToFile,
   )
@@ -93,7 +94,7 @@ viteBuildTest =
     viteBuildWithApiUrl = appendInlineEnvVars [apiUrlEnvVar] <$> viteBuild
 
     assertBuildOutputContains :: String -> ShellCommandBuilder WaspProjectContext ShellCommand
-    assertBuildOutputContains value = return $ "grep -r '" ++ value ++ "' " ++ SP.fromRelDir viteBuildDirPath
+    assertBuildOutputContains value = return $ "grep -r '" ++ value ++ "' " ++ toShellPath (SP.fromRelDir viteBuildDirPath)
 
     writeMainPageTsx :: ShellCommandBuilder WaspProjectContext ShellCommand
     writeMainPageTsx = do

--- a/waspc/e2e-tests/Tests/WaspDbMigrateDevTest.hs
+++ b/waspc/e2e-tests/Tests/WaspDbMigrateDevTest.hs
@@ -3,7 +3,7 @@ module Tests.WaspDbMigrateDevTest (waspDbMigrateDevTest) where
 import Control.Monad.Reader (MonadReader (ask))
 import qualified Data.Text as T
 import NeatInterpolation (trimming)
-import ShellCommands (ShellCommand, ShellCommandBuilder, WaspProjectContext (..), appendToPrismaFile, createTestWaspProject, inTestWaspProjectDir, waspCliDbMigrateDev, (~&&))
+import ShellCommands (ShellCommand, ShellCommandBuilder, WaspProjectContext (..), appendToPrismaFile, createTestWaspProject, inTestWaspProjectDir, toShellPath, waspCliDbMigrateDev, (~&&))
 import StrongPath (fromAbsDir, (</>))
 import Test (Test (..), TestCase (..))
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
@@ -71,7 +71,7 @@ assertMigrationDirsExist migrationName = do
           </> dbRootDirInGeneratedAppDir
           </> dbMigrationsDirInDbRootDir
   return $
-    ("cd " ++ fromAbsDir waspMigrationsDir)
+    ("cd " ++ toShellPath (fromAbsDir waspMigrationsDir))
       ~&& ("[ -d \"$(find . -type d -name '*" ++ migrationName ++ "*' -print -quit)\" ]")
-      ~&& ("cd " ++ fromAbsDir waspOutMigrationsDir)
+      ~&& ("cd " ++ toShellPath (fromAbsDir waspOutMigrationsDir))
       ~&& ("[ -d \"$(find . -type d -name '*" ++ migrationName ++ "*' -print -quit)\" ]")

--- a/waspc/e2e-tests/Tests/WaspSpecAvailableTest.hs
+++ b/waspc/e2e-tests/Tests/WaspSpecAvailableTest.hs
@@ -9,6 +9,7 @@ import ShellCommands
     createTestWaspProject,
     inTestWaspProjectDir,
     setWaspDbToPSQL,
+    toShellPath,
     waspCliBuild,
     waspCliBuildStart,
     waspCliClean,
@@ -113,7 +114,7 @@ waspSpecAvailableTest =
     corruptWaspSpecVersion = do
       context <- ask
       let waspSpecDir = context.waspProjectDir </> [reldir|.wasp/spec|]
-      return $ "(cd " ++ fromAbsDir waspSpecDir ++ " && npm pkg set version=9.9.9)"
+      return $ "(cd " ++ toShellPath (fromAbsDir waspSpecDir) ++ " && npm pkg set version=9.9.9)"
 
     assertCommandFailsWithInstallHint ::
       ShellCommandBuilder WaspProjectContext ShellCommand ->


### PR DESCRIPTION
## Description

**Draft / smoke check — not meant to merge as-is.**

Spike for #3404: now that bash is a requirement for developing Wasp on Windows (via mise), check how far the waspc CLI e2e tests get on a Windows runner if we simply force the existing shell-command harness through bash instead of doing the full ShellCommandBuilder-to-IO refactor.

Changes:

- e2e harness runs every built command via `bash -c` instead of `System.Process.shell`/`callCommand` (which use cmd.exe on Windows).
- Paths embedded into command strings are converted to forward slashes (bash treats backslashes as escapes; Git Bash accepts `C:/foo` paths).
- `rm -rf`/`mkdir -p` setup shell-outs replaced with platform-agnostic `System.Directory` calls.
- Removed the `mingw32` skip in `e2e-tests/Main.hs`.
- **TEMPORARY, revert before un-drafting**: `ci.yaml` only runs `waspc-test`; its matrix is trimmed to `windows-latest`; unit tests skipped; Docker skipped on Windows; rsync borrowed from the runner's MSYS2 for the kitchen-sink test.

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.