### PR TITLE
Refactor `wasp start db`

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Start/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start/Db.hs
@@ -10,7 +10,6 @@ import Data.Maybe (isJust)
 import qualified Options.Applicative as Opt
 import StrongPath (Abs, Dir, File', Path', Rel, fromRelFile)
 import System.Environment (lookupEnv)
-import System.Process (callCommand)
 import Text.Printf (printf)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App.Db as AS.App.Db
@@ -22,6 +21,7 @@ import Wasp.Cli.Command.Compile (analyze)
 import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.Require.InWaspProject (InWaspProject (InWaspProject))
 import Wasp.Cli.Command.Require.WaspSpecAvailable (WaspSpecAvailable (WaspSpecAvailable))
+import Wasp.Cli.Message (cliSendMessage)
 import Wasp.Cli.Util.Parser (withArguments)
 import Wasp.Db.Postgres (defaultPostgresDockerImageSpec)
 import qualified Wasp.Message as Msg
@@ -124,47 +124,29 @@ startPostgresDevDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath 
     "To run PostgreSQL dev database, Wasp needs `docker` installed and in PATH."
   throwIfDevDbPortIsAlreadyInUse
 
-  cliSendMessageC . Msg.Info $
-    unlines
-      [ "✨ Starting a PostgreSQL dev database (based on your Wasp config) ✨",
-        "",
-        "Additional info:",
-        " ℹ Using Docker image: " <> dbDockerImage,
-        "   with the data volume mounted at: " <> dbDockerVolumeMountPath,
-        " ℹ Connection URL, in case you might want to connect with external tools:",
-        "     " <> connectionUrl,
-        " ℹ Database data is persisted in a Docker volume with the following name"
-          <> " (useful to know if you will want to delete it at some point):",
-        "     " <> dockerVolumeName
-      ]
-
-  cliSendMessageC $ Msg.Info "..."
-
-  -- NOTE: POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_DB below are really used by the docker image
-  --   only when initializing the database -> if it already exists, they will be ignored.
-  --   This is how the postgres Docker image works.
-  let command =
-        unwords
-          [ "docker run",
-            printf "--name %s" dockerContainerName,
-            "--rm",
-            printf "--publish %d:5432" Dev.Postgres.defaultDevPort,
-            printf "-v %s:%s" dockerVolumeName dbDockerVolumeMountPath,
-            printf "--env POSTGRES_PASSWORD=%s" Dev.Postgres.defaultDevPass,
-            printf "--env POSTGRES_USER=%s" Dev.Postgres.defaultDevUser,
-            printf "--env POSTGRES_DB=%s" dbName,
-            dbDockerImage
-          ]
-  liftIO $ callCommand command
+  liftIO $
+    Dev.Postgres.startDevPostgresDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath printDevDbInfo
   where
-    dockerVolumeName = Dev.Postgres.makeWaspDevDbDockerVolumeName waspProjectDir appName
-    dockerContainerName = Dev.Postgres.makeWaspDevDbDockerContainerName waspProjectDir appName
-    dbName = Dev.Postgres.makeDevDbName waspProjectDir appName
-    connectionUrl = Dev.Postgres.makeDevConnectionUrl waspProjectDir appName
+    printDevDbInfo :: Dev.Postgres.DevPostgresDb -> IO ()
+    printDevDbInfo devPostgresDb = do
+      cliSendMessage . Msg.Info $
+        unlines
+          [ "✨ Starting a PostgreSQL dev database (based on your Wasp config) ✨",
+            "",
+            "Additional info:",
+            " ℹ Using Docker image: " <> dbDockerImage,
+            "   with the data volume mounted at: " <> dbDockerVolumeMountPath,
+            " ℹ Connection URL, in case you might want to connect with external tools:",
+            "     " <> devPostgresDb.connectionUrl,
+            " ℹ Database data is persisted in a Docker volume with the following name"
+              <> " (useful to know if you will want to delete it at some point):",
+            "     " <> devPostgresDb.dockerVolumeName
+          ]
+      cliSendMessage $ Msg.Info "..."
 
     throwIfDevDbPortIsAlreadyInUse :: Command ()
     throwIfDevDbPortIsAlreadyInUse = do
-      -- I am checking both conditions because of Docker having virtual network on Mac which
+      -- We check both conditions because of Docker having virtual network on Mac which
       -- always gives precedence to native ports so checking only if we can open the port is
       -- not enough because we can open it even if Docker container is already bound to that port.
       whenM (liftIO $ Socket.checkIfPortIsInUse devDbSocketAddress) throwPortAlreadyInUseError

--- a/waspc/cli/src/Wasp/Cli/Command/Start/Db.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start/Db.hs
@@ -21,7 +21,6 @@ import Wasp.Cli.Command.Compile (analyze)
 import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.Require.InWaspProject (InWaspProject (InWaspProject))
 import Wasp.Cli.Command.Require.WaspSpecAvailable (WaspSpecAvailable (WaspSpecAvailable))
-import Wasp.Cli.Message (cliSendMessage)
 import Wasp.Cli.Util.Parser (withArguments)
 import Wasp.Db.Postgres (defaultPostgresDockerImageSpec)
 import qualified Wasp.Message as Msg
@@ -124,25 +123,25 @@ startPostgresDevDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath 
     "To run PostgreSQL dev database, Wasp needs `docker` installed and in PATH."
   throwIfDevDbPortIsAlreadyInUse
 
-  liftIO $
-    Dev.Postgres.startDevPostgresDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath printDevDbInfo
+  cliSendMessageC . Msg.Info $
+    unlines
+      [ "✨ Starting a PostgreSQL dev database (based on your Wasp config) ✨",
+        "",
+        "Additional info:",
+        " ℹ Using Docker image: " <> dbDockerImage,
+        "   with the data volume mounted at: " <> dbDockerVolumeMountPath,
+        " ℹ Connection URL, in case you might want to connect with external tools:",
+        "     " <> devPostgresDb.connectionUrl,
+        " ℹ Database data is persisted in a Docker volume with the following name"
+          <> " (useful to know if you will want to delete it at some point):",
+        "     " <> devPostgresDb.dockerVolumeName
+      ]
+
+  cliSendMessageC $ Msg.Info "..."
+
+  liftIO $ Dev.Postgres.runDevPostgresDb devPostgresDb
   where
-    printDevDbInfo :: Dev.Postgres.DevPostgresDb -> IO ()
-    printDevDbInfo devPostgresDb = do
-      cliSendMessage . Msg.Info $
-        unlines
-          [ "✨ Starting a PostgreSQL dev database (based on your Wasp config) ✨",
-            "",
-            "Additional info:",
-            " ℹ Using Docker image: " <> dbDockerImage,
-            "   with the data volume mounted at: " <> dbDockerVolumeMountPath,
-            " ℹ Connection URL, in case you might want to connect with external tools:",
-            "     " <> devPostgresDb.connectionUrl,
-            " ℹ Database data is persisted in a Docker volume with the following name"
-              <> " (useful to know if you will want to delete it at some point):",
-            "     " <> devPostgresDb.dockerVolumeName
-          ]
-      cliSendMessage $ Msg.Info "..."
+    devPostgresDb = Dev.Postgres.makeDevPostgresDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath
 
     throwIfDevDbPortIsAlreadyInUse :: Command ()
     throwIfDevDbPortIsAlreadyInUse = do

--- a/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
+++ b/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
@@ -1,6 +1,7 @@
 -- | This module captures how Wasp runs a PostgreSQL dev database.
 module Wasp.Project.Db.Dev.Postgres
-  ( startDevPostgresDb,
+  ( makeDevPostgresDb,
+    runDevPostgresDb,
     DevPostgresDb (connectionUrl, dockerVolumeName),
     discoverDevConnectionUrl,
     defaultDevPort,
@@ -15,53 +16,45 @@ import Wasp.Db.Postgres (makeConnectionUrl, postgresMaxDbNameLength)
 import Wasp.Project.Common (WaspProjectDir, makeAppUniqueId)
 import Wasp.Util.Docker (DockerImageName, DockerVolumeMountPath, getDockerContainerHostPort)
 
--- | Connection info of a Wasp project's dev db. There is no way to obtain it
--- without starting the database ('startDevPostgresDb') or discovering an
--- already running one ('discoverDevConnectionUrl').
 data DevPostgresDb = DevPostgresDb
   { connectionUrl :: String,
-    dockerVolumeName :: String
+    dockerVolumeName :: String,
+    runDbCommand :: String
   }
 
--- | Runs a PostgreSQL dev database in a Docker container, unique for the Wasp
--- project with the specified path and name. The database's connection info
--- exists only once the database is provisioned, so it is passed to the given
--- callback right before the run. Blocks until the database shuts down.
-startDevPostgresDb ::
+makeDevPostgresDb ::
   Path' Abs (Dir WaspProjectDir) ->
   String ->
   DockerImageName ->
   DockerVolumeMountPath ->
-  (DevPostgresDb -> IO ()) ->
-  IO ()
-startDevPostgresDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath onDbProvisioned = do
-  onDbProvisioned devPostgresDb
-  callCommand dockerRunCommand
+  DevPostgresDb
+makeDevPostgresDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath =
+  DevPostgresDb
+    { connectionUrl = makeDevConnectionUrl waspProjectDir appName,
+      dockerVolumeName = volumeName,
+      -- NOTE: POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_DB below are really used by the docker image
+      --   only when initializing the database -> if it already exists, they will be ignored.
+      --   This is how the postgres Docker image works.
+      runDbCommand =
+        unwords
+          [ "docker run",
+            printf "--name %s" dockerContainerName,
+            "--rm",
+            printf "--publish %d:5432" defaultDevPort,
+            printf "-v %s:%s" volumeName dbDockerVolumeMountPath,
+            printf "--env POSTGRES_PASSWORD=%s" defaultDevPass,
+            printf "--env POSTGRES_USER=%s" defaultDevUser,
+            printf "--env POSTGRES_DB=%s" dbName,
+            dbDockerImage
+          ]
+    }
   where
-    devPostgresDb =
-      DevPostgresDb
-        { connectionUrl = makeDevConnectionUrl waspProjectDir appName,
-          dockerVolumeName = makeWaspDevDbDockerVolumeName waspProjectDir appName
-        }
-
-    -- NOTE: POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_DB below are really used by the docker image
-    --   only when initializing the database -> if it already exists, they will be ignored.
-    --   This is how the postgres Docker image works.
-    dockerRunCommand =
-      unwords
-        [ "docker run",
-          printf "--name %s" dockerContainerName,
-          "--rm",
-          printf "--publish %d:5432" defaultDevPort,
-          printf "-v %s:%s" devPostgresDb.dockerVolumeName dbDockerVolumeMountPath,
-          printf "--env POSTGRES_PASSWORD=%s" defaultDevPass,
-          printf "--env POSTGRES_USER=%s" defaultDevUser,
-          printf "--env POSTGRES_DB=%s" dbName,
-          dbDockerImage
-        ]
-
+    volumeName = makeWaspDevDbDockerVolumeName waspProjectDir appName
     dockerContainerName = makeWaspDevDbDockerContainerName waspProjectDir appName
     dbName = makeDevDbName waspProjectDir appName
+
+runDevPostgresDb :: DevPostgresDb -> IO ()
+runDevPostgresDb devPostgresDb = callCommand devPostgresDb.runDbCommand
 
 -- | Returns the connection URL of this Wasp project's dev db if it is up,
 -- 'Nothing' otherwise.

--- a/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
+++ b/waspc/src/Wasp/Project/Db/Dev/Postgres.hs
@@ -1,21 +1,67 @@
 -- | This module captures how Wasp runs a PostgreSQL dev database.
 module Wasp.Project.Db.Dev.Postgres
-  ( discoverDevConnectionUrl,
-    defaultDevUser,
-    makeDevDbName,
-    defaultDevPass,
+  ( startDevPostgresDb,
+    DevPostgresDb (connectionUrl, dockerVolumeName),
+    discoverDevConnectionUrl,
     defaultDevPort,
-    makeDevConnectionUrl,
-    makeWaspDevDbDockerContainerName,
-    makeWaspDevDbDockerVolumeName,
     waspDevDbDockerVolumePrefix,
   )
 where
 
 import StrongPath (Abs, Dir, Path')
+import System.Process (callCommand)
+import Text.Printf (printf)
 import Wasp.Db.Postgres (makeConnectionUrl, postgresMaxDbNameLength)
 import Wasp.Project.Common (WaspProjectDir, makeAppUniqueId)
-import Wasp.Util.Docker (getDockerContainerHostPort)
+import Wasp.Util.Docker (DockerImageName, DockerVolumeMountPath, getDockerContainerHostPort)
+
+-- | Connection info of a Wasp project's dev db. There is no way to obtain it
+-- without starting the database ('startDevPostgresDb') or discovering an
+-- already running one ('discoverDevConnectionUrl').
+data DevPostgresDb = DevPostgresDb
+  { connectionUrl :: String,
+    dockerVolumeName :: String
+  }
+
+-- | Runs a PostgreSQL dev database in a Docker container, unique for the Wasp
+-- project with the specified path and name. The database's connection info
+-- exists only once the database is provisioned, so it is passed to the given
+-- callback right before the run. Blocks until the database shuts down.
+startDevPostgresDb ::
+  Path' Abs (Dir WaspProjectDir) ->
+  String ->
+  DockerImageName ->
+  DockerVolumeMountPath ->
+  (DevPostgresDb -> IO ()) ->
+  IO ()
+startDevPostgresDb waspProjectDir appName dbDockerImage dbDockerVolumeMountPath onDbProvisioned = do
+  onDbProvisioned devPostgresDb
+  callCommand dockerRunCommand
+  where
+    devPostgresDb =
+      DevPostgresDb
+        { connectionUrl = makeDevConnectionUrl waspProjectDir appName,
+          dockerVolumeName = makeWaspDevDbDockerVolumeName waspProjectDir appName
+        }
+
+    -- NOTE: POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_DB below are really used by the docker image
+    --   only when initializing the database -> if it already exists, they will be ignored.
+    --   This is how the postgres Docker image works.
+    dockerRunCommand =
+      unwords
+        [ "docker run",
+          printf "--name %s" dockerContainerName,
+          "--rm",
+          printf "--publish %d:5432" defaultDevPort,
+          printf "-v %s:%s" devPostgresDb.dockerVolumeName dbDockerVolumeMountPath,
+          printf "--env POSTGRES_PASSWORD=%s" defaultDevPass,
+          printf "--env POSTGRES_USER=%s" defaultDevUser,
+          printf "--env POSTGRES_DB=%s" dbName,
+          dbDockerImage
+        ]
+
+    dockerContainerName = makeWaspDevDbDockerContainerName waspProjectDir appName
+    dbName = makeDevDbName waspProjectDir appName
 
 -- | Returns the connection URL of this Wasp project's dev db if it is up,
 -- 'Nothing' otherwise.


### PR DESCRIPTION
I disliked how different parts of the `Db.hs` relied on calling specific functions from `Postgres.hs` and expecting them to return the same data. The functions are pure so it worked, but there was an extra hassle of always sending the correct arguments and computing fundamentally cooupled data separately (`dbPass`, `connectionUrl`, etc.) 