### PR TITLE
Add `wasp show build` command

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -9,6 +9,7 @@
 
 ### 🔧 Small improvements
 
+- Added a `wasp show build` command that prints information about your app's current build: build type, generation time, generating Wasp version, and project dir size. With `--json`, it prints the same information as JSON. ([#4623](https://github.com/wasp-lang/wasp/pull/4623))
 - `wasp start` now finds the managed dev database by asking Docker where the project's database container is running, instead of assuming `localhost:5432`. This means Wasp will no longer accidentally connect to an unrelated database that happens to be listening on port 5432. ([#4567](https://github.com/wasp-lang/wasp/pull/4567))
 - Newly created projects no longer open the browser automatically on `wasp start`. ([#4553](https://github.com/wasp-lang/wasp/pull/4553))
 - Upgraded internal `morgan` to 1.11, which fixes ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Wasp's usage was unaffected by the vulnerability. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -5,7 +5,6 @@
 ### ⚠️ Breaking Changes
 
 - Moved internal server-only import paths under the `wasp/server/...` prefix. These paths are not part of the documented public API, but if your app imported any of them, update the import path or switch to documented public imports like `wasp/server/auth`. ([#4557](https://github.com/wasp-lang/wasp/pull/4557))
-- Removed the `wasp info` command, in favor of the new `wasp show` family of commands. ([#4622](https://github.com/wasp-lang/wasp/pull/4622))
 
 ### 🔧 Small improvements
 

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -29,6 +29,7 @@ import Wasp.Cli.Command.Deploy (deploy)
 import Wasp.Cli.Command.Deps (deps)
 import Wasp.Cli.Command.Dockerfile (printDockerfile)
 import Wasp.Cli.Command.Doctor (doctor)
+import Wasp.Cli.Command.Info (info)
 import Wasp.Cli.Command.Install (install)
 import Wasp.Cli.Command.News (news)
 import Wasp.Cli.Command.Show (showCommand)
@@ -63,6 +64,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
         ["telemetry"] -> Command.Call.Telemetry
         ["deps"] -> Command.Call.Deps
         ["dockerfile"] -> Command.Call.Dockerfile
+        ["info"] -> Command.Call.Info
         ("show" : showArgs) -> Command.Call.Show showArgs
         ["news"] -> Command.Call.News
         ["studio"] -> Command.Call.Studio
@@ -93,6 +95,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
     Command.Call.Telemetry -> runCommand Telemetry.telemetry
     Command.Call.Deps -> runCommand deps
     Command.Call.Dockerfile -> runCommand printDockerfile
+    Command.Call.Info -> runCommand info
     Command.Call.Show showArgs -> runCommand $ showCommand showArgs
     Command.Call.News -> runCommand news
     Command.Call.PrintBashCompletionInstruction -> runCommand printBashCompletionInstruction
@@ -161,6 +164,7 @@ printUsage =
         cmd   "    telemetry             Prints telemetry status.",
         cmd   "    deps                  Prints the dependencies that Wasp uses in your project.",
         cmd   "    dockerfile            Prints the contents of the Wasp generated Dockerfile.",
+        cmd   "    info                  Prints basic information about the current Wasp project.",
         cmd   "    show build [--json]   Prints information about your app's current build.",
         cmd   "    test                  Executes tests in your project.",
         cmd   "    studio                (experimental) GUI for inspecting your Wasp app.",

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -31,6 +31,7 @@ import Wasp.Cli.Command.Dockerfile (printDockerfile)
 import Wasp.Cli.Command.Doctor (doctor)
 import Wasp.Cli.Command.Install (install)
 import Wasp.Cli.Command.News (news)
+import Wasp.Cli.Command.Show (showCommand)
 import Wasp.Cli.Command.Start (start)
 import qualified Wasp.Cli.Command.Start.Db as Command.Start.Db
 import Wasp.Cli.Command.Studio (studio)
@@ -62,6 +63,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
         ["telemetry"] -> Command.Call.Telemetry
         ["deps"] -> Command.Call.Deps
         ["dockerfile"] -> Command.Call.Dockerfile
+        ("show" : showArgs) -> Command.Call.Show showArgs
         ["news"] -> Command.Call.News
         ["studio"] -> Command.Call.Studio
         ["completion"] -> Command.Call.PrintBashCompletionInstruction
@@ -91,6 +93,7 @@ main = withUtf8 . (`E.catch` handleInternalErrors) $ do
     Command.Call.Telemetry -> runCommand Telemetry.telemetry
     Command.Call.Deps -> runCommand deps
     Command.Call.Dockerfile -> runCommand printDockerfile
+    Command.Call.Show showArgs -> runCommand $ showCommand showArgs
     Command.Call.News -> runCommand news
     Command.Call.PrintBashCompletionInstruction -> runCommand printBashCompletionInstruction
     Command.Call.BashCompletionListCommands -> runCommand bashCompletion
@@ -158,6 +161,7 @@ printUsage =
         cmd   "    telemetry             Prints telemetry status.",
         cmd   "    deps                  Prints the dependencies that Wasp uses in your project.",
         cmd   "    dockerfile            Prints the contents of the Wasp generated Dockerfile.",
+        cmd   "    show build [--json]   Prints information about your app's current build.",
         cmd   "    test                  Executes tests in your project.",
         cmd   "    studio                (experimental) GUI for inspecting your Wasp app.",
         cmd   "    news                  Read the latest Wasp-related news.",

--- a/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
@@ -21,8 +21,10 @@ bashCompletion = do
   case inputArgs of
     [] -> listCommands commands
     ["db"] -> listCommands dbSubCommands
+    ["show"] -> listCommands showSubCommands
     [cmdPrefix] -> listMatchingCommands cmdPrefix commands
     ["db", cmdPrefix] -> listMatchingCommands cmdPrefix dbSubCommands
+    ["show", cmdPrefix] -> listMatchingCommands cmdPrefix showSubCommands
     _ -> liftIO . putStrLn $ ""
   where
     commands =
@@ -40,10 +42,12 @@ bashCompletion = do
         "telemetry",
         "deps",
         "dockerfile",
+        "show",
         "test",
         "studio"
       ]
     dbSubCommands = ["start", "reset", "seed", "migrate-dev", "studio"]
+    showSubCommands = ["build"]
     listMatchingCommands :: String -> [String] -> Command ()
     listMatchingCommands cmdPrefix cmdList = listCommands $ filter (cmdPrefix `isPrefixOf`) cmdList
     listCommands :: [String] -> Command ()

--- a/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BashCompletion.hs
@@ -42,6 +42,7 @@ bashCompletion = do
         "telemetry",
         "deps",
         "dockerfile",
+        "info",
         "show",
         "test",
         "studio"

--- a/waspc/cli/src/Wasp/Cli/Command/Call.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Call.hs
@@ -16,6 +16,7 @@ data Call
   | Telemetry
   | Deps
   | Dockerfile
+  | Info
   | Show Arguments
   | News
   | Studio

--- a/waspc/cli/src/Wasp/Cli/Command/Call.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Call.hs
@@ -16,6 +16,7 @@ data Call
   | Telemetry
   | Deps
   | Dockerfile
+  | Show Arguments
   | News
   | Studio
   | PrintBashCompletionInstruction

--- a/waspc/cli/src/Wasp/Cli/Command/Common.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Common.hs
@@ -1,19 +1,48 @@
 module Wasp.Cli.Command.Common
-  ( throwIfExeIsNotAvailable,
+  ( readWaspCompileInfo,
+    throwIfExeIsNotAvailable,
     deleteDirectoryIfExistsVerbosely,
   )
 where
 
 import qualified Control.Monad.Except as E
 import Control.Monad.IO.Class (liftIO)
+import qualified Data.Text as T
+import NeatInterpolation (trimming)
 import StrongPath (Abs, Dir, Path')
 import qualified StrongPath as SP
 import StrongPath.Operations
 import System.Directory (findExecutable)
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Message (cliSendMessageC)
+import qualified Wasp.Generator.WaspInfo as WI
 import qualified Wasp.Message as Msg
+import Wasp.Project (WaspProjectDir)
+import qualified Wasp.Project.Common as Project.Common
 import qualified Wasp.Util.IO as IOUtil
+
+readWaspCompileInfo :: Path' Abs (Dir WaspProjectDir) -> IO String
+readWaspCompileInfo waspDir =
+  either showError showWaspInfo
+    <$> WI.safeRead generatedAppDir
+  where
+    showError WI.NotFound = "No compile information found"
+    showError WI.IncompatibleFormat = "Incompatible compile information"
+
+    showWaspInfo waspInfo =
+      T.unpack
+        [trimming|
+          ${buildType} build, generated at ${generatedAt}, by Wasp ${waspVersion}.
+        |]
+      where
+        buildType = T.pack $ show $ WI.buildType waspInfo
+        generatedAt = T.pack $ show $ WI.generatedAt waspInfo
+        waspVersion = T.pack $ WI.waspVersion waspInfo
+
+    generatedAppDir =
+      waspDir
+        </> Project.Common.dotWaspDirInWaspProjectDir
+        </> Project.Common.generatedAppDirInDotWaspDir
 
 throwIfExeIsNotAvailable :: String -> String -> Command ()
 throwIfExeIsNotAvailable exeName explanationMsg = do

--- a/waspc/cli/src/Wasp/Cli/Command/Info.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Info.hs
@@ -1,0 +1,52 @@
+module Wasp.Cli.Command.Info
+  ( info,
+  )
+where
+
+import Control.Arrow ()
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import StrongPath (Abs, Dir, Path', fromRelFile)
+import StrongPath.Operations ()
+import System.Directory (getFileSize)
+import qualified Wasp.AppSpec.Valid as ASV
+import Wasp.Cli.Command (Command, require)
+import Wasp.Cli.Command.Common (readWaspCompileInfo)
+import Wasp.Cli.Command.Compile (analyze)
+import Wasp.Cli.Command.Message (cliSendMessageC)
+import Wasp.Cli.Command.Require.InWaspProject (InWaspProject (InWaspProject))
+import Wasp.Cli.Command.Require.WaspSpecAvailable (WaspSpecAvailable (WaspSpecAvailable))
+import Wasp.Cli.Terminal (title)
+import qualified Wasp.Message as Msg
+import Wasp.Project (WaspProjectDir)
+import qualified Wasp.Util.IO as IOUtil
+import qualified Wasp.Util.Terminal as Term
+
+info :: Command ()
+info = do
+  InWaspProject waspDir <- require
+  WaspSpecAvailable <- require
+
+  compileInfo <- liftIO $ readWaspCompileInfo waspDir
+  projectSize <- liftIO $ readDirectorySizeMB waspDir
+
+  appSpec <- analyze waspDir
+  let (appName, _) = ASV.getApp appSpec
+
+  cliSendMessageC $
+    Msg.Info $
+      unlines
+        [ "",
+          title "Project information",
+          printInfo "Name" appName,
+          printInfo "Database system" $ show $ ASV.getValidDbSystem appSpec,
+          printInfo "Last compile" compileInfo,
+          printInfo "Project dir size" projectSize
+        ]
+
+printInfo :: String -> String -> String
+printInfo key value = Term.applyStyles [Term.Cyan] key ++ ": " <> Term.applyStyles [Term.White] value
+
+readDirectorySizeMB :: Path' Abs (Dir WaspProjectDir) -> IO String
+readDirectorySizeMB path = (++ " MB") . show . (`div` 1000000) . sum <$> allFileSizes
+  where
+    allFileSizes = IOUtil.listDirectoryDeep path >>= mapM (getFileSize . fromRelFile)

--- a/waspc/cli/src/Wasp/Cli/Command/Show.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Show.hs
@@ -1,0 +1,35 @@
+module Wasp.Cli.Command.Show
+  ( showCommand,
+  )
+where
+
+import Data.List (intercalate)
+import qualified Options.Applicative as Opt
+import Wasp.Cli.Command (Command)
+import Wasp.Cli.Command.Call (Arguments)
+import Wasp.Cli.Command.Show.Build (buildShowSubcommand)
+import Wasp.Cli.Command.Show.Subcommand (ShowSubcommand (..), runShowSubcommand)
+import Wasp.Cli.Util.Parser (withArguments)
+
+-- | Prints information about the project, e.g. its current build with
+-- `wasp show build`.
+showCommand :: Arguments -> Command ()
+showCommand = withArguments "wasp show" showParser id
+
+subcommands :: [ShowSubcommand]
+subcommands = [buildShowSubcommand]
+
+showParser :: Opt.Parser (Command ())
+showParser =
+  Opt.hsubparser $ mconcat $ subcommandsMetavar : (toOptCommand <$> subcommands)
+  where
+    toOptCommand subcommand =
+      Opt.command subcommand.name $
+        Opt.info (runShowSubcommand subcommand <$> jsonFlagParser subcommand) $
+          Opt.progDesc subcommand.description
+
+    jsonFlagParser subcommand =
+      Opt.switch (Opt.long "json" <> Opt.help subcommand.jsonHelp)
+
+    subcommandsMetavar =
+      Opt.metavar $ "<" <> intercalate "|" ((.name) <$> subcommands) <> ">"

--- a/waspc/cli/src/Wasp/Cli/Command/Show/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Show/Build.hs
@@ -1,0 +1,75 @@
+module Wasp.Cli.Command.Show.Build
+  ( buildShowSubcommand,
+  )
+where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Aeson (object, (.=))
+import qualified Data.Aeson as Aeson
+import StrongPath (Abs, Dir, Path', (</>))
+import qualified StrongPath as SP
+import System.Directory (getFileSize)
+import Wasp.AppSpec.Core.Inspectable (InspectionDatapoint, InspectionEntry (InspectionEntry))
+import Wasp.Cli.Command (Command, require)
+import Wasp.Cli.Command.Require.InWaspProject (InWaspProject (InWaspProject))
+import Wasp.Cli.Command.Show.Subcommand (ShowSubcommand (..))
+import qualified Wasp.Generator.WaspInfo as WI
+import Wasp.Project (WaspProjectDir)
+import qualified Wasp.Project.Common as Project.Common
+import qualified Wasp.Util.IO as IOUtil
+
+-- | Shows information about the project's current build: as a human-readable
+-- overview by default, or as JSON with --json.
+buildShowSubcommand :: ShowSubcommand
+buildShowSubcommand =
+  ShowSubcommand
+    { name = "build",
+      description = "Prints information about your app's current build",
+      jsonHelp = "Print the build information as JSON.",
+      getInspectionEntries = buildAsEntries <$> getBuildInfo,
+      getJson = buildAsJson <$> getBuildInfo
+    }
+
+-- | The compile information of the current build (if any), and the project dir
+-- size.
+type BuildInfo = (WI.ReadResult, String)
+
+getBuildInfo :: Command BuildInfo
+getBuildInfo = do
+  InWaspProject waspDir <- require
+  waspInfoOrError <- liftIO $ WI.safeRead $ generatedAppDir waspDir
+  projectDirSize <- liftIO $ readDirectorySizeMB waspDir
+  return (waspInfoOrError, projectDirSize)
+  where
+    generatedAppDir waspDir =
+      waspDir
+        </> Project.Common.dotWaspDirInWaspProjectDir
+        </> Project.Common.generatedAppDirInDotWaspDir
+
+readDirectorySizeMB :: Path' Abs (Dir WaspProjectDir) -> IO String
+readDirectorySizeMB path = (++ " MB") . show . (`div` 1000000) . sum <$> allFileSizes
+  where
+    allFileSizes = IOUtil.listDirectoryDeep path >>= mapM (getFileSize . SP.fromRelFile)
+
+buildAsEntries :: BuildInfo -> [InspectionEntry]
+buildAsEntries (waspInfoOrError, projectDirSize) =
+  [ InspectionEntry "Build" $
+      lastCompileDatapoints ++ [("Project dir size", projectDirSize)]
+  ]
+  where
+    lastCompileDatapoints :: [InspectionDatapoint]
+    lastCompileDatapoints = case waspInfoOrError of
+      Left WI.NotFound -> [("Last compile", "No compile information found")]
+      Left WI.IncompatibleFormat -> [("Last compile", "Incompatible compile information")]
+      Right waspInfo ->
+        [ ("Type", show $ WI.buildType waspInfo),
+          ("Generated at", show $ WI.generatedAt waspInfo),
+          ("Wasp version", WI.waspVersion waspInfo)
+        ]
+
+buildAsJson :: BuildInfo -> Aeson.Value
+buildAsJson (waspInfoOrError, projectDirSize) =
+  object
+    [ "lastCompile" .= either (const Nothing) Just waspInfoOrError,
+      "projectDirSize" .= projectDirSize
+    ]

--- a/waspc/cli/src/Wasp/Cli/Command/Show/Subcommand.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Show/Subcommand.hs
@@ -1,0 +1,35 @@
+module Wasp.Cli.Command.Show.Subcommand
+  ( ShowSubcommand (..),
+    runShowSubcommand,
+  )
+where
+
+import Control.Monad.IO.Class (liftIO)
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Encode.Pretty (encodePretty)
+import qualified Data.ByteString.Lazy.Char8 as BSL8
+import Wasp.AppSpec.Core.Inspectable (InspectionEntry)
+import Wasp.Cli.Command (Command)
+import Wasp.Cli.Command.Show.Table (renderEntriesAsTables)
+
+-- | Describes a `wasp show` subcommand: both its CLI parser and its
+-- implementation are derived from this description.
+data ShowSubcommand = ShowSubcommand
+  { name :: String,
+    description :: String,
+    -- | Help text for the subcommand's --json flag.
+    jsonHelp :: String,
+    -- | Gathers the data behind the subcommand's human-readable overview.
+    getInspectionEntries :: Command [InspectionEntry],
+    -- | Gathers the data behind the subcommand's --json output.
+    getJson :: Command Aeson.Value
+  }
+
+runShowSubcommand :: ShowSubcommand -> Bool -> Command ()
+runShowSubcommand subcommand isJson = liftIO . putStr =<< render
+  where
+    render
+      | isJson = renderJson <$> subcommand.getJson
+      | otherwise = renderEntriesAsTables <$> subcommand.getInspectionEntries
+
+    renderJson value = BSL8.unpack $ encodePretty value <> "\n"

--- a/waspc/cli/src/Wasp/Cli/Command/Show/Table.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Show/Table.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE TupleSections #-}
+
+module Wasp.Cli.Command.Show.Table
+  ( renderEntriesAsTables,
+  )
+where
+
+import Data.List (intercalate, nub, sortOn)
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe, mapMaybe)
+import Wasp.AppSpec.Core.Inspectable (InspectionDatapoint, InspectionEntry (..))
+import Wasp.Cli.Terminal (title)
+import Wasp.Util (alignColumns)
+import qualified Wasp.Util.Terminal as Term
+
+-- | Renders inspection entries as per-category tables: entries are grouped by
+-- their heading, and each group becomes a table with one row per entry.
+renderEntriesAsTables :: [InspectionEntry] -> String
+renderEntriesAsTables entries =
+  intercalate "\n" (renderCategory . fmap sortEntriesByFirstColumnValue <$> categoryPairs)
+  where
+    categoryPairs = orderedGroupWith heading datapoints entries
+
+    sortEntriesByFirstColumnValue :: [[InspectionDatapoint]] -> [[InspectionDatapoint]]
+    sortEntriesByFirstColumnValue = sortOn $ \case
+      [] -> ""
+      ((_, firstColumnValue) : _) -> firstColumnValue
+
+    renderCategory (title', datapointLists) =
+      unlines $
+        title title'
+          : ( ("  " ++)
+                <$>
+                -- We run the "underline" _after_ aligning columns, as the
+                -- underline ANSI sequences otherwise get counted in the column
+                -- width calculation and throw off the alignment.
+                underlineFirstRow (alignColumns $ toRows datapointLists)
+            )
+
+toRows :: [[InspectionDatapoint]] -> [[String]]
+toRows datapointLists = columns : (toRow columns <$> datapointLists)
+  where
+    columns = nub $ fst <$> concat datapointLists
+
+toRow :: [String] -> [InspectionDatapoint] -> [String]
+toRow columns datapointList = [fromMaybe "" $ Map.lookup column rowMap | column <- columns]
+  where
+    rowMap = Map.fromList datapointList
+
+orderedGroupWith :: (Ord k) => (a -> k) -> (a -> v) -> [a] -> [(k, [v])]
+orderedGroupWith fk fv xs =
+  mapMaybe lookupPair orderedUniqueKeys
+  where
+    orderedUniqueKeys = nub $ fst <$> asPairs
+
+    lookupPair k = (k,) <$> Map.lookup k asGroupedMap
+    asGroupedMap = Map.fromListWith (++) asPairs
+
+    asPairs = (\x -> (fk x, [fv x])) <$> xs
+
+underlineFirstRow :: [String] -> [String]
+underlineFirstRow [] = []
+underlineFirstRow (firstRow : rest) =
+  Term.applyStyles [Term.Underline] firstRow : rest

--- a/waspc/cli/src/Wasp/Cli/Util/Parser.hs
+++ b/waspc/cli/src/Wasp/Cli/Util/Parser.hs
@@ -44,5 +44,7 @@ parseArguments cmdName parser args =
   where
     parserInfo = Opt.info (parser <**> Opt.helper) Opt.fullDesc
 
+-- | We show the full help on parse errors (instead of only the usage line) so
+-- that e.g. `wasp show` without a subcommand tells you which subcommands exist.
 parserPreferences :: Opt.ParserPrefs
-parserPreferences = Opt.defaultPrefs
+parserPreferences = Opt.prefs Opt.showHelpOnError

--- a/waspc/e2e-tests/Main.hs
+++ b/waspc/e2e-tests/Main.hs
@@ -25,6 +25,7 @@ import Tests.WaspDbResetTest (waspDbResetTest)
 import Tests.WaspDbSeedTest (waspDbSeedTest)
 import Tests.WaspDepsTest (waspDepsTest)
 import Tests.WaspDockerfileTest (waspDockerfileTest)
+import Tests.WaspInfoTest (waspInfoTest)
 import Tests.WaspInstallTest (waspInstallTest)
 import Tests.WaspNewTest (waspNewTest)
 import Tests.WaspShowTest (waspShowTest)
@@ -106,6 +107,7 @@ e2eTests = do
         -- FIXME: waspBuildStartTest,
         waspCleanTest,
         waspSpecAvailableTest,
+        waspInfoTest,
         waspShowTest,
         waspInstallTest,
         waspDepsTest,

--- a/waspc/e2e-tests/Main.hs
+++ b/waspc/e2e-tests/Main.hs
@@ -27,6 +27,7 @@ import Tests.WaspDepsTest (waspDepsTest)
 import Tests.WaspDockerfileTest (waspDockerfileTest)
 import Tests.WaspInstallTest (waspInstallTest)
 import Tests.WaspNewTest (waspNewTest)
+import Tests.WaspShowTest (waspShowTest)
 import Tests.WaspSpecAvailableTest (waspSpecAvailableTest)
 import Tests.WaspSpecEntityTypesTest (waspSpecEntityTypesTest)
 import Tests.WaspTelemetryTest (waspTelemetryTest)
@@ -105,6 +106,7 @@ e2eTests = do
         -- FIXME: waspBuildStartTest,
         waspCleanTest,
         waspSpecAvailableTest,
+        waspShowTest,
         waspInstallTest,
         waspDepsTest,
         waspDockerfileTest,

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -34,6 +34,7 @@ module ShellCommands
     waspCliClean,
     waspCliStudio,
     waspCliDbStudio,
+    waspCliInfo,
     waspCliShowBuild,
     waspCliShowBuildJson,
     waspCliDeps,
@@ -231,6 +232,9 @@ waspCliDbReset =
 
 waspCliDbStudio :: ShellCommandBuilder WaspProjectContext ShellCommand
 waspCliDbStudio = return "$WASP_CLI_CMD db studio"
+
+waspCliInfo :: ShellCommandBuilder WaspProjectContext ShellCommand
+waspCliInfo = return "$WASP_CLI_CMD info"
 
 waspCliShowBuild :: ShellCommandBuilder WaspProjectContext ShellCommand
 waspCliShowBuild = return "$WASP_CLI_CMD show build"

--- a/waspc/e2e-tests/ShellCommands.hs
+++ b/waspc/e2e-tests/ShellCommands.hs
@@ -34,6 +34,8 @@ module ShellCommands
     waspCliClean,
     waspCliStudio,
     waspCliDbStudio,
+    waspCliShowBuild,
+    waspCliShowBuildJson,
     waspCliDeps,
     waspCliDeploy,
     waspCliInstall,
@@ -229,6 +231,31 @@ waspCliDbReset =
 
 waspCliDbStudio :: ShellCommandBuilder WaspProjectContext ShellCommand
 waspCliDbStudio = return "$WASP_CLI_CMD db studio"
+
+waspCliShowBuild :: ShellCommandBuilder WaspProjectContext ShellCommand
+waspCliShowBuild = return "$WASP_CLI_CMD show build"
+
+-- | Runs `wasp show build --json` and asserts that stdout alone is valid JSON
+-- with the expected {lastCompile, projectDirSize} envelope, where lastCompile
+-- is null (no build yet) or a {buildType, generatedAt, waspVersion} object.
+waspCliShowBuildJson :: ShellCommandBuilder WaspProjectContext ShellCommand
+waspCliShowBuildJson =
+  return $
+    "$WASP_CLI_CMD show build --json"
+      ~| ( "node -e \""
+             ++ "let d = '';"
+             ++ " process.stdin.on('data', (c) => (d += c));"
+             ++ " process.stdin.on('end', () => {"
+             ++ " const s = JSON.parse(d);"
+             ++ " const lastCompileOk ="
+             ++ " s.lastCompile === null ||"
+             ++ " (typeof s.lastCompile === 'object' &&"
+             ++ " typeof s.lastCompile.buildType === 'string' &&"
+             ++ " typeof s.lastCompile.generatedAt === 'string' &&"
+             ++ " typeof s.lastCompile.waspVersion === 'string');"
+             ++ " if (!lastCompileOk || typeof s.projectDirSize !== 'string') process.exit(1);"
+             ++ " });\""
+         )
 
 waspCliDeps :: ShellCommandBuilder WaspProjectContext ShellCommand
 waspCliDeps = return "$WASP_CLI_CMD deps"

--- a/waspc/e2e-tests/Tests/WaspInfoTest.hs
+++ b/waspc/e2e-tests/Tests/WaspInfoTest.hs
@@ -1,0 +1,28 @@
+module Tests.WaspInfoTest (waspInfoTest) where
+
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliInfo)
+import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
+
+-- TODO: Test `wasp info` values change properly:
+-- name, database, project dir size, last compile.
+waspInfoTest :: Test
+waspInfoTest =
+  Test
+    "wasp-info"
+    [ TestCase
+        "fail-outside-project"
+        (return [waspCliInfoFails]),
+      TestCase
+        "succeed-inside-project"
+        ( sequence
+            [ createTestWaspProject minimalStarterTemplate,
+              inTestWaspProjectDir
+                [ waspCliInfo
+                ]
+            ]
+        )
+    ]
+  where
+    waspCliInfoFails :: ShellCommand
+    waspCliInfoFails = "! $WASP_CLI_CMD info"

--- a/waspc/e2e-tests/Tests/WaspShowTest.hs
+++ b/waspc/e2e-tests/Tests/WaspShowTest.hs
@@ -1,0 +1,33 @@
+module Tests.WaspShowTest (waspShowTest) where
+
+import ShellCommands (ShellCommand, createTestWaspProject, inTestWaspProjectDir, waspCliShowBuild, waspCliShowBuildJson)
+import Test (Test (..), TestCase (..))
+import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
+
+waspShowTest :: Test
+waspShowTest =
+  Test
+    "wasp-show"
+    [ TestCase
+        "fail-without-subcommand"
+        (return [waspCliShowFails]),
+      TestCase
+        "fail-outside-project"
+        (return [waspCliShowBuildFails]),
+      TestCase
+        "succeed-inside-project"
+        ( sequence
+            [ createTestWaspProject minimalStarterTemplate,
+              inTestWaspProjectDir
+                [ waspCliShowBuild,
+                  waspCliShowBuildJson
+                ]
+            ]
+        )
+    ]
+  where
+    waspCliShowFails :: ShellCommand
+    waspCliShowFails = "! $WASP_CLI_CMD show"
+
+    waspCliShowBuildFails :: ShellCommand
+    waspCliShowBuildFails = "! $WASP_CLI_CMD show build"

--- a/waspc/e2e-tests/Tests/WaspSpecAvailableTest.hs
+++ b/waspc/e2e-tests/Tests/WaspSpecAvailableTest.hs
@@ -18,6 +18,7 @@ import ShellCommands
     waspCliDeploy,
     waspCliDeps,
     waspCliDockerfile,
+    waspCliInfo,
     waspCliInstall,
     waspCliNews,
     waspCliShowBuild,
@@ -47,6 +48,7 @@ waspSpecAvailableTest =
                     assertCommandFailsWithInstallHint
                     [ waspCliCompile,
                       waspCliBuild,
+                      waspCliInfo,
                       waspCliDeps,
                       waspCliDockerfile,
                       waspCliStudio,

--- a/waspc/e2e-tests/Tests/WaspSpecAvailableTest.hs
+++ b/waspc/e2e-tests/Tests/WaspSpecAvailableTest.hs
@@ -20,6 +20,7 @@ import ShellCommands
     waspCliDockerfile,
     waspCliInstall,
     waspCliNews,
+    waspCliShowBuild,
     waspCliStart,
     waspCliStartDb,
     waspCliStudio,
@@ -92,6 +93,7 @@ waspSpecAvailableTest =
                   -- Project-scoped commands that don't require wasp-spec to be installed.
                   [ waspCliClean,
                     waspCliInstall,
+                    waspCliShowBuild,
                     -- Project-agnostic commands. They don't read the project,
                     -- so they should be unaffected by wasp-spec presence.
                     waspCliVersion,

--- a/waspc/src/Wasp/AppSpec/Core/Inspectable.hs
+++ b/waspc/src/Wasp/AppSpec/Core/Inspectable.hs
@@ -1,0 +1,17 @@
+module Wasp.AppSpec.Core.Inspectable
+  ( InspectionEntry (..),
+    InspectionDatapoint,
+  )
+where
+
+data InspectionEntry = InspectionEntry
+  { -- | The category heading for this inspection entry. This is used to group
+    -- related data points together.
+    heading :: String,
+    -- | A list of (label, content) that represent the data points for this
+    -- inspection entry.
+    datapoints :: [InspectionDatapoint]
+  }
+  deriving (Show, Eq)
+
+type InspectionDatapoint = (String, String)

--- a/waspc/src/Wasp/Util.hs
+++ b/waspc/src/Wasp/Util.hs
@@ -17,6 +17,7 @@ module Wasp.Util
     indent,
     concatShortPrefixAndText,
     concatPrefixAndText,
+    alignColumns,
     insertAt,
     leftPad,
     trim,
@@ -57,7 +58,7 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.UTF8 as BSU
 import Data.Char (isSpace, isUpper, toLower, toUpper)
-import Data.List (group, intercalate, sort)
+import Data.List (group, intercalate, sort, transpose)
 import Data.List.Split (splitOn, wordsBy)
 import Data.Map (Map)
 import qualified Data.Map.Merge.Lazy as Map.Merge
@@ -178,6 +179,15 @@ concatShortPrefixAndText prefix text =
 concatPrefixAndText :: String -> String -> String
 concatPrefixAndText prefix text =
   if length (lines text) <= 1 then prefix ++ text else prefix ++ "\n" ++ indent 2 text
+
+-- | Given a table (list of list of strings), computes the maximum width of each
+-- column and pads each cell so that the column has the same width in every row.
+alignColumns :: [[String]] -> [String]
+alignColumns rows = renderRow <$> rows
+  where
+    renderRow = intercalate "  " . zipWith padToWidth columnWidths
+    padToWidth width cell = cell ++ replicate (width - length cell) ' '
+    columnWidths = map (maximum . map length) $ transpose rows
 
 -- | Adds given element to the start of the given list until the list is of specified length.
 -- leftPad ' ' 4 "hi" == "  hi"

--- a/waspc/tests/UtilTest.hs
+++ b/waspc/tests/UtilTest.hs
@@ -121,6 +121,15 @@ spec_concatPrefixAndText = do
     it "put all the text below the prefix, indented for 2 spaces, if text has multiple lines" $ do
       concatPrefixAndText "prefix: " "foo\nbar" `shouldBe` "prefix: \n  foo\n  bar"
 
+spec_alignColumns :: Spec
+spec_alignColumns = do
+  it "aligns cells into columns and drops trailing whitespace" $
+    alignColumns
+      [ ["/", "HomeRoute", ""],
+        ["/login", "LoginRoute", "[auth]"]
+      ]
+      `shouldBe` ["/       HomeRoute         ", "/login  LoginRoute  [auth]"]
+
 spec_leftPad :: Spec
 spec_leftPad = do
   describe "leftPad should" $ do

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -514,6 +514,7 @@ library cli-lib
     Wasp.Cli.Command.Deps
     Wasp.Cli.Command.Dockerfile
     Wasp.Cli.Command.Doctor
+    Wasp.Cli.Command.Info
     Wasp.Cli.Command.Install
     Wasp.Cli.Command.Message
     Wasp.Cli.Command.News
@@ -745,6 +746,7 @@ test-suite waspc-e2e-tests
     Tests.WaspDbStudioTest
     Tests.WaspDepsTest
     Tests.WaspDockerfileTest
+    Tests.WaspInfoTest
     Tests.WaspInstallTest
     Tests.WaspNewTest
     Tests.WaspShowTest

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -215,6 +215,7 @@ library
     Wasp.AppSpec.Core.Decl
     Wasp.AppSpec.Core.Decl.JSON
     Wasp.AppSpec.Core.Decl.JSON.TH
+    Wasp.AppSpec.Core.Inspectable
     Wasp.AppSpec.Core.IsDecl
     Wasp.AppSpec.Core.Ref
     Wasp.AppSpec.Crud
@@ -526,6 +527,10 @@ library cli-lib
     Wasp.Cli.Command.Require.InWaspProject
     Wasp.Cli.Command.Require.ValidNodeAndNpm
     Wasp.Cli.Command.Require.WaspSpecAvailable
+    Wasp.Cli.Command.Show
+    Wasp.Cli.Command.Show.Build
+    Wasp.Cli.Command.Show.Subcommand
+    Wasp.Cli.Command.Show.Table
     Wasp.Cli.Command.Start
     Wasp.Cli.Command.Start.Db
     Wasp.Cli.Command.Studio
@@ -742,6 +747,7 @@ test-suite waspc-e2e-tests
     Tests.WaspDockerfileTest
     Tests.WaspInstallTest
     Tests.WaspNewTest
+    Tests.WaspShowTest
     Tests.WaspSpecAvailableTest
     Tests.WaspSpecEntityTypesTest
     Tests.WaspStartTest

--- a/web/docs/general/cli.md
+++ b/web/docs/general/cli.md
@@ -41,6 +41,7 @@ COMMANDS
     telemetry             Prints telemetry status.
     deps                  Prints the dependencies that Wasp uses in your project.
     dockerfile            Prints the contents of the Wasp generated Dockerfile.
+    show build [--json]   Prints information about your app's current build.
     test                  Executes tests in your project.
     studio                (experimental) GUI for inspecting your Wasp app.
     news                  Read the latest Wasp-related news.
@@ -145,6 +146,7 @@ Our telemetry is anonymized and very limited in its scope: check https://wasp.sh
 
 ```
 - `wasp deps` lists the dependencies that Wasp uses in your project.
+- `wasp show build` prints information about your app's current build: when it was last compiled and how big the project directory is. It also supports the `--json` flag.
 - `wasp studio` shows you an graphical overview of your application in a graph: pages, queries, actions, data model etc.
 
 ### Database Commands

--- a/web/docs/general/cli.md
+++ b/web/docs/general/cli.md
@@ -41,6 +41,7 @@ COMMANDS
     telemetry             Prints telemetry status.
     deps                  Prints the dependencies that Wasp uses in your project.
     dockerfile            Prints the contents of the Wasp generated Dockerfile.
+    info                  Prints basic information about the current Wasp project.
     show build [--json]   Prints information about your app's current build.
     test                  Executes tests in your project.
     studio                (experimental) GUI for inspecting your Wasp app.
@@ -146,6 +147,7 @@ Our telemetry is anonymized and very limited in its scope: check https://wasp.sh
 
 ```
 - `wasp deps` lists the dependencies that Wasp uses in your project.
+- `wasp info` provides basic details about the current Wasp project.
 - `wasp show build` prints information about your app's current build: when it was last compiled and how big the project directory is. It also supports the `--json` flag.
 - `wasp studio` shows you an graphical overview of your application in a graph: pages, queries, actions, data model etc.
 


### PR DESCRIPTION
## Description

Part of the stack replacing `wasp info` (#4622) with the `wasp show` family of commands:

1. Remove `wasp info` (#4622)
2. **This PR**: add `wasp show build`
3. Add `wasp show spec` (#4451)

Adds the `wasp show` command with its first subcommand, `wasp show build`, which prints information about the current build: build type, generation time, generating Wasp version, and project dir size. With `--json`, it prints the same information as JSON.

```
$ wasp show build
Build
  Type         Generated at                    Wasp version  Project dir size
  Development  2026-08-05 15:08:57.100269 UTC  0.26.0        275 MB
```

Each `wasp show` subcommand is described by a `ShowSubcommand` structure ({name, description, jsonHelp, getInspectionEntries, getJson}), from which both the optparse-applicative parser and the implementation are derived. The follow-up PR plugs `wasp show spec` into the same structure.

Also enables `showHelpOnError` in our shared optparse-applicative preferences, so that a bare `wasp show` lists the available subcommands in its error output.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- For the table column alignment; command behavior is covered by the wasp-show CLI e2e tests. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- CLI-only feature; covered by the wasp-show e2e tests in waspc/e2e-tests. -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Already at 0.26.0 on main. -->
