### PR TITLE
[DO NOT MERGE] Pullfrog multifile review smoke test

### DIFF
--- a/waspc/tests/Node/InternalTest.hs
+++ b/waspc/tests/Node/InternalTest.hs
@@ -8,8 +8,8 @@ spec_NodeInternal :: Spec
 spec_NodeInternal =
   describe "parseVersionFromCommandOutput" $ do
     it "parses a version when the version string is at the end" $ do
-      let output = "Some informational output...\nVersion: 20.3.1"
-      parseVersionFromCommandOutput output `shouldBe` Right (Version 20 3 1)
+      let info = "Some informational output...\nVersion: 20.3.1"
+      parseVersionFromCommandOutput info `shouldBe` Right (Version 20 3 1)
 
     it "parses a version when the version string is in the middle" $ do
       let output = "Starting up v20.3.1 and initializing modules"

--- a/waspc/tests/SemanticVersion/VersionTest.hs
+++ b/waspc/tests/SemanticVersion/VersionTest.hs
@@ -38,7 +38,7 @@ spec_SemanticVersion_Version = do
       isLeft (parseVersion "") `shouldBe` True
 
   describe "versionParser" $ do
-    let looseParseVersion = P.parse versionParser ""
+    let looseParseVersion = P.parse (versionParser <* P.eof) ""
 
     it "parses full versions with trailing content" $ do
       looseParseVersion "1.2.3.4.5.6.7.8.9.0" `shouldBe` Right (Version 1 2 3)

--- a/waspc/tests/Util/DockerTest.hs
+++ b/waspc/tests/Util/DockerTest.hs
@@ -9,6 +9,9 @@ spec_parseDockerPortOutput = do
     it "parses single-line output" $ do
       parseDockerPortOutput "0.0.0.0:5432\n" `shouldBe` Just 5432
 
+    it "parses single-line output without a trailing newline" $ do
+      parseDockerPortOutput "0.0.0.0:5432" `shouldBe` Just 5432
+
     it "parses multi-line output by using the first line" $ do
       parseDockerPortOutput "0.0.0.0:5433\n[::]:5434\n" `shouldBe` Just 5433
 

--- a/waspc/tests/Util/WebRouterPathTest.hs
+++ b/waspc/tests/Util/WebRouterPathTest.hs
@@ -40,5 +40,6 @@ spec_WebRouterPathTest = do
       matches "/users/:id?" "/users/42"
       matches "/users/:id?" "/users"
   where
+    -- Check that the route pattern matches the path.
     matches routePattern path = doesConcretePathMatchRoutePattern routePattern path `shouldBe` True
     doesNotMatch routePattern path = doesConcretePathMatchRoutePattern routePattern path `shouldBe` False


### PR DESCRIPTION
## Description

This intentionally flawed PR exists only to smoke test Pullfrog review behavior across multiple files. Do not merge. A unit-test failure is expected.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.