### PR TITLE
Dim the description text in the `wasp new` template picker (#4547)

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Interactive.hs
+++ b/waspc/cli/src/Wasp/Cli/Interactive.hs
@@ -118,7 +118,7 @@ askToChoose question options = do
         showIndex idx = "[" ++ show (idx :: Int) ++ "]"
 
         showDescription (idx, option) = case showOptionDescription option of
-          Just description -> "\n" <> replicate indentLength ' ' <> description
+          Just description -> "\n" <> replicate indentLength ' ' <> Term.applyStyles [Term.Grey] description
           Nothing -> ""
           where
             indentLength = length (showIndex idx) + 1


### PR DESCRIPTION
## Description

Closes #4547

### The problem

When creating a project with `wasp new`, the interactive starter-template picker applies bold styling so liberally that the visual hierarchy flattens — there's no distinction between the thing you're choosing and the supporting information about it.

### What I changed

In `waspc/cli/src/Wasp/Cli/Interactive.hs`, in the `askToChoose` helper that renders the picker, I gave the text a clear emphasis hierarchy:

* **Questions** (`Choose a starter template`, `Enter the project name ...`) stay **bold** — they're the prompt.
* **Option names** (`basic`, `minimal`, `saas`) stay **bold** — they're the selectable labels and should stand out from their descriptions.
* **Descriptions** are now **dimmed / greyed** (`Term.Grey`) — supporting detail is pushed into the background instead of competing for attention.

The `[n]` index and `(default)` badges keep their yellow highlight.

The result reads as: **bold question → bold choices → dim details.**

### Before / After

#### Before

<img width="1363" height="302" alt="Screenshot 2026-08-09 154914" src="https://github.com/user-attachments/assets/e135d1fd-c2b7-4873-947c-d50dd61ca0a6" />

#### After

<img width="913" height="266" alt="Screenshot 2026-08-09 155047" src="https://github.com/user-attachments/assets/36fd7ce5-b9a6-4a08-8b62-81bd40e46eb4" />

### How I verified it

* Rebuilt the CLI (`cabal build wasp-cli`).
* Ran `wasp new` and inspected the raw ANSI output:

```text
bold    → Enter the project name (e.g. my-project)
bold    → Choose a starter template
yellow  → [1]
bold    → basic
yellow  →  (default)
grey    → A basic starter template designed to help you get up and running quickly. ...
yellow  → [2]
bold    → minimal
grey    → A minimal starter template that features just a single page.
yellow  → [3]
bold    → saas
grey    → Everything a SaaS needs! Comes with Auth, ChatGPT API, Tailwind, ...
```

* `ormolu --mode check` passes on the changed file. (HLint isn't installed in my local environment — it's disabled via the repo's `MISE_ENV=ci` config.)

## Type of change

* **Just code/docs improvement** <!-- no functional change -->

## Checklist

I verified my change by running `wasp new` and confirming the descriptions now render dimmed while the questions and option names keep the emphasis.

* Tests and apps: I added **unit tests** for my change.
* Documentation/changelog/version: not affected (pure styling change).