### PR TITLE
Add CPU architecture to telemetry and normalize os/arch names

### DIFF
--- a/scripts/make-npm-packages/templates/main-package/postinstall.js
+++ b/scripts/make-npm-packages/templates/main-package/postinstall.js
@@ -17,7 +17,7 @@ async function sendAnalytics() {
     distinct_id: generateDistinctId(),
     properties: {
       os: getOS(),
-      arch: process.arch,
+      arch: getArch(),
       context:
         (process.env.WASP_TELEMETRY_CONTEXT ?? "") + (isCI() ? " CI" : ""),
     },
@@ -37,6 +37,10 @@ function generateDistinctId() {
   return `${random}${timestamp}`;
 }
 
+// We report the OS and the CPU architecture under the same names everywhere we
+// send telemetry from. Keep in sync with:
+// - https://github.com/wasp-lang/get-wasp-sh/blob/master/installer.sh
+// - https://github.com/wasp-lang/wasp/blob/main/waspc/cli/src/Wasp/Cli/Command/Telemetry/Project.hs
 function getOS() {
   switch (process.platform) {
     case "linux":
@@ -45,6 +49,17 @@ function getOS() {
       return "osx";
     case "win32":
       return "windows";
+    default:
+      return "Unknown";
+  }
+}
+
+function getArch() {
+  switch (process.arch) {
+    case "x64":
+      return "x86_64";
+    case "arm64":
+      return "aarch64";
     default:
       return "Unknown";
   }

--- a/scripts/make-npm-packages/templates/main-package/postinstall.js
+++ b/scripts/make-npm-packages/templates/main-package/postinstall.js
@@ -17,6 +17,7 @@ async function sendAnalytics() {
     distinct_id: generateDistinctId(),
     properties: {
       os: getOS(),
+      arch: process.arch,
       context:
         (process.env.WASP_TELEMETRY_CONTEXT ?? "") + (isCI() ? " CI" : ""),
     },

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -19,6 +19,7 @@
 - Newly created projects no longer open the browser automatically on `wasp start`. ([#4553](https://github.com/wasp-lang/wasp/pull/4553))
 - Upgraded internal `morgan` to 1.11, which fixes ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Wasp's usage was unaffected by the vulnerability. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
 - The `<region>` argument of `wasp deploy fly` is now case-insensitive, so e.g. `MIA` is accepted instead of being rejected as an invalid region. ([#4588](https://github.com/wasp-lang/wasp/pull/4588))
+- Our anonymous [telemetry](https://wasp.sh/docs/telemetry) now also reports the CPU architecture (e.g. `x86_64`), so we know which platforms to prioritize. You can disable telemetry by setting `WASP_TELEMETRY_DISABLE=1`. ([#4641](https://github.com/wasp-lang/wasp/pull/4641))
 
 ## 0.25.0
 

--- a/waspc/cli/src/Wasp/Cli/Command/Telemetry/Project.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Telemetry/Project.hs
@@ -146,6 +146,7 @@ data ProjectTelemetryData = ProjectTelemetryData
     _projectHash :: ProjectHash,
     _waspVersion :: String,
     _os :: String,
+    _arch :: String,
     _isBuild :: Bool,
     _deployCmdArgs :: String,
     _context :: String
@@ -158,7 +159,8 @@ getProjectTelemetryData userSignature projectHash cmdCall context =
     { _userSignature = userSignature,
       _projectHash = projectHash,
       _waspVersion = showVersion version,
-      _os = System.Info.os,
+      _os = getOS,
+      _arch = getArch,
       _isBuild = case cmdCall of
         Command.Call.Build -> True
         _ -> False,
@@ -167,6 +169,23 @@ getProjectTelemetryData userSignature projectHash cmdCall context =
         _ -> "",
       _context = context
     }
+
+-- | We report the OS and the CPU architecture under the same names everywhere we
+-- send telemetry from, so that the data lines up. Keep in sync with:
+-- - https://github.com/wasp-lang/get-wasp-sh/blob/master/installer.sh
+-- - scripts/make-npm-packages/templates/main-package/postinstall.js
+getOS :: String
+getOS = case System.Info.os of
+  "linux" -> "linux"
+  "darwin" -> "osx"
+  "mingw32" -> "windows"
+  _ -> "Unknown"
+
+getArch :: String
+getArch = case System.Info.arch of
+  "x86_64" -> "x86_64"
+  "aarch64" -> "aarch64"
+  _ -> "Unknown"
 
 -- | To preserve user's privacy, we capture only args (from `wasp deploy ...` cmd)
 -- that are from the predefined set of keywords.
@@ -190,6 +209,7 @@ sendTelemetryData telemetryData = do
                   "project_hash" .= _projectHashValue (_projectHash telemetryData),
                   "wasp_version" .= _waspVersion telemetryData,
                   "os" .= _os telemetryData,
+                  "arch" .= _arch telemetryData,
                   "is_build" .= _isBuild telemetryData,
                   "deploy_cmd_args" .= _deployCmdArgs telemetryData,
                   "context" .= _context telemetryData

--- a/web/docs/telemetry.md
+++ b/web/docs/telemetry.md
@@ -29,6 +29,8 @@ Our telemetry implementation is anonymized and very limited in its scope, focuse
     "deploy_cmd_args": "fly;deploy",
     "wasp_version": "0.1.9.1",
     "os": "linux",
+    // CPU architecture: "x86_64", "aarch64", or "Unknown".
+    "arch": "x86_64",
     // "CI" if running on CI, and whatever is the content of "WASP_TELEMETRY_CONTEXT" env var.
     // We use this to track when execution is happening in some special context, like on Gitpod, Replit or similar.
     "context": "CI"
@@ -50,6 +52,8 @@ Our telemetry implementation is anonymized and very limited in its scope, focuse
     // Randomly generated id.
     "distinct_id": "274701613078193779564259",
     "os": "linux",
+    // CPU architecture: "x86_64", "aarch64", or "Unknown".
+    "arch": "x86_64",
     // "CI" if running on CI, empty string otherwise.
     "context": "CI"
   }


### PR DESCRIPTION
## Description

We couldn't tell how many of our users are on ARM vs x64, so this adds an `arch` property to the telemetry sent by the `wasp` CLI and by the `wasp` npm package's postinstall hook. It also normalizes the naming across contexts: `os` and `arch` now use the same vocabulary everywhere (`linux`/`osx`/`windows` and `x86_64`/`aarch64`, `Unknown` otherwise), matching the `install.sh` script and our release artifact names. Heads up for the dashboards: the CLI's `os` property used to send the raw GHC values (`darwin`, `mingw32`), so from this release on those become `osx` and `windows`.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!-- Version not bumped: 0.26.0 hasn't been released yet, so it's already bumped on `main`. -->
