### PR TITLE
Update Fly database deployment flags

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -4,11 +4,13 @@
 
 ### ⚠️ Breaking Changes
 
+- Renamed the Fly database deployment flags `--vm-size`, `--initial-cluster-size`, and `--volume-size` to `--db-vm-size`, `--db-initial-cluster-size`, and `--db-volume-size`, respectively. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
 - Moved internal server-only import paths under the `wasp/server/...` prefix. These paths are not part of the documented public API, but if your app imported any of them, update the import path or switch to documented public imports like `wasp/server/auth`. ([#4557](https://github.com/wasp-lang/wasp/pull/4557))
 - Removed the `wasp info` command, in favor of the new `wasp show` family of commands. ([#4622](https://github.com/wasp-lang/wasp/pull/4622))
 
 ### 🎉 New Features
 
+- Added the `--db-vm-memory`, `--db-vm-cpus`, and `--db-vm-cpu-kind` options to `wasp deploy fly launch` and `wasp deploy fly create-db`. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
 - Now Wasp fails more gracefully when multiple commands are running in the same project. ([#4504](https://github.com/wasp-lang/wasp/pull/4504))
 - Added a `wasp show spec [--json]` command that prints an overview of your app as Wasp sees it: routes, pages, queries, actions, APIs, CRUDs, and jobs. ([#4451](https://github.com/wasp-lang/wasp/pull/4451))
 - Added the `wasp show build [--json]` command to print information about the last build. ([#4625](https://github.com/wasp-lang/wasp/pull/4625))

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -4,7 +4,8 @@
 
 ### ⚠️ Breaking Changes
 
-- Renamed the Fly database deployment flags `--vm-size`, `--initial-cluster-size`, and `--volume-size` to `--db-vm-size`, `--db-initial-cluster-size`, and `--db-volume-size`, respectively. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
+- Renamed the `wasp deploy fly` flags `--vm-size`, `--initial-cluster-size`, and `--volume-size` to `--db-vm-size`, `--db-initial-cluster-size`, and `--db-volume-size`, respectively. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
+- `wasp deploy fly` now requires Fly CLI version 0.4.82 or newer. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
 - Moved internal server-only import paths under the `wasp/server/...` prefix. These paths are not part of the documented public API, but if your app imported any of them, update the import path or switch to documented public imports like `wasp/server/auth`. ([#4557](https://github.com/wasp-lang/wasp/pull/4557))
 - Removed the `wasp info` command, in favor of the new `wasp show` family of commands. ([#4622](https://github.com/wasp-lang/wasp/pull/4622))
 

--- a/waspc/data/packages/deploy/src/common/cliVersion.ts
+++ b/waspc/data/packages/deploy/src/common/cliVersion.ts
@@ -1,0 +1,32 @@
+import semver, { SemVer } from "semver";
+
+export function parseCliVersion(cliName: string, rawVersion: string): SemVer {
+  const version = semver.parse(rawVersion);
+
+  if (version === null) {
+    throw new Error(`Unable to parse ${cliName} version "${rawVersion}".`);
+  }
+
+  return version;
+}
+
+export function assertCliVersionMeetsMinimum({
+  cliName,
+  currentVersion,
+  minimumVersion,
+  updateInstructions,
+}: {
+  cliName: string;
+  currentVersion: SemVer;
+  minimumVersion: SemVer;
+  updateInstructions: string;
+}): void {
+  if (!semver.gte(currentVersion, minimumVersion)) {
+    throw new Error(
+      [
+        `Wasp expects at least ${cliName} version ${minimumVersion}.`,
+        updateInstructions,
+      ].join("\n"),
+    );
+  }
+}

--- a/waspc/data/packages/deploy/src/providers/fly/CommonCmdOptions.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/CommonCmdOptions.ts
@@ -8,9 +8,12 @@ export interface CommonCmdOptions {
 }
 
 export interface DbOptions {
-  vmSize: string;
-  initialClusterSize: string;
-  volumeSize: string;
+  dbVmSize: string;
+  dbVmMemory?: string;
+  dbVmCpus?: string;
+  dbVmCpuKind?: string;
+  dbInitialClusterSize: string;
+  dbVolumeSize: string;
   dbImage?: string;
 }
 

--- a/waspc/data/packages/deploy/src/providers/fly/CommonCmdOptions.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/CommonCmdOptions.ts
@@ -7,8 +7,12 @@ export interface CommonCmdOptions {
   org?: string;
 }
 
+/**
+ * All database CLI options are optional for users, for fields we require we provide defaults.
+ */
 export interface DbOptions {
   dbVmSize: string;
+  // These `dbVm*` options override the CPU and memory values set by `dbVmSize`.
   dbVmMemory?: string;
   dbVmCpus?: string;
   dbVmCpuKind?: string;

--- a/waspc/data/packages/deploy/src/providers/fly/commands/createDb/createDb.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/commands/createDb/createDb.ts
@@ -45,12 +45,24 @@ export async function createDb(
     "--region",
     deploymentInstructions.region,
     "--vm-size",
-    cmdOptions.vmSize,
+    cmdOptions.dbVmSize,
     "--initial-cluster-size",
-    cmdOptions.initialClusterSize,
+    cmdOptions.dbInitialClusterSize,
     "--volume-size",
-    cmdOptions.volumeSize,
+    cmdOptions.dbVolumeSize,
   ];
+
+  if (cmdOptions.dbVmMemory) {
+    createArgs.push("--vm-memory", cmdOptions.dbVmMemory);
+  }
+
+  if (cmdOptions.dbVmCpus) {
+    createArgs.push("--vm-cpus", cmdOptions.dbVmCpus);
+  }
+
+  if (cmdOptions.dbVmCpuKind) {
+    createArgs.push("--vm-cpu-kind", cmdOptions.dbVmCpuKind);
+  }
 
   if (cmdOptions.dbImage) {
     createArgs.push("--image-ref", cmdOptions.dbImage);

--- a/waspc/data/packages/deploy/src/providers/fly/flyCli.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/flyCli.ts
@@ -1,5 +1,10 @@
 import { confirm } from "@inquirer/prompts";
+import { SemVer } from "semver";
 import { $ } from "zx";
+import {
+  assertCliVersionMeetsMinimum,
+  parseCliVersion,
+} from "../../common/cliVersion.js";
 import { getFullCommandName } from "../../common/commander.js";
 import { executeFlyCommand } from "./index.js";
 import {
@@ -7,14 +12,7 @@ import {
   FlySecretListSchema,
 } from "./jsonOutputSchemas.js";
 
-export async function flyctlExists(): Promise<boolean> {
-  try {
-    await $`flyctl version`;
-    return true;
-  } catch {
-    return false;
-  }
-}
+const minSupportedFlyCliVersion = new SemVer("0.4.82");
 
 export async function isUserLoggedIn(): Promise<boolean> {
   try {
@@ -48,13 +46,38 @@ async function ensureUserLoggedIn(): Promise<void> {
 }
 
 export async function ensureFlyReady(): Promise<void> {
-  const doesFlyctlExist = await flyctlExists();
-  if (!doesFlyctlExist) {
+  const flyCliVersion = await getFlyCliVersion();
+  assertCliVersionMeetsMinimum({
+    cliName: "Fly CLI",
+    currentVersion: flyCliVersion,
+    minimumVersion: minSupportedFlyCliVersion,
+    updateInstructions:
+      "Read how to update the Fly CLI here: https://fly.io/docs/hands-on/install-flyctl",
+  });
+  await ensureUserLoggedIn();
+}
+
+async function getFlyCliVersion(): Promise<SemVer> {
+  const result = await $({ nothrow: true })`flyctl version`;
+
+  if (result.exitCode !== 0) {
     throw new Error(
-      `The Fly.io CLI is not available on this system.\nPlease install the flyctl here: https://fly.io/docs/hands-on/install-flyctl`,
+      [
+        "Failed to get Fly CLI version. Most likely the Fly CLI is not installed.",
+        "Read how to install the Fly CLI here: https://fly.io/docs/hands-on/install-flyctl",
+      ].join("\n"),
     );
   }
-  await ensureUserLoggedIn();
+
+  const match = result.stdout.match(/flyctl(?:\.exe)? v?(\S+)/);
+
+  if (match === null) {
+    throw new Error(
+      `Failed to get Fly CLI version from output "${result.stdout.trim()}".`,
+    );
+  }
+
+  return parseCliVersion("Fly CLI", match[1]);
 }
 
 export async function assertRegionIsValid(region: string): Promise<void> {

--- a/waspc/data/packages/deploy/src/providers/fly/index.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/index.ts
@@ -29,18 +29,21 @@ class FlyCommand extends Command {
   }
   addDbOptions(): this {
     return this.option(
-      "--vm-size <vmSize>",
-      "flyctl postgres create option",
+      "--db-vm-size <vmSize>",
+      "Fly Postgres VM size",
       "shared-cpu-1x",
     )
+      .option("--db-vm-memory <vmMemory>", "Fly Postgres VM memory in MB")
+      .option("--db-vm-cpus <vmCpus>", "Fly Postgres VM CPU count")
+      .option("--db-vm-cpu-kind <vmCpuKind>", "Fly Postgres VM CPU kind")
       .option(
-        "--initial-cluster-size <initialClusterSize>",
-        "flyctl postgres create option",
+        "--db-initial-cluster-size <initialClusterSize>",
+        "Fly Postgres initial cluster size",
         "1",
       )
       .option(
-        "--volume-size <volumeSize>",
-        "flyctl postgres create option",
+        "--db-volume-size <volumeSize>",
+        "Fly Postgres volume size in GB",
         "1",
       )
       .option(

--- a/waspc/data/packages/deploy/src/providers/railway/railwayCli.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayCli.ts
@@ -1,7 +1,11 @@
-import semver, { SemVer } from "semver";
+import { SemVer } from "semver";
 import { $ } from "zx";
 
 import { confirm } from "@inquirer/prompts";
+import {
+  assertCliVersionMeetsMinimum,
+  parseCliVersion,
+} from "../../common/cliVersion.js";
 import { RailwayCliExe, RailwayProjectName } from "./brandedTypes.js";
 import { serviceNameSuffixes } from "./railwayService/nameGenerator.js";
 
@@ -14,7 +18,13 @@ export async function ensureRailwayCliReady(
   railwayExe: RailwayCliExe,
 ): Promise<void> {
   const railwayCliVersion = await getRailwayCliVersion(railwayExe);
-  assertUsingMinimumSupportedRailwayCliVersion(railwayCliVersion);
+  assertCliVersionMeetsMinimum({
+    cliName: "Railway CLI",
+    currentVersion: railwayCliVersion,
+    minimumVersion: minSupportedRailwayCliVersion,
+    updateInstructions:
+      "Read how to update the Railway CLI here: https://docs.railway.com/guides/cli",
+  });
   await ensureUserLoggedIn(railwayExe);
 }
 
@@ -72,25 +82,7 @@ async function getRailwayCliVersion(
     );
   }
 
-  const version = semver.parse(match[1]);
-
-  if (version === null) {
-    throw new Error(`Unable to parse Railway CLI version "${match[1]}".`);
-  }
-
-  return version;
-}
-
-function assertUsingMinimumSupportedRailwayCliVersion(
-  railwayCliVersion: SemVer,
-): void {
-  if (!semver.gte(railwayCliVersion, minSupportedRailwayCliVersion)) {
-    const message = [
-      `Wasp expects at least Railway CLI version ${minSupportedRailwayCliVersion}.`,
-      "Read how to update the Railway CLI here: https://docs.railway.com/guides/cli",
-    ].join("\n");
-    throw new Error(message);
-  }
+  return parseCliVersion("Railway CLI", match[1]);
 }
 
 export function assertRailwayProjectNameIsValid(

--- a/web/docs/deployment/deployment-methods/wasp-deploy/_fly-db-options.md
+++ b/web/docs/deployment/deployment-methods/wasp-deploy/_fly-db-options.md
@@ -1,0 +1,9 @@
+- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`.
+- `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
+- `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
+- `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
+- `--db-initial-cluster-size <initialClusterSize>` sets the initial number of database machines. It defaults to `1`.
+- `--db-volume-size <volumeSize>` sets the database volume size in GB. It defaults to `1`.
+- `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
+
+See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.

--- a/web/docs/deployment/deployment-methods/wasp-deploy/_fly-db-options.md
+++ b/web/docs/deployment/deployment-methods/wasp-deploy/_fly-db-options.md
@@ -1,7 +1,9 @@
-- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`.
-- `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
-- `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
-- `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
+All database options are optional.
+
+- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`. The VM size determines the CPU kind, CPU count, and memory. Use the following options to override those values:
+  - `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
+  - `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
+  - `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
 - `--db-initial-cluster-size <initialClusterSize>` sets the initial number of database machines. It defaults to `1`.
 - `--db-volume-size <volumeSize>` sets the database volume size in GB. It defaults to `1`.
 - `--db-image <dbImage>` sets a custom PostgreSQL Docker image.

--- a/web/docs/deployment/deployment-methods/wasp-deploy/_fly-db-options.md
+++ b/web/docs/deployment/deployment-methods/wasp-deploy/_fly-db-options.md
@@ -7,3 +7,5 @@
 - `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
 
 See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
+
+Fly accepts only certain combinations of CPU kind, CPU count, and memory. If you set `--db-vm-cpus` or `--db-vm-cpu-kind`, pick a `--db-vm-memory` value that fits Fly's [machine sizing rules](https://fly.io/docs/machines/guides-examples/machine-sizing/).

--- a/web/docs/deployment/deployment-methods/wasp-deploy/fly.md
+++ b/web/docs/deployment/deployment-methods/wasp-deploy/fly.md
@@ -6,6 +6,7 @@ import { Required } from '@site/src/components/Tag';
 import LaunchCommandEnvVars from './\_launch-command-env-vars.md'
 import CiCdMention from './\_ci-cd-mention.md'
 import CustomServerUrlOption from './\_custom-server-url-option.md'
+import FlyDbOptions from './\_fly-db-options.md'
 
 [Fly.io](https://fly.io/) is a platform for running containerized apps and microservices on servers around the world. It makes deploying and managing your apps straightforward with minimal setup.
 
@@ -205,15 +206,13 @@ Your custom PostgreSQL image must be compatible with Fly.io, as their platform h
 We have crafted a small guide on [how to create a custom Docker image with PostGIS or pgvector for Fly.io](https://gist.github.com/cprecioso/e19e883138241c1a446f48d6187aae75). You can also use it as a starting point to create your own images with other extensions.
 
 :::tip
-You only need to specify the Docker image once, when first creating the app with any of these commands:
+You only need to specify the Docker image once, when creating the database:
 
 ```shell
 wasp deploy fly create-db <region> --db-image <custom-postgres-image>
-wasp deploy fly setup <app-name> <region> --db-image <custom-postgres-image>
 wasp deploy fly launch <app-name> <region> --db-image <custom-postgres-image>
 ```
 :::
-
 
 ## API Reference
 
@@ -242,6 +241,10 @@ wasp deploy fly setup <app-name> <region>
 wasp deploy fly create-db <region>
 wasp deploy fly deploy
 ```
+
+#### Database options
+
+<FlyDbOptions />
 
 #### Environment Variables {#fly-launch-environment-variables}
 
@@ -306,6 +309,10 @@ It accepts the following arguments:
 - `<region>` <Required />
 
   The region where your app will be deployed. Read how to find the available regions [here](#flyio-regions).
+
+#### Database options
+
+<FlyDbOptions />
 
 :::caution Execute Only Once
 You should only run `create-db` once per app. If you run it multiple times, it creates multiple databases, but your app needs only one.

--- a/web/docs/migration-guide.md
+++ b/web/docs/migration-guide.md
@@ -104,6 +104,16 @@ you'll have to add a one new additional line to it:
 </Tabs>
 
 
-### 4. Enjoy your updated Wasp app
+### 4. Update Fly database deployment flags
+
+If you use database sizing options with `wasp deploy fly launch` or `wasp deploy fly create-db`, rename them as follows:
+
+| Before                  | After                              |
+| ----------------------- | ---------------------------------- |
+| `--vm-size`             | `--db-vm-size`                     |
+| `--initial-cluster-size` | `--db-initial-cluster-size`        |
+| `--volume-size`         | `--db-volume-size`                 |
+
+### 5. Enjoy your updated Wasp app
 
 That's it!

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -11571,12 +11571,18 @@ wasp deploy fly deploy
 
 ##### Database options
 
-- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`.
-- `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
-- `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
-- `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
+All database options are optional.
+
+- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`. The VM size determines the CPU kind, CPU count, and memory. Use the following options to override those values:
+
+  - `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
+  - `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
+  - `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
+
 - `--db-initial-cluster-size <initialClusterSize>` sets the initial number of database machines. It defaults to `1`.
+
 - `--db-volume-size <volumeSize>` sets the database volume size in GB. It defaults to `1`.
+
 - `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
 
 See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
@@ -11653,12 +11659,18 @@ It accepts the following arguments:
 
 ##### Database options
 
-- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`.
-- `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
-- `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
-- `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
+All database options are optional.
+
+- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`. The VM size determines the CPU kind, CPU count, and memory. Use the following options to override those values:
+
+  - `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
+  - `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
+  - `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
+
 - `--db-initial-cluster-size <initialClusterSize>` sets the initial number of database machines. It defaults to `1`.
+
 - `--db-volume-size <volumeSize>` sets the database volume size in GB. It defaults to `1`.
+
 - `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
 
 See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -11581,6 +11581,8 @@ wasp deploy fly deploy
 
 See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
 
+Fly accepts only certain combinations of CPU kind, CPU count, and memory. If you set `--db-vm-cpus` or `--db-vm-cpu-kind`, pick a `--db-vm-memory` value that fits Fly's [machine sizing rules](https://fly.io/docs/machines/guides-examples/machine-sizing/).
+
 ##### Environment Variables {#fly-launch-environment-variables}
 
 ###### Server
@@ -11660,6 +11662,8 @@ It accepts the following arguments:
 - `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
 
 See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
+
+Fly accepts only certain combinations of CPU kind, CPU count, and memory. If you set `--db-vm-cpus` or `--db-vm-cpu-kind`, pick a `--db-vm-memory` value that fits Fly's [machine sizing rules](https://fly.io/docs/machines/guides-examples/machine-sizing/).
 
 :::caution[Execute Only Once]
 You should only run `create-db` once per app. If you run it multiple times, it creates multiple databases, but your app needs only one.

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -11533,11 +11533,10 @@ Your custom PostgreSQL image must be compatible with Fly.io, as their platform h
 We have crafted a small guide on [how to create a custom Docker image with PostGIS or pgvector for Fly.io](https://gist.github.com/cprecioso/e19e883138241c1a446f48d6187aae75). You can also use it as a starting point to create your own images with other extensions.
 
 :::tip
-You only need to specify the Docker image once, when first creating the app with any of these commands:
+You only need to specify the Docker image once, when creating the database:
 
 ```shell
 wasp deploy fly create-db <region> --db-image <custom-postgres-image>
-wasp deploy fly setup <app-name> <region> --db-image <custom-postgres-image>
 wasp deploy fly launch <app-name> <region> --db-image <custom-postgres-image>
 ```
 :::
@@ -11569,6 +11568,18 @@ wasp deploy fly setup <app-name> <region>
 wasp deploy fly create-db <region>
 wasp deploy fly deploy
 ```
+
+##### Database options
+
+- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`.
+- `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
+- `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
+- `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
+- `--db-initial-cluster-size <initialClusterSize>` sets the initial number of database machines. It defaults to `1`.
+- `--db-volume-size <volumeSize>` sets the database volume size in GB. It defaults to `1`.
+- `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
+
+See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
 
 ##### Environment Variables {#fly-launch-environment-variables}
 
@@ -11637,6 +11648,18 @@ It accepts the following arguments:
 - `<region>` required
 
   The region where your app will be deployed. Read how to find the available regions [here](#flyio-regions).
+
+##### Database options
+
+- `--db-vm-size <vmSize>` sets the database VM size. It defaults to `shared-cpu-1x`.
+- `--db-vm-memory <vmMemory>` sets the database VM memory in MB.
+- `--db-vm-cpus <vmCpus>` sets the database VM CPU count.
+- `--db-vm-cpu-kind <vmCpuKind>` sets the database VM CPU kind.
+- `--db-initial-cluster-size <initialClusterSize>` sets the initial number of database machines. It defaults to `1`.
+- `--db-volume-size <volumeSize>` sets the database volume size in GB. It defaults to `1`.
+- `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
+
+See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
 
 :::caution[Execute Only Once]
 You should only run `create-db` once per app. If you run it multiple times, it creates multiple databases, but your app needs only one.
@@ -15420,7 +15443,17 @@ COPY libs .wasp/out/libs
 # ...
 ```
 
-#### 4. Enjoy your updated Wasp app
+#### 4. Update Fly database deployment flags
+
+If you use database sizing options with `wasp deploy fly launch` or `wasp deploy fly create-db`, rename them as follows:
+
+| Before                   | After                       |
+| ------------------------ | --------------------------- |
+| `--vm-size`              | `--db-vm-size`              |
+| `--initial-cluster-size` | `--db-initial-cluster-size` |
+| `--volume-size`          | `--db-volume-size`          |
+
+#### 5. Enjoy your updated Wasp app
 
 That's it!
 


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

- Prefixed Fly database options with `--db-` because options such as `--vm-size` looked app-wide when passed through `launch`, despite configuring only the database VM. 
- For completeness, we also added both the related CPU and memory options, even though only the memory option is needed by the follow-up CI fix.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [x] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [x] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->

