### PR TITLE
Give Fly CI database more memory

### DIFF
--- a/.github/workflows/ci-deploy-test.yaml
+++ b/.github/workflows/ci-deploy-test.yaml
@@ -59,7 +59,9 @@ jobs:
           # - We use a Bash array for `$ENV_VAR_ARGUMENTS` to ensure proper
           # word splitting (i.e., force Bash to interpret the flags separately
           # instead of passing it as a single string value).
-          yes | wasp-cli deploy fly launch "$APP_PREFIX" "$FLY_REGION" --org "$FLY_ORG" "${ENV_VAR_ARGUMENTS[@]}"
+          # - We give the database 512 MB of RAM because Fly's default is not
+          # enough for our e2e test bursts.
+          yes | wasp-cli deploy fly launch "$APP_PREFIX" "$FLY_REGION" --org "$FLY_ORG" --db-vm-memory 512 "${ENV_VAR_ARGUMENTS[@]}"
 
       - name: Get deployed app hostnames
         id: get-hostnames

--- a/web/docs/deployment/deployment-methods/wasp-deploy/_fly-db-options.md
+++ b/web/docs/deployment/deployment-methods/wasp-deploy/_fly-db-options.md
@@ -8,6 +8,8 @@ All database options are optional.
 - `--db-volume-size <volumeSize>` sets the database volume size in GB. It defaults to `1`.
 - `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
 
+Some apps need more database memory than Fly provides by default. If yours does, use `--db-vm-memory` when you create the database.
+
 See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
 
 Fly accepts only certain combinations of CPU kind, CPU count, and memory. If you set `--db-vm-cpus` or `--db-vm-cpu-kind`, pick a `--db-vm-memory` value that fits Fly's [machine sizing rules](https://fly.io/docs/machines/guides-examples/machine-sizing/).

--- a/web/docs/guides/deployment/cloud-providers/flyio.md
+++ b/web/docs/guides/deployment/cloud-providers/flyio.md
@@ -56,6 +56,8 @@ This will ask you a series of questions, such as asking you to choose a region a
 
   We still need to set up several environment variables.
 
+Some apps need more database memory than the **Development** preset provides. If yours does, choose a database setup with more memory. See Fly.io's [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for the available options.
+
 :::info What if the database setup fails?
 If your attempts to initiate a new app fail for whatever reason, then you should run `fly apps destroy <app-name>` before trying again. Fly does not allow you to create multiple apps with the same name.
 

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -11585,6 +11585,8 @@ All database options are optional.
 
 - `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
 
+Some apps need more database memory than Fly provides by default. If yours does, use `--db-vm-memory` when you create the database.
+
 See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
 
 Fly accepts only certain combinations of CPU kind, CPU count, and memory. If you set `--db-vm-cpus` or `--db-vm-cpu-kind`, pick a `--db-vm-memory` value that fits Fly's [machine sizing rules](https://fly.io/docs/machines/guides-examples/machine-sizing/).
@@ -11672,6 +11674,8 @@ All database options are optional.
 - `--db-volume-size <volumeSize>` sets the database volume size in GB. It defaults to `1`.
 
 - `--db-image <dbImage>` sets a custom PostgreSQL Docker image.
+
+Some apps need more database memory than Fly provides by default. If yours does, use `--db-vm-memory` when you create the database.
 
 See Fly.io's [`postgres create` reference](https://fly.io/docs/flyctl/postgres-create/) for details and its [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for available machine sizes.
 
@@ -19969,6 +19973,8 @@ This will ask you a series of questions, such as asking you to choose a region a
 - Say **no** to **Would you like to deploy now?** (and to any additional questions).
 
   We still need to set up several environment variables.
+
+Some apps need more database memory than the **Development** preset provides. If yours does, choose a database setup with more memory. See Fly.io's [VM size documentation](https://fly.io/docs/flyctl/platform-vm-sizes/) for the available options.
 
 :::info[What if the database setup fails?]
 If your attempts to initiate a new app fail for whatever reason, then you should run `fly apps destroy <app-name>` before trying again. Fly does not allow you to create multiple apps with the same name.


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Give the Fly CI database 512 MB for e2e test bursts and add light memory-sizing guidance. Closes #4564.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
