### PR TITLE
Scope Wasp's Vite plugins and config to the client and ssr environments

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,12 +1,18 @@
 {{={= =}=}}
 import { type Plugin } from 'vite'
 import path from 'path'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 export function detectServerImports(): Plugin {
   let parsePathToUserCode!: ParsePathToUserCodeFn
   return {
     name: 'wasp:detect-server-imports',
     enforce: 'pre',
+    // Importing server code is only forbidden in the environments that process
+    // client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       parsePathToUserCode = createPathToUserCodeParser(config.root)
     },

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/envFile.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'
 import { expand, type DotenvPopulateInput } from 'dotenv-expand'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 const envFileName = '{= clientEnvFileName =}'
 
@@ -26,16 +27,29 @@ export function envFile(): Plugin {
       })
       envFilePath = resolve(rootDir, envFileName)
 
-      const prefixedVars = Object.entries(envVars)
-        .reduce((acc, [key, value]) => {
-          acc[`import.meta.env.${key}`] = JSON.stringify(value)
-          return acc
-        }, {} as Record<string, string>)
+      const makeDefine = () =>
+        Object.entries(envVars).reduce(
+          (acc, [key, value]) => {
+            acc[`import.meta.env.${key}`] = JSON.stringify(value)
+            return acc
+          },
+          {} as Record<string, string>
+        )
 
       return {
         // Disable Vite's default .env loading.
         envDir: false,
-        define: prefixedVars,
+        // We only inline the client env variables into the environments that
+        // process client code: `client` and `ssr` (which prerenders the client
+        // app). Defining them at the top level would leak them into every other
+        // environment (e.g. the server environment).
+        //
+        // We build a fresh `define` object per environment because Vite merges
+        // (and sometimes mutates) each environment's options separately.
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: { define: makeDefine() },
+          [ENVIRONMENT_NAMES.SSR]: { define: makeDefine() },
+        },
       }
     },
     configureServer(server) {

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,5 +1,6 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 interface TypeScriptCheckOptions {
   srcTsConfigPath: string
@@ -9,6 +10,10 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
+    // `buildStart` runs once per environment, but the type check covers the
+    // whole project, so we only run it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     async buildStart() {
       await runTsc(options.srcTsConfigPath)
     },

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -6,6 +6,7 @@ import {
   createServer as createViteServer,
   isRunnableDevEnvironment
 } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const PLUGIN_NAME = "wasp:validate-env";
 const CLIENT_ENV_SCHEMA_VALIDATION_MODULE = "{= clientEnvSchemaValidationModulePath =}"
@@ -15,10 +16,14 @@ export function validateEnv(): Plugin {
 
   return {
     name: PLUGIN_NAME,
+    // `buildStart` runs once per environment, but the client env schema only
+    // needs to be validated once, so we only do it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     configResolved(config) {
       resolvedConfig = config;
     },
-    // We validate just before any artifacts are built.
+    // We validate just before the client artifacts are built.
     async buildStart() {
       // We need to import the client env schema validation module
       // through a Vite server, because both the user and the Wasp schema

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,6 +1,7 @@
 {{={= =}=}}
 import path from "node:path";
 import { type Plugin } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)
@@ -26,6 +27,11 @@ export function virtualUserModules(): Plugin {
   return {
     name: "wasp:virtual-user-modules",
     enforce: "pre",
+    // These virtual modules point to the user's client code, so they only make
+    // sense in the environments that process it.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       clientRootDir = config.root;
     },

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -6,6 +6,7 @@ import {
   getSsrEntryTsxContent,
 } from "../virtual-files/index.js";
 import { makeVirtualFilesResolver, type VirtualFiles } from "../virtual-files/resolver.js";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const resolveVirtualFiles = makeVirtualFilesResolver([
   { id: "{= clientEntryPointPath =}", load: getClientEntryTsxContent },
@@ -19,6 +20,11 @@ export function virtualWaspModules(): Plugin {
   return {
     name: "wasp:virtual-wasp-modules",
     enforce: "pre",
+    // These virtual modules are the client app's entry points, so they only
+    // make sense in the environments that process client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       virtualFiles = resolveVirtualFiles(config.root);
     },

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,7 +1,8 @@
 {{={= =}=}}
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import { type EnvironmentOptions, type PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -36,9 +37,6 @@ export function waspConfig(): PluginOption {
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
         base: forcedOptions["base"],
-        optimizeDeps: {
-          exclude: {=& depsExcludedFromOptimization =}
-        },
         server: {
           port: useUserValue(config.server?.port, {= defaultClientPort =}),
           host: useUserValue(config.server?.host, "0.0.0.0"),
@@ -48,15 +46,9 @@ export function waspConfig(): PluginOption {
           outDir: forcedOptions["build.outDir"],
         },
         resolve: {
-          // These packages rely on a single instance per page. Not deduping them
-          // causes runtime errors (e.g., hook rule violation in react, QueryClient
-          // instance error in react-query, Invariant Error in react-router).
-          dedupe: [
-            "react",
-            "react-dom",
-            "@tanstack/react-query",
-            "react-router",
-          ],
+          // `resolve.alias` is not a per-environment option in Vite, it is
+          // always shared by all environments, so we must set it at the top
+          // level.
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -72,6 +64,10 @@ export function waspConfig(): PluginOption {
             },
           ],
         },
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: makeClientCodeEnvironmentOptions(),
+          [ENVIRONMENT_NAMES.SSR]: makeClientCodeEnvironmentOptions(),
+        },
         test: {
           globals: useUserValue(config.test?.globals, true),
           environment: useUserValue(config.test?.environment, "jsdom"),
@@ -82,6 +78,34 @@ export function waspConfig(): PluginOption {
           ],
         },
       };
+    },
+  };
+}
+
+/**
+ * Options for the environments that process client code: `client` and `ssr`
+ * (which prerenders the client app). Keeping them here instead of at the top
+ * level of the config stops them from leaking into other environments (e.g. the
+ * server environment).
+ *
+ * We build a fresh object per environment because Vite merges (and sometimes
+ * mutates) each environment's options separately.
+ */
+function makeClientCodeEnvironmentOptions(): EnvironmentOptions {
+  return {
+    optimizeDeps: {
+      exclude: {=& depsExcludedFromOptimization =}
+    },
+    resolve: {
+      // These packages rely on a single instance per page. Not deduping them
+      // causes runtime errors (e.g., hook rule violation in react, QueryClient
+      // instance error in react-query, Invariant Error in react-router).
+      dedupe: [
+        "react",
+        "react-dom",
+        "@tanstack/react-query",
+        "react-router",
+      ],
     },
   };
 }

--- a/waspc/data/Generator/templates/sdk/wasp/vite/constants.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/vite/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Names of the Vite environments Wasp uses.
+ *
+ * `client` and `ssr` are Vite's built-in environments, see
+ * https://vite.dev/guide/api-environment. `ssr` prerenders the client app, so
+ * it processes the same code as `client`.
+ *
+ * `server` is Wasp's own environment for the Node.js server.
+ *
+ * This module is meant to be shared by all of Wasp's Vite plugins, which is why
+ * it sits outside of them. It is internal: plugins import it with a relative
+ * path, it is not part of the SDK's public exports.
+ */
+export const ENVIRONMENT_NAMES = {
+  CLIENT: "client",
+  SSR: "ssr",
+  SERVER: "server",
+} as const;

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
@@ -829,6 +829,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.js
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.js
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.js.map
 wasp-app/.wasp/out/sdk/wasp/entities/index.ts
 wasp-app/.wasp/out/sdk/wasp/env/index.ts
 wasp-app/.wasp/out/sdk/wasp/env/validation.ts
@@ -900,6 +904,7 @@ wasp-app/.wasp/out/sdk/wasp/universal/types.ts
 wasp-app/.wasp/out/sdk/wasp/universal/url.ts
 wasp-app/.wasp/out/sdk/wasp/universal/validators.ts
 wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
+wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
 wasp-app/.wasp/out/sdk/wasp/wasp-ssr.d.ts
 wasp-app/.wasp/out/sdk/wasp/wasp-user-virtual-modules.d.ts
 wasp-app/.wasp/out/server/.env

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -711,42 +711,42 @@
             "file",
             "sdk/wasp/client/vite/plugins/detectServerImports.ts"
         ],
-        "93885302fbb1758384e990fb6a7eac52fa03459f4df66a2b59eb8ac7b3e5c14a"
+        "73e142deeace394aaf2239e14eb45c9a2cb67a17e6c1290deab9c7b4b734c15c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/envFile.ts"
         ],
-        "0fafefac0b8c9ecfa0cac06f13e084ac8e1661d8fbead6e2d8b2bc7a08c9b035"
+        "f5433b4cf330b12609708e539d69c992960105f4e0caf9bae36685c687890dac"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
+        "7d27a76654606cd1e1b125946b0a2e916c4270259a325ec9af40d496ee68d37c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/validateEnv.ts"
         ],
-        "c172e926843b4ab12f96ebe79a70124d233d9d7fd948de0cdcd3388565402400"
+        "8f5634ff8d7559937a1a5d99bb27fe3e260b7aa664c4515c09f36a5cd6d6ad03"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "7adfcc09494f75c2fa87cfeb6b7fc88089ab1a33ecede3125c6b892eea20a8e1"
+        "846be82cf509723c268939aa9671c6bcf60e3d34f3131488205f8aaf752fe558"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualWaspModules.ts"
         ],
-        "4aede5b77417f38713a8f8b72b119d8a060e1ef1984945ceca249119b528b38a"
+        "2f5980e12f84a48ebf78376fe685d3d82e3501243f31b257bd037d62673434db"
     ],
     [
         [
@@ -760,7 +760,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "a8e6a5cbffb010d02729e3cb4046de73ede1844b773417b8f394f60bdd9312cc"
+        "9bd6e13b2e2d586b82f41b7a36d341cdb88bd50f8e8605517ed0b92d713bdc26"
     ],
     [
         [
@@ -1335,6 +1335,13 @@
             "sdk/wasp/vite-env.d.ts"
         ],
         "65996936fbb042915f7b74a200fcdde7e410f32a669b1ab9597cfaa4b0faddb5"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/vite/constants.ts"
+        ],
+        "f79b835ec058aa391780df0e9f4ea401b9de6793a7faeec7afe0f221d1119648"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,11 +1,17 @@
 import { type Plugin } from 'vite'
 import path from 'path'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 export function detectServerImports(): Plugin {
   let parsePathToUserCode!: ParsePathToUserCodeFn
   return {
     name: 'wasp:detect-server-imports',
     enforce: 'pre',
+    // Importing server code is only forbidden in the environments that process
+    // client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       parsePathToUserCode = createPathToUserCodeParser(config.root)
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'
 import { expand, type DotenvPopulateInput } from 'dotenv-expand'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 const envFileName = '.env.client'
 
@@ -25,16 +26,29 @@ export function envFile(): Plugin {
       })
       envFilePath = resolve(rootDir, envFileName)
 
-      const prefixedVars = Object.entries(envVars)
-        .reduce((acc, [key, value]) => {
-          acc[`import.meta.env.${key}`] = JSON.stringify(value)
-          return acc
-        }, {} as Record<string, string>)
+      const makeDefine = () =>
+        Object.entries(envVars).reduce(
+          (acc, [key, value]) => {
+            acc[`import.meta.env.${key}`] = JSON.stringify(value)
+            return acc
+          },
+          {} as Record<string, string>
+        )
 
       return {
         // Disable Vite's default .env loading.
         envDir: false,
-        define: prefixedVars,
+        // We only inline the client env variables into the environments that
+        // process client code: `client` and `ssr` (which prerenders the client
+        // app). Defining them at the top level would leak them into every other
+        // environment (e.g. the server environment).
+        //
+        // We build a fresh `define` object per environment because Vite merges
+        // (and sometimes mutates) each environment's options separately.
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: { define: makeDefine() },
+          [ENVIRONMENT_NAMES.SSR]: { define: makeDefine() },
+        },
       }
     },
     configureServer(server) {

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,5 +1,6 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 interface TypeScriptCheckOptions {
   srcTsConfigPath: string
@@ -9,6 +10,10 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
+    // `buildStart` runs once per environment, but the type check covers the
+    // whole project, so we only run it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     async buildStart() {
       await runTsc(options.srcTsConfigPath)
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -5,6 +5,7 @@ import {
   createServer as createViteServer,
   isRunnableDevEnvironment
 } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const PLUGIN_NAME = "wasp:validate-env";
 const CLIENT_ENV_SCHEMA_VALIDATION_MODULE = ".wasp/out/sdk/wasp/client/env.ts"
@@ -14,10 +15,14 @@ export function validateEnv(): Plugin {
 
   return {
     name: PLUGIN_NAME,
+    // `buildStart` runs once per environment, but the client env schema only
+    // needs to be validated once, so we only do it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     configResolved(config) {
       resolvedConfig = config;
     },
-    // We validate just before any artifacts are built.
+    // We validate just before the client artifacts are built.
     async buildStart() {
       // We need to import the client env schema validation module
       // through a Vite server, because both the user and the Wasp schema

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { type Plugin } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)
@@ -23,6 +24,11 @@ export function virtualUserModules(): Plugin {
   return {
     name: "wasp:virtual-user-modules",
     enforce: "pre",
+    // These virtual modules point to the user's client code, so they only make
+    // sense in the environments that process it.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       clientRootDir = config.root;
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -5,6 +5,7 @@ import {
   getSsrEntryTsxContent,
 } from "../virtual-files/index.js";
 import { makeVirtualFilesResolver, type VirtualFiles } from "../virtual-files/resolver.js";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const resolveVirtualFiles = makeVirtualFilesResolver([
   { id: "/@wasp/client-entry.tsx", load: getClientEntryTsxContent },
@@ -18,6 +19,11 @@ export function virtualWaspModules(): Plugin {
   return {
     name: "wasp:virtual-wasp-modules",
     enforce: "pre",
+    // These virtual modules are the client app's entry points, so they only
+    // make sense in the environments that process client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       virtualFiles = resolveVirtualFiles(config.root);
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import { type EnvironmentOptions, type PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -35,9 +36,6 @@ export function waspConfig(): PluginOption {
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
         base: forcedOptions["base"],
-        optimizeDeps: {
-          exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
-        },
         server: {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
@@ -47,15 +45,9 @@ export function waspConfig(): PluginOption {
           outDir: forcedOptions["build.outDir"],
         },
         resolve: {
-          // These packages rely on a single instance per page. Not deduping them
-          // causes runtime errors (e.g., hook rule violation in react, QueryClient
-          // instance error in react-query, Invariant Error in react-router).
-          dedupe: [
-            "react",
-            "react-dom",
-            "@tanstack/react-query",
-            "react-router",
-          ],
+          // `resolve.alias` is not a per-environment option in Vite, it is
+          // always shared by all environments, so we must set it at the top
+          // level.
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -71,6 +63,10 @@ export function waspConfig(): PluginOption {
             },
           ],
         },
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: makeClientCodeEnvironmentOptions(),
+          [ENVIRONMENT_NAMES.SSR]: makeClientCodeEnvironmentOptions(),
+        },
         test: {
           globals: useUserValue(config.test?.globals, true),
           environment: useUserValue(config.test?.environment, "jsdom"),
@@ -81,6 +77,34 @@ export function waspConfig(): PluginOption {
           ],
         },
       };
+    },
+  };
+}
+
+/**
+ * Options for the environments that process client code: `client` and `ssr`
+ * (which prerenders the client app). Keeping them here instead of at the top
+ * level of the config stops them from leaking into other environments (e.g. the
+ * server environment).
+ *
+ * We build a fresh object per environment because Vite merges (and sometimes
+ * mutates) each environment's options separately.
+ */
+function makeClientCodeEnvironmentOptions(): EnvironmentOptions {
+  return {
+    optimizeDeps: {
+      exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
+    },
+    resolve: {
+      // These packages rely on a single instance per page. Not deduping them
+      // causes runtime errors (e.g., hook rule violation in react, QueryClient
+      // instance error in react-query, Invariant Error in react-router).
+      dedupe: [
+        "react",
+        "react-dom",
+        "@tanstack/react-query",
+        "react-router",
+      ],
     },
   };
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Names of the Vite environments Wasp uses.
+ *
+ * `client` and `ssr` are Vite's built-in environments, see
+ * https://vite.dev/guide/api-environment. `ssr` prerenders the client app, so
+ * it processes the same code as `client`.
+ *
+ * `server` is Wasp's own environment for the Node.js server.
+ *
+ * This module is meant to be shared by all of Wasp's Vite plugins, which is why
+ * it sits outside of them. It is internal: plugins import it with a relative
+ * path, it is not part of the SDK's public exports.
+ */
+export const ENVIRONMENT_NAMES = {
+  CLIENT: "client",
+  SSR: "ssr",
+  SERVER: "server",
+} as const;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
@@ -373,6 +373,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.js
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.js
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.js.map
 wasp-app/.wasp/out/sdk/wasp/entities/index.ts
 wasp-app/.wasp/out/sdk/wasp/env/index.ts
 wasp-app/.wasp/out/sdk/wasp/env/validation.ts
@@ -406,6 +410,7 @@ wasp-app/.wasp/out/sdk/wasp/universal/types.ts
 wasp-app/.wasp/out/sdk/wasp/universal/url.ts
 wasp-app/.wasp/out/sdk/wasp/universal/validators.ts
 wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
+wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
 wasp-app/.wasp/out/sdk/wasp/wasp-ssr.d.ts
 wasp-app/.wasp/out/sdk/wasp/wasp-user-virtual-modules.d.ts
 wasp-app/.wasp/out/server/.gitignore

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -291,42 +291,42 @@
             "file",
             "sdk/wasp/client/vite/plugins/detectServerImports.ts"
         ],
-        "93885302fbb1758384e990fb6a7eac52fa03459f4df66a2b59eb8ac7b3e5c14a"
+        "73e142deeace394aaf2239e14eb45c9a2cb67a17e6c1290deab9c7b4b734c15c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/envFile.ts"
         ],
-        "0fafefac0b8c9ecfa0cac06f13e084ac8e1661d8fbead6e2d8b2bc7a08c9b035"
+        "f5433b4cf330b12609708e539d69c992960105f4e0caf9bae36685c687890dac"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
+        "7d27a76654606cd1e1b125946b0a2e916c4270259a325ec9af40d496ee68d37c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/validateEnv.ts"
         ],
-        "c172e926843b4ab12f96ebe79a70124d233d9d7fd948de0cdcd3388565402400"
+        "8f5634ff8d7559937a1a5d99bb27fe3e260b7aa664c4515c09f36a5cd6d6ad03"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "1b3926387257ed4e1b45bd10fc6e490cead654d494376d61ee8af6ff4fd4e4ae"
+        "4aa28abce6cb2bc6384f0750fee0de60359d468d2c1539f33a93b95e9790c6c2"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualWaspModules.ts"
         ],
-        "4aede5b77417f38713a8f8b72b119d8a060e1ef1984945ceca249119b528b38a"
+        "2f5980e12f84a48ebf78376fe685d3d82e3501243f31b257bd037d62673434db"
     ],
     [
         [
@@ -340,7 +340,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "a8e6a5cbffb010d02729e3cb4046de73ede1844b773417b8f394f60bdd9312cc"
+        "9bd6e13b2e2d586b82f41b7a36d341cdb88bd50f8e8605517ed0b92d713bdc26"
     ],
     [
         [
@@ -628,6 +628,13 @@
             "sdk/wasp/vite-env.d.ts"
         ],
         "65996936fbb042915f7b74a200fcdde7e410f32a669b1ab9597cfaa4b0faddb5"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/vite/constants.ts"
+        ],
+        "f79b835ec058aa391780df0e9f4ea401b9de6793a7faeec7afe0f221d1119648"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,11 +1,17 @@
 import { type Plugin } from 'vite'
 import path from 'path'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 export function detectServerImports(): Plugin {
   let parsePathToUserCode!: ParsePathToUserCodeFn
   return {
     name: 'wasp:detect-server-imports',
     enforce: 'pre',
+    // Importing server code is only forbidden in the environments that process
+    // client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       parsePathToUserCode = createPathToUserCodeParser(config.root)
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'
 import { expand, type DotenvPopulateInput } from 'dotenv-expand'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 const envFileName = '.env.client'
 
@@ -25,16 +26,29 @@ export function envFile(): Plugin {
       })
       envFilePath = resolve(rootDir, envFileName)
 
-      const prefixedVars = Object.entries(envVars)
-        .reduce((acc, [key, value]) => {
-          acc[`import.meta.env.${key}`] = JSON.stringify(value)
-          return acc
-        }, {} as Record<string, string>)
+      const makeDefine = () =>
+        Object.entries(envVars).reduce(
+          (acc, [key, value]) => {
+            acc[`import.meta.env.${key}`] = JSON.stringify(value)
+            return acc
+          },
+          {} as Record<string, string>
+        )
 
       return {
         // Disable Vite's default .env loading.
         envDir: false,
-        define: prefixedVars,
+        // We only inline the client env variables into the environments that
+        // process client code: `client` and `ssr` (which prerenders the client
+        // app). Defining them at the top level would leak them into every other
+        // environment (e.g. the server environment).
+        //
+        // We build a fresh `define` object per environment because Vite merges
+        // (and sometimes mutates) each environment's options separately.
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: { define: makeDefine() },
+          [ENVIRONMENT_NAMES.SSR]: { define: makeDefine() },
+        },
       }
     },
     configureServer(server) {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,5 +1,6 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 interface TypeScriptCheckOptions {
   srcTsConfigPath: string
@@ -9,6 +10,10 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
+    // `buildStart` runs once per environment, but the type check covers the
+    // whole project, so we only run it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     async buildStart() {
       await runTsc(options.srcTsConfigPath)
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -5,6 +5,7 @@ import {
   createServer as createViteServer,
   isRunnableDevEnvironment
 } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const PLUGIN_NAME = "wasp:validate-env";
 const CLIENT_ENV_SCHEMA_VALIDATION_MODULE = ".wasp/out/sdk/wasp/client/env.ts"
@@ -14,10 +15,14 @@ export function validateEnv(): Plugin {
 
   return {
     name: PLUGIN_NAME,
+    // `buildStart` runs once per environment, but the client env schema only
+    // needs to be validated once, so we only do it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     configResolved(config) {
       resolvedConfig = config;
     },
-    // We validate just before any artifacts are built.
+    // We validate just before the client artifacts are built.
     async buildStart() {
       // We need to import the client env schema validation module
       // through a Vite server, because both the user and the Wasp schema

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { type Plugin } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)
@@ -22,6 +23,11 @@ export function virtualUserModules(): Plugin {
   return {
     name: "wasp:virtual-user-modules",
     enforce: "pre",
+    // These virtual modules point to the user's client code, so they only make
+    // sense in the environments that process it.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       clientRootDir = config.root;
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -5,6 +5,7 @@ import {
   getSsrEntryTsxContent,
 } from "../virtual-files/index.js";
 import { makeVirtualFilesResolver, type VirtualFiles } from "../virtual-files/resolver.js";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const resolveVirtualFiles = makeVirtualFilesResolver([
   { id: "/@wasp/client-entry.tsx", load: getClientEntryTsxContent },
@@ -18,6 +19,11 @@ export function virtualWaspModules(): Plugin {
   return {
     name: "wasp:virtual-wasp-modules",
     enforce: "pre",
+    // These virtual modules are the client app's entry points, so they only
+    // make sense in the environments that process client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       virtualFiles = resolveVirtualFiles(config.root);
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import { type EnvironmentOptions, type PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -35,9 +36,6 @@ export function waspConfig(): PluginOption {
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
         base: forcedOptions["base"],
-        optimizeDeps: {
-          exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
-        },
         server: {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
@@ -47,15 +45,9 @@ export function waspConfig(): PluginOption {
           outDir: forcedOptions["build.outDir"],
         },
         resolve: {
-          // These packages rely on a single instance per page. Not deduping them
-          // causes runtime errors (e.g., hook rule violation in react, QueryClient
-          // instance error in react-query, Invariant Error in react-router).
-          dedupe: [
-            "react",
-            "react-dom",
-            "@tanstack/react-query",
-            "react-router",
-          ],
+          // `resolve.alias` is not a per-environment option in Vite, it is
+          // always shared by all environments, so we must set it at the top
+          // level.
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -71,6 +63,10 @@ export function waspConfig(): PluginOption {
             },
           ],
         },
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: makeClientCodeEnvironmentOptions(),
+          [ENVIRONMENT_NAMES.SSR]: makeClientCodeEnvironmentOptions(),
+        },
         test: {
           globals: useUserValue(config.test?.globals, true),
           environment: useUserValue(config.test?.environment, "jsdom"),
@@ -81,6 +77,34 @@ export function waspConfig(): PluginOption {
           ],
         },
       };
+    },
+  };
+}
+
+/**
+ * Options for the environments that process client code: `client` and `ssr`
+ * (which prerenders the client app). Keeping them here instead of at the top
+ * level of the config stops them from leaking into other environments (e.g. the
+ * server environment).
+ *
+ * We build a fresh object per environment because Vite merges (and sometimes
+ * mutates) each environment's options separately.
+ */
+function makeClientCodeEnvironmentOptions(): EnvironmentOptions {
+  return {
+    optimizeDeps: {
+      exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
+    },
+    resolve: {
+      // These packages rely on a single instance per page. Not deduping them
+      // causes runtime errors (e.g., hook rule violation in react, QueryClient
+      // instance error in react-query, Invariant Error in react-router).
+      dedupe: [
+        "react",
+        "react-dom",
+        "@tanstack/react-query",
+        "react-router",
+      ],
     },
   };
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Names of the Vite environments Wasp uses.
+ *
+ * `client` and `ssr` are Vite's built-in environments, see
+ * https://vite.dev/guide/api-environment. `ssr` prerenders the client app, so
+ * it processes the same code as `client`.
+ *
+ * `server` is Wasp's own environment for the Node.js server.
+ *
+ * This module is meant to be shared by all of Wasp's Vite plugins, which is why
+ * it sits outside of them. It is internal: plugins import it with a relative
+ * path, it is not part of the SDK's public exports.
+ */
+export const ENVIRONMENT_NAMES = {
+  CLIENT: "client",
+  SSR: "ssr",
+  SERVER: "server",
+} as const;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
@@ -371,6 +371,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.js
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.js
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.js.map
 wasp-app/.wasp/out/sdk/wasp/entities/index.ts
 wasp-app/.wasp/out/sdk/wasp/env/index.ts
 wasp-app/.wasp/out/sdk/wasp/env/validation.ts
@@ -404,6 +408,7 @@ wasp-app/.wasp/out/sdk/wasp/universal/types.ts
 wasp-app/.wasp/out/sdk/wasp/universal/url.ts
 wasp-app/.wasp/out/sdk/wasp/universal/validators.ts
 wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
+wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
 wasp-app/.wasp/out/sdk/wasp/wasp-ssr.d.ts
 wasp-app/.wasp/out/sdk/wasp/wasp-user-virtual-modules.d.ts
 wasp-app/.wasp/out/server/.env

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -291,42 +291,42 @@
             "file",
             "sdk/wasp/client/vite/plugins/detectServerImports.ts"
         ],
-        "93885302fbb1758384e990fb6a7eac52fa03459f4df66a2b59eb8ac7b3e5c14a"
+        "73e142deeace394aaf2239e14eb45c9a2cb67a17e6c1290deab9c7b4b734c15c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/envFile.ts"
         ],
-        "0fafefac0b8c9ecfa0cac06f13e084ac8e1661d8fbead6e2d8b2bc7a08c9b035"
+        "f5433b4cf330b12609708e539d69c992960105f4e0caf9bae36685c687890dac"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
+        "7d27a76654606cd1e1b125946b0a2e916c4270259a325ec9af40d496ee68d37c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/validateEnv.ts"
         ],
-        "c172e926843b4ab12f96ebe79a70124d233d9d7fd948de0cdcd3388565402400"
+        "8f5634ff8d7559937a1a5d99bb27fe3e260b7aa664c4515c09f36a5cd6d6ad03"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "1b3926387257ed4e1b45bd10fc6e490cead654d494376d61ee8af6ff4fd4e4ae"
+        "4aa28abce6cb2bc6384f0750fee0de60359d468d2c1539f33a93b95e9790c6c2"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualWaspModules.ts"
         ],
-        "4aede5b77417f38713a8f8b72b119d8a060e1ef1984945ceca249119b528b38a"
+        "2f5980e12f84a48ebf78376fe685d3d82e3501243f31b257bd037d62673434db"
     ],
     [
         [
@@ -340,7 +340,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "a8e6a5cbffb010d02729e3cb4046de73ede1844b773417b8f394f60bdd9312cc"
+        "9bd6e13b2e2d586b82f41b7a36d341cdb88bd50f8e8605517ed0b92d713bdc26"
     ],
     [
         [
@@ -628,6 +628,13 @@
             "sdk/wasp/vite-env.d.ts"
         ],
         "65996936fbb042915f7b74a200fcdde7e410f32a669b1ab9597cfaa4b0faddb5"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/vite/constants.ts"
+        ],
+        "f79b835ec058aa391780df0e9f4ea401b9de6793a7faeec7afe0f221d1119648"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,11 +1,17 @@
 import { type Plugin } from 'vite'
 import path from 'path'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 export function detectServerImports(): Plugin {
   let parsePathToUserCode!: ParsePathToUserCodeFn
   return {
     name: 'wasp:detect-server-imports',
     enforce: 'pre',
+    // Importing server code is only forbidden in the environments that process
+    // client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       parsePathToUserCode = createPathToUserCodeParser(config.root)
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'
 import { expand, type DotenvPopulateInput } from 'dotenv-expand'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 const envFileName = '.env.client'
 
@@ -25,16 +26,29 @@ export function envFile(): Plugin {
       })
       envFilePath = resolve(rootDir, envFileName)
 
-      const prefixedVars = Object.entries(envVars)
-        .reduce((acc, [key, value]) => {
-          acc[`import.meta.env.${key}`] = JSON.stringify(value)
-          return acc
-        }, {} as Record<string, string>)
+      const makeDefine = () =>
+        Object.entries(envVars).reduce(
+          (acc, [key, value]) => {
+            acc[`import.meta.env.${key}`] = JSON.stringify(value)
+            return acc
+          },
+          {} as Record<string, string>
+        )
 
       return {
         // Disable Vite's default .env loading.
         envDir: false,
-        define: prefixedVars,
+        // We only inline the client env variables into the environments that
+        // process client code: `client` and `ssr` (which prerenders the client
+        // app). Defining them at the top level would leak them into every other
+        // environment (e.g. the server environment).
+        //
+        // We build a fresh `define` object per environment because Vite merges
+        // (and sometimes mutates) each environment's options separately.
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: { define: makeDefine() },
+          [ENVIRONMENT_NAMES.SSR]: { define: makeDefine() },
+        },
       }
     },
     configureServer(server) {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,5 +1,6 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 interface TypeScriptCheckOptions {
   srcTsConfigPath: string
@@ -9,6 +10,10 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
+    // `buildStart` runs once per environment, but the type check covers the
+    // whole project, so we only run it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     async buildStart() {
       await runTsc(options.srcTsConfigPath)
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -5,6 +5,7 @@ import {
   createServer as createViteServer,
   isRunnableDevEnvironment
 } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const PLUGIN_NAME = "wasp:validate-env";
 const CLIENT_ENV_SCHEMA_VALIDATION_MODULE = ".wasp/out/sdk/wasp/client/env.ts"
@@ -14,10 +15,14 @@ export function validateEnv(): Plugin {
 
   return {
     name: PLUGIN_NAME,
+    // `buildStart` runs once per environment, but the client env schema only
+    // needs to be validated once, so we only do it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     configResolved(config) {
       resolvedConfig = config;
     },
-    // We validate just before any artifacts are built.
+    // We validate just before the client artifacts are built.
     async buildStart() {
       // We need to import the client env schema validation module
       // through a Vite server, because both the user and the Wasp schema

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { type Plugin } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)
@@ -22,6 +23,11 @@ export function virtualUserModules(): Plugin {
   return {
     name: "wasp:virtual-user-modules",
     enforce: "pre",
+    // These virtual modules point to the user's client code, so they only make
+    // sense in the environments that process it.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       clientRootDir = config.root;
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -5,6 +5,7 @@ import {
   getSsrEntryTsxContent,
 } from "../virtual-files/index.js";
 import { makeVirtualFilesResolver, type VirtualFiles } from "../virtual-files/resolver.js";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const resolveVirtualFiles = makeVirtualFilesResolver([
   { id: "/@wasp/client-entry.tsx", load: getClientEntryTsxContent },
@@ -18,6 +19,11 @@ export function virtualWaspModules(): Plugin {
   return {
     name: "wasp:virtual-wasp-modules",
     enforce: "pre",
+    // These virtual modules are the client app's entry points, so they only
+    // make sense in the environments that process client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       virtualFiles = resolveVirtualFiles(config.root);
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import { type EnvironmentOptions, type PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -35,9 +36,6 @@ export function waspConfig(): PluginOption {
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
         base: forcedOptions["base"],
-        optimizeDeps: {
-          exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
-        },
         server: {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
@@ -47,15 +45,9 @@ export function waspConfig(): PluginOption {
           outDir: forcedOptions["build.outDir"],
         },
         resolve: {
-          // These packages rely on a single instance per page. Not deduping them
-          // causes runtime errors (e.g., hook rule violation in react, QueryClient
-          // instance error in react-query, Invariant Error in react-router).
-          dedupe: [
-            "react",
-            "react-dom",
-            "@tanstack/react-query",
-            "react-router",
-          ],
+          // `resolve.alias` is not a per-environment option in Vite, it is
+          // always shared by all environments, so we must set it at the top
+          // level.
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -71,6 +63,10 @@ export function waspConfig(): PluginOption {
             },
           ],
         },
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: makeClientCodeEnvironmentOptions(),
+          [ENVIRONMENT_NAMES.SSR]: makeClientCodeEnvironmentOptions(),
+        },
         test: {
           globals: useUserValue(config.test?.globals, true),
           environment: useUserValue(config.test?.environment, "jsdom"),
@@ -81,6 +77,34 @@ export function waspConfig(): PluginOption {
           ],
         },
       };
+    },
+  };
+}
+
+/**
+ * Options for the environments that process client code: `client` and `ssr`
+ * (which prerenders the client app). Keeping them here instead of at the top
+ * level of the config stops them from leaking into other environments (e.g. the
+ * server environment).
+ *
+ * We build a fresh object per environment because Vite merges (and sometimes
+ * mutates) each environment's options separately.
+ */
+function makeClientCodeEnvironmentOptions(): EnvironmentOptions {
+  return {
+    optimizeDeps: {
+      exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
+    },
+    resolve: {
+      // These packages rely on a single instance per page. Not deduping them
+      // causes runtime errors (e.g., hook rule violation in react, QueryClient
+      // instance error in react-query, Invariant Error in react-router).
+      dedupe: [
+        "react",
+        "react-dom",
+        "@tanstack/react-query",
+        "react-router",
+      ],
     },
   };
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Names of the Vite environments Wasp uses.
+ *
+ * `client` and `ssr` are Vite's built-in environments, see
+ * https://vite.dev/guide/api-environment. `ssr` prerenders the client app, so
+ * it processes the same code as `client`.
+ *
+ * `server` is Wasp's own environment for the Node.js server.
+ *
+ * This module is meant to be shared by all of Wasp's Vite plugins, which is why
+ * it sits outside of them. It is internal: plugins import it with a relative
+ * path, it is not part of the SDK's public exports.
+ */
+export const ENVIRONMENT_NAMES = {
+  CLIENT: "client",
+  SSR: "ssr",
+  SERVER: "server",
+} as const;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
@@ -382,6 +382,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.js
 wasp-app/.wasp/out/sdk/wasp/dist/universal/validators.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.js
+wasp-app/.wasp/out/sdk/wasp/dist/vite/constants.js.map
 wasp-app/.wasp/out/sdk/wasp/entities/index.ts
 wasp-app/.wasp/out/sdk/wasp/env/index.ts
 wasp-app/.wasp/out/sdk/wasp/env/validation.ts
@@ -415,6 +419,7 @@ wasp-app/.wasp/out/sdk/wasp/universal/types.ts
 wasp-app/.wasp/out/sdk/wasp/universal/url.ts
 wasp-app/.wasp/out/sdk/wasp/universal/validators.ts
 wasp-app/.wasp/out/sdk/wasp/vite-env.d.ts
+wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
 wasp-app/.wasp/out/sdk/wasp/wasp-ssr.d.ts
 wasp-app/.wasp/out/sdk/wasp/wasp-user-virtual-modules.d.ts
 wasp-app/.wasp/out/server/.env

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -291,42 +291,42 @@
             "file",
             "sdk/wasp/client/vite/plugins/detectServerImports.ts"
         ],
-        "93885302fbb1758384e990fb6a7eac52fa03459f4df66a2b59eb8ac7b3e5c14a"
+        "73e142deeace394aaf2239e14eb45c9a2cb67a17e6c1290deab9c7b4b734c15c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/envFile.ts"
         ],
-        "0fafefac0b8c9ecfa0cac06f13e084ac8e1661d8fbead6e2d8b2bc7a08c9b035"
+        "f5433b4cf330b12609708e539d69c992960105f4e0caf9bae36685c687890dac"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
+        "7d27a76654606cd1e1b125946b0a2e916c4270259a325ec9af40d496ee68d37c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/validateEnv.ts"
         ],
-        "c172e926843b4ab12f96ebe79a70124d233d9d7fd948de0cdcd3388565402400"
+        "8f5634ff8d7559937a1a5d99bb27fe3e260b7aa664c4515c09f36a5cd6d6ad03"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "1b3926387257ed4e1b45bd10fc6e490cead654d494376d61ee8af6ff4fd4e4ae"
+        "4aa28abce6cb2bc6384f0750fee0de60359d468d2c1539f33a93b95e9790c6c2"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualWaspModules.ts"
         ],
-        "4aede5b77417f38713a8f8b72b119d8a060e1ef1984945ceca249119b528b38a"
+        "2f5980e12f84a48ebf78376fe685d3d82e3501243f31b257bd037d62673434db"
     ],
     [
         [
@@ -340,7 +340,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "a8e6a5cbffb010d02729e3cb4046de73ede1844b773417b8f394f60bdd9312cc"
+        "9bd6e13b2e2d586b82f41b7a36d341cdb88bd50f8e8605517ed0b92d713bdc26"
     ],
     [
         [
@@ -635,6 +635,13 @@
             "sdk/wasp/vite-env.d.ts"
         ],
         "65996936fbb042915f7b74a200fcdde7e410f32a669b1ab9597cfaa4b0faddb5"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/vite/constants.ts"
+        ],
+        "f79b835ec058aa391780df0e9f4ea401b9de6793a7faeec7afe0f221d1119648"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,11 +1,17 @@
 import { type Plugin } from 'vite'
 import path from 'path'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 export function detectServerImports(): Plugin {
   let parsePathToUserCode!: ParsePathToUserCodeFn
   return {
     name: 'wasp:detect-server-imports',
     enforce: 'pre',
+    // Importing server code is only forbidden in the environments that process
+    // client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       parsePathToUserCode = createPathToUserCodeParser(config.root)
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'
 import { expand, type DotenvPopulateInput } from 'dotenv-expand'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 const envFileName = '.env.client'
 
@@ -25,16 +26,29 @@ export function envFile(): Plugin {
       })
       envFilePath = resolve(rootDir, envFileName)
 
-      const prefixedVars = Object.entries(envVars)
-        .reduce((acc, [key, value]) => {
-          acc[`import.meta.env.${key}`] = JSON.stringify(value)
-          return acc
-        }, {} as Record<string, string>)
+      const makeDefine = () =>
+        Object.entries(envVars).reduce(
+          (acc, [key, value]) => {
+            acc[`import.meta.env.${key}`] = JSON.stringify(value)
+            return acc
+          },
+          {} as Record<string, string>
+        )
 
       return {
         // Disable Vite's default .env loading.
         envDir: false,
-        define: prefixedVars,
+        // We only inline the client env variables into the environments that
+        // process client code: `client` and `ssr` (which prerenders the client
+        // app). Defining them at the top level would leak them into every other
+        // environment (e.g. the server environment).
+        //
+        // We build a fresh `define` object per environment because Vite merges
+        // (and sometimes mutates) each environment's options separately.
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: { define: makeDefine() },
+          [ENVIRONMENT_NAMES.SSR]: { define: makeDefine() },
+        },
       }
     },
     configureServer(server) {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,5 +1,6 @@
 import { type Plugin } from 'vite'
 import { spawn } from 'node:child_process'
+import { ENVIRONMENT_NAMES } from '../../../vite/constants.js'
 
 interface TypeScriptCheckOptions {
   srcTsConfigPath: string
@@ -9,6 +10,10 @@ export function typescriptCheck(options: TypeScriptCheckOptions): Plugin {
   return {
     name: 'wasp:typescript-check',
     apply: 'build',
+    // `buildStart` runs once per environment, but the type check covers the
+    // whole project, so we only run it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     async buildStart() {
       await runTsc(options.srcTsConfigPath)
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/validateEnv.ts
@@ -5,6 +5,7 @@ import {
   createServer as createViteServer,
   isRunnableDevEnvironment
 } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const PLUGIN_NAME = "wasp:validate-env";
 const CLIENT_ENV_SCHEMA_VALIDATION_MODULE = ".wasp/out/sdk/wasp/client/env.ts"
@@ -14,10 +15,14 @@ export function validateEnv(): Plugin {
 
   return {
     name: PLUGIN_NAME,
+    // `buildStart` runs once per environment, but the client env schema only
+    // needs to be validated once, so we only do it in the client environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT,
     configResolved(config) {
       resolvedConfig = config;
     },
-    // We validate just before any artifacts are built.
+    // We validate just before the client artifacts are built.
     async buildStart() {
       // We need to import the client env schema validation module
       // through a Vite server, because both the user and the Wasp schema

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { type Plugin } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)
@@ -22,6 +23,11 @@ export function virtualUserModules(): Plugin {
   return {
     name: "wasp:virtual-user-modules",
     enforce: "pre",
+    // These virtual modules point to the user's client code, so they only make
+    // sense in the environments that process it.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       clientRootDir = config.root;
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -5,6 +5,7 @@ import {
   getSsrEntryTsxContent,
 } from "../virtual-files/index.js";
 import { makeVirtualFilesResolver, type VirtualFiles } from "../virtual-files/resolver.js";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 const resolveVirtualFiles = makeVirtualFilesResolver([
   { id: "/@wasp/client-entry.tsx", load: getClientEntryTsxContent },
@@ -18,6 +19,11 @@ export function virtualWaspModules(): Plugin {
   return {
     name: "wasp:virtual-wasp-modules",
     enforce: "pre",
+    // These virtual modules are the client app's entry points, so they only
+    // make sense in the environments that process client code.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.CLIENT ||
+      environment.name === ENVIRONMENT_NAMES.SSR,
     configResolved(config) {
       virtualFiles = resolveVirtualFiles(config.root);
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import { type EnvironmentOptions, type PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.
 // In that merge, primitive values from waspConfig take precedence, and
@@ -35,9 +36,6 @@ export function waspConfig(): PluginOption {
       // Returned config is merged with the user's config by Vite (mergeConfig).
       return {
         base: forcedOptions["base"],
-        optimizeDeps: {
-          exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
-        },
         server: {
           port: useUserValue(config.server?.port, 3000),
           host: useUserValue(config.server?.host, "0.0.0.0"),
@@ -47,15 +45,9 @@ export function waspConfig(): PluginOption {
           outDir: forcedOptions["build.outDir"],
         },
         resolve: {
-          // These packages rely on a single instance per page. Not deduping them
-          // causes runtime errors (e.g., hook rule violation in react, QueryClient
-          // instance error in react-query, Invariant Error in react-router).
-          dedupe: [
-            "react",
-            "react-dom",
-            "@tanstack/react-query",
-            "react-router",
-          ],
+          // `resolve.alias` is not a per-environment option in Vite, it is
+          // always shared by all environments, so we must set it at the top
+          // level.
           alias: [
             {
               // Vite doesn't look for `.prisma/client` imports in the `node_modules`
@@ -71,6 +63,10 @@ export function waspConfig(): PluginOption {
             },
           ],
         },
+        environments: {
+          [ENVIRONMENT_NAMES.CLIENT]: makeClientCodeEnvironmentOptions(),
+          [ENVIRONMENT_NAMES.SSR]: makeClientCodeEnvironmentOptions(),
+        },
         test: {
           globals: useUserValue(config.test?.globals, true),
           environment: useUserValue(config.test?.environment, "jsdom"),
@@ -81,6 +77,34 @@ export function waspConfig(): PluginOption {
           ],
         },
       };
+    },
+  };
+}
+
+/**
+ * Options for the environments that process client code: `client` and `ssr`
+ * (which prerenders the client app). Keeping them here instead of at the top
+ * level of the config stops them from leaking into other environments (e.g. the
+ * server environment).
+ *
+ * We build a fresh object per environment because Vite merges (and sometimes
+ * mutates) each environment's options separately.
+ */
+function makeClientCodeEnvironmentOptions(): EnvironmentOptions {
+  return {
+    optimizeDeps: {
+      exclude: ['wasp', '@wasp.sh/lib-auth', '@wasp.sh/lib-vite-ssr']
+    },
+    resolve: {
+      // These packages rely on a single instance per page. Not deduping them
+      // causes runtime errors (e.g., hook rule violation in react, QueryClient
+      // instance error in react-query, Invariant Error in react-router).
+      dedupe: [
+        "react",
+        "react-dom",
+        "@tanstack/react-query",
+        "react-router",
+      ],
     },
   };
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/vite/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Names of the Vite environments Wasp uses.
+ *
+ * `client` and `ssr` are Vite's built-in environments, see
+ * https://vite.dev/guide/api-environment. `ssr` prerenders the client app, so
+ * it processes the same code as `client`.
+ *
+ * `server` is Wasp's own environment for the Node.js server.
+ *
+ * This module is meant to be shared by all of Wasp's Vite plugins, which is why
+ * it sits outside of them. It is internal: plugins import it with a relative
+ * path, it is not part of the SDK's public exports.
+ */
+export const ENVIRONMENT_NAMES = {
+  CLIENT: "client",
+  SSR: "ssr",
+  SERVER: "server",
+} as const;

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -119,6 +119,9 @@ genSdk spec =
       C.genFileCopy [relfile|client/test/setup.ts|],
       C.genFileCopy [relfile|client/hooks.ts|],
       C.genFileCopy [relfile|client/index.ts|],
+      -- Shared by all of Wasp's Vite plugins, which is why it doesn't live
+      -- inside any of them.
+      C.genFileCopy [relfile|vite/constants.ts|],
       genClientConfigFile,
       genServerConfigFile spec,
       genTsConfigJson,


### PR DESCRIPTION
## Description

> Part of the Vite server unification stack (PR 1/5). Base: `main`.

Preparation for making the Wasp server a Vite environment. Today all of Wasp's
own Vite plugins apply to every environment, and client-only config (`define`,
`resolve.dedupe`, `optimizeDeps`) is set at the top level of the Vite config, so
it silently leaks into every environment Vite creates. Once we declare a
`server` environment (PR 3), that leakage would start to matter.

This PR scopes everything explicitly, with no user-visible behavior change:

- New internal module `wasp/vite/constants.ts` (SDK-internal, not exported)
  holding `ENVIRONMENT_NAMES = { CLIENT, SSR, SERVER }`. It sits outside
  `client/vite` because `server/vite` will import it too.
- `applyToEnvironment` set on Wasp's own client plugins:
  - `client` + `ssr` for `virtualUserModules`, `virtualWaspModules`,
    `detectServerImports` (the `ssr` environment prerenders the client app, so
    it processes the same code).
  - `client` only for `typescriptCheck` and `validateEnv`, whose `buildStart`
    hooks should run once per build, not once per environment.
- `waspConfig` now returns `resolve.dedupe` and `optimizeDeps` under
  `environments.client` / `environments.ssr` instead of at the top level.
  `envFile` does the same for the `import.meta.env.*` `define` map.

Notes:

- We deliberately do **not** wrap third-party plugins (`@vitejs/plugin-react`,
  `@wasp.sh/lib-vite-ssr`) with environment filters. A spike showed that a
  blanket `applyToEnvironment` wrapper clobbers a plugin's own gating and
  silently degrades client HMR from react-refresh to full page reloads. Only
  Wasp's own plugins get `applyToEnvironment`, set directly on them.
- `resolve.alias` stays at the top level: it is not a per-environment option in
  Vite 8 (`SharedEnvironmentOptions["resolve"]` is `EnvironmentResolveOptions`,
  which has no `alias`; Vite's config resolution assigns the same alias array to
  every environment). This is called out with a comment in `waspConfig.ts`.
- Side effect (improvement, not a behavior change for users): `tsc --noEmit` and
  client env-schema validation now run once per `vite build` instead of once per
  environment.

### Verification

- E2E snapshots regenerated and confirmed with a comparison-mode run; full e2e
  suite green.
- Client build byte-identity: generated a minimal-starter app with the dev CLI,
  ran `npx vite build` before and after the change in the same project, and
  compared SHA-256 of every file in `.wasp/out/web-app/build`: identical.
- Dev HMR canary (headless Chromium): editing a component produces
  `hmr update /src/MainPage.tsx` on the server and `[vite] hot updated:` in the
  browser, the DOM updates, and a page-scoped marker survives, i.e. no full page
  reload.
- Inspected the resolved Vite config: `define`, `resolve.dedupe` and
  `optimizeDeps.exclude` are now present only on the `client` and `ssr`
  environments and absent from the top level.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- Not applicable: this is a generated-template refactor. It is covered by the e2e snapshot tests plus the existing `vite-build` / `vite-config` e2e tests, and by the byte-identity and HMR checks above. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
