### PR TITLE
Split the generated server into start.ts and a thin production entry

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/index.ts
@@ -1,3 +1,3 @@
 export { type JobFn } from './types'
 export { registerJob, createJobDefinition } from './pgBossJob.js'
-export { startPgBoss } from './pgBoss.js'
+export { startPgBoss, stopPgBoss } from './pgBoss.js'

--- a/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/pgBoss.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/pgBoss.ts
@@ -35,6 +35,7 @@ enum PgBossStatus {
   Unstarted = 'Unstarted',
   Starting = 'Starting',
   Started = 'Started',
+  Stopped = 'Stopped',
   Error = 'Error',
 }
 
@@ -73,4 +74,48 @@ export async function startPgBoss(): Promise<void> {
 
   console.log('pg-boss started!')
   pgBossStatus = PgBossStatus.Started
+}
+
+// PRIVATE API
+/**
+ * Stops pg-boss's job monitoring and destroys its database connections.
+ *
+ * If pg-boss is still starting, we first wait for it to finish starting, so we
+ * never leave a half-started instance behind.
+ *
+ * A stopped pg-boss instance can't be started again, so this should only be
+ * called when shutting the server down.
+ */
+export async function stopPgBoss(): Promise<void> {
+  // There is nothing to stop if pg-boss was never started, if it already
+  // stopped, or if it failed to start.
+  if (
+    pgBossStatus !== PgBossStatus.Starting &&
+    pgBossStatus !== PgBossStatus.Started
+  ) {
+    return
+  }
+
+  try {
+    await pgBossStarted
+  } catch {
+    // pg-boss never finished starting, so there is nothing to stop.
+    return
+  }
+  pgBossStatus = PgBossStatus.Stopped
+
+  console.log('Stopping pg-boss...')
+
+  // `boss.stop()` resolves before pg-boss is done shutting down, the "stopped"
+  // event is the only signal that it really finished.
+  // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#stopoptions
+  const pgBossStopped = new Promise<void>((resolve) => {
+    boss.once('stopped', () => resolve())
+  })
+  // `destroy: true` also closes pg-boss's connection pool, without it the
+  // database connections stay open.
+  await boss.stop({ graceful: false, destroy: true })
+  await pgBossStopped
+
+  console.log('pg-boss stopped!')
 }

--- a/waspc/data/Generator/templates/server/src/server.ts
+++ b/waspc/data/Generator/templates/server/src/server.ts
@@ -1,76 +1,8 @@
-{{={= =}=}}
-import http from 'http'
+import { startServer } from './start.js'
 
-import app from './app.js'
-import { config } from 'wasp/server'
-
-{=# setupFn.isDefined =}
-{=& setupFn.importStatement =}
-import { ServerSetupFn } from 'wasp/server'
-import { ServerSetupFnContext } from 'wasp/server/types'
-{=/ setupFn.isDefined =}
-
-{=# isPgBossJobExecutorUsed =}
-import { startPgBoss } from 'wasp/server/jobs/core/pgBoss'
-import './jobs/core/allJobs.js'
-{=/ isPgBossJobExecutorUsed =}
-
-{=# userWebSocketFn.isDefined =}
-import { init as initWebSocket } from './webSocket/initialization.js'
-{=/ userWebSocketFn.isDefined =}
-
-const startServer = async () => {
-  {=# isPgBossJobExecutorUsed =}
-  await startPgBoss()
-  {=/ isPgBossJobExecutorUsed =}
-
-  const port = normalizePort(config.port)
-  app.set('port', port)
-
-  const server = http.createServer(app)
-
-  {=# setupFn.isDefined =}
-  const serverSetupFnContext: ServerSetupFnContext = { app, server }
-  await ({= setupFn.importIdentifier =} as ServerSetupFn)(serverSetupFnContext)
-  {=/ setupFn.isDefined =}
-
-  {=# userWebSocketFn.isDefined =}
-  await initWebSocket(server)
-  {=/ userWebSocketFn.isDefined =}
-
-  server.listen(port)
-
-  server.on('error', (error: NodeJS.ErrnoException) => {
-    if (error.syscall !== 'listen') throw error
-    const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
-    // handle specific listen errors with friendly messages
-    switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges')
-      process.exit(1)
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use')
-      process.exit(1)
-    default:
-      throw error
-    }
-  })
-
-  server.on('listening', () => {
-    const addr = server.address()
-    const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
-    console.log('Server listening on ' + bind)
-  })
-}
-
-startServer().catch(e => console.error(e))
-
-/**
- * Normalize a port into a number, string, or false.
- */
-function normalizePort (val) {
-  const port = parseInt(val, 10)
-  if (isNaN(port)) return val // named pipe
-  if (port >= 0) return port // port number
-  return false
-}
+// This is the production entrypoint of the server: it starts the server and
+// exits the process if it can't be started.
+startServer().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/waspc/data/Generator/templates/server/src/start.ts
+++ b/waspc/data/Generator/templates/server/src/start.ts
@@ -1,0 +1,130 @@
+{{={= =}=}}
+import http from 'http'
+
+import app from './app.js'
+import { config{=# areThereAnyEntitiesDefined =}, prisma{=/ areThereAnyEntitiesDefined =} } from 'wasp/server'
+
+{=# setupFn.isDefined =}
+{=& setupFn.importStatement =}
+import { ServerSetupFn } from 'wasp/server'
+import { ServerSetupFnContext } from 'wasp/server/types'
+{=/ setupFn.isDefined =}
+
+{=# isPgBossJobExecutorUsed =}
+import { startPgBoss, stopPgBoss } from 'wasp/server/jobs/core/pgBoss'
+import './jobs/core/allJobs.js'
+{=/ isPgBossJobExecutorUsed =}
+
+{=# userWebSocketFn.isDefined =}
+import { init as initWebSocket } from './webSocket/initialization.js'
+{=/ userWebSocketFn.isDefined =}
+
+export type ServerHandle = {
+  /**
+   * Stops the server and disposes of everything it started.
+   */
+  close: () => Promise<void>
+}
+
+/**
+ * Starts the server and returns a handle for stopping it.
+ *
+ * It rejects if the server fails to start (e.g. if its port is already taken),
+ * so the caller can decide what to do about it.
+ */
+export async function startServer(): Promise<ServerHandle> {
+  {=# isPgBossJobExecutorUsed =}
+  await startPgBoss()
+  {=/ isPgBossJobExecutorUsed =}
+
+  const port = normalizePort(config.port)
+  app.set('port', port)
+
+  const server = http.createServer(app)
+
+  {=# setupFn.isDefined =}
+  const serverSetupFnContext: ServerSetupFnContext = { app, server }
+  await ({= setupFn.importIdentifier =} as ServerSetupFn)(serverSetupFnContext)
+  {=/ setupFn.isDefined =}
+
+  {=# userWebSocketFn.isDefined =}
+  const io = await initWebSocket(server)
+  {=/ userWebSocketFn.isDefined =}
+
+  await listen(server, port)
+
+  const addr = server.address()
+  const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
+  console.log('Server listening on ' + bind)
+
+  return {
+    async close() {
+      await closeHttpServer(server)
+      {=# userWebSocketFn.isDefined =}
+      io.close()
+      {=/ userWebSocketFn.isDefined =}
+      {=# areThereAnyEntitiesDefined =}
+      await prisma.$disconnect()
+      {=/ areThereAnyEntitiesDefined =}
+      {=# isPgBossJobExecutorUsed =}
+      await stopPgBoss()
+      {=/ isPgBossJobExecutorUsed =}
+    },
+  }
+}
+
+/**
+ * Starts listening on the given port, resolving once the server is listening
+ * and rejecting if it can't listen.
+ */
+function listen(server: http.Server, port): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off('listening', onListening)
+      reject(makeListenErrorFriendlier(error, port))
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      resolve()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port)
+  })
+}
+
+/**
+ * Replaces the most common listen errors with friendlier messages, keeping the
+ * original error as the cause.
+ */
+function makeListenErrorFriendlier(error: NodeJS.ErrnoException, port): Error {
+  if (error.syscall !== 'listen') return error
+  const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
+  switch (error.code) {
+  case 'EACCES':
+    return new Error(bind + ' requires elevated privileges', { cause: error })
+  case 'EADDRINUSE':
+    return new Error(bind + ' is already in use', { cause: error })
+  default:
+    return error
+  }
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+    // `close` stops the server from accepting new connections, but it only
+    // completes once all the existing connections are done, so we close them.
+    server.closeAllConnections()
+  })
+}
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+function normalizePort (val) {
+  const port = parseInt(val, 10)
+  if (isNaN(port)) return val // named pipe
+  if (port >= 0) return port // port number
+  return false
+}

--- a/waspc/data/Generator/templates/server/src/webSocket/initialization.ts
+++ b/waspc/data/Generator/templates/server/src/webSocket/initialization.ts
@@ -14,7 +14,8 @@ import { makeAuthUserIfPossible } from 'wasp/auth/user'
 {=& userWebSocketFn.importStatement =}
 
 // Initializes the WebSocket server and invokes the user's WebSocket function.
-export async function init(server: http.Server): Promise<void> {
+// It returns the WebSocket server so the caller can close it.
+export async function init(server: http.Server): Promise<Server> {
   // TODO: In the future, we can consider allowing a clustering option.
   // Ref: https://github.com/wasp-lang/wasp/issues/1228
 
@@ -39,6 +40,8 @@ export async function init(server: http.Server): Promise<void> {
   }
 
   await ({= userWebSocketFn.importIdentifier =} as any)(io, context)
+
+  return io
 }
 
 {=# isAuthEnabled =}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
@@ -1017,6 +1017,7 @@ wasp-app/.wasp/out/server/src/routes/operations/updateTaskIsDone.js
 wasp-app/.wasp/out/server/src/routes/operations/voidToStringAuth.js
 wasp-app/.wasp/out/server/src/routes/operations/voidToStringNoAuth.js
 wasp-app/.wasp/out/server/src/server.ts
+wasp-app/.wasp/out/server/src/start.ts
 wasp-app/.wasp/out/server/src/views/wrong-port.ts
 wasp-app/.wasp/out/server/src/webSocket/initialization.ts
 wasp-app/.wasp/out/server/tsconfig.json

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1145,14 +1145,14 @@
             "file",
             "sdk/wasp/server/jobs/core/pgBoss/index.ts"
         ],
-        "ba33f9b0680dd2a6fdea55c2eb8f8163ad60f4ebbac8b459d5c1a2a708524bec"
+        "896169ce7112e3e8c4e805cebbacaae0232b501f661eb3960cc24f1d3afee8b6"
     ],
     [
         [
             "file",
             "sdk/wasp/server/jobs/core/pgBoss/pgBoss.ts"
         ],
-        "44ea6eb19cb4e283e24b4d3da1105539ef81cd36dfeb71d9fa5695f0b0c15b34"
+        "441e23dec1c7556fc42cb1bc9de5fb86c7b7073985d85a05590790290f17378c"
     ],
     [
         [
@@ -2125,7 +2125,14 @@
             "file",
             "server/src/server.ts"
         ],
-        "6236e531606fc6432114a206eafe0206ebe2805ff81e6077eaeb594471a2f6f1"
+        "fec635eae8b4c93094606e952f0b02ea27e49bd3940f282b3fbca98d507400a9"
+    ],
+    [
+        [
+            "file",
+            "server/src/start.ts"
+        ],
+        "5aa23122c298604d1e37c9197ac6cf4b09db954a670071232882e6202d66eb79"
     ],
     [
         [
@@ -2139,7 +2146,7 @@
             "file",
             "server/src/webSocket/initialization.ts"
         ],
-        "0b15b0069d02f049d4ab08271f5add429244989f0c6925b3bd8b0971d58fbb6b"
+        "832c6726ee307abba732a7ab40075cd66de612ccb44b9b3b15f6156fcf418879"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/index.ts
@@ -1,3 +1,3 @@
 export { type JobFn } from './types'
 export { registerJob, createJobDefinition } from './pgBossJob.js'
-export { startPgBoss } from './pgBoss.js'
+export { startPgBoss, stopPgBoss } from './pgBoss.js'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/pgBoss.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/pgBoss.ts
@@ -35,6 +35,7 @@ enum PgBossStatus {
   Unstarted = 'Unstarted',
   Starting = 'Starting',
   Started = 'Started',
+  Stopped = 'Stopped',
   Error = 'Error',
 }
 
@@ -73,4 +74,48 @@ export async function startPgBoss(): Promise<void> {
 
   console.log('pg-boss started!')
   pgBossStatus = PgBossStatus.Started
+}
+
+// PRIVATE API
+/**
+ * Stops pg-boss's job monitoring and destroys its database connections.
+ *
+ * If pg-boss is still starting, we first wait for it to finish starting, so we
+ * never leave a half-started instance behind.
+ *
+ * A stopped pg-boss instance can't be started again, so this should only be
+ * called when shutting the server down.
+ */
+export async function stopPgBoss(): Promise<void> {
+  // There is nothing to stop if pg-boss was never started, if it already
+  // stopped, or if it failed to start.
+  if (
+    pgBossStatus !== PgBossStatus.Starting &&
+    pgBossStatus !== PgBossStatus.Started
+  ) {
+    return
+  }
+
+  try {
+    await pgBossStarted
+  } catch {
+    // pg-boss never finished starting, so there is nothing to stop.
+    return
+  }
+  pgBossStatus = PgBossStatus.Stopped
+
+  console.log('Stopping pg-boss...')
+
+  // `boss.stop()` resolves before pg-boss is done shutting down, the "stopped"
+  // event is the only signal that it really finished.
+  // Ref: https://github.com/timgit/pg-boss/blob/master/docs/readme.md#stopoptions
+  const pgBossStopped = new Promise<void>((resolve) => {
+    boss.once('stopped', () => resolve())
+  })
+  // `destroy: true` also closes pg-boss's connection pool, without it the
+  // database connections stay open.
+  await boss.stop({ graceful: false, destroy: true })
+  await pgBossStopped
+
+  console.log('pg-boss stopped!')
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/server.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/server.ts
@@ -1,63 +1,8 @@
-import http from 'http'
+import { startServer } from './start.js'
 
-import app from './app.js'
-import { config } from 'wasp/server'
-
-import { serverSetup } from '../../../../src/serverSetup'
-import { ServerSetupFn } from 'wasp/server'
-import { ServerSetupFnContext } from 'wasp/server/types'
-
-import { startPgBoss } from 'wasp/server/jobs/core/pgBoss'
-import './jobs/core/allJobs.js'
-
-import { init as initWebSocket } from './webSocket/initialization.js'
-
-const startServer = async () => {
-  await startPgBoss()
-
-  const port = normalizePort(config.port)
-  app.set('port', port)
-
-  const server = http.createServer(app)
-
-  const serverSetupFnContext: ServerSetupFnContext = { app, server }
-  await (serverSetup as ServerSetupFn)(serverSetupFnContext)
-
-  await initWebSocket(server)
-
-  server.listen(port)
-
-  server.on('error', (error: NodeJS.ErrnoException) => {
-    if (error.syscall !== 'listen') throw error
-    const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
-    // handle specific listen errors with friendly messages
-    switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges')
-      process.exit(1)
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use')
-      process.exit(1)
-    default:
-      throw error
-    }
-  })
-
-  server.on('listening', () => {
-    const addr = server.address()
-    const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
-    console.log('Server listening on ' + bind)
-  })
-}
-
-startServer().catch(e => console.error(e))
-
-/**
- * Normalize a port into a number, string, or false.
- */
-function normalizePort (val) {
-  const port = parseInt(val, 10)
-  if (isNaN(port)) return val // named pipe
-  if (port >= 0) return port // port number
-  return false
-}
+// This is the production entrypoint of the server: it starts the server and
+// exits the process if it can't be started.
+startServer().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/start.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/start.ts
@@ -1,0 +1,111 @@
+import http from 'http'
+
+import app from './app.js'
+import { config, prisma } from 'wasp/server'
+
+import { serverSetup } from '../../../../src/serverSetup'
+import { ServerSetupFn } from 'wasp/server'
+import { ServerSetupFnContext } from 'wasp/server/types'
+
+import { startPgBoss, stopPgBoss } from 'wasp/server/jobs/core/pgBoss'
+import './jobs/core/allJobs.js'
+
+import { init as initWebSocket } from './webSocket/initialization.js'
+
+export type ServerHandle = {
+  /**
+   * Stops the server and disposes of everything it started.
+   */
+  close: () => Promise<void>
+}
+
+/**
+ * Starts the server and returns a handle for stopping it.
+ *
+ * It rejects if the server fails to start (e.g. if its port is already taken),
+ * so the caller can decide what to do about it.
+ */
+export async function startServer(): Promise<ServerHandle> {
+  await startPgBoss()
+
+  const port = normalizePort(config.port)
+  app.set('port', port)
+
+  const server = http.createServer(app)
+
+  const serverSetupFnContext: ServerSetupFnContext = { app, server }
+  await (serverSetup as ServerSetupFn)(serverSetupFnContext)
+
+  const io = await initWebSocket(server)
+
+  await listen(server, port)
+
+  const addr = server.address()
+  const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
+  console.log('Server listening on ' + bind)
+
+  return {
+    async close() {
+      await closeHttpServer(server)
+      io.close()
+      await prisma.$disconnect()
+      await stopPgBoss()
+    },
+  }
+}
+
+/**
+ * Starts listening on the given port, resolving once the server is listening
+ * and rejecting if it can't listen.
+ */
+function listen(server: http.Server, port): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off('listening', onListening)
+      reject(makeListenErrorFriendlier(error, port))
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      resolve()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port)
+  })
+}
+
+/**
+ * Replaces the most common listen errors with friendlier messages, keeping the
+ * original error as the cause.
+ */
+function makeListenErrorFriendlier(error: NodeJS.ErrnoException, port): Error {
+  if (error.syscall !== 'listen') return error
+  const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
+  switch (error.code) {
+  case 'EACCES':
+    return new Error(bind + ' requires elevated privileges', { cause: error })
+  case 'EADDRINUSE':
+    return new Error(bind + ' is already in use', { cause: error })
+  default:
+    return error
+  }
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+    // `close` stops the server from accepting new connections, but it only
+    // completes once all the existing connections are done, so we close them.
+    server.closeAllConnections()
+  })
+}
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+function normalizePort (val) {
+  const port = parseInt(val, 10)
+  if (isNaN(port)) return val // named pipe
+  if (port >= 0) return port // port number
+  return false
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/webSocket/initialization.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/webSocket/initialization.ts
@@ -11,7 +11,8 @@ import { makeAuthUserIfPossible } from 'wasp/auth/user'
 import { chatWebSocket } from '../../../../../src/features/chat/webSocket'
 
 // Initializes the WebSocket server and invokes the user's WebSocket function.
-export async function init(server: http.Server): Promise<void> {
+// It returns the WebSocket server so the caller can close it.
+export async function init(server: http.Server): Promise<Server> {
   // TODO: In the future, we can consider allowing a clustering option.
   // Ref: https://github.com/wasp-lang/wasp/issues/1228
 
@@ -35,6 +36,8 @@ export async function init(server: http.Server): Promise<void> {
   }
 
   await (chatWebSocket as any)(io, context)
+
+  return io
 }
 
 async function addUserToSocketDataIfAuthenticated(socket: Socket, next: (err?: Error) => void) {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
@@ -427,6 +427,7 @@ wasp-app/.wasp/out/server/src/plugins/virtualUserModules.js
 wasp-app/.wasp/out/server/src/routes/index.js
 wasp-app/.wasp/out/server/src/routes/operations/index.js
 wasp-app/.wasp/out/server/src/server.ts
+wasp-app/.wasp/out/server/src/start.ts
 wasp-app/.wasp/out/server/tsconfig.json
 wasp-app/.wasp/out/src/Main.css
 wasp-app/.wasp/out/src/MainPage.tsx

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -746,7 +746,14 @@
             "file",
             "server/src/server.ts"
         ],
-        "b58b023d27d41801136784aba57e2708eb1b47024adcc4fd179be1a10ff54899"
+        "fec635eae8b4c93094606e952f0b02ea27e49bd3940f282b3fbca98d507400a9"
+    ],
+    [
+        [
+            "file",
+            "server/src/start.ts"
+        ],
+        "d4cc42efeead16917ad80a8135e5b9814195dd5864d68ff73472c2e34e215f90"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/server/src/server.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/server/src/server.ts
@@ -1,53 +1,8 @@
-import http from 'http'
+import { startServer } from './start.js'
 
-import app from './app.js'
-import { config } from 'wasp/server'
-
-
-
-
-const startServer = async () => {
-
-  const port = normalizePort(config.port)
-  app.set('port', port)
-
-  const server = http.createServer(app)
-
-
-
-  server.listen(port)
-
-  server.on('error', (error: NodeJS.ErrnoException) => {
-    if (error.syscall !== 'listen') throw error
-    const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
-    // handle specific listen errors with friendly messages
-    switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges')
-      process.exit(1)
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use')
-      process.exit(1)
-    default:
-      throw error
-    }
-  })
-
-  server.on('listening', () => {
-    const addr = server.address()
-    const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
-    console.log('Server listening on ' + bind)
-  })
-}
-
-startServer().catch(e => console.error(e))
-
-/**
- * Normalize a port into a number, string, or false.
- */
-function normalizePort (val) {
-  const port = parseInt(val, 10)
-  if (isNaN(port)) return val // named pipe
-  if (port >= 0) return port // port number
-  return false
-}
+// This is the production entrypoint of the server: it starts the server and
+// exits the process if it can't be started.
+startServer().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/server/src/start.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/server/src/start.ts
@@ -1,0 +1,98 @@
+import http from 'http'
+
+import app from './app.js'
+import { config } from 'wasp/server'
+
+
+
+
+export type ServerHandle = {
+  /**
+   * Stops the server and disposes of everything it started.
+   */
+  close: () => Promise<void>
+}
+
+/**
+ * Starts the server and returns a handle for stopping it.
+ *
+ * It rejects if the server fails to start (e.g. if its port is already taken),
+ * so the caller can decide what to do about it.
+ */
+export async function startServer(): Promise<ServerHandle> {
+
+  const port = normalizePort(config.port)
+  app.set('port', port)
+
+  const server = http.createServer(app)
+
+
+
+  await listen(server, port)
+
+  const addr = server.address()
+  const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
+  console.log('Server listening on ' + bind)
+
+  return {
+    async close() {
+      await closeHttpServer(server)
+    },
+  }
+}
+
+/**
+ * Starts listening on the given port, resolving once the server is listening
+ * and rejecting if it can't listen.
+ */
+function listen(server: http.Server, port): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off('listening', onListening)
+      reject(makeListenErrorFriendlier(error, port))
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      resolve()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port)
+  })
+}
+
+/**
+ * Replaces the most common listen errors with friendlier messages, keeping the
+ * original error as the cause.
+ */
+function makeListenErrorFriendlier(error: NodeJS.ErrnoException, port): Error {
+  if (error.syscall !== 'listen') return error
+  const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
+  switch (error.code) {
+  case 'EACCES':
+    return new Error(bind + ' requires elevated privileges', { cause: error })
+  case 'EADDRINUSE':
+    return new Error(bind + ' is already in use', { cause: error })
+  default:
+    return error
+  }
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+    // `close` stops the server from accepting new connections, but it only
+    // completes once all the existing connections are done, so we close them.
+    server.closeAllConnections()
+  })
+}
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+function normalizePort (val) {
+  const port = parseInt(val, 10)
+  if (isNaN(port)) return val // named pipe
+  if (port >= 0) return port // port number
+  return false
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
@@ -425,6 +425,7 @@ wasp-app/.wasp/out/server/src/plugins/virtualUserModules.js
 wasp-app/.wasp/out/server/src/routes/index.js
 wasp-app/.wasp/out/server/src/routes/operations/index.js
 wasp-app/.wasp/out/server/src/server.ts
+wasp-app/.wasp/out/server/src/start.ts
 wasp-app/.wasp/out/server/src/views/wrong-port.ts
 wasp-app/.wasp/out/server/tsconfig.json
 wasp-app/.wasp/out/types/app/sdk/register.ts

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -746,7 +746,14 @@
             "file",
             "server/src/server.ts"
         ],
-        "b58b023d27d41801136784aba57e2708eb1b47024adcc4fd179be1a10ff54899"
+        "fec635eae8b4c93094606e952f0b02ea27e49bd3940f282b3fbca98d507400a9"
+    ],
+    [
+        [
+            "file",
+            "server/src/start.ts"
+        ],
+        "d4cc42efeead16917ad80a8135e5b9814195dd5864d68ff73472c2e34e215f90"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/server/src/server.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/server/src/server.ts
@@ -1,53 +1,8 @@
-import http from 'http'
+import { startServer } from './start.js'
 
-import app from './app.js'
-import { config } from 'wasp/server'
-
-
-
-
-const startServer = async () => {
-
-  const port = normalizePort(config.port)
-  app.set('port', port)
-
-  const server = http.createServer(app)
-
-
-
-  server.listen(port)
-
-  server.on('error', (error: NodeJS.ErrnoException) => {
-    if (error.syscall !== 'listen') throw error
-    const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
-    // handle specific listen errors with friendly messages
-    switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges')
-      process.exit(1)
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use')
-      process.exit(1)
-    default:
-      throw error
-    }
-  })
-
-  server.on('listening', () => {
-    const addr = server.address()
-    const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
-    console.log('Server listening on ' + bind)
-  })
-}
-
-startServer().catch(e => console.error(e))
-
-/**
- * Normalize a port into a number, string, or false.
- */
-function normalizePort (val) {
-  const port = parseInt(val, 10)
-  if (isNaN(port)) return val // named pipe
-  if (port >= 0) return port // port number
-  return false
-}
+// This is the production entrypoint of the server: it starts the server and
+// exits the process if it can't be started.
+startServer().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/server/src/start.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/server/src/start.ts
@@ -1,0 +1,98 @@
+import http from 'http'
+
+import app from './app.js'
+import { config } from 'wasp/server'
+
+
+
+
+export type ServerHandle = {
+  /**
+   * Stops the server and disposes of everything it started.
+   */
+  close: () => Promise<void>
+}
+
+/**
+ * Starts the server and returns a handle for stopping it.
+ *
+ * It rejects if the server fails to start (e.g. if its port is already taken),
+ * so the caller can decide what to do about it.
+ */
+export async function startServer(): Promise<ServerHandle> {
+
+  const port = normalizePort(config.port)
+  app.set('port', port)
+
+  const server = http.createServer(app)
+
+
+
+  await listen(server, port)
+
+  const addr = server.address()
+  const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
+  console.log('Server listening on ' + bind)
+
+  return {
+    async close() {
+      await closeHttpServer(server)
+    },
+  }
+}
+
+/**
+ * Starts listening on the given port, resolving once the server is listening
+ * and rejecting if it can't listen.
+ */
+function listen(server: http.Server, port): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off('listening', onListening)
+      reject(makeListenErrorFriendlier(error, port))
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      resolve()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port)
+  })
+}
+
+/**
+ * Replaces the most common listen errors with friendlier messages, keeping the
+ * original error as the cause.
+ */
+function makeListenErrorFriendlier(error: NodeJS.ErrnoException, port): Error {
+  if (error.syscall !== 'listen') return error
+  const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
+  switch (error.code) {
+  case 'EACCES':
+    return new Error(bind + ' requires elevated privileges', { cause: error })
+  case 'EADDRINUSE':
+    return new Error(bind + ' is already in use', { cause: error })
+  default:
+    return error
+  }
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+    // `close` stops the server from accepting new connections, but it only
+    // completes once all the existing connections are done, so we close them.
+    server.closeAllConnections()
+  })
+}
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+function normalizePort (val) {
+  const port = parseInt(val, 10)
+  if (isNaN(port)) return val // named pipe
+  if (port >= 0) return port // port number
+  return false
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
@@ -436,6 +436,7 @@ wasp-app/.wasp/out/server/src/plugins/virtualUserModules.js
 wasp-app/.wasp/out/server/src/routes/index.js
 wasp-app/.wasp/out/server/src/routes/operations/index.js
 wasp-app/.wasp/out/server/src/server.ts
+wasp-app/.wasp/out/server/src/start.ts
 wasp-app/.wasp/out/server/src/views/wrong-port.ts
 wasp-app/.wasp/out/server/tsconfig.json
 wasp-app/.wasp/out/types/app/sdk/register.ts

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -753,7 +753,14 @@
             "file",
             "server/src/server.ts"
         ],
-        "b58b023d27d41801136784aba57e2708eb1b47024adcc4fd179be1a10ff54899"
+        "fec635eae8b4c93094606e952f0b02ea27e49bd3940f282b3fbca98d507400a9"
+    ],
+    [
+        [
+            "file",
+            "server/src/start.ts"
+        ],
+        "2df9a50608900681ed01e2647ca95561467022331c72fc8056a9114ecfd65a16"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/server/src/server.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/server/src/server.ts
@@ -1,53 +1,8 @@
-import http from 'http'
+import { startServer } from './start.js'
 
-import app from './app.js'
-import { config } from 'wasp/server'
-
-
-
-
-const startServer = async () => {
-
-  const port = normalizePort(config.port)
-  app.set('port', port)
-
-  const server = http.createServer(app)
-
-
-
-  server.listen(port)
-
-  server.on('error', (error: NodeJS.ErrnoException) => {
-    if (error.syscall !== 'listen') throw error
-    const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
-    // handle specific listen errors with friendly messages
-    switch (error.code) {
-    case 'EACCES':
-      console.error(bind + ' requires elevated privileges')
-      process.exit(1)
-    case 'EADDRINUSE':
-      console.error(bind + ' is already in use')
-      process.exit(1)
-    default:
-      throw error
-    }
-  })
-
-  server.on('listening', () => {
-    const addr = server.address()
-    const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
-    console.log('Server listening on ' + bind)
-  })
-}
-
-startServer().catch(e => console.error(e))
-
-/**
- * Normalize a port into a number, string, or false.
- */
-function normalizePort (val) {
-  const port = parseInt(val, 10)
-  if (isNaN(port)) return val // named pipe
-  if (port >= 0) return port // port number
-  return false
-}
+// This is the production entrypoint of the server: it starts the server and
+// exits the process if it can't be started.
+startServer().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/server/src/start.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/server/src/start.ts
@@ -1,0 +1,99 @@
+import http from 'http'
+
+import app from './app.js'
+import { config, prisma } from 'wasp/server'
+
+
+
+
+export type ServerHandle = {
+  /**
+   * Stops the server and disposes of everything it started.
+   */
+  close: () => Promise<void>
+}
+
+/**
+ * Starts the server and returns a handle for stopping it.
+ *
+ * It rejects if the server fails to start (e.g. if its port is already taken),
+ * so the caller can decide what to do about it.
+ */
+export async function startServer(): Promise<ServerHandle> {
+
+  const port = normalizePort(config.port)
+  app.set('port', port)
+
+  const server = http.createServer(app)
+
+
+
+  await listen(server, port)
+
+  const addr = server.address()
+  const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port
+  console.log('Server listening on ' + bind)
+
+  return {
+    async close() {
+      await closeHttpServer(server)
+      await prisma.$disconnect()
+    },
+  }
+}
+
+/**
+ * Starts listening on the given port, resolving once the server is listening
+ * and rejecting if it can't listen.
+ */
+function listen(server: http.Server, port): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off('listening', onListening)
+      reject(makeListenErrorFriendlier(error, port))
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      resolve()
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port)
+  })
+}
+
+/**
+ * Replaces the most common listen errors with friendlier messages, keeping the
+ * original error as the cause.
+ */
+function makeListenErrorFriendlier(error: NodeJS.ErrnoException, port): Error {
+  if (error.syscall !== 'listen') return error
+  const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port
+  switch (error.code) {
+  case 'EACCES':
+    return new Error(bind + ' requires elevated privileges', { cause: error })
+  case 'EADDRINUSE':
+    return new Error(bind + ' is already in use', { cause: error })
+  default:
+    return error
+  }
+}
+
+function closeHttpServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+    // `close` stops the server from accepting new connections, but it only
+    // completes once all the existing connections are done, so we close them.
+    server.closeAllConnections()
+  })
+}
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+function normalizePort (val) {
+  const port = parseInt(val, 10)
+  if (isNaN(port)) return val // named pipe
+  if (port >= 0) return port // port number
+  return false
+}

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -243,7 +243,8 @@ genSrcDir :: AppSpec -> Generator [FileDraft]
 genSrcDir spec =
   sequence
     [ genFileCopy [relfile|app.js|],
-      genServerJs spec
+      genFileCopy [relfile|server.ts|],
+      genStartTs spec
     ]
     <++> genRoutesDir spec
     <++> genViewsDir spec
@@ -256,17 +257,20 @@ genSrcDir spec =
   where
     genFileCopy = return . C.mkSrcTmplFd
 
-genServerJs :: AppSpec -> Generator FileDraft
-genServerJs spec =
+genStartTs :: AppSpec -> Generator FileDraft
+genStartTs spec =
   return $
     C.mkTmplFdWithDstAndData
-      (C.asTmplFile [relfile|src/server.ts|])
-      (C.asServerFile [relfile|src/server.ts|])
+      (C.asTmplFile [relfile|src/start.ts|])
+      (C.asServerFile [relfile|src/start.ts|])
       ( Just $
           object
             [ "setupFn" .= extImportToImportJson relPathToServerSrcDir maybeSetupJsFunction,
               "isPgBossJobExecutorUsed" .= isPgBossJobExecutorUsed spec,
-              "userWebSocketFn" .= mkWebSocketFnImport maybeWebSocket [reldirP|./|]
+              "userWebSocketFn" .= mkWebSocketFnImport maybeWebSocket [reldirP|./|],
+              -- Without entities, the SDK's Prisma client is `null`, so we
+              -- can't disconnect from it.
+              "areThereAnyEntitiesDefined" .= AS.Util.hasEntities spec
             ]
       )
   where


### PR DESCRIPTION
## Description

> Part of the Vite server unification stack (PR 2/5). Base: `cprecioso/vite-env-gating` ([#4645](https://github.com/wasp-lang/wasp/pull/4645)).

Gives the generated server a proper start/stop API, so a later PR can start and
restart it in-process (inside the Vite dev server) instead of restarting the
whole Node process with nodemon.

- `src/server.ts` is split in two:
  - the new `src/start.ts` holds all the startup logic and exports
    `startServer(): Promise<ServerHandle>`, where `ServerHandle.close()` disposes
    of everything the server started (HTTP server + open connections, socket.io,
    Prisma, pg-boss),
  - `src/server.ts` is now just the production entrypoint: it starts the server
    and exits with a non-zero code if it can't.
- Listen errors (`EACCES`, `EADDRINUSE`) no longer call `process.exit` from deep
  inside the startup code. They reject `startServer()` with the same friendly
  message, and the production entrypoint is the one that exits. This is what
  makes it safe to start the server inside a process it doesn't own.
- The SDK gets the missing disposal pieces: `stopPgBoss()` (private API, next to
  `startPgBoss()`) and `init()` in `src/webSocket/initialization.ts` now returns
  the socket.io server so it can be closed.

Nothing about production changes: the bundle entrypoint is still
`src/server.ts`, the server is still bundled with rollup, dev mode is still
driven by nodemon, and `close()` is not called anywhere yet.

Details worth knowing:

- pg-boss v8's `stop()` resolves before pg-boss is actually done shutting down,
  so `stopPgBoss()` waits for the `stopped` event and uses `destroy: true` (which
  also closes pg-boss's connection pool). Without both, restarting the server
  leaks database connections.
- `prisma.$disconnect()` is only generated for apps that have entities, because
  the SDK's Prisma client is `null` when there are none.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
