### PR TITLE
[auth-fixes 1/12] Fix undefined WASP_INSTALL_CMD in `./run test:examples`

### DIFF
--- a/waspc/run
+++ b/waspc/run
@@ -72,7 +72,7 @@ function run_examples_e2e_tests() {
   )
 
   for path in "${paths[@]}"; do
-    if ! eval "(cd $REPOSITORY_ROOT/$path && copy_env_server_example_if_needed && $WASP_INSTALL_CMD && npm run test)"; then
+    if ! eval "(cd $REPOSITORY_ROOT/$path && copy_env_server_example_if_needed && $WASP_CLI_INSTALL_CMD && npm run test)"; then
       echo -e "${RED}E2E tests failed in $path${RESET}"
       return 1
     fi


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (1 of 12). Stacked on `main`.

`waspc/run:75` expanded `$WASP_INSTALL_CMD`, which is never defined anywhere in the script. The real variable is `$WASP_CLI_INSTALL_CMD`, defined at `:38` and used correctly at `:53`.

Because the expansion is empty, the `eval`'d command string ends up with `&& &&` in it, which is a bash syntax error. So `./run test:examples` is a hard failure on the first example, not a silent degradation.

**Reproduction (before).**

```
$ ./run test:examples
Running: run_examples_e2e_tests

./run: eval: line 75: syntax error near unexpected token `&&'
./run: eval: line 75: `(cd /.../examples/tutorials/TodoApp && copy_env_server_example_if_needed &&  && npm run test)'
E2E tests failed in examples/tutorials/TodoApp
EXIT CODE: 1
```

**After.**

```
$ ./run test:examples
Running: run_examples_e2e_tests

[ Wasp ] Starting npm install
[ Wasp ] added 228 packages, and audited 232 packages in 2s
...
```

The install runs and the loop proceeds into the first example's tests.

**Fix.** `$WASP_INSTALL_CMD` → `$WASP_CLI_INSTALL_CMD`.

No generated output changes, so no e2e snapshot update is needed.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended. <!-- Not applicable: this is a repo dev script, verified by running `./run test:examples` itself (output above). -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The `run` script has no test harness. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- Dev-script-only change, nothing user-facing. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- No user-facing change. -->

