### PR TITLE
[auth-fixes 2/12] Fix the `lib-auth` root export and the stale entrypoint names in its README

### DIFF
--- a/waspc/data/Generator/libs/README.md
+++ b/waspc/data/Generator/libs/README.md
@@ -45,7 +45,7 @@ Here's the list of possible exports you can have in a lib:
 
 | Export Path | Node.js | Browser | Description                  |
 | ----------- | ------- | ------- | ---------------------------- |
-| `./index`   | ✅      | ✅      | Code used in both runtimes   |
+| `.`         | ✅      | ✅      | Code used in both runtimes   |
 | `./node`    | ✅      | ❌      | Code used in Node.js runtime |
 | `./browser` | ❌      | ✅      | Code used in browser runtime |
 
@@ -53,7 +53,7 @@ For example, if you have an `auth` lib that has code that's for both runtimes, b
 
 ```json
 "exports": {
-  "./index": {
+  ".": {
     "types": "./dist/index.d.ts",
     "default": "./dist/index.js"
   },

--- a/waspc/data/Generator/libs/auth/README.md
+++ b/waspc/data/Generator/libs/auth/README.md
@@ -4,17 +4,17 @@ This library exports code related to Wasp's auth which is used in the generated 
 
 ## What's inside
 
-The has multiple entry points:
+The library has multiple entry points:
 
-- `sdk` - used in the Wasp SDK in any runtime (`@wasp.sh/lib-auth/sdk`)
-- `sdk/browser` - used in the Wasp SDK in the browser runtime (`@wasp.sh/lib-auth/sdk/browser`)
-- `server` - used in the `server` app (`@wasp.sh/lib-auth/server`)
+- `index` - used in any runtime (`@wasp.sh/lib-auth`)
+- `node` - used in the Node.js runtime (`@wasp.sh/lib-auth/node`)
+- `browser` - used in the browser runtime (`@wasp.sh/lib-auth/browser`)
 
 Read more about the naming convention for exports in the parent [README](../README.md#lib-exports-naming-convention).
 
 ### Lib version
 
-Read more about versioning and why we pin the version to `0.0.0` in the parent [README](../README.md#lib-version).
+Read more about versioning and why we keep the version in sync with the Wasp compiler version in the parent [README](../README.md#lib-version).
 
 ## Development
 

--- a/waspc/data/Generator/libs/auth/package.json
+++ b/waspc/data/Generator/libs/auth/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "exports": {
-    "./index": {
+    ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/auth/wasp.sh-lib-auth-0.26.0.tgz"
         ],
-        "c6f765e681683f621442eb1a4a8045d8d4f92853d3ccd3477dad8f7fa5ede3a5"
+        "35480e2a814f4c24e9bb22f8e6c0a43fbca98c1cf0612108bcf0f4c1302262f0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth/wasp.sh-lib-auth-0.26.0.tgz"
         ],
-        "c6f765e681683f621442eb1a4a8045d8d4f92853d3ccd3477dad8f7fa5ede3a5"
+        "35480e2a814f4c24e9bb22f8e6c0a43fbca98c1cf0612108bcf0f4c1302262f0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth/wasp.sh-lib-auth-0.26.0.tgz"
         ],
-        "c6f765e681683f621442eb1a4a8045d8d4f92853d3ccd3477dad8f7fa5ede3a5"
+        "35480e2a814f4c24e9bb22f8e6c0a43fbca98c1cf0612108bcf0f4c1302262f0"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth/wasp.sh-lib-auth-0.26.0.tgz"
         ],
-        "c6f765e681683f621442eb1a4a8045d8d4f92853d3ccd3477dad8f7fa5ede3a5"
+        "35480e2a814f4c24e9bb22f8e6c0a43fbca98c1cf0612108bcf0f4c1302262f0"
     ],
     [
         [


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (2 of 12). Stacked on `fix/auth-run-examples-install-var`.

Two related problems in the `lib-auth` package:

1. `waspc/data/Generator/libs/auth/README.md` documented entrypoints `sdk`, `sdk/browser` and `server`. None of those exist. It also contained the sentence fragment "The has multiple entry points".
2. `waspc/data/Generator/libs/auth/package.json` declared the neutral entrypoint as the subpath `"./index"`, so the package root `@wasp.sh/lib-auth` did not resolve at all — importing it fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

**Reproduction.** No runtime behaviour changes, both claims are checkable directly:

```
$ grep -n -A10 '"exports"' waspc/data/Generator/libs/auth/package.json
6:  "exports": {
7-    "./index": {
8-      "types": "./dist/index.d.ts",
9-      "default": "./dist/index.js"
```

**Fix.** Corrected the entrypoint names and the typo in the README, and changed the manifest's neutral entrypoint from `"./index"` to `"."` (same `dist/index.*` targets).

`waspc/data/Generator/libs/README.md` is the convention doc, and it states the intended import paths are `@wasp.sh/lib-auth`, `@wasp.sh/lib-auth/node` and `@wasp.sh/lib-auth/browser`. So the manifest was the side that was wrong: nothing in the repo imports `@wasp.sh/lib-auth/index`, the sibling `lib-vite-ssr` already uses `"."`, and `.` is the standard key for a package root. The convention doc's export table and example still showed `"./index"`, which is what the manifest copied, so those are corrected too.

Also fixed a stale line in the lib README that pointed at a "why we pin the version to `0.0.0`" explanation — the parent README says libs are versioned as the current compiler version, and `package.json` says `0.26.0`.

**Note on the snapshot commit.** The README and manifest live inside the `lib-auth` package, which is packed into a tarball that the generated app installs. Changing them changes the tarball's hash, which is recorded in the generated `.waspchecksums`. So this PR carries a snapshot update of four `.waspchecksums` files and nothing else. Regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended. <!-- Not applicable: internal package manifest and README, no runtime behaviour. The generated apps only import `/node` and `/browser`, which are unchanged. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- Documentation and manifest change. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- These are internal READMEs, not user docs. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- Internal package, no user-visible change. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- One bump for the whole series. -->
