### PR TITLE
[auth-fixes 3/12] Fix email verification resend throttle reading the wrong timestamp

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -19,6 +19,7 @@
 - Newly created projects no longer open the browser automatically on `wasp start`. ([#4553](https://github.com/wasp-lang/wasp/pull/4553))
 - Upgraded internal `morgan` to 1.11, which fixes ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Wasp's usage was unaffected by the vulnerability. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
 - The `<region>` argument of `wasp deploy fly` is now case-insensitive, so e.g. `MIA` is accepted instead of being rejected as an invalid region. ([#4588](https://github.com/wasp-lang/wasp/pull/4588))
+- Fixed the throttle on resending the email verification email, which checked when the last password reset email was sent instead of the last verification email. ([#4651](https://github.com/wasp-lang/wasp/pull/4651))
 
 ## 0.25.0
 

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
@@ -91,7 +91,7 @@ export function getSignupRoute({
       // we are not checking if the email was sent or not!
       const { isResendAllowed, timeLeft } = isEmailResendAllowed(
         providerData,
-        'passwordResetSentAt',
+        'emailVerificationSentAt',
       )
       if (!isResendAllowed) {
         throw new HttpError(

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1600,7 +1600,7 @@
             "file",
             "server/src/auth/providers/email/signup.ts"
         ],
-        "cdddee253eaa8b0fa7fd93004793a3a61c119bf5f2033ecc646e4b7b3e3cd7c2"
+        "25074db819296b746625d633b9309e87113ad9122819ba555cb13916d5cc383c"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/signup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/signup.ts
@@ -91,7 +91,7 @@ export function getSignupRoute({
       // we are not checking if the email was sent or not!
       const { isResendAllowed, timeLeft } = isEmailResendAllowed(
         providerData,
-        'passwordResetSentAt',
+        'emailVerificationSentAt',
       )
       if (!isResendAllowed) {
         throw new HttpError(


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (3 of 12). Stacked on `fix/auth-lib-auth-readme-entrypoints`.

`signup.ts` passed `'passwordResetSentAt'` to `isEmailResendAllowed`, but the verification path writes `emailVerificationSentAt`. A fresh signup never sets `passwordResetSentAt`, so the throttle never fired.

**Reproduction (before).** Sign up twice on the same unverified address, back to back:

```
$ curl -X POST /auth/email/signup -d '{"email":"throttle-...@example.com","password":"Password123","username":"throttleuser"}'
{"success":true}
HTTP 200

$ curl -X POST /auth/email/signup -d '{"email":"throttle-...@example.com","password":"Password123","username":"throttleuser"}'
{"success":true}
HTTP 200
```

Second attempt is unthrottled. Each one sends another verification email and, via the delete-and-recreate path at `signup.ts:104`, destroys and recreates the account.

**After.**

```
$ curl -X POST /auth/email/signup -d '{"email":"throttle-...@example.com",...}'
{"success":true}
HTTP 200

$ curl -X POST /auth/email/signup -d '{"email":"throttle-...@example.com",...}'
{"message":"Please wait 60 secs before trying again."}
HTTP 400
```

**Fix.** One word: `'passwordResetSentAt'` → `'emailVerificationSentAt'` in `templates/server/src/auth/providers/email/signup.ts`.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- See the before/after HTTP output above. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated server templates have no unit test harness; verified against a running app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- Documented behaviour is unchanged; the throttle now actually applies. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->


