### PR TITLE
[auth-fixes 4/12] Guard against an unguarded null dereference in `verifyEmail`

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -20,6 +20,7 @@
 - Upgraded internal `morgan` to 1.11, which fixes ([CVE-2026-5078](https://www.cve.org/CVERecord?id=CVE-2026-5078)). Wasp's usage was unaffected by the vulnerability. ([#4573](https://github.com/wasp-lang/wasp/pull/4573))
 - The `<region>` argument of `wasp deploy fly` is now case-insensitive, so e.g. `MIA` is accepted instead of being rejected as an invalid region. ([#4588](https://github.com/wasp-lang/wasp/pull/4588))
 - Fixed the throttle on resending the email verification email, which checked when the last password reset email was sent instead of the last verification email. ([#4651](https://github.com/wasp-lang/wasp/pull/4651))
+- Verifying an email now returns an "invalid credentials" error instead of crashing the server when the account behind the verification link no longer exists. ([#4652](https://github.com/wasp-lang/wasp/pull/4652))
 
 ## 0.25.0
 

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/verifyEmail.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/verifyEmail.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { validateJWT } from 'wasp/server/auth/jwt';
 import {
+  createInvalidCredentialsError,
   createProviderId,
   findAuthIdentity,
   findAuthWithUserBy,
@@ -34,6 +35,10 @@ export async function verifyEmail(
     });
 
     const auth = await findAuthWithUserBy({ id: authIdentity.authId })
+
+    if (auth === null) {
+        throw createInvalidCredentialsError();
+    }
 
     await onAfterEmailVerifiedHook({ req, email, user: auth.user });
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1607,7 +1607,7 @@
             "file",
             "server/src/auth/providers/email/verifyEmail.ts"
         ],
-        "97986f2345b92fb41f2dd9983acb501542512da5f3fe97a0cb20756cadb6f202"
+        "d3b75adf041988926a97b741a5d7cf01d9c96904411ba34242f673c5da02e572"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/verifyEmail.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/verifyEmail.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { validateJWT } from 'wasp/server/auth/jwt';
 import {
+  createInvalidCredentialsError,
   createProviderId,
   findAuthIdentity,
   findAuthWithUserBy,
@@ -34,6 +35,10 @@ export async function verifyEmail(
     });
 
     const auth = await findAuthWithUserBy({ id: authIdentity.authId })
+
+    if (auth === null) {
+        throw createInvalidCredentialsError();
+    }
 
     await onAfterEmailVerifiedHook({ req, email, user: auth.user });
 


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (4 of 12). Stacked on `fix/auth-email-verification-throttle`.

`findAuthWithUserBy` returns `null` when the `Auth` row has no linked `User`, but `verifyEmail.ts` dereferenced `auth.user` without a check. Every other call site guards it.

**Reproduction (before).** Sign up, unlink the `User` from the `Auth` row, then use the still-valid verification token:

```
$ curl -X POST /repro/unlink-user -d '{"email":"orphan-...@example.com"}'
{"ok":true,"authId":"e1f51172-bc14-42c1-8938-002f3b37cbe8","userId":null}
HTTP 200

$ curl -X POST /auth/email/verify-email -d '{"token":"eyJhbGciOiJIUzI1NiIs..."}'
TypeError: Cannot read properties of null (reading 'user')
    at verifyEmail (/.../.wasp/out/server/src/auth/providers/email/verifyEmail.ts:38:61)
HTTP 500
```

**After.**

```
$ curl -X POST /auth/email/verify-email -d '{"token":"eyJhbGciOiJIUzI1NiIs..."}'
{"message":"Invalid credentials","data":{}}
HTTP 401
```

Also caught by the compiler once `strict` is on (the last PR in this series):
`src/auth/providers/email/verifyEmail.ts(38,56): error TS18047: 'auth' is possibly 'null'.`

**Fix.** `if (auth === null) throw createInvalidCredentialsError()` before the hook call.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- See the before/after HTTP output above. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated server templates have no unit test harness; verified against a running app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. The last PR in this series turns on `strict`, which makes the compiler catch this class of bug. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->


