### PR TITLE
[auth-fixes 5/12] Invalidate existing sessions on password reset

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -21,6 +21,7 @@
 - The `<region>` argument of `wasp deploy fly` is now case-insensitive, so e.g. `MIA` is accepted instead of being rejected as an invalid region. ([#4588](https://github.com/wasp-lang/wasp/pull/4588))
 - Fixed the throttle on resending the email verification email, which checked when the last password reset email was sent instead of the last verification email. ([#4651](https://github.com/wasp-lang/wasp/pull/4651))
 - Verifying an email now returns an "invalid credentials" error instead of crashing the server when the account behind the verification link no longer exists. ([#4652](https://github.com/wasp-lang/wasp/pull/4652))
+- Resetting a password now logs the account out everywhere, so sessions created before the reset stop working. ([#4653](https://github.com/wasp-lang/wasp/pull/4653))
 
 ## 0.25.0
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
@@ -76,3 +76,9 @@ async function getAuthUserData(userId: {= userEntityUpper =}['id']): Promise<Aut
 export function invalidateSession(sessionId: string): Promise<void> {
   return auth.invalidateSession(sessionId);
 }
+
+// PRIVATE API
+// Invalidates all sessions belonging to the `authId` in the database
+export function invalidateAllSessionsForAuthId(authId: string): Promise<void> {
+  return auth.invalidateUserSessions(authId);
+}

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
@@ -6,6 +6,7 @@ import {
     getProviderDataWithPassword,
 } from 'wasp/server/auth/utils';
 import { validateJWT } from 'wasp/server/auth/jwt'
+import { invalidateAllSessionsForAuthId } from 'wasp/server/auth/session'
 import { ensureTokenIsPresent, ensurePasswordIsPresent, ensureValidPassword } from 'wasp/auth/validation';
 import { HttpError } from 'wasp/server';
 
@@ -37,6 +38,10 @@ export async function resetPassword(
         // in the DB
         hashedPassword: password,
     });
+
+    // Changing the password invalidates all the existing sessions, so that
+    // somebody who got hold of a session can't keep using it.
+    await invalidateAllSessionsForAuthId(authIdentity.authId);
 
     res.json({ success: true });
 };

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1033,7 +1033,7 @@
             "file",
             "sdk/wasp/server/auth/session.ts"
         ],
-        "296b9b87dbde28fecbb6879c947ba20e5ab11b3ae7c5917b19307cde73871b71"
+        "c72f7c2c3523de4c53b01fdb31b3827466facf4908c8de185302ee37855319b2"
     ],
     [
         [
@@ -1593,7 +1593,7 @@
             "file",
             "server/src/auth/providers/email/resetPassword.ts"
         ],
-        "7c23987065f0bd9871b76243ec8db87321f23c7e85cfbfe97b8fdbbcf6653d25"
+        "8621cf89c4fa6cb14f6b0ca1cf69b53acf63ae454fb070190c5d9d3b5efd0d18"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
@@ -75,3 +75,9 @@ async function getAuthUserData(userId: User['id']): Promise<AuthUserData> {
 export function invalidateSession(sessionId: string): Promise<void> {
   return auth.invalidateSession(sessionId);
 }
+
+// PRIVATE API
+// Invalidates all sessions belonging to the `authId` in the database
+export function invalidateAllSessionsForAuthId(authId: string): Promise<void> {
+  return auth.invalidateUserSessions(authId);
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/resetPassword.ts
@@ -6,6 +6,7 @@ import {
     getProviderDataWithPassword,
 } from 'wasp/server/auth/utils';
 import { validateJWT } from 'wasp/server/auth/jwt'
+import { invalidateAllSessionsForAuthId } from 'wasp/server/auth/session'
 import { ensureTokenIsPresent, ensurePasswordIsPresent, ensureValidPassword } from 'wasp/auth/validation';
 import { HttpError } from 'wasp/server';
 
@@ -37,6 +38,10 @@ export async function resetPassword(
         // in the DB
         hashedPassword: password,
     });
+
+    // Changing the password invalidates all the existing sessions, so that
+    // somebody who got hold of a session can't keep using it.
+    await invalidateAllSessionsForAuthId(authIdentity.authId);
 
     res.json({ success: true });
 };


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (5 of 12). Stacked on `fix/auth-verify-email-null-guard`.

After a successful password reset, sessions issued before the reset stayed live. Wasp had no "invalidate all sessions" primitive at all.

**Reproduction (before).** Log in, reset the password, reuse the old session:

```
$ curl /auth/me -H 'Authorization: Bearer <session>'
{"json":{"id":"44562120-...","username":"resetuser",...}}
HTTP 200

$ curl -X POST /auth/email/reset-password -d '{"token":"...","password":"NewPassword123"}'
{"success":true}
HTTP 200

$ curl /auth/me -H 'Authorization: Bearer <same session>'
{"json":{"id":"44562120-...","username":"resetuser",...}}
HTTP 200
```

The session survives the password change.

**After.**

```
$ curl /auth/me -H 'Authorization: Bearer <same session>'
{"message":"Invalid credentials","data":{}}
HTTP 401
```

**Fix.** Added `invalidateAllSessionsForAuthId(authId)` to `sdk/wasp/server/auth/session.ts` (wraps Lucia's `invalidateUserSessions`) and called it from `resetPassword.ts` after the password write.

**Behaviour change.** Users who reset their password are now logged out everywhere, which is the expected behaviour for a password reset (the whole point is usually that someone else may hold a session).

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- See the before/after HTTP output above. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated server templates have no unit test harness; verified against a running app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- Worth a line in the auth docs when the series lands; flagging for review. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->


