### PR TITLE
[auth-audit 6/14] Await the auth email send instead of firing and forgetting

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
@@ -72,9 +72,16 @@ async function sendEmailAndSaveMetadata(
   const providerData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
   await updateAuthIdentityProviderData<'email'>(providerId, providerData, metadata);
 
-  emailSender.send(content).catch((e) => {
+  // Delivery failures must not change the response. Both `signup` and
+  // `requestPasswordReset` return `{ success: true }` on branches that send
+  // nothing at all (an already-verified account, an unknown address), so
+  // surfacing a send error here would let a caller tell those branches apart
+  // and enumerate registered addresses. Log it for the operator instead.
+  try {
+    await emailSender.send(content);
+  } catch (e) {
     console.error('Failed to send email', e);
-  });
+  }
 }
 
 // PUBLIC API

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/requestPasswordReset.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/requestPasswordReset.ts
@@ -65,8 +65,10 @@ export function getRequestPasswordResetRoute({
                 },
             );
         } catch (e: any) {
-            console.error("Failed to send password reset email:", e);
-            throw new HttpError(500, "Failed to send password reset email.");
+            // `sendPasswordResetEmail` handles delivery failures itself, so
+            // anything reaching here comes from preparing or recording the email.
+            console.error("Failed to prepare the password reset email:", e);
+            throw new HttpError(500, "Failed to prepare the password reset email.");
         }
     
         res.json({ success: true });

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
@@ -150,8 +150,10 @@ export function getSignupRoute({
         ...getVerificationEmailContent({ verificationLink }),
       })
     } catch (e: unknown) {
-      console.error('Failed to send email verification email:', e)
-      throw new HttpError(500, 'Failed to send email verification email.')
+      // `sendEmailVerificationEmail` handles delivery failures itself, so
+      // anything reaching here comes from preparing or recording the email.
+      console.error('Failed to prepare the email verification email:', e)
+      throw new HttpError(500, 'Failed to prepare the email verification email.')
     }
 
     res.json({ success: true })

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -928,7 +928,7 @@
             "file",
             "sdk/wasp/server/auth/email/utils.ts"
         ],
-        "fbfb680c1cfb964be0893f681a7c72150d97631ce1c19bd0543df6903e22b5da"
+        "cb1bf14d97d7cbf0d5b5bed0311ac11d0cee5d61e64c24fef5c47d26ddb331c6"
     ],
     [
         [
@@ -1586,7 +1586,7 @@
             "file",
             "server/src/auth/providers/email/requestPasswordReset.ts"
         ],
-        "3646670b948ccae196e59adf96c46ef4f83781d16b3e87616b3635af8a0553af"
+        "177a5a3bfcd90a40d0f85413bcf271a8d90091a3665766b733f291de0f87dd75"
     ],
     [
         [
@@ -1600,7 +1600,7 @@
             "file",
             "server/src/auth/providers/email/signup.ts"
         ],
-        "25074db819296b746625d633b9309e87113ad9122819ba555cb13916d5cc383c"
+        "93571b8921518e045a2365819b9a92ca49961466eb715f3cf1a9320d0adb398f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/email/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/email/utils.ts
@@ -71,9 +71,16 @@ async function sendEmailAndSaveMetadata(
   const providerData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
   await updateAuthIdentityProviderData<'email'>(providerId, providerData, metadata);
 
-  emailSender.send(content).catch((e) => {
+  // Delivery failures must not change the response. Both `signup` and
+  // `requestPasswordReset` return `{ success: true }` on branches that send
+  // nothing at all (an already-verified account, an unknown address), so
+  // surfacing a send error here would let a caller tell those branches apart
+  // and enumerate registered addresses. Log it for the operator instead.
+  try {
+    await emailSender.send(content);
+  } catch (e) {
     console.error('Failed to send email', e);
-  });
+  }
 }
 
 // PUBLIC API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/requestPasswordReset.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/requestPasswordReset.ts
@@ -65,8 +65,10 @@ export function getRequestPasswordResetRoute({
                 },
             );
         } catch (e: any) {
-            console.error("Failed to send password reset email:", e);
-            throw new HttpError(500, "Failed to send password reset email.");
+            // `sendPasswordResetEmail` handles delivery failures itself, so
+            // anything reaching here comes from preparing or recording the email.
+            console.error("Failed to prepare the password reset email:", e);
+            throw new HttpError(500, "Failed to prepare the password reset email.");
         }
     
         res.json({ success: true });

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/signup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/signup.ts
@@ -150,8 +150,10 @@ export function getSignupRoute({
         ...getVerificationEmailContent({ verificationLink }),
       })
     } catch (e: unknown) {
-      console.error('Failed to send email verification email:', e)
-      throw new HttpError(500, 'Failed to send email verification email.')
+      // `sendEmailVerificationEmail` handles delivery failures itself, so
+      // anything reaching here comes from preparing or recording the email.
+      console.error('Failed to prepare the email verification email:', e)
+      throw new HttpError(500, 'Failed to prepare the email verification email.')
     }
 
     res.json({ success: true })


### PR DESCRIPTION
## Description

Part of the **auth audit** series (6 of 14). Stacked on `fix/auth-reset-password-invalidate-sessions`.

`sendEmailAndSaveMetadata` in `sdk/wasp/server/auth/email/utils.ts` fired the send without awaiting it:

```ts
await updateAuthIdentityProviderData<'email'>(providerId, providerData, metadata);

emailSender.send(content).catch((e) => {
  console.error('Failed to send email', e);
});
```

Three things follow from that, and it's worth being precise about each because the obvious reading of this code is wrong in two of the three:

1. **Delivery failures were already logged.** That inner `.catch` writes them to the console. It is *not* true that a failed send left no trace. What it logs is generic — `'Failed to send email'` — with nothing saying whether it was a verification email or a password reset email, so an operator reading the log can't tell which flow broke.

2. **The call-site `try/catch` never fired for a delivery failure.** The rejection was consumed by that inner `.catch`, so the promise the call site saw always resolved. `throw new HttpError(500, 'Failed to send email verification email.')` was unreachable for the reason its own message names, and callers got `{ success: true }` whether or not the mail server was reachable.

3. **But that `try/catch` was not dead code.** It still caught everything on the lines *above* the send: `findAuthIdentity` returning null (`throw new Error('User with email: … not found.')`) and any database error from `updateAuthIdentityProviderData`. So it fired regularly — just never for sending.

**The real defect is (3) combined with (2): a `catch` block whose message names a cause it can never have.** An operator who saw `Failed to send email verification email.` in production was being pointed at the mail server when the actual fault was the database or a missing auth identity.

## Fix

Move the swallow *inside* `sendEmailAndSaveMetadata`, so that metadata and database errors keep propagating exactly as they do on `main`, and only delivery failures are made non-observable:

```ts
await updateAuthIdentityProviderData<'email'>(providerId, providerData, metadata);

// Delivery failures must not change the response. Both `signup` and
// `requestPasswordReset` return `{ success: true }` on branches that send
// nothing at all (an already-verified account, an unknown address), so
// surfacing a send error here would let a caller tell those branches apart
// and enumerate registered addresses. Log it for the operator instead.
try {
  await emailSender.send(content);
} catch (e) {
  console.error('Failed to send email', e);
}
```

The `await` is kept. It makes the metadata-before-send ordering real rather than incidental, and it makes the error catchable at a defined point instead of arriving on a detached promise.

Then the two call-site messages in `server/src/auth/providers/email/signup.ts` and `requestPasswordReset.ts` are corrected to describe what they can actually catch:

```diff
-      console.error('Failed to send email verification email:', e)
-      throw new HttpError(500, 'Failed to send email verification email.')
+      // `sendEmailVerificationEmail` handles delivery failures itself, so
+      // anything reaching here comes from preparing or recording the email.
+      console.error('Failed to prepare the email verification email:', e)
+      throw new HttpError(500, 'Failed to prepare the email verification email.')
```

## Before/after behaviour

| Endpoint | Send path | `main` | This PR |
| --- | --- | --- | --- |
| `POST /auth/email/signup` | send succeeds | `200 {"success":true}` | `200 {"success":true}` |
| `POST /auth/email/signup` | send fails | `200 {"success":true}`, `Failed to send email` in the log | `200 {"success":true}`, `Failed to send email` in the log |
| `POST /auth/email/request-password-reset` | send succeeds | `200 {"success":true}` | `200 {"success":true}` |
| `POST /auth/email/request-password-reset` | send fails | `200 {"success":true}`, `Failed to send email` in the log | `200 {"success":true}`, `Failed to send email` in the log |

All four cells are `{ success: true }` on both sides. **This PR does not change what any caller sees.** What changes is that the response now waits for the send to settle, and that the two 500 messages no longer misattribute their cause.

## Why awaiting alone would have been wrong

The tempting one-line fix is to replace `.catch(...)` with `await` and let the existing `try/catch` turn a delivery failure into a 500. That would be a security regression.

Both endpoints already return `{ success: true }` on branches that send nothing at all:

- `signup` — when the account exists and is already verified, it calls `doFakeWork()` and returns `{ success: true }` without sending.
- `requestPasswordReset` — when no auth identity matches the address, it calls `doFakeWork()` and returns `{ success: true }` without sending.

Those branches exist precisely so a caller can't tell a registered address from an unregistered one. If a delivery failure produced a 500 while the no-send branches produced a 200, then during any mail outage — which an attacker can often provoke or simply wait for — the status code becomes an oracle: 500 means "this address is registered and we tried to mail it", 200 means "it isn't". `doFakeWork()` exists to close exactly this class of leak; wiring the send failure into the status code would reopen it through a different door.

## What this gives up

A caller can never learn that delivery failed. That is unchanged from `main` — the inner `.catch` already guaranteed it — but it is a real limitation and worth naming rather than leaving implicit. A user whose verification email is dropped by the mail provider sees a successful signup and simply never receives the mail.

Surfacing that properly requires a channel that isn't the response status: a metric, or an `onEmailSendFailed` hook the app can wire to its own alerting. Both are out of scope here.

## Known pre-existing gap, not addressed here

A **database** failure during the metadata write still produces a 500 on the has-identity branch, while the no-identity branch returns 200. That is the same shape of leak as above, through `updateAuthIdentityProviderData` rather than through the send. It is present on `main`, this PR neither introduces nor fixes it, and closing it means deciding what these endpoints should do when the database is down — a separate change. Flagging it so nobody reads this PR as having closed it.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- The `main` column of the table above was reproduced against a running app with `emailSender: { provider: "SMTP" }` pointed at a dead `127.0.0.1:2525`: `POST /auth/email/signup` returned 200 `{"success":true}` and logged `Failed to send email Error: connect ECONNREFUSED 127.0.0.1:2525`. The "This PR" column is the same behaviour by construction — the swallow moved from `.catch()` to `try/catch` around an awaited call — and was not re-run against SMTP. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated server templates have no unit test harness; verified against a running app with a dead SMTP endpoint instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- No user-visible behaviour change, so nothing to document. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- Nothing a user would notice changes: all four response paths are identical to `main`. The other PRs in this series that do change user-visible behaviour carry entries. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- One bump for the whole series, at release-prep time. -->
