### PR TITLE
[auth-fixes 6/12] Add the missing `slack` branch to the `OAuthData` hook type

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -22,6 +22,7 @@
 - Fixed the throttle on resending the email verification email, which checked when the last password reset email was sent instead of the last verification email. ([#4651](https://github.com/wasp-lang/wasp/pull/4651))
 - Verifying an email now returns an "invalid credentials" error instead of crashing the server when the account behind the verification link no longer exists. ([#4652](https://github.com/wasp-lang/wasp/pull/4652))
 - Resetting a password now logs the account out everywhere, so sessions created before the reset stop working. ([#4653](https://github.com/wasp-lang/wasp/pull/4653))
+- The `OAuthData` type your auth hooks receive now properly includes the `slack` provider. ([#4655](https://github.com/wasp-lang/wasp/pull/4655))
 
 ## 0.25.0
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/hooks.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/hooks.ts
@@ -187,5 +187,8 @@ export type OAuthData = {
   {=# enabledProviders.isMicrosoftAuthEnabled =}
   | { providerName: 'microsoft'; tokens: import('arctic').MicrosoftEntraIdTokens }
   {=/ enabledProviders.isMicrosoftAuthEnabled =}
+  {=# enabledProviders.isSlackAuthEnabled =}
+  | { providerName: 'slack'; tokens: import('arctic').SlackTokens }
+  {=/ enabledProviders.isSlackAuthEnabled =}
   | never
 )

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -935,7 +935,7 @@
             "file",
             "sdk/wasp/server/auth/hooks.ts"
         ],
-        "cc3061d8d51ad18e69f3b15e00174b17d172c989ba583094b8fc5d51023ff527"
+        "9ce8ef2582a86b3bc4301f26b7327f38952fc3b4fec7c4930440cac2484475d8"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/hooks.ts
@@ -175,5 +175,6 @@ export type OAuthData = {
   | { providerName: 'discord'; tokens: import('arctic').DiscordTokens }
   | { providerName: 'github'; tokens: import('arctic').GitHubTokens }
   | { providerName: 'microsoft'; tokens: import('arctic').MicrosoftEntraIdTokens }
+  | { providerName: 'slack'; tokens: import('arctic').SlackTokens }
   | never
 )


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (6 of 12). Stacked on `fix/auth-reset-password-invalidate-sessions`.

`sdk/wasp/server/auth/hooks.ts` built the `OAuthData` union from branches for google, discord, github, keycloak and microsoft. There was no slack branch, despite Slack being a supported provider.

This is worse than "the hook type is wrong". With Slack auth enabled, the generated server does not compile at all, so the app will not start.

**Reproduction (before).** `wasp start` on an app with `slack: {}` in `auth.methods`:

```
> @wasp.sh/generated-server@0.0.0 bundle
> tsc --build && rollup --config --silent

src/auth/providers/config/slack.ts(46,46): error TS2322: Type 'Promise<SlackTokens>' is not assignable to type 'Promise<GoogleTokens>'.
  Type 'SlackTokens' is missing the following properties from type 'GoogleTokens': refreshToken, accessTokenExpiresAt
npm error command failed
npm error command sh -c tsc --build && rollup --config --silent
[nodemon] app crashed - waiting for file changes before starting...
```

The Slack provider's tokens get checked against the only other branch in the union.

**After.** The same app boots, and a hook can narrow on `"slack"`:

```ts
export const onAfterLogin: OnAfterLoginHook = async ({ oauth }) => {
  if (oauth?.providerName === "slack") {
    console.log(oauth.tokens.accessToken);
  }
};
```

```
$ npx tsc -p tsconfig.src.json --noEmit
$ echo $?
0
```

That the file is actually being checked — changing `"slack"` to `"slackk"` in the same file:

```
src/repro/slackHook.ts(4,7): error TS2367: This comparison appears to be unintentional because the types '"google" | "slack" | undefined' and '"slackk"' have no overlap.
src/repro/slackHook.ts(5,23): error TS2339: Property 'tokens' does not exist on type 'never'.
```

The union contains `"slack"`.

**Fix.** Added the `{ providerName: 'slack'; tokens: import('arctic').SlackTokens }` branch behind `enabledProviders.isSlackAuthEnabled`. `SlackTokens` is exported by `arctic` (`^1.2.1` resolves to 1.9.2, which has it).

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- App with Slack auth enabled: fails to build before, boots and type-checks after. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated SDK templates have no unit test harness; verified with `tsc` against a real app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->


