### PR TITLE
[auth-audit 8/15] Stop reporting every P2002 as "same identity already exists"

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -170,7 +170,7 @@ export function rethrowPossibleAuthError(e: unknown): void {
   // Prisma code P2002 is for unique constraint violations.
   if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
     throw new HttpError(422, 'Save failed', {
-      message: `user with the same identity already exists`,
+      message: getUniqueConstraintViolationMessage(e),
     })
   }
 
@@ -207,6 +207,46 @@ export function rethrowPossibleAuthError(e: unknown): void {
   }
 
   throw e
+}
+
+// A P2002 can come either from the {= authIdentityEntityUpper =} primary key
+// (the identity really does already exist) or from a unique field on the
+// developer's own {= userEntityUpper =} entity (e.g. `email` written by
+// `userSignupFields`). Those are different problems and need different messages.
+//
+// We only ever name the constraint's fields, never the value that collided.
+function getUniqueConstraintViolationMessage(
+  e: Prisma.PrismaClientKnownRequestError,
+): string {
+  const fields = getUniqueConstraintFields(e)
+
+  if (fields.length === 0) {
+    return 'a record with the same unique field already exists'
+  }
+
+  const isAuthIdentityConstraint = fields.every((field) =>
+    ['providerName', 'providerUserId'].includes(field),
+  )
+  if (isAuthIdentityConstraint) {
+    return 'user with the same identity already exists'
+  }
+
+  return `user with the same ${fields.join(', ')} already exists`
+}
+
+function getUniqueConstraintFields(
+  e: Prisma.PrismaClientKnownRequestError,
+): string[] {
+  // `target` is an array of column names on most connectors, and a single
+  // string on some (e.g. SQLite reports "Model.field").
+  const target = e.meta?.target
+  if (Array.isArray(target)) {
+    return target.filter((field): field is string => typeof field === 'string')
+  }
+  if (typeof target === 'string') {
+    return target.split(',').map((field) => field.trim().split('.').pop()!)
+  }
+  return []
 }
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1040,7 +1040,7 @@
             "file",
             "sdk/wasp/server/auth/utils.ts"
         ],
-        "5b9841dab9d3247727b5c7c74c5a0b11ac29a419e7571211483af1200fe825bc"
+        "a9f8e2840ecbda94ac64528b0f18ff70febc3db51cc9f6545965727959dd8fab"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/utils.ts
@@ -169,7 +169,7 @@ export function rethrowPossibleAuthError(e: unknown): void {
   // Prisma code P2002 is for unique constraint violations.
   if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
     throw new HttpError(422, 'Save failed', {
-      message: `user with the same identity already exists`,
+      message: getUniqueConstraintViolationMessage(e),
     })
   }
 
@@ -206,6 +206,46 @@ export function rethrowPossibleAuthError(e: unknown): void {
   }
 
   throw e
+}
+
+// A P2002 can come either from the AuthIdentity primary key
+// (the identity really does already exist) or from a unique field on the
+// developer's own User entity (e.g. `email` written by
+// `userSignupFields`). Those are different problems and need different messages.
+//
+// We only ever name the constraint's fields, never the value that collided.
+function getUniqueConstraintViolationMessage(
+  e: Prisma.PrismaClientKnownRequestError,
+): string {
+  const fields = getUniqueConstraintFields(e)
+
+  if (fields.length === 0) {
+    return 'a record with the same unique field already exists'
+  }
+
+  const isAuthIdentityConstraint = fields.every((field) =>
+    ['providerName', 'providerUserId'].includes(field),
+  )
+  if (isAuthIdentityConstraint) {
+    return 'user with the same identity already exists'
+  }
+
+  return `user with the same ${fields.join(', ')} already exists`
+}
+
+function getUniqueConstraintFields(
+  e: Prisma.PrismaClientKnownRequestError,
+): string[] {
+  // `target` is an array of column names on most connectors, and a single
+  // string on some (e.g. SQLite reports "Model.field").
+  const target = e.meta?.target
+  if (Array.isArray(target)) {
+    return target.filter((field): field is string => typeof field === 'string')
+  }
+  if (typeof target === 'string') {
+    return target.split(',').map((field) => field.trim().split('.').pop()!)
+  }
+  return []
 }
 
 // PRIVATE API


### PR DESCRIPTION
## Description

Part of the **auth audit** series (8 of 15). Stacked on `fix/auth-slack-oauth-data-type`.

`rethrowPossibleAuthError` mapped every unique-constraint violation (Prisma `P2002`) to the same message. A developer whose `userSignupFields` writes `email` into a `@unique` column on `User` hits this on the second OAuth provider with the same address — and the message is wrong in both halves: the identity is new, and it's the `User` row that collided.

**Reproduction (before).** Two OAuth signups, different `providerUserId`, same email into `User.email`:

```
$ curl -X POST /repro/oauth-create-user -d '{"providerUserId":"g1-...","email":"collide-...@example.com"}'
{"ok":true,"userId":"9309a133-d0d5-4007-a9da-073d5e4c2374"}
HTTP 200

$ curl -X POST /repro/oauth-create-user -d '{"providerUserId":"g2-...","email":"collide-...@example.com"}'
{"message":"Save failed","data":{"message":"user with the same identity already exists"}}
HTTP 422
```

**After.**

```
$ curl -X POST /repro/oauth-create-user -d '{"providerUserId":"g2-...","email":"collide-...@example.com"}'
{"message":"Save failed","data":{"message":"user with the same email already exists"}}
HTTP 422
```

**Fix.** `rethrowPossibleAuthError` now reads `e.meta.target`. If every colliding field is `providerName` or `providerUserId`, the old message is kept — it is accurate there. Otherwise the message names the colliding field(s).

The message contains only constraint field names, never a value, so it leaks nothing an attacker didn't submit. `meta.target` is an array of column names on most connectors and a string on some (SQLite reports `Model.field`); both shapes are handled, and the fallback for a missing `target` is a generic message.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- See the before/after HTTP output above. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated SDK templates have no unit test harness; verified against a running app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- Left for the series' release-prep pass so the 15 PRs don't all conflict on the same file. Note the error message text changes for non-identity collisions. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->
