### PR TITLE
[auth-fixes 7/12] Validate the reset token before the password in `resetPassword`

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -23,6 +23,7 @@
 - Verifying an email now returns an "invalid credentials" error instead of crashing the server when the account behind the verification link no longer exists. ([#4652](https://github.com/wasp-lang/wasp/pull/4652))
 - Resetting a password now logs the account out everywhere, so sessions created before the reset stop working. ([#4653](https://github.com/wasp-lang/wasp/pull/4653))
 - The `OAuthData` type your auth hooks receive now properly includes the `slack` provider. ([#4655](https://github.com/wasp-lang/wasp/pull/4655))
+- Password reset now rejects an invalid or expired token before it looks at the new password, so someone without a valid reset link can no longer probe your app's password rules. ([#4657](https://github.com/wasp-lang/wasp/pull/4657))
 
 ## 0.25.0
 

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
@@ -15,13 +15,17 @@ export async function resetPassword(
     res: Response,
 ): Promise<void> {
     const args = req.body ?? {};
-    ensureValidArgs(args);
+    // NOTE: The token is validated before the password so that an unauthenticated
+    // caller with an invalid token can't learn the deployment's password policy.
+    ensureTokenIsPresent(args);
 
     const { token, password } = args;
     const { email } = await validateJWT<{ email: string }>(token)
         .catch(() => {
             throw new HttpError(400, "Password reset failed, invalid token");
         });
+
+    ensureValidPasswordArg(args);
 
     const providerId = createProviderId('email', email);
     const authIdentity = await findAuthIdentity(providerId);
@@ -46,8 +50,7 @@ export async function resetPassword(
     res.json({ success: true });
 };
 
-function ensureValidArgs(args: object): void {
-    ensureTokenIsPresent(args);
+function ensureValidPasswordArg(args: object): void {
     ensurePasswordIsPresent(args);
     ensureValidPassword(args);
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1593,7 +1593,7 @@
             "file",
             "server/src/auth/providers/email/resetPassword.ts"
         ],
-        "8621cf89c4fa6cb14f6b0ca1cf69b53acf63ae454fb070190c5d9d3b5efd0d18"
+        "f280cb3434c959b47f9fc7ba3ad8ba8921d7f24813c44be8ed8e80538f1fff9c"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/resetPassword.ts
@@ -15,13 +15,17 @@ export async function resetPassword(
     res: Response,
 ): Promise<void> {
     const args = req.body ?? {};
-    ensureValidArgs(args);
+    // NOTE: The token is validated before the password so that an unauthenticated
+    // caller with an invalid token can't learn the deployment's password policy.
+    ensureTokenIsPresent(args);
 
     const { token, password } = args;
     const { email } = await validateJWT<{ email: string }>(token)
         .catch(() => {
             throw new HttpError(400, "Password reset failed, invalid token");
         });
+
+    ensureValidPasswordArg(args);
 
     const providerId = createProviderId('email', email);
     const authIdentity = await findAuthIdentity(providerId);
@@ -46,8 +50,7 @@ export async function resetPassword(
     res.json({ success: true });
 };
 
-function ensureValidArgs(args: object): void {
-    ensureTokenIsPresent(args);
+function ensureValidPasswordArg(args: object): void {
     ensurePasswordIsPresent(args);
     ensureValidPassword(args);
 }


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (7 of 12). Stacked on `fix/auth-slack-oauth-data-type`.

`ensureValidArgs(args)` ran before `validateJWT(token)`, so an unauthenticated caller with a forged token learned the deployment's password policy one rule at a time.

**Reproduction (before).**

```
$ curl -X POST /auth/email/reset-password -d '{"token":"forged.token.value","password":"abc"}'
{"message":"Validation failed","data":{"message":"password must be at least 8 characters"}}
HTTP 422
```

No valid token, and the response describes the policy. Lengthening the password walks to the next rule.

**After.**

```
$ curl -X POST /auth/email/reset-password -d '{"token":"forged.token.value","password":"abc"}'
{"message":"Password reset failed, invalid token"}
HTTP 400
```

**Fix.** Split `ensureValidArgs` into `ensureTokenIsPresent(args)` before `validateJWT` and `ensureValidPasswordArg(args)` after it. The token presence check stays first because `validateJWT(undefined)` needs a defined argument, and it reveals nothing.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- See the before/after HTTP output above. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated server templates have no unit test harness; verified against a running app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->


