### PR TITLE
[auth-fixes 8/12] Return 401 instead of 500 for a session on an unlinked `Auth`

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/lucia.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/lucia.ts
@@ -22,7 +22,7 @@ const prismaAdapter = new PrismaAdapter(
  *    make fetching the User easier.
  */
 export const auth = new Lucia<{}, {
-  userId: {= userEntityUpper =}['id']
+  userId: {= userEntityUpper =}['id'] | null
 }>(prismaAdapter, {
   // Since we are not using cookies, we don't need to set any cookie options.
   // But in the future, if we decide to use cookies, we can set them here.
@@ -47,7 +47,7 @@ declare module "lucia" {
     Lucia: typeof auth;
     DatabaseSessionAttributes: {};
     DatabaseUserAttributes: {
-      userId: {= userEntityUpper =}['id']
+      userId: {= userEntityUpper =}['id'] | null
     };
   }
 }

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
@@ -46,6 +46,11 @@ export async function getSessionAndUserFromSessionId(sessionId: string): Promise
     return null;
   }
 
+  // Such a session can't identify a user, so we treat it as unauthenticated.
+  if (authEntity.userId === null) {
+    return null;
+  }
+
   return {
     session,
     user: await getAuthUserData(authEntity.userId)

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -956,7 +956,7 @@
             "file",
             "sdk/wasp/server/auth/lucia.ts"
         ],
-        "6ad98f2dd688ed660244432f54837a67e7c3534e57a9134994b7dd1a0a579d39"
+        "2d517314735c150c0928a38eaf47329bb9c5b4b4e4d7b5deb6ee8f14fc97422c"
     ],
     [
         [
@@ -1033,7 +1033,7 @@
             "file",
             "sdk/wasp/server/auth/session.ts"
         ],
-        "c72f7c2c3523de4c53b01fdb31b3827466facf4908c8de185302ee37855319b2"
+        "eef71ef3254da456d6c27c0307a0d382d281ec6c7c56503f78c02d0980da478e"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/lucia.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/lucia.ts
@@ -21,7 +21,7 @@ const prismaAdapter = new PrismaAdapter(
  *    make fetching the User easier.
  */
 export const auth = new Lucia<{}, {
-  userId: User['id']
+  userId: User['id'] | null
 }>(prismaAdapter, {
   // Since we are not using cookies, we don't need to set any cookie options.
   // But in the future, if we decide to use cookies, we can set them here.
@@ -46,7 +46,7 @@ declare module "lucia" {
     Lucia: typeof auth;
     DatabaseSessionAttributes: {};
     DatabaseUserAttributes: {
-      userId: User['id']
+      userId: User['id'] | null
     };
   }
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
@@ -45,6 +45,11 @@ export async function getSessionAndUserFromSessionId(sessionId: string): Promise
     return null;
   }
 
+  // Such a session can't identify a user, so we treat it as unauthenticated.
+  if (authEntity.userId === null) {
+    return null;
+  }
+
   return {
     session,
     user: await getAuthUserData(authEntity.userId)


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (8 of 12). Stacked on `fix/auth-reset-password-token-first`.

`Auth.userId` is nullable in the schema, but Lucia's `getUserAttributes` re-declared it as non-null, so `getSessionAndUserFromSessionId` passed `null` straight into a Prisma `findUnique({ where: { id: userId } })`.

**Reproduction (before).** Create an `Auth` row with no `User`, mint a session for it, make an authenticated request:

```
$ curl -X POST /repro/orphan-session
{"authId":"b033e1b3-2f9d-40a0-a302-92835c5b5a9b","sessionId":"gvujrru355xba57gr4axrwhtq62jgkrdxqsw2lh7"}

$ curl /repro/whoami -H 'Authorization: Bearer gvujrru...'
PrismaClientValidationError:
Invalid `.findUnique()` invocation in
/.../.wasp/out/sdk/wasp/dist/server/auth/session.js:35:10
        where: {
      +   id: String
        },
Argument `id` must not be null.
    at async getAuthUserData (.../session.js:34:18)
    at async getSessionAndUserFromSessionId (.../session.js:30:15)
HTTP 500
```

**After.**

```
$ curl /repro/whoami -H 'Authorization: Bearer 2b2d4dy...'
{"message":"Invalid credentials","data":{}}
HTTP 401
```

**Fix.** Declared `userId` as `User['id'] | null` in `lucia.ts` (both the `Lucia<>` type argument and the `DatabaseUserAttributes` augmentation), and returned `null` from `getSessionAndUserFromSessionId` when it is null. A session that cannot identify a user is unauthenticated, not a server error.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- See the before/after HTTP output above. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated SDK templates have no unit test harness; verified against a running app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- Left for the series' release-prep pass so the 15 PRs don't all conflict on the same file. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->

