### PR TITLE
[auth-fixes 9/12] Run `onBeforeSignupHook` before `userSignupFields` on all signup paths

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -24,6 +24,7 @@
 - Resetting a password now logs the account out everywhere, so sessions created before the reset stop working. ([#4653](https://github.com/wasp-lang/wasp/pull/4653))
 - The `OAuthData` type your auth hooks receive now properly includes the `slack` provider. ([#4655](https://github.com/wasp-lang/wasp/pull/4655))
 - Password reset now rejects an invalid or expired token before it looks at the new password, so someone without a valid reset link can no longer probe your app's password rules. ([#4657](https://github.com/wasp-lang/wasp/pull/4657))
+- `onBeforeSignup` now runs before `userSignupFields` on every signup method: email, username and password, and OAuth. ([#4659](https://github.com/wasp-lang/wasp/pull/4659))
 
 ## 0.25.0
 

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
@@ -107,6 +107,14 @@ export function getSignupRoute({
       }
     }
 
+    // The hook runs first so it can veto the signup (by throwing) before the
+    // developer's `userSignupFields` getters run.
+    try {
+      await onBeforeSignupHook({ req, providerId })
+    } catch (e: unknown) {
+      rethrowPossibleAuthError(e)
+    }
+
     const userFields = await validateAndGetUserFields(fields, userSignupFields)
 
     const newUserProviderData = await sanitizeAndSerializeProviderData<'email'>(
@@ -119,7 +127,6 @@ export function getSignupRoute({
     )
 
     try {
-      await onBeforeSignupHook({ req, providerId })
       const user = await createUser(
         providerId,
         newUserProviderData,

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/user.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/user.ts
@@ -111,6 +111,10 @@ async function getAuthIdFromProviderDetails({
 
     return authId
   } else {
+    // The hook runs first so it can veto the signup (by throwing) before the
+    // developer's `userSignupFields` getters run.
+    await onBeforeSignupHook({ req, providerId })
+
     const userFields = await validateAndGetUserFields(
       { profile: providerProfile },
       userSignupFields,
@@ -118,8 +122,7 @@ async function getAuthIdFromProviderDetails({
 
     // For now, we don't have any extra data for the oauth providers, so we just pass an empty object.
     const providerData = await sanitizeAndSerializeProviderData({})
-  
-    await onBeforeSignupHook({ req, providerId })
+
     const user = await createUser(
       providerId,
       providerData,

--- a/waspc/data/Generator/templates/server/src/auth/providers/username/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/username/signup.ts
@@ -24,18 +24,26 @@ export function getSignupRoute({
     const fields = req.body ?? {}
     ensureValidArgs(fields)
 
+    const providerId = createProviderId('username', fields.username)
+
+    // The hook runs first so it can veto the signup (by throwing) before the
+    // developer's `userSignupFields` getters run.
+    try {
+      await onBeforeSignupHook({ req, providerId })
+    } catch (e: unknown) {
+      rethrowPossibleAuthError(e)
+    }
+
     const userFields = await validateAndGetUserFields(
       fields,
       userSignupFields,
     );
 
-    const providerId = createProviderId('username', fields.username)
     const providerData = await sanitizeAndSerializeProviderData<'username'>({
       hashedPassword: fields.password,
     })
 
     try {
-      await onBeforeSignupHook({ req, providerId })
       const user = await createUser(
         providerId,
         providerData,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1600,7 +1600,7 @@
             "file",
             "server/src/auth/providers/email/signup.ts"
         ],
-        "25074db819296b746625d633b9309e87113ad9122819ba555cb13916d5cc383c"
+        "36980d460729b3ae58c2bbee24144cf21909ea77e642f4ad65c75b107455fad8"
     ],
     [
         [
@@ -1663,7 +1663,7 @@
             "file",
             "server/src/auth/providers/oauth/user.ts"
         ],
-        "ed52ae25dc265ee5928374ad5acf19fc4236e1ff0bb9accc335c7419e4df5eff"
+        "70c10d31134efc795abb2f38a3c1a81dbbb21a2806551d74867df1f8a80dee42"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/signup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/signup.ts
@@ -107,6 +107,14 @@ export function getSignupRoute({
       }
     }
 
+    // The hook runs first so it can veto the signup (by throwing) before the
+    // developer's `userSignupFields` getters run.
+    try {
+      await onBeforeSignupHook({ req, providerId })
+    } catch (e: unknown) {
+      rethrowPossibleAuthError(e)
+    }
+
     const userFields = await validateAndGetUserFields(fields, userSignupFields)
 
     const newUserProviderData = await sanitizeAndSerializeProviderData<'email'>(
@@ -119,7 +127,6 @@ export function getSignupRoute({
     )
 
     try {
-      await onBeforeSignupHook({ req, providerId })
       const user = await createUser(
         providerId,
         newUserProviderData,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/user.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/user.ts
@@ -110,6 +110,10 @@ async function getAuthIdFromProviderDetails({
 
     return authId
   } else {
+    // The hook runs first so it can veto the signup (by throwing) before the
+    // developer's `userSignupFields` getters run.
+    await onBeforeSignupHook({ req, providerId })
+
     const userFields = await validateAndGetUserFields(
       { profile: providerProfile },
       userSignupFields,
@@ -117,8 +121,7 @@ async function getAuthIdFromProviderDetails({
 
     // For now, we don't have any extra data for the oauth providers, so we just pass an empty object.
     const providerData = await sanitizeAndSerializeProviderData({})
-  
-    await onBeforeSignupHook({ req, providerId })
+
     const user = await createUser(
       providerId,
       providerData,


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (9 of 12). Stacked on `fix/auth-unlinked-auth-401`.

On every signup path, `validateAndGetUserFields` ran before `onBeforeSignupHook`, so a hook whose documented job is to veto a signup could only do so after the developer's field getters had already run. Those getters are arbitrary user code that may call external services or have side effects, so they should not run for a signup the hook is about to reject.

The three providers were also inconsistent about where the hook sat relative to the rest of the signup work, so this PR moves the call in all of them:

- `server/src/auth/providers/oauth/user.ts`
- `server/src/auth/providers/email/signup.ts`
- `server/src/auth/providers/username/signup.ts`

**Reproduction (before, OAuth path).** A `userSignupFields` with logging getters plus an `onBeforeSignupHook` that throws for any `providerUserId` starting with `veto-`, driven through the real `finishOAuthFlowAndGetRedirectUri` (this needs live Google credentials to reach through a browser, so a script calls the generated server's own function directly — the same function the callback route calls, so the ordering under test is real):

```
$ npx tsx --env-file=.env bug8.ts
providerUserId: veto-1786396344218
[repro] userSignupFields getter ran for username
[repro] userSignupFields getter ran for email
[repro] onBeforeSignupHook ran veto-1786396344218
threw: [repro] onBeforeSignupHook vetoed the signup
```

**After.**

```
$ npx tsx --env-file=.env bug8.ts
providerUserId: veto-1786395984031
[repro] onBeforeSignupHook ran veto-1786395984031
threw: [repro] onBeforeSignupHook vetoed the signup
```

The getters do not run.

**Fix.** Moved the `await onBeforeSignupHook(...)` call above `validateAndGetUserFields` in all three providers. In the username provider this also meant moving `createProviderId` up, since the hook needs the `providerId` (it only depends on the already-validated request fields). In the email provider the hook now sits after the existing-identity handling, exactly where it did before relative to that block, so the anti-enumeration behaviour for an already-verified email is unchanged.

**Error handling is unchanged.** In the email and username providers the hook used to sit inside the same `try` as `createUser` and `onAfterSignupHook`, so errors thrown from it went through `rethrowPossibleAuthError`. Moving it out of that block would have made a Prisma error from the *before* hook surface as a raw 500 while the identical error from the *after* hook still got translated. To avoid that asymmetry, each relocated call gets its own narrow `try`/`catch` calling `rethrowPossibleAuthError`. Field validation stays outside any boundary, as before. The OAuth path needed nothing: its hook sits inside `finishOAuthFlowAndGetRedirectUri`, which `oauth/handler.ts` already calls from a `try { … } catch { rethrowPossibleAuthError }` that this PR doesn't touch.

Deliberately **not** done: adding `providerProfile` to the hook params. Out of scope here.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- See the before/after script output above, driven through the generated server's real OAuth finish function. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated server templates have no unit test harness; verified against a running app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- The auth hooks docs already describe `onBeforeSignup` as the veto point; this makes the code match. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->

