### PR TITLE
[auth-fixes 10/12] Set `sameSite` explicitly on the OAuth state cookies

### DIFF
--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/cookies.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/cookies.ts
@@ -19,6 +19,10 @@ export function setOAuthCookieValue(
   res.cookie(cookieName, value, {
     httpOnly: true,
     secure: !config.isDevelopment,
+    // The OAuth callback is a top-level GET navigation, which `lax` permits.
+    // We set it explicitly because an omitted `sameSite` is not `lax` in every
+    // browser.
+    sameSite: "lax",
     path: "/",
     maxAge: 60 * 60 * 1000, // 1 hour
   });

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1628,7 +1628,7 @@
             "file",
             "server/src/auth/providers/oauth/cookies.ts"
         ],
-        "8171c10fd4a07294f0b1121575bb1a3cfba0859167e3f4dab6004b6eff0d7f73"
+        "15fd04a3866ca2c1b59c2d91e66c20da4030688baf2352019111ae7df389ea10"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/cookies.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/cookies.ts
@@ -19,6 +19,10 @@ export function setOAuthCookieValue(
   res.cookie(cookieName, value, {
     httpOnly: true,
     secure: !config.isDevelopment,
+    // The OAuth callback is a top-level GET navigation, which `lax` permits.
+    // We set it explicitly because an omitted `sameSite` is not `lax` in every
+    // browser.
+    sameSite: "lax",
     path: "/",
     maxAge: 60 * 60 * 1000, // 1 hour
   });


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (10 of 12). Stacked on `fix/auth-oauth-hook-before-signup-fields`.

`setOAuthCookieValue` set `httpOnly`, `secure`, `path` and `maxAge`, but no `sameSite`.

**Reproduction (before).**

```
$ curl -s -i /auth/google/login | grep -i set-cookie
Set-Cookie: google_state=pEmJWXaPdpi8UbxuA-8K1JvtWjHeB1QNsdifRZF-xq4; Max-Age=3600; Path=/; Expires=Mon, 10 Aug 2026 22:12:03 GMT; HttpOnly
Set-Cookie: google_codeVerifier=2WeBSU13TmMZKDBSV5zm1hm94xOWy7QzrcH9PUOzi6g; Max-Age=3600; Path=/; Expires=Mon, 10 Aug 2026 22:12:03 GMT; HttpOnly
```

**After.**

```
$ curl -s -i /auth/google/login | grep -i set-cookie
Set-Cookie: google_state=UwgrKpetGzSceHkEOHNd3zsmkmItWL5fuU0BBOsru8g; Max-Age=3600; Path=/; Expires=Mon, 10 Aug 2026 22:07:13 GMT; HttpOnly; SameSite=Lax
Set-Cookie: google_codeVerifier=tYLAdWrobI6rfbaX0AkToNi15kKDRTLmNTWvwKVLHZE; Max-Age=3600; Path=/; Expires=Mon, 10 Aug 2026 22:07:13 GMT; HttpOnly; SameSite=Lax
```

**Fix.** `sameSite: "lax"`.

This is not only codifying Chrome's default. Firefox and Safari do not apply lax-by-default, so an omitted `sameSite` behaves as `None` there and the state cookie travels on cross-site requests. Setting it explicitly genuinely tightens CSRF protection on those browsers.

No regression: no Wasp provider uses `response_mode=form_post`, and the callback route is registered as a GET, which `Lax` permits. Better Auth, Auth.js and Arctic all set `lax` explicitly.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- See the before/after `Set-Cookie` headers above. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated server templates have no unit test harness; verified against a running app instead. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Same reason. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- Left for the series' release-prep pass so the 15 PRs don't all conflict on the same file. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Same reason: one bump for the whole series. -->

