### PR TITLE
[auth-fixes 11/12] Make `getOAuthCookieValue` declare a return type it can honour

### DIFF
--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/cookies.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/cookies.ts
@@ -32,7 +32,7 @@ export function getOAuthCookieValue(
   provider: ProviderConfig,
   req: ExpressRequest,
   fieldName: OAuthStateFieldName,
-): string {
+): string | undefined {
   const cookieName = `${provider.id}_${fieldName}`;
   const cookies = parseCookies(req.headers.cookie ?? "");
   return cookies.get(cookieName);

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/state.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/state.ts
@@ -134,7 +134,11 @@ function getCodeVerifier(
     req,
     'codeVerifier'
   );
-  return { codeVerifier };
+  // The cookie can be missing (dropped by the browser, or expired while the user
+  // sat on the consent screen). `validateOAuthState` rejects an empty code
+  // verifier, so we normalize the missing case into one instead of lying about
+  // the type.
+  return { codeVerifier: codeVerifier ?? '' };
 }
 
 function isOAuthStateWithPKCE(

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1628,7 +1628,7 @@
             "file",
             "server/src/auth/providers/oauth/cookies.ts"
         ],
-        "15fd04a3866ca2c1b59c2d91e66c20da4030688baf2352019111ae7df389ea10"
+        "1be2e0c1165e2b3cc07fce6d613a004ed42a05dae13b19c8d0f3825e0b9a0a4d"
     ],
     [
         [
@@ -1649,7 +1649,7 @@
             "file",
             "server/src/auth/providers/oauth/state.ts"
         ],
-        "65b028a240f5eaf7b4553be328b784ccffef05792a1fd5f438b795c506292fde"
+        "859a7a244cffb3c6bf6e308b43293c9ad06122dcc73a3fbaa362add8a9ebd3c5"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/cookies.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/cookies.ts
@@ -32,7 +32,7 @@ export function getOAuthCookieValue(
   provider: ProviderConfig,
   req: ExpressRequest,
   fieldName: OAuthStateFieldName,
-): string {
+): string | undefined {
   const cookieName = `${provider.id}_${fieldName}`;
   const cookies = parseCookies(req.headers.cookie ?? "");
   return cookies.get(cookieName);

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/state.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/state.ts
@@ -134,7 +134,11 @@ function getCodeVerifier(
     req,
     'codeVerifier'
   );
-  return { codeVerifier };
+  // The cookie can be missing (dropped by the browser, or expired while the user
+  // sat on the consent screen). `validateOAuthState` rejects an empty code
+  // verifier, so we normalize the missing case into one instead of lying about
+  // the type.
+  return { codeVerifier: codeVerifier ?? '' };
 }
 
 function isOAuthStateWithPKCE(


### PR DESCRIPTION
## Description

Part of the **auth fixes** series (11 of 12). Stacked on `fix/auth-oauth-state-cookie-samesite`.

`getOAuthCookieValue` declared `: string` and returned `Map.get()`, which is `string | undefined`. The lie propagated into `getCodeVerifier`, whose declared `{ codeVerifier: string }` could hold `undefined` whenever the cookie was dropped or expired.

**Reproduction (before).** Under `strict` (the next-but-one PR in this series):

```
src/auth/providers/oauth/cookies.ts(34,3): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
```

Not reachable as a crash today — the `Missing code verifier` guard catches it first — so the failure mode is a type that any new call site would trust and dereference.

**After.** No TSC error; `wasp start` compiles clean.

**Fix.** `getOAuthCookieValue` now returns `string | undefined`. `getCodeVerifier` normalizes a missing cookie to `''`. Runtime behaviour is unchanged in both branches: `undefined` and `''` are equally falsy for `validateOAuthState`'s `!state.codeVerifier` check, and the error ordering (`Invalid code` → `Invalid state` → `Missing code verifier`) is preserved.

This PR sits directly before the `strict` PR because `strict` is what surfaces the problem.

E2E snapshots regenerated with `./run build && ./run test:waspc:e2e:accept-all`, never hand-edited.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- Verified with `tsc` on a real app's generated server, and the OAuth login flow still works. -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- The generated server templates have no unit test harness; the compiler is the check here. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- `strict: true` (next PR in the series) is the regression guard: it fails the build if the return type goes back to lying. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- No user-visible behaviour change; internal type correctness. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- One bump for the whole series, at release-prep time. -->

