### PR TITLE
Type-check the app while `wasp start` runs

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -6,7 +6,7 @@
 
 Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide) for step-by-step documentation on how to upgrade.
 
-- Wasp now runs and bundles your server with Vite, the same way it already did with your client. ([#4645](https://github.com/wasp-lang/wasp/pull/4645), [#4646](https://github.com/wasp-lang/wasp/pull/4646), [#4665](https://github.com/wasp-lang/wasp/pull/4665), [#4667](https://github.com/wasp-lang/wasp/pull/4667), [#4668](https://github.com/wasp-lang/wasp/pull/4668))
+- Wasp now runs and bundles your server with Vite, the same way it already did with your client. ([#4645](https://github.com/wasp-lang/wasp/pull/4645), [#4646](https://github.com/wasp-lang/wasp/pull/4646), [#4665](https://github.com/wasp-lang/wasp/pull/4665), [#4667](https://github.com/wasp-lang/wasp/pull/4667), [#4668](https://github.com/wasp-lang/wasp/pull/4668), [#4669](https://github.com/wasp-lang/wasp/pull/4669))
 
   You must add the `waspServer()` plugin from `wasp/server/vite` to your `vite.config.ts`, otherwise Wasp won't compile your app:
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -25,7 +25,7 @@ Remember to check out the [migration guide](https://wasp.sh/docs/migration-guide
   - `wasp start` now runs a single process for your whole app, so client and server logs share the `[ App ]` prefix. The `[ Client ]` and `[ Server ]` prefixes are now only used by `wasp build start`.
   - Your server restarts in place, in well under a second, and only when you change code it actually uses. Changing client-only code no longer restarts it.
   - An unhandled rejection or an uncaught exception in your server code no longer kills your app in development. Wasp logs it and keeps running until your next change.
-  - Wasp no longer type-checks your server code while you develop, only when it bundles it. `wasp build` still fails on server type errors.
+  - Wasp type-checks your whole app on every change while you develop and reports the errors in the terminal, but it no longer refuses to start your server because of them: types don't exist at runtime, so you can keep trying your app out while you fix them. `wasp build` still fails on type errors.
   - Rollup and nodemon are gone from the generated server's dev dependencies, and so are the `watch` and `bundle-and-start` scripts in `.wasp/out/server/package.json`.
   - The server bundle can now contain shared chunks in `.wasp/out/server/bundle/assets/`, next to `bundle/server.js`. Deployments that copy the whole `bundle` directory (like the Dockerfile Wasp generates) need no changes.
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/vite/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/vite/index.ts
@@ -2,6 +2,7 @@ import { type PluginOption } from "vite";
 import { detectClientImports } from "./plugins/detectClientImports.js";
 import { devRunner } from "./plugins/devRunner.js";
 import { envFile } from "./plugins/envFile.js";
+import { typescriptCheck } from "./plugins/typescriptCheck.js";
 import { virtualUserModules } from "./plugins/virtualUserModules.js";
 import { waspServerConfig } from "./plugins/waspServerConfig.js";
 
@@ -21,5 +22,6 @@ export function waspServer(): PluginOption {
     virtualUserModules(),
     detectClientImports(),
     devRunner(),
+    typescriptCheck(),
   ];
 }

--- a/waspc/data/Generator/templates/sdk/wasp/server/vite/logging.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/vite/logging.ts
@@ -1,0 +1,24 @@
+/**
+ * In development a single process prints the client's logs, the server's logs
+ * and Vite's own, so Wasp's server-side plugins tag what they have to say.
+ */
+const logPrefix = "\x1b[35m[server]\x1b[0m";
+
+/**
+ * We log through `console` instead of Vite's logger because the logger belongs
+ * to a config object, and the config a plugin sees isn't always the one of the
+ * dev server the user is looking at (`wasp:validate-env` resolves a silent
+ * config of its own).
+ */
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function log(message: string): void {
+  console.log(`${logPrefix} ${message}`);
+}
+
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function logError(message: string, error?: unknown): void {
+  console.error(`${logPrefix} ${message}`);
+  if (error !== undefined) {
+    console.error(error);
+  }
+}

--- a/waspc/data/Generator/templates/sdk/wasp/server/vite/plugins/devRunner.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/vite/plugins/devRunner.ts
@@ -7,6 +7,7 @@ import {
   type ViteDevServer,
 } from "vite";
 import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
 
 // PRIVATE API (used by the `wasp:server-env-file` plugin)
 export const DEV_RUNNER_PLUGIN_NAME = "wasp:server-dev-runner";
@@ -314,23 +315,4 @@ function installProcessGuards(): void {
     logError("Uncaught exception in server code:", error);
     log("The dev server is still running, fix the error above and save.");
   });
-}
-
-const logPrefix = "\x1b[35m[server]\x1b[0m";
-
-/**
- * We log through `console` instead of Vite's logger because the logger belongs
- * to a config object, and the config the plugin sees isn't always the one of
- * the dev server the user is looking at (`wasp:validate-env` resolves a silent
- * config of its own).
- */
-function log(message: string): void {
-  console.log(`${logPrefix} ${message}`);
-}
-
-function logError(message: string, error?: unknown): void {
-  console.error(`${logPrefix} ${message}`);
-  if (error !== undefined) {
-    console.error(error);
-  }
 }

--- a/waspc/data/Generator/templates/sdk/wasp/server/vite/plugins/typescriptCheck.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/vite/plugins/typescriptCheck.ts
@@ -1,0 +1,203 @@
+{{={= =}=}}
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { type Plugin, type ViteDevServer } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
+
+/**
+ * The user's TypeScript project: all the code they write, client and server
+ * alike, checked with their own compiler options.
+ *
+ * This is the same project the client's `wasp:typescript-check` plugin checks
+ * when Wasp builds the app for production. The code Wasp generates is checked
+ * by the server's `bundle` script instead: checking it needs the user's
+ * project to be built first, and building it would mean writing files that
+ * nothing reads while the user develops.
+ */
+const srcTsConfigPath = "{= srcTsConfigPath =}";
+
+/**
+ * Wasp regenerates a lot of files at once, so we wait for the burst of changes
+ * to settle instead of checking once per file. Same value as the dev runner's
+ * restart debounce, so a change starts the check and the restart together.
+ */
+const checkDebounceMs = 150;
+
+/**
+ * TSC's incremental cache is the only file the check writes. Reacting to it
+ * would make every check schedule the next one.
+ */
+const tscCacheFileExtension = ".tsbuildinfo";
+
+/**
+ * Type-checks the user's code while they develop it.
+ *
+ * Vite itself never type-checks: it strips the types away without looking at
+ * them. This check runs next to the server instead of in front of it, because
+ * types don't exist at runtime: a type error is worth reporting, but it
+ * shouldn't stop the user from trying their app out.
+ */
+export function typescriptCheck(): Plugin {
+  let viteDevServer: ViteDevServer | undefined;
+  let runningCheck: ChildProcess | undefined;
+  let checkTimeout: NodeJS.Timeout | undefined;
+  let lastReportedErrors: string | undefined;
+
+  function scheduleCheck(): void {
+    clearTimeout(checkTimeout);
+    checkTimeout = setTimeout(runCheck, checkDebounceMs);
+  }
+
+  /**
+   * Whatever a running check is about to say is already out of date, and
+   * letting checks pile up would leave one TypeScript process per change
+   * behind.
+   */
+  function stopRunningCheck(): void {
+    runningCheck?.kill();
+    runningCheck = undefined;
+  }
+
+  function runCheck(): void {
+    if (!viteDevServer) {
+      return;
+    }
+    stopRunningCheck();
+
+    const waspProjectDir = viteDevServer.config.root;
+    const check = spawn(
+      "tsc",
+      [
+        "--project",
+        path.resolve(waspProjectDir, srcTsConfigPath),
+        // Emitting would only slow the check down, and the files TSC writes
+        // would look like changes worth checking again.
+        "--noEmit",
+        // One line per error, which is what we can prefix and forward.
+        "--pretty",
+        "false",
+      ],
+      {
+        cwd: waspProjectDir,
+        // We report TypeScript's output ourselves so it can't get mixed up
+        // with the app's own output.
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      },
+    );
+    runningCheck = check;
+
+    const outputChunks: string[] = [];
+    const collectOutput = (chunk: unknown): void => {
+      outputChunks.push(String(chunk));
+    };
+    check.stdout?.on("data", collectOutput);
+    check.stderr?.on("data", collectOutput);
+
+    check.once("error", (error) => {
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      logError("Wasp couldn't run TypeScript to check your code:", error);
+    });
+
+    check.once("close", (exitCode) => {
+      // A check we stopped ourselves has nothing to say, a newer one is on its
+      // way.
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      reportCheckResult(exitCode, outputChunks.join(""));
+    });
+  }
+
+  function reportCheckResult(exitCode: number | null, output: string): void {
+    if (exitCode === 0) {
+      if (lastReportedErrors !== undefined) {
+        log("No more TypeScript errors.");
+        lastReportedErrors = undefined;
+      }
+      return;
+    }
+    // One change to the user's code makes Wasp regenerate code and rebuild the
+    // SDK, so a single save runs the check a few times. Saying the same thing
+    // over and over would only make the errors harder to read.
+    if (output === lastReportedErrors) {
+      return;
+    }
+    lastReportedErrors = output;
+
+    const outputLines = output
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .filter((line) => line !== "");
+    if (outputLines.length === 0) {
+      logError(
+        `TypeScript stopped with exit code ${exitCode} and said nothing.`,
+      );
+      return;
+    }
+
+    logError("TypeScript found errors in your code:");
+    for (const line of outputLines) {
+      logError(line);
+    }
+    log("Your app keeps running, but `wasp build` fails until you fix them.");
+  }
+
+  return {
+    name: "wasp:dev-typescript-check",
+    // Production builds check the user's code through the
+    // `wasp:typescript-check` plugin and the generated code through the
+    // server's `bundle` script.
+    apply: "serve",
+    // The check covers the whole app, so it must run once per change, not once
+    // per environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.SERVER,
+    configureServer(server) {
+      // Some Vite servers exist only to run a module once (the one
+      // `wasp:validate-env` starts, for example). Nobody watches their output
+      // and they never see a file change.
+      const { httpServer } = server;
+      if (server.config.server.middlewareMode || !httpServer) {
+        return;
+      }
+
+      viteDevServer = server;
+
+      httpServer.once("listening", scheduleCheck);
+    },
+    hotUpdate({ file }) {
+      if (file.endsWith(tscCacheFileExtension)) {
+        return;
+      }
+      // Every environment gets this hook for every changed file, so we ignore
+      // the modules Vite matched: a type error in code the server never
+      // imports (a React component the user hasn't opened yet, for example) is
+      // still an error in their app.
+      scheduleCheck();
+      // Returning nothing leaves the update to the plugins that handle it.
+    },
+    // `closeBundle` is Vite's teardown hook. Without it, a Vite dev server
+    // restart (which happens when, for example, `.env.client` changes) would
+    // leave the running check behind.
+    closeBundle() {
+      // Vite reuses these plugin instances for the temporary server
+      // `wasp:validate-env` starts, so this hook also runs when that server
+      // closes.
+      if (
+        this.environment !==
+        viteDevServer?.environments[ENVIRONMENT_NAMES.SERVER]
+      ) {
+        return;
+      }
+
+      clearTimeout(checkTimeout);
+      stopRunningCheck();
+    },
+  };
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
@@ -804,6 +804,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.js
@@ -816,6 +820,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.js
@@ -924,9 +932,11 @@ wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
 wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/utils.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
+wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/detectClientImports.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/envFile.ts
+wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/virtualUserModules.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/waspServerConfig.ts
 wasp-app/.wasp/out/sdk/wasp/server/webSocket/index.ts

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1278,7 +1278,14 @@
             "file",
             "sdk/wasp/server/vite/index.ts"
         ],
-        "c75a86364ab4a3bece51427db274baa824b289044b3a51b062fdec900078afa3"
+        "1b469cb8d8d6398b29525a248f0f2d5e6db86c0d98442c214aaa80032c9ebd01"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/vite/logging.ts"
+        ],
+        "058311aa7123beaaa3a699b66526d9cacb9ebabfbff128d733d4210508da1da3"
     ],
     [
         [
@@ -1292,7 +1299,7 @@
             "file",
             "sdk/wasp/server/vite/plugins/devRunner.ts"
         ],
-        "47812d05fa520827de14d5c0c8e772c7b0cd2ae68deb62ae821f7a037cf574ec"
+        "47176a5272199b0b5e0ee4fe7cfeb4131e75ef09f7c72a4e5b83e7e3a18af02a"
     ],
     [
         [
@@ -1300,6 +1307,13 @@
             "sdk/wasp/server/vite/plugins/envFile.ts"
         ],
         "de86f0a07793613eaae755ebf235e3815081828a2a54af4852796b7e6bfa7c80"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/vite/plugins/typescriptCheck.ts"
+        ],
+        "14804a9933eab6b85007e46ca0bf31bc501bdac25629660122caa6572f49064f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
@@ -2,6 +2,7 @@ import { type PluginOption } from "vite";
 import { detectClientImports } from "./plugins/detectClientImports.js";
 import { devRunner } from "./plugins/devRunner.js";
 import { envFile } from "./plugins/envFile.js";
+import { typescriptCheck } from "./plugins/typescriptCheck.js";
 import { virtualUserModules } from "./plugins/virtualUserModules.js";
 import { waspServerConfig } from "./plugins/waspServerConfig.js";
 
@@ -21,5 +22,6 @@ export function waspServer(): PluginOption {
     virtualUserModules(),
     detectClientImports(),
     devRunner(),
+    typescriptCheck(),
   ];
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
@@ -1,0 +1,24 @@
+/**
+ * In development a single process prints the client's logs, the server's logs
+ * and Vite's own, so Wasp's server-side plugins tag what they have to say.
+ */
+const logPrefix = "\x1b[35m[server]\x1b[0m";
+
+/**
+ * We log through `console` instead of Vite's logger because the logger belongs
+ * to a config object, and the config a plugin sees isn't always the one of the
+ * dev server the user is looking at (`wasp:validate-env` resolves a silent
+ * config of its own).
+ */
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function log(message: string): void {
+  console.log(`${logPrefix} ${message}`);
+}
+
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function logError(message: string, error?: unknown): void {
+  console.error(`${logPrefix} ${message}`);
+  if (error !== undefined) {
+    console.error(error);
+  }
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
@@ -6,6 +6,7 @@ import {
   type ViteDevServer,
 } from "vite";
 import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
 
 // PRIVATE API (used by the `wasp:server-env-file` plugin)
 export const DEV_RUNNER_PLUGIN_NAME = "wasp:server-dev-runner";
@@ -313,23 +314,4 @@ function installProcessGuards(): void {
     logError("Uncaught exception in server code:", error);
     log("The dev server is still running, fix the error above and save.");
   });
-}
-
-const logPrefix = "\x1b[35m[server]\x1b[0m";
-
-/**
- * We log through `console` instead of Vite's logger because the logger belongs
- * to a config object, and the config the plugin sees isn't always the one of
- * the dev server the user is looking at (`wasp:validate-env` resolves a silent
- * config of its own).
- */
-function log(message: string): void {
-  console.log(`${logPrefix} ${message}`);
-}
-
-function logError(message: string, error?: unknown): void {
-  console.error(`${logPrefix} ${message}`);
-  if (error !== undefined) {
-    console.error(error);
-  }
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
@@ -1,0 +1,202 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { type Plugin, type ViteDevServer } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
+
+/**
+ * The user's TypeScript project: all the code they write, client and server
+ * alike, checked with their own compiler options.
+ *
+ * This is the same project the client's `wasp:typescript-check` plugin checks
+ * when Wasp builds the app for production. The code Wasp generates is checked
+ * by the server's `bundle` script instead: checking it needs the user's
+ * project to be built first, and building it would mean writing files that
+ * nothing reads while the user develops.
+ */
+const srcTsConfigPath = "tsconfig.src.json";
+
+/**
+ * Wasp regenerates a lot of files at once, so we wait for the burst of changes
+ * to settle instead of checking once per file. Same value as the dev runner's
+ * restart debounce, so a change starts the check and the restart together.
+ */
+const checkDebounceMs = 150;
+
+/**
+ * TSC's incremental cache is the only file the check writes. Reacting to it
+ * would make every check schedule the next one.
+ */
+const tscCacheFileExtension = ".tsbuildinfo";
+
+/**
+ * Type-checks the user's code while they develop it.
+ *
+ * Vite itself never type-checks: it strips the types away without looking at
+ * them. This check runs next to the server instead of in front of it, because
+ * types don't exist at runtime: a type error is worth reporting, but it
+ * shouldn't stop the user from trying their app out.
+ */
+export function typescriptCheck(): Plugin {
+  let viteDevServer: ViteDevServer | undefined;
+  let runningCheck: ChildProcess | undefined;
+  let checkTimeout: NodeJS.Timeout | undefined;
+  let lastReportedErrors: string | undefined;
+
+  function scheduleCheck(): void {
+    clearTimeout(checkTimeout);
+    checkTimeout = setTimeout(runCheck, checkDebounceMs);
+  }
+
+  /**
+   * Whatever a running check is about to say is already out of date, and
+   * letting checks pile up would leave one TypeScript process per change
+   * behind.
+   */
+  function stopRunningCheck(): void {
+    runningCheck?.kill();
+    runningCheck = undefined;
+  }
+
+  function runCheck(): void {
+    if (!viteDevServer) {
+      return;
+    }
+    stopRunningCheck();
+
+    const waspProjectDir = viteDevServer.config.root;
+    const check = spawn(
+      "tsc",
+      [
+        "--project",
+        path.resolve(waspProjectDir, srcTsConfigPath),
+        // Emitting would only slow the check down, and the files TSC writes
+        // would look like changes worth checking again.
+        "--noEmit",
+        // One line per error, which is what we can prefix and forward.
+        "--pretty",
+        "false",
+      ],
+      {
+        cwd: waspProjectDir,
+        // We report TypeScript's output ourselves so it can't get mixed up
+        // with the app's own output.
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      },
+    );
+    runningCheck = check;
+
+    const outputChunks: string[] = [];
+    const collectOutput = (chunk: unknown): void => {
+      outputChunks.push(String(chunk));
+    };
+    check.stdout?.on("data", collectOutput);
+    check.stderr?.on("data", collectOutput);
+
+    check.once("error", (error) => {
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      logError("Wasp couldn't run TypeScript to check your code:", error);
+    });
+
+    check.once("close", (exitCode) => {
+      // A check we stopped ourselves has nothing to say, a newer one is on its
+      // way.
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      reportCheckResult(exitCode, outputChunks.join(""));
+    });
+  }
+
+  function reportCheckResult(exitCode: number | null, output: string): void {
+    if (exitCode === 0) {
+      if (lastReportedErrors !== undefined) {
+        log("No more TypeScript errors.");
+        lastReportedErrors = undefined;
+      }
+      return;
+    }
+    // One change to the user's code makes Wasp regenerate code and rebuild the
+    // SDK, so a single save runs the check a few times. Saying the same thing
+    // over and over would only make the errors harder to read.
+    if (output === lastReportedErrors) {
+      return;
+    }
+    lastReportedErrors = output;
+
+    const outputLines = output
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .filter((line) => line !== "");
+    if (outputLines.length === 0) {
+      logError(
+        `TypeScript stopped with exit code ${exitCode} and said nothing.`,
+      );
+      return;
+    }
+
+    logError("TypeScript found errors in your code:");
+    for (const line of outputLines) {
+      logError(line);
+    }
+    log("Your app keeps running, but `wasp build` fails until you fix them.");
+  }
+
+  return {
+    name: "wasp:dev-typescript-check",
+    // Production builds check the user's code through the
+    // `wasp:typescript-check` plugin and the generated code through the
+    // server's `bundle` script.
+    apply: "serve",
+    // The check covers the whole app, so it must run once per change, not once
+    // per environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.SERVER,
+    configureServer(server) {
+      // Some Vite servers exist only to run a module once (the one
+      // `wasp:validate-env` starts, for example). Nobody watches their output
+      // and they never see a file change.
+      const { httpServer } = server;
+      if (server.config.server.middlewareMode || !httpServer) {
+        return;
+      }
+
+      viteDevServer = server;
+
+      httpServer.once("listening", scheduleCheck);
+    },
+    hotUpdate({ file }) {
+      if (file.endsWith(tscCacheFileExtension)) {
+        return;
+      }
+      // Every environment gets this hook for every changed file, so we ignore
+      // the modules Vite matched: a type error in code the server never
+      // imports (a React component the user hasn't opened yet, for example) is
+      // still an error in their app.
+      scheduleCheck();
+      // Returning nothing leaves the update to the plugins that handle it.
+    },
+    // `closeBundle` is Vite's teardown hook. Without it, a Vite dev server
+    // restart (which happens when, for example, `.env.client` changes) would
+    // leave the running check behind.
+    closeBundle() {
+      // Vite reuses these plugin instances for the temporary server
+      // `wasp:validate-env` starts, so this hook also runs when that server
+      // closes.
+      if (
+        this.environment !==
+        viteDevServer?.environments[ENVIRONMENT_NAMES.SERVER]
+      ) {
+        return;
+      }
+
+      clearTimeout(checkTimeout);
+      stopRunningCheck();
+    },
+  };
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/snapshot-file-list.manifest
@@ -352,6 +352,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.js
@@ -364,6 +368,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.js
@@ -431,9 +439,11 @@ wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
 wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/utils.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
+wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/detectClientImports.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/envFile.ts
+wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/virtualUserModules.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/waspServerConfig.ts
 wasp-app/.wasp/out/sdk/wasp/tsconfig.json

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -578,7 +578,14 @@
             "file",
             "sdk/wasp/server/vite/index.ts"
         ],
-        "c75a86364ab4a3bece51427db274baa824b289044b3a51b062fdec900078afa3"
+        "1b469cb8d8d6398b29525a248f0f2d5e6db86c0d98442c214aaa80032c9ebd01"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/vite/logging.ts"
+        ],
+        "058311aa7123beaaa3a699b66526d9cacb9ebabfbff128d733d4210508da1da3"
     ],
     [
         [
@@ -592,7 +599,7 @@
             "file",
             "sdk/wasp/server/vite/plugins/devRunner.ts"
         ],
-        "47812d05fa520827de14d5c0c8e772c7b0cd2ae68deb62ae821f7a037cf574ec"
+        "47176a5272199b0b5e0ee4fe7cfeb4131e75ef09f7c72a4e5b83e7e3a18af02a"
     ],
     [
         [
@@ -600,6 +607,13 @@
             "sdk/wasp/server/vite/plugins/envFile.ts"
         ],
         "de86f0a07793613eaae755ebf235e3815081828a2a54af4852796b7e6bfa7c80"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/vite/plugins/typescriptCheck.ts"
+        ],
+        "14804a9933eab6b85007e46ca0bf31bc501bdac25629660122caa6572f49064f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
@@ -2,6 +2,7 @@ import { type PluginOption } from "vite";
 import { detectClientImports } from "./plugins/detectClientImports.js";
 import { devRunner } from "./plugins/devRunner.js";
 import { envFile } from "./plugins/envFile.js";
+import { typescriptCheck } from "./plugins/typescriptCheck.js";
 import { virtualUserModules } from "./plugins/virtualUserModules.js";
 import { waspServerConfig } from "./plugins/waspServerConfig.js";
 
@@ -21,5 +22,6 @@ export function waspServer(): PluginOption {
     virtualUserModules(),
     detectClientImports(),
     devRunner(),
+    typescriptCheck(),
   ];
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
@@ -1,0 +1,24 @@
+/**
+ * In development a single process prints the client's logs, the server's logs
+ * and Vite's own, so Wasp's server-side plugins tag what they have to say.
+ */
+const logPrefix = "\x1b[35m[server]\x1b[0m";
+
+/**
+ * We log through `console` instead of Vite's logger because the logger belongs
+ * to a config object, and the config a plugin sees isn't always the one of the
+ * dev server the user is looking at (`wasp:validate-env` resolves a silent
+ * config of its own).
+ */
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function log(message: string): void {
+  console.log(`${logPrefix} ${message}`);
+}
+
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function logError(message: string, error?: unknown): void {
+  console.error(`${logPrefix} ${message}`);
+  if (error !== undefined) {
+    console.error(error);
+  }
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
@@ -6,6 +6,7 @@ import {
   type ViteDevServer,
 } from "vite";
 import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
 
 // PRIVATE API (used by the `wasp:server-env-file` plugin)
 export const DEV_RUNNER_PLUGIN_NAME = "wasp:server-dev-runner";
@@ -313,23 +314,4 @@ function installProcessGuards(): void {
     logError("Uncaught exception in server code:", error);
     log("The dev server is still running, fix the error above and save.");
   });
-}
-
-const logPrefix = "\x1b[35m[server]\x1b[0m";
-
-/**
- * We log through `console` instead of Vite's logger because the logger belongs
- * to a config object, and the config the plugin sees isn't always the one of
- * the dev server the user is looking at (`wasp:validate-env` resolves a silent
- * config of its own).
- */
-function log(message: string): void {
-  console.log(`${logPrefix} ${message}`);
-}
-
-function logError(message: string, error?: unknown): void {
-  console.error(`${logPrefix} ${message}`);
-  if (error !== undefined) {
-    console.error(error);
-  }
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
@@ -1,0 +1,202 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { type Plugin, type ViteDevServer } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
+
+/**
+ * The user's TypeScript project: all the code they write, client and server
+ * alike, checked with their own compiler options.
+ *
+ * This is the same project the client's `wasp:typescript-check` plugin checks
+ * when Wasp builds the app for production. The code Wasp generates is checked
+ * by the server's `bundle` script instead: checking it needs the user's
+ * project to be built first, and building it would mean writing files that
+ * nothing reads while the user develops.
+ */
+const srcTsConfigPath = "tsconfig.src.json";
+
+/**
+ * Wasp regenerates a lot of files at once, so we wait for the burst of changes
+ * to settle instead of checking once per file. Same value as the dev runner's
+ * restart debounce, so a change starts the check and the restart together.
+ */
+const checkDebounceMs = 150;
+
+/**
+ * TSC's incremental cache is the only file the check writes. Reacting to it
+ * would make every check schedule the next one.
+ */
+const tscCacheFileExtension = ".tsbuildinfo";
+
+/**
+ * Type-checks the user's code while they develop it.
+ *
+ * Vite itself never type-checks: it strips the types away without looking at
+ * them. This check runs next to the server instead of in front of it, because
+ * types don't exist at runtime: a type error is worth reporting, but it
+ * shouldn't stop the user from trying their app out.
+ */
+export function typescriptCheck(): Plugin {
+  let viteDevServer: ViteDevServer | undefined;
+  let runningCheck: ChildProcess | undefined;
+  let checkTimeout: NodeJS.Timeout | undefined;
+  let lastReportedErrors: string | undefined;
+
+  function scheduleCheck(): void {
+    clearTimeout(checkTimeout);
+    checkTimeout = setTimeout(runCheck, checkDebounceMs);
+  }
+
+  /**
+   * Whatever a running check is about to say is already out of date, and
+   * letting checks pile up would leave one TypeScript process per change
+   * behind.
+   */
+  function stopRunningCheck(): void {
+    runningCheck?.kill();
+    runningCheck = undefined;
+  }
+
+  function runCheck(): void {
+    if (!viteDevServer) {
+      return;
+    }
+    stopRunningCheck();
+
+    const waspProjectDir = viteDevServer.config.root;
+    const check = spawn(
+      "tsc",
+      [
+        "--project",
+        path.resolve(waspProjectDir, srcTsConfigPath),
+        // Emitting would only slow the check down, and the files TSC writes
+        // would look like changes worth checking again.
+        "--noEmit",
+        // One line per error, which is what we can prefix and forward.
+        "--pretty",
+        "false",
+      ],
+      {
+        cwd: waspProjectDir,
+        // We report TypeScript's output ourselves so it can't get mixed up
+        // with the app's own output.
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      },
+    );
+    runningCheck = check;
+
+    const outputChunks: string[] = [];
+    const collectOutput = (chunk: unknown): void => {
+      outputChunks.push(String(chunk));
+    };
+    check.stdout?.on("data", collectOutput);
+    check.stderr?.on("data", collectOutput);
+
+    check.once("error", (error) => {
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      logError("Wasp couldn't run TypeScript to check your code:", error);
+    });
+
+    check.once("close", (exitCode) => {
+      // A check we stopped ourselves has nothing to say, a newer one is on its
+      // way.
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      reportCheckResult(exitCode, outputChunks.join(""));
+    });
+  }
+
+  function reportCheckResult(exitCode: number | null, output: string): void {
+    if (exitCode === 0) {
+      if (lastReportedErrors !== undefined) {
+        log("No more TypeScript errors.");
+        lastReportedErrors = undefined;
+      }
+      return;
+    }
+    // One change to the user's code makes Wasp regenerate code and rebuild the
+    // SDK, so a single save runs the check a few times. Saying the same thing
+    // over and over would only make the errors harder to read.
+    if (output === lastReportedErrors) {
+      return;
+    }
+    lastReportedErrors = output;
+
+    const outputLines = output
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .filter((line) => line !== "");
+    if (outputLines.length === 0) {
+      logError(
+        `TypeScript stopped with exit code ${exitCode} and said nothing.`,
+      );
+      return;
+    }
+
+    logError("TypeScript found errors in your code:");
+    for (const line of outputLines) {
+      logError(line);
+    }
+    log("Your app keeps running, but `wasp build` fails until you fix them.");
+  }
+
+  return {
+    name: "wasp:dev-typescript-check",
+    // Production builds check the user's code through the
+    // `wasp:typescript-check` plugin and the generated code through the
+    // server's `bundle` script.
+    apply: "serve",
+    // The check covers the whole app, so it must run once per change, not once
+    // per environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.SERVER,
+    configureServer(server) {
+      // Some Vite servers exist only to run a module once (the one
+      // `wasp:validate-env` starts, for example). Nobody watches their output
+      // and they never see a file change.
+      const { httpServer } = server;
+      if (server.config.server.middlewareMode || !httpServer) {
+        return;
+      }
+
+      viteDevServer = server;
+
+      httpServer.once("listening", scheduleCheck);
+    },
+    hotUpdate({ file }) {
+      if (file.endsWith(tscCacheFileExtension)) {
+        return;
+      }
+      // Every environment gets this hook for every changed file, so we ignore
+      // the modules Vite matched: a type error in code the server never
+      // imports (a React component the user hasn't opened yet, for example) is
+      // still an error in their app.
+      scheduleCheck();
+      // Returning nothing leaves the update to the plugins that handle it.
+    },
+    // `closeBundle` is Vite's teardown hook. Without it, a Vite dev server
+    // restart (which happens when, for example, `.env.client` changes) would
+    // leave the running check behind.
+    closeBundle() {
+      // Vite reuses these plugin instances for the temporary server
+      // `wasp:validate-env` starts, so this hook also runs when that server
+      // closes.
+      if (
+        this.environment !==
+        viteDevServer?.environments[ENVIRONMENT_NAMES.SERVER]
+      ) {
+        return;
+      }
+
+      clearTimeout(checkTimeout);
+      stopRunningCheck();
+    },
+  };
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/snapshot-file-list.manifest
@@ -350,6 +350,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.js
@@ -362,6 +366,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.js
@@ -429,9 +437,11 @@ wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
 wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/utils.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
+wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/detectClientImports.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/envFile.ts
+wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/virtualUserModules.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/waspServerConfig.ts
 wasp-app/.wasp/out/sdk/wasp/tsconfig.json

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -578,7 +578,14 @@
             "file",
             "sdk/wasp/server/vite/index.ts"
         ],
-        "c75a86364ab4a3bece51427db274baa824b289044b3a51b062fdec900078afa3"
+        "1b469cb8d8d6398b29525a248f0f2d5e6db86c0d98442c214aaa80032c9ebd01"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/vite/logging.ts"
+        ],
+        "058311aa7123beaaa3a699b66526d9cacb9ebabfbff128d733d4210508da1da3"
     ],
     [
         [
@@ -592,7 +599,7 @@
             "file",
             "sdk/wasp/server/vite/plugins/devRunner.ts"
         ],
-        "47812d05fa520827de14d5c0c8e772c7b0cd2ae68deb62ae821f7a037cf574ec"
+        "47176a5272199b0b5e0ee4fe7cfeb4131e75ef09f7c72a4e5b83e7e3a18af02a"
     ],
     [
         [
@@ -600,6 +607,13 @@
             "sdk/wasp/server/vite/plugins/envFile.ts"
         ],
         "de86f0a07793613eaae755ebf235e3815081828a2a54af4852796b7e6bfa7c80"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/vite/plugins/typescriptCheck.ts"
+        ],
+        "14804a9933eab6b85007e46ca0bf31bc501bdac25629660122caa6572f49064f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
@@ -2,6 +2,7 @@ import { type PluginOption } from "vite";
 import { detectClientImports } from "./plugins/detectClientImports.js";
 import { devRunner } from "./plugins/devRunner.js";
 import { envFile } from "./plugins/envFile.js";
+import { typescriptCheck } from "./plugins/typescriptCheck.js";
 import { virtualUserModules } from "./plugins/virtualUserModules.js";
 import { waspServerConfig } from "./plugins/waspServerConfig.js";
 
@@ -21,5 +22,6 @@ export function waspServer(): PluginOption {
     virtualUserModules(),
     detectClientImports(),
     devRunner(),
+    typescriptCheck(),
   ];
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
@@ -1,0 +1,24 @@
+/**
+ * In development a single process prints the client's logs, the server's logs
+ * and Vite's own, so Wasp's server-side plugins tag what they have to say.
+ */
+const logPrefix = "\x1b[35m[server]\x1b[0m";
+
+/**
+ * We log through `console` instead of Vite's logger because the logger belongs
+ * to a config object, and the config a plugin sees isn't always the one of the
+ * dev server the user is looking at (`wasp:validate-env` resolves a silent
+ * config of its own).
+ */
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function log(message: string): void {
+  console.log(`${logPrefix} ${message}`);
+}
+
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function logError(message: string, error?: unknown): void {
+  console.error(`${logPrefix} ${message}`);
+  if (error !== undefined) {
+    console.error(error);
+  }
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
@@ -6,6 +6,7 @@ import {
   type ViteDevServer,
 } from "vite";
 import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
 
 // PRIVATE API (used by the `wasp:server-env-file` plugin)
 export const DEV_RUNNER_PLUGIN_NAME = "wasp:server-dev-runner";
@@ -313,23 +314,4 @@ function installProcessGuards(): void {
     logError("Uncaught exception in server code:", error);
     log("The dev server is still running, fix the error above and save.");
   });
-}
-
-const logPrefix = "\x1b[35m[server]\x1b[0m";
-
-/**
- * We log through `console` instead of Vite's logger because the logger belongs
- * to a config object, and the config the plugin sees isn't always the one of
- * the dev server the user is looking at (`wasp:validate-env` resolves a silent
- * config of its own).
- */
-function log(message: string): void {
-  console.log(`${logPrefix} ${message}`);
-}
-
-function logError(message: string, error?: unknown): void {
-  console.error(`${logPrefix} ${message}`);
-  if (error !== undefined) {
-    console.error(error);
-  }
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
@@ -1,0 +1,202 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { type Plugin, type ViteDevServer } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
+
+/**
+ * The user's TypeScript project: all the code they write, client and server
+ * alike, checked with their own compiler options.
+ *
+ * This is the same project the client's `wasp:typescript-check` plugin checks
+ * when Wasp builds the app for production. The code Wasp generates is checked
+ * by the server's `bundle` script instead: checking it needs the user's
+ * project to be built first, and building it would mean writing files that
+ * nothing reads while the user develops.
+ */
+const srcTsConfigPath = "tsconfig.src.json";
+
+/**
+ * Wasp regenerates a lot of files at once, so we wait for the burst of changes
+ * to settle instead of checking once per file. Same value as the dev runner's
+ * restart debounce, so a change starts the check and the restart together.
+ */
+const checkDebounceMs = 150;
+
+/**
+ * TSC's incremental cache is the only file the check writes. Reacting to it
+ * would make every check schedule the next one.
+ */
+const tscCacheFileExtension = ".tsbuildinfo";
+
+/**
+ * Type-checks the user's code while they develop it.
+ *
+ * Vite itself never type-checks: it strips the types away without looking at
+ * them. This check runs next to the server instead of in front of it, because
+ * types don't exist at runtime: a type error is worth reporting, but it
+ * shouldn't stop the user from trying their app out.
+ */
+export function typescriptCheck(): Plugin {
+  let viteDevServer: ViteDevServer | undefined;
+  let runningCheck: ChildProcess | undefined;
+  let checkTimeout: NodeJS.Timeout | undefined;
+  let lastReportedErrors: string | undefined;
+
+  function scheduleCheck(): void {
+    clearTimeout(checkTimeout);
+    checkTimeout = setTimeout(runCheck, checkDebounceMs);
+  }
+
+  /**
+   * Whatever a running check is about to say is already out of date, and
+   * letting checks pile up would leave one TypeScript process per change
+   * behind.
+   */
+  function stopRunningCheck(): void {
+    runningCheck?.kill();
+    runningCheck = undefined;
+  }
+
+  function runCheck(): void {
+    if (!viteDevServer) {
+      return;
+    }
+    stopRunningCheck();
+
+    const waspProjectDir = viteDevServer.config.root;
+    const check = spawn(
+      "tsc",
+      [
+        "--project",
+        path.resolve(waspProjectDir, srcTsConfigPath),
+        // Emitting would only slow the check down, and the files TSC writes
+        // would look like changes worth checking again.
+        "--noEmit",
+        // One line per error, which is what we can prefix and forward.
+        "--pretty",
+        "false",
+      ],
+      {
+        cwd: waspProjectDir,
+        // We report TypeScript's output ourselves so it can't get mixed up
+        // with the app's own output.
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      },
+    );
+    runningCheck = check;
+
+    const outputChunks: string[] = [];
+    const collectOutput = (chunk: unknown): void => {
+      outputChunks.push(String(chunk));
+    };
+    check.stdout?.on("data", collectOutput);
+    check.stderr?.on("data", collectOutput);
+
+    check.once("error", (error) => {
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      logError("Wasp couldn't run TypeScript to check your code:", error);
+    });
+
+    check.once("close", (exitCode) => {
+      // A check we stopped ourselves has nothing to say, a newer one is on its
+      // way.
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      reportCheckResult(exitCode, outputChunks.join(""));
+    });
+  }
+
+  function reportCheckResult(exitCode: number | null, output: string): void {
+    if (exitCode === 0) {
+      if (lastReportedErrors !== undefined) {
+        log("No more TypeScript errors.");
+        lastReportedErrors = undefined;
+      }
+      return;
+    }
+    // One change to the user's code makes Wasp regenerate code and rebuild the
+    // SDK, so a single save runs the check a few times. Saying the same thing
+    // over and over would only make the errors harder to read.
+    if (output === lastReportedErrors) {
+      return;
+    }
+    lastReportedErrors = output;
+
+    const outputLines = output
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .filter((line) => line !== "");
+    if (outputLines.length === 0) {
+      logError(
+        `TypeScript stopped with exit code ${exitCode} and said nothing.`,
+      );
+      return;
+    }
+
+    logError("TypeScript found errors in your code:");
+    for (const line of outputLines) {
+      logError(line);
+    }
+    log("Your app keeps running, but `wasp build` fails until you fix them.");
+  }
+
+  return {
+    name: "wasp:dev-typescript-check",
+    // Production builds check the user's code through the
+    // `wasp:typescript-check` plugin and the generated code through the
+    // server's `bundle` script.
+    apply: "serve",
+    // The check covers the whole app, so it must run once per change, not once
+    // per environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.SERVER,
+    configureServer(server) {
+      // Some Vite servers exist only to run a module once (the one
+      // `wasp:validate-env` starts, for example). Nobody watches their output
+      // and they never see a file change.
+      const { httpServer } = server;
+      if (server.config.server.middlewareMode || !httpServer) {
+        return;
+      }
+
+      viteDevServer = server;
+
+      httpServer.once("listening", scheduleCheck);
+    },
+    hotUpdate({ file }) {
+      if (file.endsWith(tscCacheFileExtension)) {
+        return;
+      }
+      // Every environment gets this hook for every changed file, so we ignore
+      // the modules Vite matched: a type error in code the server never
+      // imports (a React component the user hasn't opened yet, for example) is
+      // still an error in their app.
+      scheduleCheck();
+      // Returning nothing leaves the update to the plugins that handle it.
+    },
+    // `closeBundle` is Vite's teardown hook. Without it, a Vite dev server
+    // restart (which happens when, for example, `.env.client` changes) would
+    // leave the running check behind.
+    closeBundle() {
+      // Vite reuses these plugin instances for the temporary server
+      // `wasp:validate-env` starts, so this hook also runs when that server
+      // closes.
+      if (
+        this.environment !==
+        viteDevServer?.environments[ENVIRONMENT_NAMES.SERVER]
+      ) {
+        return;
+      }
+
+      clearTimeout(checkTimeout);
+      stopRunningCheck();
+    },
+  };
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/snapshot-file-list.manifest
@@ -361,6 +361,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/index.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/logging.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/detectClientImports.js
@@ -373,6 +377,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/envFile.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/typescriptCheck.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/vite/plugins/virtualUserModules.js
@@ -440,9 +448,11 @@ wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
 wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/utils.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
+wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/detectClientImports.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/envFile.ts
+wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/virtualUserModules.ts
 wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/waspServerConfig.ts
 wasp-app/.wasp/out/sdk/wasp/tsconfig.json

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -585,7 +585,14 @@
             "file",
             "sdk/wasp/server/vite/index.ts"
         ],
-        "c75a86364ab4a3bece51427db274baa824b289044b3a51b062fdec900078afa3"
+        "1b469cb8d8d6398b29525a248f0f2d5e6db86c0d98442c214aaa80032c9ebd01"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/vite/logging.ts"
+        ],
+        "058311aa7123beaaa3a699b66526d9cacb9ebabfbff128d733d4210508da1da3"
     ],
     [
         [
@@ -599,7 +606,7 @@
             "file",
             "sdk/wasp/server/vite/plugins/devRunner.ts"
         ],
-        "47812d05fa520827de14d5c0c8e772c7b0cd2ae68deb62ae821f7a037cf574ec"
+        "47176a5272199b0b5e0ee4fe7cfeb4131e75ef09f7c72a4e5b83e7e3a18af02a"
     ],
     [
         [
@@ -607,6 +614,13 @@
             "sdk/wasp/server/vite/plugins/envFile.ts"
         ],
         "de86f0a07793613eaae755ebf235e3815081828a2a54af4852796b7e6bfa7c80"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/vite/plugins/typescriptCheck.ts"
+        ],
+        "14804a9933eab6b85007e46ca0bf31bc501bdac25629660122caa6572f49064f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/index.ts
@@ -2,6 +2,7 @@ import { type PluginOption } from "vite";
 import { detectClientImports } from "./plugins/detectClientImports.js";
 import { devRunner } from "./plugins/devRunner.js";
 import { envFile } from "./plugins/envFile.js";
+import { typescriptCheck } from "./plugins/typescriptCheck.js";
 import { virtualUserModules } from "./plugins/virtualUserModules.js";
 import { waspServerConfig } from "./plugins/waspServerConfig.js";
 
@@ -21,5 +22,6 @@ export function waspServer(): PluginOption {
     virtualUserModules(),
     detectClientImports(),
     devRunner(),
+    typescriptCheck(),
   ];
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/logging.ts
@@ -1,0 +1,24 @@
+/**
+ * In development a single process prints the client's logs, the server's logs
+ * and Vite's own, so Wasp's server-side plugins tag what they have to say.
+ */
+const logPrefix = "\x1b[35m[server]\x1b[0m";
+
+/**
+ * We log through `console` instead of Vite's logger because the logger belongs
+ * to a config object, and the config a plugin sees isn't always the one of the
+ * dev server the user is looking at (`wasp:validate-env` resolves a silent
+ * config of its own).
+ */
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function log(message: string): void {
+  console.log(`${logPrefix} ${message}`);
+}
+
+// PRIVATE API (used by Wasp's `server` environment plugins)
+export function logError(message: string, error?: unknown): void {
+  console.error(`${logPrefix} ${message}`);
+  if (error !== undefined) {
+    console.error(error);
+  }
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/devRunner.ts
@@ -6,6 +6,7 @@ import {
   type ViteDevServer,
 } from "vite";
 import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
 
 // PRIVATE API (used by the `wasp:server-env-file` plugin)
 export const DEV_RUNNER_PLUGIN_NAME = "wasp:server-dev-runner";
@@ -313,23 +314,4 @@ function installProcessGuards(): void {
     logError("Uncaught exception in server code:", error);
     log("The dev server is still running, fix the error above and save.");
   });
-}
-
-const logPrefix = "\x1b[35m[server]\x1b[0m";
-
-/**
- * We log through `console` instead of Vite's logger because the logger belongs
- * to a config object, and the config the plugin sees isn't always the one of
- * the dev server the user is looking at (`wasp:validate-env` resolves a silent
- * config of its own).
- */
-function log(message: string): void {
-  console.log(`${logPrefix} ${message}`);
-}
-
-function logError(message: string, error?: unknown): void {
-  console.error(`${logPrefix} ${message}`);
-  if (error !== undefined) {
-    console.error(error);
-  }
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/vite/plugins/typescriptCheck.ts
@@ -1,0 +1,202 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { type Plugin, type ViteDevServer } from "vite";
+import { ENVIRONMENT_NAMES } from "../../../vite/constants.js";
+import { log, logError } from "../logging.js";
+
+/**
+ * The user's TypeScript project: all the code they write, client and server
+ * alike, checked with their own compiler options.
+ *
+ * This is the same project the client's `wasp:typescript-check` plugin checks
+ * when Wasp builds the app for production. The code Wasp generates is checked
+ * by the server's `bundle` script instead: checking it needs the user's
+ * project to be built first, and building it would mean writing files that
+ * nothing reads while the user develops.
+ */
+const srcTsConfigPath = "tsconfig.src.json";
+
+/**
+ * Wasp regenerates a lot of files at once, so we wait for the burst of changes
+ * to settle instead of checking once per file. Same value as the dev runner's
+ * restart debounce, so a change starts the check and the restart together.
+ */
+const checkDebounceMs = 150;
+
+/**
+ * TSC's incremental cache is the only file the check writes. Reacting to it
+ * would make every check schedule the next one.
+ */
+const tscCacheFileExtension = ".tsbuildinfo";
+
+/**
+ * Type-checks the user's code while they develop it.
+ *
+ * Vite itself never type-checks: it strips the types away without looking at
+ * them. This check runs next to the server instead of in front of it, because
+ * types don't exist at runtime: a type error is worth reporting, but it
+ * shouldn't stop the user from trying their app out.
+ */
+export function typescriptCheck(): Plugin {
+  let viteDevServer: ViteDevServer | undefined;
+  let runningCheck: ChildProcess | undefined;
+  let checkTimeout: NodeJS.Timeout | undefined;
+  let lastReportedErrors: string | undefined;
+
+  function scheduleCheck(): void {
+    clearTimeout(checkTimeout);
+    checkTimeout = setTimeout(runCheck, checkDebounceMs);
+  }
+
+  /**
+   * Whatever a running check is about to say is already out of date, and
+   * letting checks pile up would leave one TypeScript process per change
+   * behind.
+   */
+  function stopRunningCheck(): void {
+    runningCheck?.kill();
+    runningCheck = undefined;
+  }
+
+  function runCheck(): void {
+    if (!viteDevServer) {
+      return;
+    }
+    stopRunningCheck();
+
+    const waspProjectDir = viteDevServer.config.root;
+    const check = spawn(
+      "tsc",
+      [
+        "--project",
+        path.resolve(waspProjectDir, srcTsConfigPath),
+        // Emitting would only slow the check down, and the files TSC writes
+        // would look like changes worth checking again.
+        "--noEmit",
+        // One line per error, which is what we can prefix and forward.
+        "--pretty",
+        "false",
+      ],
+      {
+        cwd: waspProjectDir,
+        // We report TypeScript's output ourselves so it can't get mixed up
+        // with the app's own output.
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      },
+    );
+    runningCheck = check;
+
+    const outputChunks: string[] = [];
+    const collectOutput = (chunk: unknown): void => {
+      outputChunks.push(String(chunk));
+    };
+    check.stdout?.on("data", collectOutput);
+    check.stderr?.on("data", collectOutput);
+
+    check.once("error", (error) => {
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      logError("Wasp couldn't run TypeScript to check your code:", error);
+    });
+
+    check.once("close", (exitCode) => {
+      // A check we stopped ourselves has nothing to say, a newer one is on its
+      // way.
+      if (runningCheck !== check) {
+        return;
+      }
+      runningCheck = undefined;
+      reportCheckResult(exitCode, outputChunks.join(""));
+    });
+  }
+
+  function reportCheckResult(exitCode: number | null, output: string): void {
+    if (exitCode === 0) {
+      if (lastReportedErrors !== undefined) {
+        log("No more TypeScript errors.");
+        lastReportedErrors = undefined;
+      }
+      return;
+    }
+    // One change to the user's code makes Wasp regenerate code and rebuild the
+    // SDK, so a single save runs the check a few times. Saying the same thing
+    // over and over would only make the errors harder to read.
+    if (output === lastReportedErrors) {
+      return;
+    }
+    lastReportedErrors = output;
+
+    const outputLines = output
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .filter((line) => line !== "");
+    if (outputLines.length === 0) {
+      logError(
+        `TypeScript stopped with exit code ${exitCode} and said nothing.`,
+      );
+      return;
+    }
+
+    logError("TypeScript found errors in your code:");
+    for (const line of outputLines) {
+      logError(line);
+    }
+    log("Your app keeps running, but `wasp build` fails until you fix them.");
+  }
+
+  return {
+    name: "wasp:dev-typescript-check",
+    // Production builds check the user's code through the
+    // `wasp:typescript-check` plugin and the generated code through the
+    // server's `bundle` script.
+    apply: "serve",
+    // The check covers the whole app, so it must run once per change, not once
+    // per environment.
+    applyToEnvironment: (environment) =>
+      environment.name === ENVIRONMENT_NAMES.SERVER,
+    configureServer(server) {
+      // Some Vite servers exist only to run a module once (the one
+      // `wasp:validate-env` starts, for example). Nobody watches their output
+      // and they never see a file change.
+      const { httpServer } = server;
+      if (server.config.server.middlewareMode || !httpServer) {
+        return;
+      }
+
+      viteDevServer = server;
+
+      httpServer.once("listening", scheduleCheck);
+    },
+    hotUpdate({ file }) {
+      if (file.endsWith(tscCacheFileExtension)) {
+        return;
+      }
+      // Every environment gets this hook for every changed file, so we ignore
+      // the modules Vite matched: a type error in code the server never
+      // imports (a React component the user hasn't opened yet, for example) is
+      // still an error in their app.
+      scheduleCheck();
+      // Returning nothing leaves the update to the plugins that handle it.
+    },
+    // `closeBundle` is Vite's teardown hook. Without it, a Vite dev server
+    // restart (which happens when, for example, `.env.client` changes) would
+    // leave the running check behind.
+    closeBundle() {
+      // Vite reuses these plugin instances for the temporary server
+      // `wasp:validate-env` starts, so this hook also runs when that server
+      // closes.
+      if (
+        this.environment !==
+        viteDevServer?.environments[ENVIRONMENT_NAMES.SERVER]
+      ) {
+        return;
+      }
+
+      clearTimeout(checkTimeout);
+      stopRunningCheck();
+    },
+  };
+}

--- a/waspc/src/Wasp/Generator/SdkGenerator/Server/VitePluginG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Server/VitePluginG.hs
@@ -5,6 +5,7 @@ import Data.Maybe (fromJust)
 import StrongPath (Dir, File', Path', Rel, relfile, (</>))
 import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
+import qualified Wasp.AppSpec as AS
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
 import qualified Wasp.Generator.SdkGenerator.Common as C
@@ -23,10 +24,12 @@ genServerVitePlugins :: AppSpec -> Generator [FileDraft]
 genServerVitePlugins spec =
   sequence
     [ genViteIndex,
+      genLogging,
       genWaspServerConfigPlugin spec,
       genDetectClientImportsPlugin,
       genDevRunnerPlugin,
       genEnvFilePlugin,
+      genTypescriptCheckPlugin spec,
       genVirtualUserModulesPlugin spec
     ]
 
@@ -34,6 +37,11 @@ genViteIndex :: Generator FileDraft
 genViteIndex = return $ C.mkTmplFd tmplPath
   where
     tmplPath = C.serverViteDirInSdkTemplatesDir </> [relfile|index.ts|]
+
+genLogging :: Generator FileDraft
+genLogging = return $ C.mkTmplFd tmplPath
+  where
+    tmplPath = C.serverViteDirInSdkTemplatesDir </> [relfile|logging.ts|]
 
 genWaspServerConfigPlugin :: AppSpec -> Generator FileDraft
 genWaspServerConfigPlugin spec = return $ C.mkTmplFdWithData tmplPath tmplData
@@ -67,6 +75,12 @@ genEnvFilePlugin = return $ C.mkTmplFdWithData tmplPath tmplData
   where
     tmplPath = C.serverVitePluginsDirInSdkTemplatesDir </> [relfile|envFile.ts|]
     tmplData = object ["serverEnvFilePath" .= toPosixFilePath serverEnvFileInWaspProjectDir]
+
+genTypescriptCheckPlugin :: AppSpec -> Generator FileDraft
+genTypescriptCheckPlugin spec = return $ C.mkTmplFdWithData tmplPath tmplData
+  where
+    tmplPath = C.serverVitePluginsDirInSdkTemplatesDir </> [relfile|typescriptCheck.ts|]
+    tmplData = object ["srcTsConfigPath" .= SP.fromRelFile (AS.srcTsConfigPath spec)]
 
 serverRootDirInWaspProjectDir :: Path' (Rel WaspProjectDir) (Dir Server.ServerRootDir)
 serverRootDirInWaspProjectDir =

--- a/web/docs/project/custom-vite-config.md
+++ b/web/docs/project/custom-vite-config.md
@@ -22,6 +22,7 @@ The `waspServer()` plugin takes care of the server:
 
 - Declaration of the [`server` environment](#the-server-environment) Wasp runs and bundles your backend with.
 - Running your server inside the Vite dev server during development.
+- [TypeScript type checking](#type-checking) during development.
 - Prevention of client imports in server code.
 
 Here's the minimal required configuration:
@@ -64,6 +65,13 @@ The `waspServer()` plugin declares a [Vite environment](https://vite.dev/guide/a
 - For production, the `npm run bundle` script in `.wasp/out/server` bundles your server through the same environment into `.wasp/out/server/bundle`. Your deployment runs it for you, for example in the Dockerfile `wasp build` generates.
 
 Running `vite build` yourself still means "build the client", it never builds the server.
+
+## Type Checking
+
+Vite doesn't type-check your code, it only strips the types away. Wasp runs TypeScript for you instead:
+
+- While `wasp start` runs, the `waspServer()` plugin type-checks your code (client and server alike) on every change and prints the errors it finds in the terminal. It doesn't hold your app back: types don't exist at runtime, so your server keeps starting and your app keeps running while you fix them.
+- `wasp build` type-checks too, and there a type error does fail the build.
 
 ## Enforced Options
 

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -10792,6 +10792,7 @@ The `waspServer()` plugin takes care of the server:
 
 - Declaration of the [`server` environment](#the-server-environment) Wasp runs and bundles your backend with.
 - Running your server inside the Vite dev server during development.
+- [TypeScript type checking](#type-checking) during development.
 - Prevention of client imports in server code.
 
 Here's the minimal required configuration:
@@ -10818,6 +10819,13 @@ The `waspServer()` plugin declares a [Vite environment](https://vite.dev/guide/a
 - For production, the `npm run bundle` script in `.wasp/out/server` bundles your server through the same environment into `.wasp/out/server/bundle`. Your deployment runs it for you, for example in the Dockerfile `wasp build` generates.
 
 Running `vite build` yourself still means "build the client", it never builds the server.
+
+### Type Checking
+
+Vite doesn't type-check your code, it only strips the types away. Wasp runs TypeScript for you instead:
+
+- While `wasp start` runs, the `waspServer()` plugin type-checks your code (client and server alike) on every change and prints the errors it finds in the terminal. It doesn't hold your app back: types don't exist at runtime, so your server keeps starting and your app keeps running while you fix them.
+- `wasp build` type-checks too, and there a type error does fail the build.
 
 ### Enforced Options
 


### PR DESCRIPTION
Follow-up on the Vite server unification stack (PR 6). Base: `cprecioso/vite-server-cleanup` (#4668).

## Description

PR 4 (#4667) replaced nodemon with Vite's module runner in development. nodemon's
`bundle-and-start` script ran `tsc --build && <bundle> && node`, so every restart
type-checked the app. The Vite dev runner only reports *transform* errors, so
`wasp start` stopped type-checking anything. This PR brings the type check back.

A new `wasp:dev-typescript-check` plugin, exported as part of `waspServer()`,
runs `tsc --project <the user's tsconfig> --noEmit` in a child process on every
change while `wasp start` runs, and reports what it finds under the dev runner's
`[server]` prefix:

```
[server] TypeScript found errors in your code:
[server] src/tasks/actions.ts(84,7): error TS2322: Type 'string' is not assignable to type 'number'.
[server] Your app keeps running, but `wasp build` fails until you fix them.
```

Design notes:

- **Non-blocking.** The check runs beside the restart, not in front of it. Types
  are erased at runtime, so a type error shouldn't stop you from exercising your
  app. Measured added restart latency: none (0.21 s median with the plugin vs
  0.30 s without, on a fresh `wasp new` app; the check is a detached child
  process).
- **Debounced and cancelable.** 150 ms debounce (the dev runner's value, for the
  same reason: Wasp regenerates many files at once), and a check still running
  when a new change arrives is killed, so an edit storm never leaves more than
  one `tsc` behind.
- **`--noEmit`, on the user's project.** The obvious invocation, `tsc --build`
  on the generated server's project, is not usable in development:
  - `tsc --build --noEmit` is rejected outright (`error TS6310: Referenced
    project ... may not disable emit`), so `--build` always writes files. Those
    writes land inside the Vite root, Vite's watcher reports them, and the check
    schedules itself again. With a type error present the project never becomes
    up to date, so it re-emits every run: I hit a real infinite loop with this
    (54 reports in the first 10 s, still climbing).
  - `tsc --project <server tsconfig> --noEmit` can't stand in for it either: in
    non-build mode TSC resolves the referenced project through its *declaration
    output*, so without a prior emit it fails with `TS6305` on every generated
    file that imports user code.
  - Checking the user's project directly has none of those problems, and it is
    what actually reports the user's errors: the generated server code casts
    user operations to `any`, and the server project's own program excludes user
    files from diagnostics. It also covers client-only code, which the server
    project never sees.

  So there is exactly one check, it emits nothing but TSC's incremental cache
  (whose `.tsbuildinfo` writes the plugin ignores), and it is the same command
  the client's build-time `wasp:typescript-check` plugin already runs.
- **Separate plugin, not part of `devRunner.ts`.** The dev runner's shutdown
  race, its `validate-env` environment-identity guard and its promise queue all
  exist because of real failures; this needs none of them beyond "kill the child
  in `closeBundle`", so it stays out of that file. It does reuse the dev
  runner's `[server]` log prefix, which moved into a small shared
  `server/vite/logging.ts` so the two plugins can't drift apart.

Repeated reports are suppressed while the output doesn't change: one save makes
Wasp regenerate code and rebuild the SDK, which runs the check a few times in a
row.

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [x] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->

There are no unit tests for the plugin: it is a TypeScript template with no
Haskell logic to test, and the generator side is covered by the e2e snapshots.
The version is not bumped because `main` is already at `0.26.0`. No dedicated
e2e test either: the behavior is a long-running dev-server interaction, and the
existing `vite-server-build` case already asserts that a type error fails
`npm run bundle`.
