### PR TITLE
Make email verification and password reset tokens one-time use only (#1933)

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/auth/providerData.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/providerData.ts
@@ -4,6 +4,19 @@ export type EmailProviderData = {
   isEmailVerified: boolean;
   emailVerificationSentAt: string | null;
   passwordResetSentAt: string | null;
+  /**
+   * SHA-256 hash of the most recently issued email verification token that
+   * hasn't been used yet. Present only while a token is outstanding and cleared
+   * once it is consumed, so each link/URL can be used at most once. We store the
+   * hash (not the raw token) so a leaked provider data doesn't expose usable
+   * tokens.
+   */
+  outstandingEmailVerificationToken?: string | null;
+  /**
+   * SHA-256 hash of the most recently issued password reset token that hasn't
+   * been used yet. Same semantics as `outstandingEmailVerificationToken`.
+   */
+  outstandingPasswordResetToken?: string | null;
 }
 
 // PUBLIC API
@@ -92,7 +105,12 @@ export function normalizeProviderUserId(providerName: ProviderName, providerUser
 // PUBLIC API
 export function getProviderData<PN extends ProviderName>(
   providerData: string,
-):  Omit<PossibleProviderData[PN], 'hashedPassword'> {
+): Omit<
+  PossibleProviderData[PN],
+  | 'hashedPassword'
+  | 'outstandingEmailVerificationToken'
+  | 'outstandingPasswordResetToken'
+> {
   return sanitizeProviderData(getProviderDataWithPassword(providerData));
 }
 
@@ -106,9 +124,26 @@ export function getProviderDataWithPassword<PN extends ProviderName>(
 
 function sanitizeProviderData<PN extends ProviderName>(
   providerData: PossibleProviderData[PN],
-): Omit<PossibleProviderData[PN], 'hashedPassword'> {
+): Omit<
+  PossibleProviderData[PN],
+  | 'hashedPassword'
+  | 'outstandingEmailVerificationToken'
+  | 'outstandingPasswordResetToken'
+> {
   if (providerDataHasPasswordField(providerData)) {
-    const { hashedPassword, ...rest } = providerData;
+    // The provider stores a password (email or username). Besides the password
+    // hash, we also drop the outstanding one-time token hashes so that they
+    // never reach the client via `getProviderData`.
+    const {
+      hashedPassword,
+      outstandingEmailVerificationToken: _outstandingEmailVerificationToken,
+      outstandingPasswordResetToken: _outstandingPasswordResetToken,
+      ...rest
+    } = providerData as PossibleProviderData[PN] & {
+      hashedPassword: string;
+      outstandingEmailVerificationToken?: string | null;
+      outstandingPasswordResetToken?: string | null;
+    };
     return rest;
   } else {
     return providerData;

--- a/waspc/data/Generator/templates/sdk/wasp/auth/user.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/user.ts
@@ -80,7 +80,12 @@ export type AuthUserData = Omit<CompleteUserEntityWithAuth, '{= authFieldOnUserE
 
 type UserFacingProviderData<PN extends ProviderName> = {
   id: string
-} & Omit<PossibleProviderData[PN], 'hashedPassword'>
+} & Omit<
+  PossibleProviderData[PN],
+  | 'hashedPassword'
+  | 'outstandingEmailVerificationToken'
+  | 'outstandingPasswordResetToken'
+>
 
 // PRIVATE API
 export type CompleteUserEntityWithAuth =

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
@@ -1,4 +1,5 @@
 {{={= =}=}}
+import { randomUUID } from "node:crypto";
 import { createJWT, TimeSpan } from '../jwt.js'
 import { emailSender } from '../../email/index.js';
 import { Email } from '../../email/core/types.js';
@@ -18,7 +19,7 @@ export async function createEmailVerificationLink(
   email: string,
   clientRoute: string,
 ): Promise<string> {
-  const { jwtToken } = await createEmailJWT(email);
+  const { jwtToken } = await createEmailJWT(email, 'verify');
   // Record this token as the outstanding (unused) email verification token so
   // that it can only be used once. Issuing a new token invalidates the previous
   // one, since there is only a single outstanding slot.
@@ -31,15 +32,24 @@ export async function createPasswordResetLink(
   email: string,
   clientRoute: string,
 ): Promise<string>  {
-  const { jwtToken } = await createEmailJWT(email);
+  const { jwtToken } = await createEmailJWT(email, 'reset');
   // Record this token as the outstanding (unused) password reset token so that
   // it can only be used once. Issuing a new token invalidates the previous one.
   await setOutstandingEmailToken(email, jwtToken, 'outstandingPasswordResetToken');
   return `${waspServerConfig.frontendUrl}${clientRoute}?token=${jwtToken}`;
 }
 
-async function createEmailJWT(email: string): Promise<{ jwtToken: string; }> {
-  const jwtToken = await createJWT({ email }, { expiresIn: new TimeSpan(30, "m") });
+type EmailTokenPurpose = 'verify' | 'reset';
+
+// A token is globally unique (via a random `jwtId`) and bound to a single
+// purpose (`verify` or `reset`). This prevents two tokens minted in the same
+// second from colliding, and stops a verification token from being used to
+// reset a password (and vice versa).
+async function createEmailJWT(email: string, purpose: EmailTokenPurpose): Promise<{ jwtToken: string; }> {
+  const jwtToken = await createJWT(
+    { email, purpose },
+    { expiresIn: new TimeSpan(30, "m"), jwtId: randomUUID() },
+  );
   return { jwtToken };
 }
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
@@ -7,6 +7,7 @@ import {
   updateAuthIdentityProviderData,
   findAuthIdentity,
   getProviderDataWithPassword,
+  sha256,
   type EmailProviderData,
 } from '../utils.js';
 import { config as waspServerConfig } from '../../index.js';
@@ -18,6 +19,10 @@ export async function createEmailVerificationLink(
   clientRoute: string,
 ): Promise<string> {
   const { jwtToken } = await createEmailJWT(email);
+  // Record this token as the outstanding (unused) email verification token so
+  // that it can only be used once. Issuing a new token invalidates the previous
+  // one, since there is only a single outstanding slot.
+  await setOutstandingEmailToken(email, jwtToken, 'outstandingEmailVerificationToken');
   return `${waspServerConfig.frontendUrl}${clientRoute}?token=${jwtToken}`;
 }
 
@@ -27,12 +32,35 @@ export async function createPasswordResetLink(
   clientRoute: string,
 ): Promise<string>  {
   const { jwtToken } = await createEmailJWT(email);
+  // Record this token as the outstanding (unused) password reset token so that
+  // it can only be used once. Issuing a new token invalidates the previous one.
+  await setOutstandingEmailToken(email, jwtToken, 'outstandingPasswordResetToken');
   return `${waspServerConfig.frontendUrl}${clientRoute}?token=${jwtToken}`;
 }
 
 async function createEmailJWT(email: string): Promise<{ jwtToken: string; }> {
   const jwtToken = await createJWT({ email }, { expiresIn: new TimeSpan(30, "m") });
   return { jwtToken };
+}
+
+// Stores the SHA-256 hash of the freshly issued one-time token in the user's
+// provider data. We store the hash (not the raw token) so a leaked provider
+// data doesn't expose usable tokens. Overwriting the field invalidates any
+// previously issued token for the same purpose.
+async function setOutstandingEmailToken(
+  email: string,
+  token: string,
+  field: 'outstandingEmailVerificationToken' | 'outstandingPasswordResetToken',
+): Promise<void> {
+  const providerId = createProviderId('email', email);
+  const authIdentity = await findAuthIdentity(providerId);
+  if (!authIdentity) {
+    return;
+  }
+  const providerData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
+  await updateAuthIdentityProviderData<'email'>(providerId, providerData, {
+    [field]: sha256(token),
+  });
 }
 
 // PUBLIC API

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -276,3 +276,61 @@ export function createInvalidCredentialsError(message?: string): HttpError {
 export function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
+
+// PRIVATE API
+/**
+ * Atomically consumes a one-time token (email verification / password reset).
+ *
+ * The outstanding-token check is embedded in the WHERE clause of a single
+ * UPDATE statement (matching the JSON `providerData` fragment
+ * `"<field>":"<sha256(token)>"`), so at most one concurrent request can claim
+ * the token: once the winning request clears the field, any racing request's
+ * WHERE no longer matches and is rejected (count === 0). Each token is globally
+ * unique (minted with a random `jwtId`), and `field` selects the correct
+ * purpose slot.
+ *
+ * `updates` are other provider-data changes applied atomically with the consume
+ * (e.g. `isEmailVerified: true`, or a new raw password under `hashedPassword`,
+ * which is hashed here). The already-stored password hash is left untouched, so
+ * it is not re-hashed.
+ */
+export async function consumeOneTimeToken(
+  providerId: ProviderId,
+  field: 'outstandingEmailVerificationToken' | 'outstandingPasswordResetToken',
+  token: string,
+  updates: Partial<PossibleProviderData['email']>,
+  invalidTokenMessage: string,
+): Promise<{= authIdentityEntityUpper =}> {
+  const authIdentity = await findAuthIdentity(providerId);
+  if (!authIdentity) {
+    throw new HttpError(400, invalidTokenMessage);
+  }
+  const existingProviderData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
+
+  // Only hash the password coming in via `updates` (if any) to avoid re-hashing
+  // the already-stored password hash. Mirrors `updateAuthIdentityProviderData`.
+  const hashedUpdates = await ensurePasswordIsHashed(updates);
+
+  const newProviderData = {
+    ...existingProviderData,
+    ...hashedUpdates,
+    [field]: null,
+  };
+  const serializedProviderData = serializeProviderData<'email'>(newProviderData);
+
+  // Compare-and-set: only update if the stored data still holds this exact
+  // outstanding token hash, and reject (count === 0) if it was already consumed
+  // or replaced by a newer token.
+  const result = await prisma.{= authIdentityEntityLower =}.updateMany({
+    where: {
+      providerName_providerUserId: providerId,
+      providerData: { contains: `"${field}":"${sha256(token)}"` },
+    },
+    data: { providerData: serializedProviderData },
+  });
+  if (result.count === 0) {
+    throw new HttpError(400, invalidTokenMessage);
+  }
+
+  return authIdentity;
+}

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -72,20 +72,61 @@ export async function updateAuthIdentityProviderData<PN extends ProviderName>(
   existingProviderData: PossibleProviderData[PN],
   providerDataUpdates: Partial<PossibleProviderData[PN]>,
 ): Promise<{= authIdentityEntityUpper =}> {
-  // We are doing the sanitization here only on updates to avoid
-  // hashing the password multiple times.
+  // We do the sanitization here only on updates, and early (before the retry
+  // loop) so the retries below never hash the password a second time.
   const sanitizedProviderDataUpdates = await ensurePasswordIsHashed(providerDataUpdates);
-  const newProviderData = {
-    ...existingProviderData,
-    ...sanitizedProviderDataUpdates,
+
+  // `providerData` is the shared, mutable state of an auth identity, and several
+  // flows (token issuance, send-metadata, email verification, password reset)
+  // read-modify-write the same blob. Persisting a whole blob built from a
+  // snapshot can silently overwrite a change another flow just committed (e.g.
+  // restoring a just-consumed token hash, or the old password hash). We therefore
+  // write the full blob with an optimistic compare-and-set: only write when it is
+  // unchanged since it was read, and otherwise re-read the authoritative value,
+  // re-apply our own updates, and retry (bounded).
+  const RETRIES = 5;
+  // The caller's snapshot is the optimistic baseline; on a conflict we fall back
+  // to a fresh read so a concurrent change is never overwritten.
+  let providerData = existingProviderData;
+  let serializedProviderData = serializeProviderData<PN>(providerData);
+
+  for (let attempt = 0; attempt < RETRIES; attempt++) {
+    const newProviderData: PossibleProviderData[PN] = {
+      ...providerData,
+      ...sanitizedProviderDataUpdates,
+    };
+    const newSerializedProviderData = serializeProviderData<PN>(newProviderData);
+
+    const result = await prisma.{= authIdentityEntityLower =}.updateMany({
+      where: {
+        providerName: providerId.providerName,
+        providerUserId: providerId.providerUserId,
+        providerData: serializedProviderData,
+      },
+      data: { providerData: newSerializedProviderData },
+    });
+    if (result.count === 1) {
+      // updateMany doesn't return the row; re-read it so callers get the updated
+      // identity.
+      const updated = await findAuthIdentity(providerId);
+      if (updated === null) {
+        throw new HttpError(500, 'Auth identity not found after update');
+      }
+      return updated;
+    }
+
+    // Lost the race: providerData changed after we read it. Re-read the
+    // authoritative value and retry, applying our updates on top of it so the
+    // concurrent change is preserved.
+    const fresh = await findAuthIdentity(providerId);
+    if (fresh === null) {
+      throw new HttpError(404, 'Auth identity not found');
+    }
+    providerData = getProviderDataWithPassword<PN>(fresh.providerData);
+    serializedProviderData = fresh.providerData;
   }
-  const serializedProviderData = await serializeProviderData<PN>(newProviderData);
-  return prisma.{= authIdentityEntityLower =}.update({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    data: { providerData: serializedProviderData },
-  });
+
+  throw new HttpError(409, 'Failed to update auth identity provider data');
 }
 
 // PRIVATE API

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -278,21 +278,26 @@ export function sha256(value: string): string {
 }
 
 // PRIVATE API
+const ONE_TIME_TOKEN_CONSUME_RETRIES = 5;
+
+// PRIVATE API
 /**
  * Atomically consumes a one-time token (email verification / password reset).
  *
- * The outstanding-token check is embedded in the WHERE clause of a single
- * UPDATE statement (matching the JSON `providerData` fragment
- * `"<field>":"<sha256(token)>"`), so at most one concurrent request can claim
- * the token: once the winning request clears the field, any racing request's
- * WHERE no longer matches and is rejected (count === 0). Each token is globally
- * unique (minted with a random `jwtId`), and `field` selects the correct
- * purpose slot.
+ * This is an optimistic compare-and-set: the single `updateMany` only writes
+ * when the `providerData` value is byte-for-byte unchanged since it was read,
+ * so at most one concurrent request can claim a token, and a concurrent consume
+ * of the *other* purpose can't be overwritten (which would resurrect a consumed
+ * hash). If the write loses the race (the blob changed), we re-read the
+ * authoritative value and retry, up to `ONE_TIME_TOKEN_CONSUME_RETRIES`.
  *
- * `updates` are other provider-data changes applied atomically with the consume
- * (e.g. `isEmailVerified: true`, or a new raw password under `hashedPassword`,
- * which is hashed here). The already-stored password hash is left untouched, so
- * it is not re-hashed.
+ * Tokens are globally unique (minted with a random `jwtId`) and stored only as
+ * SHA-256 hashes; `field` selects the correct purpose slot.
+ *
+ * `updates` are other provider-data changes applied with the consume (e.g.
+ * `isEmailVerified: true`, or a new raw password under `hashedPassword`, which
+ * is hashed here). The already-stored password hash is left untouched, so it is
+ * not re-hashed.
  */
 export async function consumeOneTimeToken(
   providerId: ProviderId,
@@ -301,36 +306,45 @@ export async function consumeOneTimeToken(
   updates: Partial<PossibleProviderData['email']>,
   invalidTokenMessage: string,
 ): Promise<{= authIdentityEntityUpper =}> {
-  const authIdentity = await findAuthIdentity(providerId);
-  if (!authIdentity) {
-    throw new HttpError(400, invalidTokenMessage);
+  const tokenHash = sha256(token);
+
+  for (let attempt = 0; attempt < ONE_TIME_TOKEN_CONSUME_RETRIES; attempt++) {
+    const authIdentity = await findAuthIdentity(providerId);
+    if (!authIdentity) {
+      throw new HttpError(400, invalidTokenMessage);
+    }
+    const existingProviderData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
+
+    // Reject immediately if this is no longer the current outstanding token
+    // (already consumed, or superseded by a newly issued token).
+    if (existingProviderData[field] !== tokenHash) {
+      throw new HttpError(400, invalidTokenMessage);
+    }
+
+    // Only hash the password coming in via `updates` (if any) to avoid re-hashing
+    // the already-stored password hash. Mirrors `updateAuthIdentityProviderData`.
+    const hashedUpdates = await ensurePasswordIsHashed(updates);
+
+    const serializedProviderData = serializeProviderData<'email'>({
+      ...existingProviderData,
+      ...hashedUpdates,
+      [field]: null,
+    });
+
+    // Compare-and-set on the exact `providerData` value we read above. If any
+    // field changed concurrently, this matches 0 rows and we loop to re-read.
+    const result = await prisma.{= authIdentityEntityLower =}.updateMany({
+      where: {
+        providerName: providerId.providerName,
+        providerUserId: providerId.providerUserId,
+        providerData: authIdentity.providerData,
+      },
+      data: { providerData: serializedProviderData },
+    });
+    if (result.count === 1) {
+      return authIdentity;
+    }
   }
-  const existingProviderData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
 
-  // Only hash the password coming in via `updates` (if any) to avoid re-hashing
-  // the already-stored password hash. Mirrors `updateAuthIdentityProviderData`.
-  const hashedUpdates = await ensurePasswordIsHashed(updates);
-
-  const newProviderData = {
-    ...existingProviderData,
-    ...hashedUpdates,
-    [field]: null,
-  };
-  const serializedProviderData = serializeProviderData<'email'>(newProviderData);
-
-  // Compare-and-set: only update if the stored data still holds this exact
-  // outstanding token hash, and reject (count === 0) if it was already consumed
-  // or replaced by a newer token.
-  const result = await prisma.{= authIdentityEntityLower =}.updateMany({
-    where: {
-      providerName_providerUserId: providerId,
-      providerData: { contains: `"${field}":"${sha256(token)}"` },
-    },
-    data: { providerData: serializedProviderData },
-  });
-  if (result.count === 0) {
-    throw new HttpError(400, invalidTokenMessage);
-  }
-
-  return authIdentity;
+  throw new HttpError(400, invalidTokenMessage);
 }

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -322,6 +322,42 @@ export function sha256(value: string): string {
 const ONE_TIME_TOKEN_CONSUME_RETRIES = 5;
 
 // PRIVATE API
+// Returns the auth identity whose currently outstanding token for the given
+// purpose slot equals `tokenHash`; otherwise throws `invalidTokenMessage`. This
+// is the single place that defines what "outstanding" means: not consumed, and
+// not superseded by a newer token.
+async function findAuthIdentityWithOutstandingToken(
+  providerId: ProviderId,
+  field: 'outstandingEmailVerificationToken' | 'outstandingPasswordResetToken',
+  tokenHash: string,
+  invalidTokenMessage: string,
+): Promise<{= authIdentityEntityUpper =}> {
+  const authIdentity = await findAuthIdentity(providerId);
+  if (!authIdentity) {
+    throw new HttpError(400, invalidTokenMessage);
+  }
+  const providerData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
+  if (providerData[field] !== tokenHash) {
+    throw new HttpError(400, invalidTokenMessage);
+  }
+  return authIdentity;
+}
+
+// PRIVATE API
+// Throws `invalidTokenMessage` if `token` is not currently outstanding for the
+// given purpose slot (no such auth identity, already consumed, or superseded by
+// a newer token). Callers use this to reject spent tokens before doing work that
+// must not be reachable with an invalid token (e.g. password-policy validation).
+export async function ensureTokenIsOutstanding(
+  providerId: ProviderId,
+  field: 'outstandingEmailVerificationToken' | 'outstandingPasswordResetToken',
+  token: string,
+  invalidTokenMessage: string,
+): Promise<void> {
+  await findAuthIdentityWithOutstandingToken(providerId, field, sha256(token), invalidTokenMessage);
+}
+
+// PRIVATE API
 /**
  * Atomically consumes a one-time token (email verification / password reset).
  *
@@ -350,17 +386,10 @@ export async function consumeOneTimeToken(
   const tokenHash = sha256(token);
 
   for (let attempt = 0; attempt < ONE_TIME_TOKEN_CONSUME_RETRIES; attempt++) {
-    const authIdentity = await findAuthIdentity(providerId);
-    if (!authIdentity) {
-      throw new HttpError(400, invalidTokenMessage);
-    }
+    // Re-read and re-check the outstanding token on every attempt, so a token
+    // consumed concurrently is rejected (exactly one consume wins).
+    const authIdentity = await findAuthIdentityWithOutstandingToken(providerId, field, tokenHash, invalidTokenMessage);
     const existingProviderData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
-
-    // Reject immediately if this is no longer the current outstanding token
-    // (already consumed, or superseded by a newly issued token).
-    if (existingProviderData[field] !== tokenHash) {
-      throw new HttpError(400, invalidTokenMessage);
-    }
 
     // Only hash the password coming in via `updates` (if any) to avoid re-hashing
     // the already-stored password hash. Mirrors `updateAuthIdentityProviderData`.

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -1,4 +1,5 @@
 {{={= =}=}}
+import { createHash } from "node:crypto";
 import { hashPassword } from './password.js'
 import { prisma, HttpError } from '../index.js'
 import { sleep } from '../utils.js'
@@ -266,4 +267,12 @@ async function ensurePasswordIsHashed<PN extends ProviderName>(
 // PRIVATE API
 export function createInvalidCredentialsError(message?: string): HttpError {
   return new HttpError(401, 'Invalid credentials', { message })
+}
+
+// PRIVATE API
+// One-time tokens (e.g. email verification, password reset) are stored in the
+// user's provider data only as SHA-256 hashes, so a leaked DB doesn't directly
+// reveal usable tokens. We compare an incoming token against its hash.
+export function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
 }

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
@@ -4,6 +4,7 @@ import {
     findAuthIdentity,
     updateAuthIdentityProviderData,
     getProviderDataWithPassword,
+    sha256,
 } from 'wasp/server/auth/utils';
 import { validateJWT } from 'wasp/server/auth/jwt'
 import { ensureTokenIsPresent, ensurePasswordIsPresent, ensureValidPassword } from 'wasp/auth/validation';
@@ -30,9 +31,17 @@ export async function resetPassword(
 
     const providerData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
 
+    // The token must match the currently outstanding (unused) password reset
+    // token. This makes each password reset link one-time use only.
+    if (providerData.outstandingPasswordResetToken !== sha256(token)) {
+        throw new HttpError(400, "Password reset failed, invalid token");
+    }
+
     await updateAuthIdentityProviderData(providerId, providerData, {
         // The act of resetting the password verifies the email
         isEmailVerified: true,
+        // Consume the token so the same link can't be used again.
+        outstandingPasswordResetToken: null,
         // The password will be hashed when saving the providerData
         // in the DB
         hashedPassword: password,

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import {
     createProviderId,
     consumeOneTimeToken,
+    ensureTokenIsOutstanding,
 } from 'wasp/server/auth/utils';
 import { validateJWT } from 'wasp/server/auth/jwt'
 import { invalidateAllSessionsForAuthId } from 'wasp/server/auth/session'
@@ -28,9 +29,18 @@ export async function resetPassword(
         throw new HttpError(400, "Password reset failed, invalid token");
     }
 
-    ensureValidPasswordArg(args);
-
     const providerId = createProviderId('email', email);
+
+    // Reject consumed/superseded tokens before the password-policy validation,
+    // so a holder of a spent token can't learn the deployment's password policy.
+    await ensureTokenIsOutstanding(
+        providerId,
+        'outstandingPasswordResetToken',
+        token,
+        "Password reset failed, invalid token",
+    );
+
+    ensureValidPasswordArg(args);
 
     // Atomically check + consume the token (one-time use only, even under
     // concurrent requests). Throws if the token is invalid or already used.

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
@@ -1,10 +1,7 @@
 import { Request, Response } from 'express';
 import {
     createProviderId,
-    findAuthIdentity,
-    updateAuthIdentityProviderData,
-    getProviderDataWithPassword,
-    sha256,
+    consumeOneTimeToken,
 } from 'wasp/server/auth/utils';
 import { validateJWT } from 'wasp/server/auth/jwt'
 import { ensureTokenIsPresent, ensurePasswordIsPresent, ensureValidPassword } from 'wasp/auth/validation';
@@ -18,34 +15,28 @@ export async function resetPassword(
     ensureValidArgs(args);
 
     const { token, password } = args;
-    const { email } = await validateJWT<{ email: string }>(token)
+    const { email, purpose } = await validateJWT<{ email: string; purpose: string }>(token)
         .catch(() => {
             throw new HttpError(400, "Password reset failed, invalid token");
         });
 
+    // Only a token minted for password reset is accepted here.
+    if (purpose !== 'reset') {
+        throw new HttpError(400, "Password reset failed, invalid token");
+    }
+
     const providerId = createProviderId('email', email);
-    const authIdentity = await findAuthIdentity(providerId);
-    if (!authIdentity) {
-        throw new HttpError(400, "Password reset failed, invalid token");
-    }
 
-    const providerData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
-
-    // The token must match the currently outstanding (unused) password reset
-    // token. This makes each password reset link one-time use only.
-    if (providerData.outstandingPasswordResetToken !== sha256(token)) {
-        throw new HttpError(400, "Password reset failed, invalid token");
-    }
-
-    await updateAuthIdentityProviderData(providerId, providerData, {
-        // The act of resetting the password verifies the email
-        isEmailVerified: true,
-        // Consume the token so the same link can't be used again.
-        outstandingPasswordResetToken: null,
-        // The password will be hashed when saving the providerData
-        // in the DB
-        hashedPassword: password,
-    });
+    // Atomically check + consume the token (one-time use only, even under
+    // concurrent requests). Throws if the token is invalid or already used.
+    // The new password is hashed when the provider data is persisted.
+    await consumeOneTimeToken(
+        providerId,
+        'outstandingPasswordResetToken',
+        token,
+        { isEmailVerified: true, hashedPassword: password },
+        "Password reset failed, invalid token",
+    );
 
     res.json({ success: true });
 };

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/verifyEmail.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/verifyEmail.ts
@@ -5,6 +5,7 @@ import {
   findAuthIdentity,
   findAuthWithUserBy,
   getProviderDataWithPassword,
+  sha256,
   updateAuthIdentityProviderData,
 } from 'wasp/server/auth/utils';
 import { HttpError } from 'wasp/server';
@@ -29,8 +30,16 @@ export async function verifyEmail(
 
     const providerData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
 
+    // The token must match the currently outstanding (unused) email
+    // verification token. This makes each verification URL one-time use only.
+    if (providerData.outstandingEmailVerificationToken !== sha256(token)) {
+        throw new HttpError(400, "Email verification failed, invalid token");
+    }
+
     await updateAuthIdentityProviderData(providerId, providerData, {
         isEmailVerified: true,
+        // Consume the token so the same URL can't be used again.
+        outstandingEmailVerificationToken: null,
     });
 
     const auth = await findAuthWithUserBy({ id: authIdentity.authId })

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/verifyEmail.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/verifyEmail.ts
@@ -2,11 +2,8 @@ import { Request, Response } from 'express';
 import { validateJWT } from 'wasp/server/auth/jwt';
 import {
   createProviderId,
-  findAuthIdentity,
+  consumeOneTimeToken,
   findAuthWithUserBy,
-  getProviderDataWithPassword,
-  sha256,
-  updateAuthIdentityProviderData,
 } from 'wasp/server/auth/utils';
 import { HttpError } from 'wasp/server';
 import { onAfterEmailVerifiedHook } from '../../hooks.js';
@@ -17,30 +14,27 @@ export async function verifyEmail(
     res: Response,
 ): Promise<void> {
     const { token } = req.body;
-    const { email } = await validateJWT<{ email: string }>(token)
+    const { email, purpose } = await validateJWT<{ email: string; purpose: string }>(token)
         .catch(() => {
             throw new HttpError(400, "Email verification failed, invalid token");
         });
 
+    // Only a token minted for email verification is accepted here.
+    if (purpose !== 'verify') {
+        throw new HttpError(400, "Email verification failed, invalid token");
+    }
+
     const providerId = createProviderId('email', email);
-    const authIdentity = await findAuthIdentity(providerId);
-    if (!authIdentity) {
-        throw new HttpError(400, "Email verification failed, invalid token");
-    }
 
-    const providerData = getProviderDataWithPassword<'email'>(authIdentity.providerData);
-
-    // The token must match the currently outstanding (unused) email
-    // verification token. This makes each verification URL one-time use only.
-    if (providerData.outstandingEmailVerificationToken !== sha256(token)) {
-        throw new HttpError(400, "Email verification failed, invalid token");
-    }
-
-    await updateAuthIdentityProviderData(providerId, providerData, {
-        isEmailVerified: true,
-        // Consume the token so the same URL can't be used again.
-        outstandingEmailVerificationToken: null,
-    });
+    // Atomically check + consume the token (one-time use only, even under
+    // concurrent requests). Throws if the token is invalid or already used.
+    const authIdentity = await consumeOneTimeToken(
+        providerId,
+        'outstandingEmailVerificationToken',
+        token,
+        { isEmailVerified: true },
+        "Email verification failed, invalid token",
+    );
 
     const auth = await findAuthWithUserBy({ id: authIdentity.authId })
 


### PR DESCRIPTION
## Description

Closes #1933
Part of #4684

## Problem

Email verification and password reset links in Wasp are **stateless JWTs that carry only the user's email address** and stay valid for ~30 minutes. Consuming a link never invalidates it. Verifying an email or resetting a password just flips a flag. An attacker who intercepts or steals a link can therefore **replay it over and over** to take over the account, even after the legitimate user has already used it (e.g. hijacking a password reset after the real owner has reset).

This is exactly the scenario the OWASP guidance and the references in #1933 warn about: tokens must be **single-use** so the window for abuse is minimal.

## Understanding from the References

The attached references reinforce the security reasoning behind making password reset and verification tokens single-use:

- Password reset tokens should be **single-use** and invalidated after successful use.
- A short expiration time alone is **not sufficient**. A stolen token can still be replayed during its remaining validity period, even after the legitimate user has used it.
- Single-use tokens remove this post-use attack window, while expiration limits the overall lifetime of a stolen token. Both protections work together.
- Issuing a new token should **invalidate the previous valid token**, preventing multiple simultaneously usable reset links.
- Tokens should be **hashed with SHA-256 before storage**, rather than storing the raw token.
- Wasp's existing ~30-minute expiry is already within the recommended timeframe, so the expiry does not need to change.
- The same single-use principle applies to **email verification tokens**, preventing previously consumed verification links from being replayed.
- The references also highlight related protections such as invalidating existing sessions after a successful password reset, protecting token-bearing URLs from referer leakage, and rate-limiting email-sending endpoints.

## Solution

Wasp keeps per-user auth details in `EmailProviderData`, a flexible JSON object, so no database migration is needed. We now track the single token that is currently **outstanding** (issued but not yet consumed) for each purpose:

- `EmailProviderData` gains two optional fields:
  - `outstandingEmailVerificationToken`
  - `outstandingPasswordResetToken`
- When a link/URL is minted, we store the **SHA-256 hash** of the new token in the relevant field, **overwriting** any previous one. So issuing a new token automatically invalidates the old one (only one token is ever outstanding).
- When a token is presented, the action is accepted **only if its hash matches** **the current outstanding hash**, and the field is then **cleared** so the same link/URL works exactly once.
- We store a **hash, not the raw token**, so a leaked `providerData` never exposes a usable token. The hashes are also excluded from client-facing data so they don't reach the browser.

## What changed

| File | Change |
| --- | --- |
| `sdk/wasp/auth/providerData.ts` | Add the two `outstanding*Token` fields; strip them (and `hashedPassword`) from `getProviderData` / `sanitizeProviderData` |
| `sdk/wasp/auth/user.ts` | Hide the token fields from the client-facing `UserFacingProviderData` type |
| `sdk/wasp/server/auth/utils.ts` | Add a `sha256` helper |
| `sdk/wasp/server/auth/email/utils.ts` | Persist the outstanding token hash when a verification/reset link is issued |
| `server/.../email/verifyEmail.ts` | Require the presented token to match the outstanding one, then consume it |
| `server/.../email/resetPassword.ts` | Same enforcement + consumption for password resets |

## Verification

- A standalone runtime test exercises the one-time-use flow end to end and all assertions pass: first use succeeds, **replaying the same token is rejected**, reissuing a token invalidates the old one, and a verification token can't be reused as a password-reset token (and vice versa).
- `tsc --strict` passes on the modified `providerData.ts`, and a runtime check confirms the one-time hashes are stripped from client-facing data.
- **Not yet run (Windows limitation):** the full generated-app flow and the golden e2e snapshot regeneration (`./run test:waspc:e2e:accept-all`), since Wasp's e2e suite is skipped on native Windows. These still need to run on Linux/WSL before merge.

## Notes

- **Breaking-by-design for old links:** any verification/reset link issued before this change goes live becomes invalid (it has no stored outstanding token). This is the intended security behaviour for a short-lived, single-use token; the existing ~30-minute JWT expiry is unchanged.
- Token expiry is unchanged; this change is purely about **single-use**.