### PR TITLE
Updated CONTRIBUTING.md (and moved Mise instructions to it).

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ While this document captures the general instructions for the whole repo, make s
 > [!NOTE]
 > **Developing on Windows?** Use the Bash shell bundled with [Git for Windows](https://git-scm.com/download/win) (often called "Git Bash"). Wasp's development scripts are Bash scripts and won't run in PowerShell or Command Prompt. If you develop inside WSL (Windows Subsystem for Linux), you are effectively on Linux, so follow the Linux instructions instead.
 
-We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haskell, Node, and code formatters). Mise is an all-in-one tool that makes it easy to set up and manage all the different tools needed for the Wasp repo. Everything is declared in a single file ([`mise.toml`](../mise.toml)), and every developer can use it to set up their environment in a consistent way. We also use it on our CI to ensure it uses the same versions of tools as well.
+We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haskell, Node, and code formatters). Mise is an all-in-one tool that makes it easy to set up and manage all the different tools needed for the Wasp repo. Everything is declared in a single file ([`mise.toml`](mise.toml)), and every developer can use it to set up their environment in a consistent way. We also use it on our CI to ensure it uses the same versions of tools as well.
 
 Run `mise install` from the root of the repo to install all the required tools. Then, you can access the mise-managed tools in different ways:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ If you have full-stack experience outside of Wasp, you should already be in a go
 
 ### Wasp CLI/compiler internals
 
-Wasp compiler is implemented in Haskell, but you will also see a lot of Javascript and other web technologies because Wasp compiles it's own code into them.
+The Wasp compiler is implemented in Haskell, but you will also see a lot of Javascript and other web technologies because Wasp compiles its own code into them.
 
 While you will need to know some Haskell, you don't have to be an expert in Haskell to contribute or understand the code since we don't use complicated Haskell features much -> most of the code is relatively straightforward, and we are happy to help with the part that is not.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ There are several main ways in which you can contribute to Wasp:
 
 We are using a monorepo approach, where one git repo contains multiple related projects.
 
-In our case, those are [web](/web) (Wasp's web page, including docs and blog), [waspc](/waspc) (Wasp CLI & framework), etc.
+In our case, those are [web](web/) (Wasp's web page, including docs and blog), [waspc](waspc/) (Wasp CLI & framework), etc.
 
 While this document captures the general instructions for the whole repo, make sure to check the README of each individual project in the repo when working on it for more detailed instructions.
 
@@ -46,7 +46,7 @@ Run `mise install` from the root of the repo to install all the required tools. 
 You can learn more and install Mise by following the [official instructions](https://mise.jdx.dev/getting-started.html), then run `mise install` from the repo root to install the required tools.
 
 > [!NOTE]
-> There are no hard dependencies on mise for local development, so if you prefer to use your own tooling, you can install each program separately, and use the versions specified in [`mise.toml`](../mise.toml) as a reference. But then, you're in charge of making sure you have the right versions of the tools installed, and keeping them up-to-date as we upgrade them.
+> There are no hard dependencies on mise for local development, so if you prefer to use your own tooling, you can install each program separately, and use the versions specified in [`mise.toml`](mise.toml) as a reference. But then, you're in charge of making sure you have the right versions of the tools installed, and keeping them up-to-date as we upgrade them.
 
 ### Basic commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,77 @@
 # Contributing to Wasp
 
-Wasp's compiler is built with Haskell and under the hood it generates a web application in React and NodeJS. Given that, there are several ways in which you can contribute:
+There are several main ways in which you can contribute to Wasp:
 
-- [Wasp compiler/CLI/LSP internals](#wasp-compilerclilsp-internals) (Haskell)
 - [Wasp as a web framework](#wasp-as-a-web-framework) (React, Node, HTML/CSS, database and so on)
+- [Wasp CLI/compiler internals](#wasp-clicompiler-internals) (Haskell)
 - [Tutorials or Example apps](#tutorials-or-example-apps)
 - [Documentation](#documentation)
 
 ## Before you begin
 
-- Check out the [**Getting Started**](https://wasp.sh/docs) guide to get familiar with Wasp's fundamentals. Ideally, you'd also build an app from the [**Pick a Tutorial**](https://wasp.sh/docs/tutorials/todo-app) page to really get a feel for it!
-- Figure out what you'd like to help with. It can be code, documentation, tutorials, etc. More on this is below.
+- Get some experience with using Wasp, if you don't have any yet.
+  Check out the [**Getting Started**](https://wasp.sh/docs) guide to get familiar with Wasp's fundamentals.
+  Ideally, you'd also build an app from the [**Pick a Tutorial**](https://wasp.sh/docs/tutorials/todo-app) page to really get a feel for it!
+- Figure out what you'd like to help with. It can be code, documentation, tutorials, etc. More on this below.
 - Join our Discord [![**Discord**](https://img.shields.io/discord/686873244791210014?label=chat%20on%20discord)](https://discord.gg/rzdnErX) for faster communication and feedback. We'd be happy to help you find the issue you'll enjoy working on, depending on your interests and skill set!
-- Below you can find links to the good first issues. If you'd like to filter the issues on your own — please, use [this link](https://github.com/wasp-lang/wasp/issues)
+
+## This repo
+
+We are using a monorepo approach, where one git repo contains multiple related projects.
+
+In our case, those are [web](/web) (Wasp's web page, including docs and blog), [waspc](/waspc) (Wasp CLI & framework), etc.
+
+While this document captures the general instructions for the whole repo, make sure to check the README of each individual project in the repo when working on it for more detailed instructions.
+
+## Dev tooling
+
+### Setup
 
 <!-- prettier-ignore -->
 > [!NOTE]
 > **Developing on Windows?** Use the Bash shell bundled with [Git for Windows](https://git-scm.com/download/win) (often called "Git Bash"). Wasp's development scripts are Bash scripts and won't run in PowerShell or Command Prompt. If you develop inside WSL (Windows Subsystem for Linux), you are effectively on Linux, so follow the Linux instructions instead.
 
-Let's jump right in!
+We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haskell, Node, and code formatters). Mise is an all-in-one tool that makes it easy to set up and manage all the different tools needed for the Wasp repo. Everything is declared in a single file ([`mise.toml`](../mise.toml)), and every developer can use it to set up their environment in a consistent way. We also use it on our CI to ensure it uses the same versions of tools as well.
 
-## Wasp compiler/CLI/LSP internals
+Run `mise install` from the root of the repo to install all the required tools. Then, you can access the mise-managed tools in different ways:
+
+- **(Recommended for local development)** You can set up your shell to automatically call the `mise activate` script. This will make sure that the specified tools and versions are in your `PATH` when you go into the repo. Check their installation instructions at https://mise.jdx.dev/installing-mise.html#shells.
+
+- You can also run [`mise en`](https://mise.jdx.dev/cli/en.html) to go into an one-off shell for the current project, similar to `nix-shell` or `virtualenv`.
+
+- If you don't want to add a shell hook, you can use the [Shims mode](https://mise.jdx.dev/dev-tools/shims.html), which lets you just add a single directory to your `PATH`, which will get populated with intelligent redirectors to the correct versions of the tools for the current working directory.
+
+- For one-off commands, you can use [the `mise exec` command](https://mise.jdx.dev/cli/exec.html) (or `mise x`) to run a specific command with the repo tools available, e.g. `mise x -- ghc --version`, `mise x -- node --version`, `mise x -- ./run build`, etc.
+
+You can learn more and install Mise by following the [official instructions](https://mise.jdx.dev/getting-started.html), then run `mise install` from the repo root to install the required tools.
+
+> [!NOTE]
+> There are no hard dependencies on mise for local development, so if you prefer to use your own tooling, you can install each program separately, and use the versions specified in [`mise.toml`](../mise.toml) as a reference. But then, you're in charge of making sure you have the right versions of the tools installed, and keeping them up-to-date as we upgrade them.
+
+### Basic commands
+
+Formatting is defined at the repo level, and you can run it from the repo root with
+```
+  npm run format:check
+```
+to check the formatting without any changes to the files, or
+```
+  npm run format:write
+```
+to check and automatically fix formatting (modifies the files).
+
+
+## Ways to contribute
+
+### Wasp as a web framework
+
+Wasp is a language for developing full-stack web apps. This means there are plenty of tasks related to web development itself, and most come down to improving one of the core features of Wasp (like Auth, Operations, Jobs, Rendering), or maybe improving our dev tooling config, etc.
+
+If you have full-stack experience outside of Wasp, you should already be in a good place to start contributing in this direction.
+
+[**Web dev issues for beginners can be found here.**](https://github.com/wasp-lang/wasp/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+label%3Awebdev)
+
+### Wasp CLI/compiler internals
 
 Wasp compiler is implemented in Haskell, but you will also see a lot of Javascript and other web technologies because Wasp compiles it's own code into them.
 
@@ -28,25 +79,15 @@ While you will need to know some Haskell, you don't have to be an expert in Hask
 
 Check the [**Wasp compiler README**](https://github.com/wasp-lang/wasp/blob/main/waspc/README.md) for all the detailed instructions and guides.
 
-[**Haskell-related issues for beginners can be found here.**](https://github.com/wasp-lang/wasp/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+label%3Ahaskell)
-
-Feel free to contact us via Discord to ask for an appropriate issue for yourself, or just open a new one if you have something specific in mind and it isn't already there!
-
-## Wasp as a web framework
-
-Wasp is a language for developing full-stack web apps. This means there are plenty of tasks related to web development itself.
-
-[**Web dev issues for beginners can be found here.**](https://github.com/wasp-lang/wasp/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+label%3Awebdev)
-
-## Tutorials or Example apps
+### Tutorials or Example apps
 
 Another great way to help is to create an app with Wasp! We have an [Examples](https://wasp.sh/docs/examples) section on our website, as well as the [Tutorials](https://wasp.sh/docs/tutorials/todo-app) page. Both of them can be improved and updated with your projects.
 
-All that's required is to create an app. And make a tutorial or a blog post to help other people reproduce your work. Some prominent examples are: [Waspello](https://wasp.sh/blog/2021/12/02/waspello), [Waspleau](https://wasp.sh/blog/2022/01/27/waspleau), [It Wasps on My Machine](https://wasp.sh/blog/2022/09/05/dev-excuses-app-tutrial) and [To-Do app](https://wasp.sh/docs/tutorials/todo-app).
+All that's required is to create an app. And make a tutorial or a blog post to help other people reproduce your work. Some prominent examples are: [Waspello](https://wasp.sh/blog/2021/12/02/waspello), [Waspleau](https://wasp.sh/blog/2022/01/27/waspleau), and [To-Do app](https://wasp.sh/docs/tutorials/todo-app).
 
 Or you can re-build your existing pet project with Wasp. That would be cool!
 
-## Documentation & Blog
+### Documentation & Blog
 
 It may sound like the simplest one, but it's super valuable! If you've found an issue, a broken link or if something was unclear on our [website](https://wasp.sh/) - please, feel free to fix it :)
 
@@ -58,11 +99,11 @@ If you'd like to write a blog post about Wasp, please contact us via [Discord](h
 
 Happy hacking!
 
-# Policies
+## Policies
 
 These are some general policies that we follow when it comes to contributions. They are not meant to be strict or exhaustive, but rather to give you a sense of what we value and expect. If you are linked here from a PR, it means that we think your contribution could be improved in some way, and following these guidelines is the best way to do it.
 
-## AIs and LLMs
+### AIs and LLMs
 
 **You are free to use AI/LLM tools and agents. But the standard remains the same: you must own and stand behind every line of code and every decision in your PR, exactly as if no AI was involved.** That means you've read it, run it, understood it, and you can explain and defend it under review.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,14 +12,14 @@ There are several main ways in which you can contribute to Wasp:
 - Get some experience with using Wasp, if you don't have any yet.
   Check out the [**Getting Started**](https://wasp.sh/docs) guide to get familiar with Wasp's fundamentals.
   Ideally, you'd also build an app from the [**Pick a Tutorial**](https://wasp.sh/docs/tutorials/todo-app) page to really get a feel for it!
-- Figure out what you'd like to help with. It can be code, documentation, tutorials, etc. More on this below.
-- Join our Discord [![**Discord**](https://img.shields.io/discord/686873244791210014?label=chat%20on%20discord)](https://discord.gg/rzdnErX) for faster communication and feedback. We'd be happy to help you find the issue you'll enjoy working on, depending on your interests and skill set!
+- Figure out what you'd like to help with. It can be code, documentation, tutorials, etc. Check [Ways to contribute](#ways-to-contribute) for more details.
+- Join our Discord [![**Discord**](https://img.shields.io/discord/686873244791210014?label=chat%20on%20discord)](https://discord.gg/rzdnErX) for faster communication and feedback. We'd be happy to help you find the issue you'll enjoy working on, depending on your interests and skill set! `#wasp-dev` channel is the perfect place to ping us with the task you want to do and how you plan to do it, which reduces duplicate or misdirected efforts.
 
 ## This repo
 
 We are using a monorepo approach, where one git repo contains multiple related projects.
 
-In our case, those are [web](web/) (Wasp's web page, including docs and blog), [waspc](waspc/) (Wasp CLI & framework), etc.
+In our case, those are [web](web/) (Wasp's web page, including docs and blog), [waspc](waspc/) (Wasp CLI & framework), [examples](examples/) (example Wasp apps), etc.
 
 While this document captures the general instructions for the whole repo, make sure to check the README of each individual project in the repo when working on it for more detailed instructions.
 
@@ -53,13 +53,13 @@ You can learn more and install Mise by following the [official instructions](htt
 Formatting is defined at the repo level, and you can run it from the repo root with
 
 ```
-  npm run format:check
+npm run format:check
 ```
 
 to check the formatting without any changes to the files, or
 
 ```
-  npm run format:write
+npm run format:write
 ```
 
 to check and automatically fix formatting (modifies the files).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,15 +51,18 @@ You can learn more and install Mise by following the [official instructions](htt
 ### Basic commands
 
 Formatting is defined at the repo level, and you can run it from the repo root with
+
 ```
   npm run format:check
 ```
+
 to check the formatting without any changes to the files, or
+
 ```
   npm run format:write
 ```
-to check and automatically fix formatting (modifies the files).
 
+to check and automatically fix formatting (modifies the files).
 
 ## Ways to contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Run `mise install` from the root of the repo to install all the required tools. 
 
 - **(Recommended for local development)** You can set up your shell to automatically call the `mise activate` script. This will make sure that the specified tools and versions are in your `PATH` when you go into the repo. Check their installation instructions at https://mise.jdx.dev/installing-mise.html#shells.
 
-- You can also run [`mise en`](https://mise.jdx.dev/cli/en.html) to go into an one-off shell for the current project, similar to `nix-shell` or `virtualenv`.
+- You can also run [`mise en`](https://mise.jdx.dev/cli/en.html) to go into a one-off shell for the current project, similar to `nix-shell` or `virtualenv`.
 
 - If you don't want to add a shell hook, you can use the [Shims mode](https://mise.jdx.dev/dev-tools/shims.html), which lets you just add a single directory to your `PATH`, which will get populated with intelligent redirectors to the correct versions of the tools for the current working directory.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ If you have full-stack experience outside of Wasp, you should already be in a go
 
 The Wasp compiler is implemented in Haskell, but you will also see a lot of Javascript and other web technologies because Wasp compiles its own code into them.
 
-While you will need to know some Haskell, you don't have to be an expert in Haskell to contribute or understand the code since we don't use complicated Haskell features much -> most of the code is relatively straightforward, and we are happy to help with the part that is not.
+While you will need to know some Haskell, you don't have to be an expert in Haskell to contribute or understand the code since we don't use complicated Haskell features often. Most of the code is relatively straightforward, and we are happy to help with the part that is not.
 
 Check the [**Wasp compiler README**](https://github.com/wasp-lang/wasp/blob/main/waspc/README.md) for all the detailed instructions and guides.
 

--- a/README.md
+++ b/README.md
@@ -161,12 +161,9 @@ React + TanStack Query, Node.js + Express.js, and Prisma.
 
 Any way you want to contribute is a good way :)!
 
-The best place to start is to check out [`waspc/`](waspc/), where you can find detailed steps for first-time contributors + technical details about the Wasp compiler.
+You can share feedback, help with the docs, examples, work on the specific Wasp features, contribute to the CLI core, etc.
 
-> [!NOTE]
-> If you develop Wasp on Windows, use the Bash shell bundled with [Git for Windows](https://git-scm.com/download/win) (often called "Git Bash"); Wasp's development scripts don't run in PowerShell or Command Prompt. If you use WSL (Windows Subsystem for Linux), follow the Linux requirements instead.
-
-The core of Wasp is built in Haskell, but there are also a lot of non-Haskell parts of Wasp, so you will certainly be able to find something for you!
+Check out [CONTRIBUTING](CONTRIBUTING.md) for more details.
 
 Even if you don't plan to submit any code, just joining the discussion on [Discord](https://discord.gg/rzdnErX) and giving your feedback is already great and helps a lot (motivates us and helps us figure out how to shape Wasp)!
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "type": "module",
   "scripts": {
     "check:prettier": "prettier --ignore-unknown --check --config prettier.config.mjs .",
-    "format:prettier": "prettier --ignore-unknown --write --config prettier.config.mjs ."
+    "format:prettier": "prettier --ignore-unknown --write --config prettier.config.mjs .",
+    "format:check": "npm run check:prettier",
+    "format:write": "npm run format:prettier"
   },
   "devDependencies": {
     "prettier": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "type": "module",
   "scripts": {
     "check:prettier": "prettier --ignore-unknown --check --config prettier.config.mjs .",
-    "format:prettier": "prettier --ignore-unknown --write --config prettier.config.mjs .",
     "format:check": "npm run check:prettier",
+    "format:prettier": "prettier --ignore-unknown --write --config prettier.config.mjs .",
     "format:write": "npm run format:prettier"
   },
   "devDependencies": {

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -54,7 +54,7 @@ Running `./run` without any arguments will print help/usage, which is a good way
 
 ### Dev tooling
 
-Follow repo-wide [Dev tooling](/CONTRIBUTING.md#dev-tooling) instructions.
+Follow repo-wide [Dev tooling](../CONTRIBUTING.md#dev-tooling) instructions.
 
 ### Build
 

--- a/waspc/README.md
+++ b/waspc/README.md
@@ -48,32 +48,13 @@ Running `./run` without any arguments will print help/usage, which is a good way
 > alias wrun="/home/martin/git/wasp-lang/wasp/waspc/run"
 > ```
 
-### Setup
-
 <!-- prettier-ignore -->
 > [!IMPORTANT]
-> **On Windows**, develop Wasp using the Bash shell bundled with [Git for Windows](https://git-scm.com/download/win) (often called "Git Bash"). The `./run` script and the rest of the development tooling are Bash scripts, so they won't work from PowerShell or Command Prompt.
->
-> If you develop inside WSL (Windows Subsystem for Linux), you are effectively on Linux, so follow the Linux setup instructions instead.
+> The `./run` script and the rest of the development tooling are Bash scripts, so they won't work from PowerShell or Command Prompt in Windows.
 
-#### Dev tooling
+### Dev tooling
 
-We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haskell, Node, and code formatters). Mise is an all-in-one tool that makes it easy to set up and manage all the different tools needed for the Wasp repo. Everything is declared in a single file ([`mise.toml`](../mise.toml)), and every developer can use it to set up their environment in a consistent way. We also use it on our CI to ensure it uses the same versions of tools as well.
-
-Run `mise install` from the root of the repo to install all the required tools. Then, you can access the mise-managed tools in different ways:
-
-- **(Recommended for local development)** You can set up your shell to automatically call the `mise activate` script. This will make sure that the specified tools and versions are in your `PATH` when you go into the repo. Check their installation instructions at https://mise.jdx.dev/installing-mise.html#shells.
-
-- You can also run [`mise en`](https://mise.jdx.dev/cli/en.html) to go into an one-off shell for the current project, similar to `nix-shell` or `virtualenv`.
-
-- If you don't want to add a shell hook, you can use the [Shims mode](https://mise.jdx.dev/dev-tools/shims.html), which lets you just add a single directory to your `PATH`, which will get populated with intelligent redirectors to the correct versions of the tools for the current working directory.
-
-- For one-off commands, you can use [the `mise exec` command](https://mise.jdx.dev/cli/exec.html) (or `mise x`) to run a specific command with the repo tools available, e.g. `mise x -- ghc --version`, `mise x -- node --version`, `mise x -- ./run build`, etc.
-
-You can learn more and install Mise by following the [official instructions](https://mise.jdx.dev/getting-started.html), then run `mise install` from the repo root to install the required tools.
-
-> [!NOTE]
-> There are no hard dependencies on mise for local development, so if you prefer to use your own tooling, you can install each program separately, and use the versions specified in [`mise.toml`](../mise.toml) as a reference. But then, you're in charge of making sure you have the right versions of the tools installed, and keeping them up-to-date as we upgrade them.
+Follow repo-wide [Dev tooling](/CONTRIBUTING.md#dev-tooling) instructions.
 
 ### Build
 


### PR DESCRIPTION
Roughly what I did:
- README.md now relies more heavily on and links to CONTRIBUTING.md.
- I cleaned up CONTRIBUTING.md a bit, update it.
- I moved Mise instructions to top level CONTRIBUTING.md and linked to them from old location in waspc/README.md.
- I added `format:check` and `format:write` run scripts to top level package.json so that these commands are not prettier specific. I left old `check:prettier` and `write:prettier` around so it doesn't stop working for people.