### PR TITLE
Name Railway database service <project-name>-db

### DIFF
--- a/waspc/data/packages/deploy/src/providers/railway/DeploymentInstructions.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/DeploymentInstructions.ts
@@ -10,7 +10,9 @@ import {
   createRailwayClientServiceName,
   createRailwayDbServiceName,
   createRailwayServerServiceName,
+  getDbServiceNameWithFallback,
 } from "./railwayService/nameGenerator.js";
+import type { RailwayProject } from "./railwayProject/RailwayProject.js";
 
 export type DeploymentInstructions<CmdOptions extends CommonCmdOptions> =
   Readonly<{
@@ -21,18 +23,26 @@ export type DeploymentInstructions<CmdOptions extends CommonCmdOptions> =
     dbServiceName: DbServiceName;
   }>;
 
+/**
+ * Creates deployment instructions for a Railway project.
+ * If a Railway project is provided, it uses fallback logic to support legacy "Postgres" database naming.
+ * Otherwise, it uses the new <project-name>-db naming pattern.
+ */
 export function createDeploymentInstructions<
   CmdOptions extends CommonCmdOptions,
 >(
   projectName: RailwayProjectName,
   cmdOptions: CmdOptions,
+  project?: RailwayProject,
 ): DeploymentInstructions<CmdOptions> {
   return Object.freeze({
     projectName,
     cmdOptions,
     clientServiceName: createRailwayClientServiceName(projectName),
     serverServiceName: createRailwayServerServiceName(projectName),
-    dbServiceName: createRailwayDbServiceName(),
+    dbServiceName: project
+      ? getDbServiceNameWithFallback(projectName, project)
+      : createRailwayDbServiceName(projectName),
   });
 }
 

--- a/waspc/data/packages/deploy/src/providers/railway/DeploymentInstructions.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/DeploymentInstructions.ts
@@ -6,13 +6,13 @@ import {
   RailwayProjectName,
   ServerServiceName,
 } from "./brandedTypes.js";
+import type { RailwayProject } from "./railwayProject/RailwayProject.js";
 import {
   createRailwayClientServiceName,
   createRailwayDbServiceName,
   createRailwayServerServiceName,
   getDbServiceNameWithFallback,
 } from "./railwayService/nameGenerator.js";
-import type { RailwayProject } from "./railwayProject/RailwayProject.js";
 
 export type DeploymentInstructions<CmdOptions extends CommonCmdOptions> =
   Readonly<{

--- a/waspc/data/packages/deploy/src/providers/railway/commands/deploy/index.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/commands/deploy/index.ts
@@ -24,17 +24,18 @@ export async function deploy(
   projectName: RailwayProjectName,
   options: DeployCmdOptions,
 ): Promise<void> {
-  const deploymentInstructions = createDeploymentInstructions(
-    projectName,
-    options,
-  );
-
-  await ensureRailwayProjectForDirectory({
+  const project = await ensureRailwayProjectForDirectory({
     projectName,
     waspProjectDir: options.waspProjectDir,
     existingProjectId: options.existingProjectId,
     railwayExe: options.railwayExe,
   });
+
+  const deploymentInstructions = createDeploymentInstructions(
+    projectName,
+    options,
+    project,
+  );
 
   waspSays("Deploying your Wasp app to Railway!");
 

--- a/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
@@ -39,11 +39,6 @@ export async function setup(
 ): Promise<void> {
   waspSays("Setting up your Wasp app with Railway!");
 
-  const deploymentInstructions = createDeploymentInstructions(
-    projectName,
-    options,
-  );
-
   const project = await setupRailwayProjectForDirectory({
     projectName,
     existingProjectId: options.existingProjectId,
@@ -51,6 +46,12 @@ export async function setup(
     railwayExe: options.railwayExe,
     workspace: options.workspace,
   });
+
+  const deploymentInstructions = createDeploymentInstructions(
+    projectName,
+    options,
+    project,
+  );
 
   await ensureWaspProjectIsBuilt(options);
 
@@ -156,7 +157,7 @@ async function setupDb({
     ]);
   } else {
     // Use the default Railway Postgres template.
-    await railwayCli(["add", "-d", "postgres"]);
+    await railwayCli(["add", "-d", "postgres", "--service", dbServiceName]);
   }
 
   // The database service deploys asynchronously and `railway add` doesn't wait

--- a/waspc/data/packages/deploy/src/providers/railway/railwayService/nameGenerator.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayService/nameGenerator.ts
@@ -1,10 +1,11 @@
+import { waspSays } from "../../../common/terminal.js";
 import {
   ClientServiceName,
   DbServiceName,
   RailwayProjectName,
   ServerServiceName,
 } from "../brandedTypes.js";
-import { waspSays } from "../../../common/terminal.js";
+import { getRailwayEnvVarValueReference } from "../env.js";
 import type { RailwayProject } from "../railwayProject/RailwayProject.js";
 
 /**
@@ -77,6 +78,12 @@ export function getDbServiceNameWithFallback(
   // Fallback to legacy "Postgres" name for existing deployments
   const legacyDbServiceName = "Postgres" as DbServiceName;
   if (project.doesServiceExist(legacyDbServiceName)) {
+    const legacyRef = getRailwayEnvVarValueReference("DATABASE_URL", {
+      serviceName: legacyDbServiceName,
+    });
+    const newRef = getRailwayEnvVarValueReference("DATABASE_URL", {
+      serviceName: newDbServiceName,
+    });
     waspSays(`
 ⚠️  Warning: Your database service is named "Postgres" (legacy naming).
    New deployments use "${newDbServiceName}".
@@ -86,8 +93,8 @@ export function getDbServiceNameWithFallback(
    2. Click on the "Postgres" service
    3. Go to Settings → rename to "${newDbServiceName}"
    4. Update your server's DATABASE_URL variable:
-      Change: \${{Postgres.DATABASE_URL}}
-      To: \${{${newDbServiceName}.DATABASE_URL}}
+      Change: ${legacyRef}
+      To: ${newRef}
   `);
     return legacyDbServiceName;
   }

--- a/waspc/data/packages/deploy/src/providers/railway/railwayService/nameGenerator.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayService/nameGenerator.ts
@@ -4,7 +4,12 @@ import {
   RailwayProjectName,
   ServerServiceName,
 } from "../brandedTypes.js";
+import { waspSays } from "../../../common/terminal.js";
+import type { RailwayProject } from "../railwayProject/RailwayProject.js";
 
+/**
+ * Creates a Railway client service name by appending the "-client" suffix to the project name.
+ */
 export function createRailwayClientServiceName(
   projectName: RailwayProjectName,
 ): ClientServiceName {
@@ -14,6 +19,9 @@ export function createRailwayClientServiceName(
   ) as ClientServiceName;
 }
 
+/**
+ * Creates a Railway server service name by appending the "-server" suffix to the project name.
+ */
 export function createRailwayServerServiceName(
   projectName: RailwayProjectName,
 ): ServerServiceName {
@@ -41,7 +49,49 @@ export const serviceNameSuffixes: Record<ServiceWithSuffixedName, string> = {
   [ServiceWithSuffixedName.Server]: "-server",
 };
 
-export function createRailwayDbServiceName(): DbServiceName {
-  // Railway doesn't allow us to choose the database service name.
-  return "Postgres" as DbServiceName;
+/**
+ * Creates a Railway database service name by appending the "-db" suffix to the project name.
+ * This matches Fly.io's pattern and ensures consistent naming across all services.
+ */
+export function createRailwayDbServiceName(
+  projectName: RailwayProjectName,
+): DbServiceName {
+  return `${projectName}-db` as DbServiceName;
+}
+
+/**
+ * Gets the database service name with fallback for legacy deployments.
+ * New deployments use <project-name>-db, but old deployments may still use "Postgres".
+ * If a legacy "Postgres" service is found, a warning is displayed to guide users on renaming.
+ */
+export function getDbServiceNameWithFallback(
+  projectName: RailwayProjectName,
+  project: RailwayProject,
+): DbServiceName {
+  const newDbServiceName = createRailwayDbServiceName(projectName);
+
+  if (project.doesServiceExist(newDbServiceName)) {
+    return newDbServiceName;
+  }
+
+  // Fallback to legacy "Postgres" name for existing deployments
+  const legacyDbServiceName = "Postgres" as DbServiceName;
+  if (project.doesServiceExist(legacyDbServiceName)) {
+    waspSays(`
+⚠️  Warning: Your database service is named "Postgres" (legacy naming).
+   New deployments use "${newDbServiceName}".
+
+   To rename your database service:
+   1. Go to your Railway project dashboard
+   2. Click on the "Postgres" service
+   3. Go to Settings → rename to "${newDbServiceName}"
+   4. Update your server's DATABASE_URL variable:
+      Change: \${{Postgres.DATABASE_URL}}
+      To: \${{${newDbServiceName}.DATABASE_URL}}
+  `);
+    return legacyDbServiceName;
+  }
+
+  // No database exists yet, return the new standard name
+  return newDbServiceName;
 }

--- a/waspc/data/packages/deploy/test/providers/railway/DeploymentInstructions.test.ts
+++ b/waspc/data/packages/deploy/test/providers/railway/DeploymentInstructions.test.ts
@@ -22,6 +22,6 @@ describe("createDeploymentInstructions", () => {
     );
     expect(result.clientServiceName).toBe(`${baseName}-client`);
     expect(result.serverServiceName).toBe(`${baseName}-server`);
-    expect(result.dbServiceName).toBe("Postgres");
+    expect(result.dbServiceName).toBe(`${baseName}-db`);
   });
 });

--- a/waspc/data/packages/deploy/test/providers/railway/nameGenerator.test.ts
+++ b/waspc/data/packages/deploy/test/providers/railway/nameGenerator.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "vitest";
 import type { RailwayProjectName } from "../../../src/providers/railway/brandedTypes.js";
+import type { RailwayProject } from "../../../src/providers/railway/railwayProject/RailwayProject.js";
 import {
   createRailwayClientServiceName,
   createRailwayDbServiceName,
   createRailwayServerServiceName,
   getDbServiceNameWithFallback,
 } from "../../../src/providers/railway/railwayService/nameGenerator.js";
-import type { RailwayProject } from "../../../src/providers/railway/railwayProject/RailwayProject.js";
 
 describe("createRailwayClientServiceName", () => {
   test("appends -client suffix", () => {

--- a/waspc/data/packages/deploy/test/providers/railway/nameGenerator.test.ts
+++ b/waspc/data/packages/deploy/test/providers/railway/nameGenerator.test.ts
@@ -4,7 +4,9 @@ import {
   createRailwayClientServiceName,
   createRailwayDbServiceName,
   createRailwayServerServiceName,
+  getDbServiceNameWithFallback,
 } from "../../../src/providers/railway/railwayService/nameGenerator.js";
+import type { RailwayProject } from "../../../src/providers/railway/railwayProject/RailwayProject.js";
 
 describe("createRailwayClientServiceName", () => {
   test("appends -client suffix", () => {
@@ -21,7 +23,51 @@ describe("createRailwayServerServiceName", () => {
 });
 
 describe("createRailwayDbServiceName", () => {
-  test("always returns Postgres", () => {
-    expect(createRailwayDbServiceName()).toBe("Postgres");
+  test("appends -db suffix to project name", () => {
+    const name = createRailwayDbServiceName("my-app" as RailwayProjectName);
+    expect(name).toBe("my-app-db");
+  });
+});
+
+/**
+ * Creates a mock Railway project for testing with the specified service names.
+ */
+function createMockProject(serviceNames: string[]): RailwayProject {
+  return {
+    id: "test-project-id",
+    name: "test-project",
+    services: serviceNames.map((name) => ({ id: `${name}-id`, name })),
+    doesServiceExist(serviceName: string) {
+      return this.services.some((s) => s.name === serviceName);
+    },
+  };
+}
+
+describe("getDbServiceNameWithFallback", () => {
+  test("returns new name when it exists", () => {
+    const project = createMockProject(["my-app-db"]);
+    const name = getDbServiceNameWithFallback(
+      "my-app" as RailwayProjectName,
+      project,
+    );
+    expect(name).toBe("my-app-db");
+  });
+
+  test("falls back to Postgres when new name doesn't exist", () => {
+    const project = createMockProject(["Postgres"]);
+    const name = getDbServiceNameWithFallback(
+      "my-app" as RailwayProjectName,
+      project,
+    );
+    expect(name).toBe("Postgres");
+  });
+
+  test("returns new name when neither exists (new deployment)", () => {
+    const project = createMockProject([]);
+    const name = getDbServiceNameWithFallback(
+      "my-app" as RailwayProjectName,
+      project,
+    );
+    expect(name).toBe("my-app-db");
   });
 });


### PR DESCRIPTION
## Description

Fixes #4673

Changes Railway database service naming from the hardcoded "Postgres" to follow the consistent `<project-name>-db` pattern, matching Fly.io's convention and aligning with client/server naming (`<project-name>-client`, `<project-name>-server`).

## Changes

### Core Changes

* **Updated `createRailwayDbServiceName()`** to generate `<project-name>-db` instead of hardcoded "Postgres"
* **Added `--service` parameter** to default Railway Postgres setup (`railway add -d postgres --service <name>`)
* **Added backward compatibility** with fallback logic for existing deployments still using "Postgres"

### Fallback Logic

* New `getDbServiceNameWithFallback()` function checks for:

  1. New naming pattern (`<project-name>-db`) - used if exists
  2. Legacy naming ("Postgres") - used if exists, with migration warning
  3. No existing database - returns new naming pattern
* Warning message guides users through renaming legacy database services

### Files Modified

* `waspc/data/packages/deploy/src/providers/railway/railwayService/nameGenerator.ts` - Core naming logic with JSDoc comments
* `waspc/data/packages/deploy/src/providers/railway/DeploymentInstructions.ts` - Added optional project parameter for fallback
* `waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts` - Pass project context and add `--service` flag
* `waspc/data/packages/deploy/src/providers/railway/commands/deploy/index.ts` - Pass project context for fallback
* `waspc/data/packages/deploy/test/providers/railway/nameGenerator.test.ts` - Updated tests and added fallback tests
* `waspc/data/packages/deploy/test/providers/railway/DeploymentInstructions.test.ts` - Updated test expectation

## Testing

* [x] All unit tests passing (657 tests)
* [x] All deploy package tests passing (66 tests)
* [x] Build successful
* [x] Added comprehensive tests for fallback logic

## Migration Path

**For new deployments:**

* Database services will automatically be created as `<project-name>-db`

**For existing deployments:**

* The system will continue using "Postgres" name
* A warning will be displayed with step-by-step instructions:

  1. Rename service in Railway dashboard
  2. Update `DATABASE_URL` environment variable reference

## Notes

* Matches Fly.io's existing pattern for consistency across providers
* No breaking changes - fully backward compatible
* JSDoc comments added to all public functions