### PR TITLE
Create Railway database with its volume attached before the first deployment

### DIFF
--- a/.github/workflows/ci-deploy-test.yaml
+++ b/.github/workflows/ci-deploy-test.yaml
@@ -126,7 +126,7 @@ jobs:
         run: wasp-cli install
 
       - name: Install Railway CLI
-        run: mise use -g github:railwayapp/cli@4.51.0
+        run: mise use -g github:railwayapp/cli@5.28.0
 
       - name: Deploy app to Railway
         working-directory: ${{ env.APP_TO_DEPLOY }}

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -6,7 +6,7 @@
 
 - Renamed the `wasp deploy fly` flags `--vm-size`, `--initial-cluster-size`, and `--volume-size` to `--db-vm-size`, `--db-initial-cluster-size`, and `--db-volume-size`, respectively. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
 - `wasp deploy fly` now requires Fly CLI version 0.4.82 or newer. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
-- Wasp Deploy for Railway now requires Railway CLI 5.28.0 or newer. ([#4647](https://github.com/wasp-lang/wasp/pull/4647), [#4712](https://github.com/wasp-lang/wasp/pull/4712))
+- Wasp Deploy for Railway now requires Railway CLI 5.28.0 or newer. ([#4712](https://github.com/wasp-lang/wasp/pull/4712))
 - Moved internal server-only import paths under the `wasp/server/...` prefix. These paths are not part of the documented public API, but if your app imported any of them, update the import path or switch to documented public imports like `wasp/server/auth`. ([#4557](https://github.com/wasp-lang/wasp/pull/4557))
 - Wasp now manages your app's URLs in development, so setting `WASP_SERVER_URL`, `WASP_WEB_CLIENT_URL`, or `REACT_APP_API_URL` yourself is now an error. ([#4692](https://github.com/wasp-lang/wasp/pull/4692))
 - Wasp now manages your app's ports in development, so setting them yourself (e.g. `server.port` in `vite.config.ts`) is now an error. ([#4591](https://github.com/wasp-lang/wasp/pull/4591))

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -6,7 +6,7 @@
 
 - Renamed the `wasp deploy fly` flags `--vm-size`, `--initial-cluster-size`, and `--volume-size` to `--db-vm-size`, `--db-initial-cluster-size`, and `--db-volume-size`, respectively. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
 - `wasp deploy fly` now requires Fly CLI version 0.4.82 or newer. ([#4642](https://github.com/wasp-lang/wasp/pull/4642))
-- Wasp Deploy for Railway now requires Railway CLI 4.51.0 or newer. ([#4647](https://github.com/wasp-lang/wasp/pull/4647))
+- Wasp Deploy for Railway now requires Railway CLI 5.28.0 or newer. ([#4647](https://github.com/wasp-lang/wasp/pull/4647), [#4712](https://github.com/wasp-lang/wasp/pull/4712))
 - Moved internal server-only import paths under the `wasp/server/...` prefix. These paths are not part of the documented public API, but if your app imported any of them, update the import path or switch to documented public imports like `wasp/server/auth`. ([#4557](https://github.com/wasp-lang/wasp/pull/4557))
 - Wasp now manages your app's URLs in development, so setting `WASP_SERVER_URL`, `WASP_WEB_CLIENT_URL`, or `REACT_APP_API_URL` yourself is now an error. ([#4692](https://github.com/wasp-lang/wasp/pull/4692))
 - Wasp now manages your app's ports in development, so setting them yourself (e.g. `server.port` in `vite.config.ts`) is now an error. ([#4591](https://github.com/wasp-lang/wasp/pull/4591))

--- a/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
@@ -20,6 +20,7 @@ import {
 } from "../../DeploymentInstructions.js";
 import { getRailwayEnvVarValueReference } from "../../env.js";
 import { clientAppPort, serverAppPort } from "../../ports.js";
+import { getLinkedEnvironmentId } from "../../railwayEnvironment/cli.js";
 import {
   initRailwayProject,
   linkRailwayProjectToWaspProjectDir,
@@ -138,12 +139,14 @@ async function setupDb({
 }: DeploymentInstructions<SetupCmdOptions>): Promise<void> {
   waspSays(`Setting up database using image: ${options.dbImage}`);
 
+  const environmentId = await getLinkedEnvironmentId(options);
   const dbService = await createDatabaseService({
     serviceName: dbServiceName,
     imageSpec: {
       image: options.dbImage,
       volumeMountPath: options.dbVolumeMountPath,
     },
+    environmentId,
     railwayExe: options.railwayExe,
     waspProjectDir: options.waspProjectDir,
   });

--- a/waspc/data/packages/deploy/src/providers/railway/jsonOutputSchemas.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/jsonOutputSchemas.ts
@@ -23,6 +23,15 @@ export const RailwayCliProjectSchema = z.object({
 
 export const RailwayProjectListSchema = z.array(RailwayCliProjectSchema);
 
+export const RailwayCliEnvironmentListSchema = z.object({
+  environments: z.array(
+    z.object({
+      id: z.string(),
+      isLinked: z.boolean(),
+    }),
+  ),
+});
+
 export const RailwayCliServiceListSchema = z.array(
   RailwayCliServiceSchema.extend({
     volumes: z.array(
@@ -55,6 +64,18 @@ export const RailwayCliServiceStatusSchema = z.object({
   // A missing status (service never deployed) or an unrecognized status
   // defaults to `null`.
   status: DeploymentStatusSchema.nullable().catch(null).default(null),
+});
+
+export const RailwayApiServiceInstanceUpdateResponseSchema = z.object({
+  data: z.object({
+    serviceInstanceUpdate: z.literal(true),
+  }),
+});
+
+export const RailwayApiServiceInstanceDeployV2ResponseSchema = z.object({
+  data: z.object({
+    serviceInstanceDeployV2: z.string(),
+  }),
 });
 
 export const RailwayCliDomainSchema = z.union([

--- a/waspc/data/packages/deploy/src/providers/railway/jsonOutputSchemas.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/jsonOutputSchemas.ts
@@ -27,6 +27,7 @@ export const RailwayCliEnvironmentListSchema = z.object({
   environments: z.array(
     z.object({
       id: z.string(),
+      name: z.string(),
       isLinked: z.boolean(),
     }),
   ),
@@ -64,18 +65,6 @@ export const RailwayCliServiceStatusSchema = z.object({
   // A missing status (service never deployed) or an unrecognized status
   // defaults to `null`.
   status: DeploymentStatusSchema.nullable().catch(null).default(null),
-});
-
-export const RailwayApiServiceInstanceUpdateResponseSchema = z.object({
-  data: z.object({
-    serviceInstanceUpdate: z.literal(true),
-  }),
-});
-
-export const RailwayApiServiceInstanceDeployV2ResponseSchema = z.object({
-  data: z.object({
-    serviceInstanceDeployV2: z.string(),
-  }),
 });
 
 export const RailwayCliDomainSchema = z.union([

--- a/waspc/data/packages/deploy/src/providers/railway/railwayCli.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayCli.ts
@@ -9,8 +9,8 @@ import {
 import { RailwayCliExe, RailwayProjectName } from "./brandedTypes.js";
 import { serviceNameSuffixes } from "./railwayService/nameGenerator.js";
 
-// Wasp relies on the `--json` output added in Railway CLI 4.51.0.
-const minSupportedRailwayCliVersion = new SemVer("4.51.0");
+// Wasp relies on the `railway api` command added in Railway CLI 5.28.0.
+const minSupportedRailwayCliVersion = new SemVer("5.28.0");
 
 export async function ensureRailwayCliReady(
   railwayExe: RailwayCliExe,

--- a/waspc/data/packages/deploy/src/providers/railway/railwayEnvironment/cli.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayEnvironment/cli.ts
@@ -22,9 +22,15 @@ export async function getLinkedEnvironmentId(options: {
   const linkedEnvironment = environments.find(
     (environment) => environment.isLinked,
   );
+  // We don't expect this to happen in a normally provisioned Railway project:
+  // `railway init` creates a default "production" environment and links it,
+  // and `railway link` always selects an environment as well.
   if (linkedEnvironment === undefined) {
+    const environmentNames = environments
+      .map((environment) => environment.name)
+      .join(", ");
     throw new Error(
-      "No Railway environment is linked to this directory. Run `railway environment` to link one.",
+      `No Railway environment is linked to this directory. Run \`railway environment\` to link one of: ${environmentNames}.`,
     );
   }
   return linkedEnvironment.id;

--- a/waspc/data/packages/deploy/src/providers/railway/railwayEnvironment/cli.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayEnvironment/cli.ts
@@ -1,0 +1,31 @@
+import { WaspProjectDir } from "../../../common/brandedTypes.js";
+import { createCommandWithCwd, runJsonCommand } from "../../../common/zx.js";
+import { RailwayCliExe } from "../brandedTypes.js";
+import { RailwayCliEnvironmentListSchema } from "../jsonOutputSchemas.js";
+
+// `railway status --json` returns all of the project's environments without
+// saying which one is linked, so we ask `railway environment list` instead.
+export async function getLinkedEnvironmentId(options: {
+  railwayExe: RailwayCliExe;
+  waspProjectDir: WaspProjectDir;
+}): Promise<string> {
+  const railwayCli = createCommandWithCwd(
+    options.railwayExe,
+    options.waspProjectDir,
+  );
+
+  const { environments } = await runJsonCommand(
+    railwayCli,
+    ["environment", "list", "--json"],
+    RailwayCliEnvironmentListSchema,
+  );
+  const linkedEnvironment = environments.find(
+    (environment) => environment.isLinked,
+  );
+  if (linkedEnvironment === undefined) {
+    throw new Error(
+      "No Railway environment is linked to this directory. Run `railway environment` to link one.",
+    );
+  }
+  return linkedEnvironment.id;
+}

--- a/waspc/data/packages/deploy/src/providers/railway/railwayService/database.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayService/database.ts
@@ -8,10 +8,18 @@ import {
   RailwayCliServiceListSchema,
   RailwayCliServiceSchema,
 } from "../jsonOutputSchemas.js";
+import {
+  RailwayServiceInstance,
+  setServiceInstanceImage,
+  startServiceInstanceDeployment,
+} from "./serviceInstance.js";
 
+// Creating a service with an image immediately starts a deployment, and
+// Postgres crashes when its volume isn't attached yet.
 export async function createDatabaseService({
   serviceName,
   imageSpec,
+  environmentId,
   railwayExe,
   waspProjectDir,
 }: {
@@ -20,22 +28,28 @@ export async function createDatabaseService({
     image: string;
     volumeMountPath: string;
   };
+  environmentId: string;
   railwayExe: RailwayCliExe;
   waspProjectDir: WaspProjectDir;
 }): Promise<RailwayCliService> {
   const options = { railwayExe, waspProjectDir };
-  const dbService = await addDatabaseService(
+  const dbService = await addDatabaseServiceWithoutImage(
     serviceName,
-    imageSpec.image,
     imageSpec.volumeMountPath,
     options,
   );
+  const dbServiceInstance: RailwayServiceInstance = {
+    serviceId: dbService.id,
+    environmentId,
+  };
 
   try {
     await addDatabaseVolume(dbService, imageSpec.volumeMountPath, options);
-  } catch (volumeError) {
-    await deleteIncompleteDatabaseService(dbService, volumeError, options);
-    throw volumeError;
+    await setServiceInstanceImage(dbServiceInstance, imageSpec.image, options);
+    await startServiceInstanceDeployment(dbServiceInstance, options);
+  } catch (setupError) {
+    await deleteIncompleteDatabaseService(dbService, setupError, options);
+    throw setupError;
   }
 
   return dbService;
@@ -60,9 +74,8 @@ export async function assertDatabaseServiceHasVolume(
   }
 }
 
-async function addDatabaseService(
+async function addDatabaseServiceWithoutImage(
   dbServiceName: DbServiceName,
-  dbImage: string,
   dbVolumeMountPath: string,
   options: {
     railwayExe: RailwayCliExe;
@@ -92,13 +105,7 @@ async function addDatabaseService(
 
   return runJsonCommand(
     railwayCli,
-    [
-      "add",
-      ...["--service", dbServiceName],
-      ...["--image", dbImage],
-      ...variableArgs,
-      "--json",
-    ],
+    ["add", ...["--service", dbServiceName], ...variableArgs, "--json"],
     RailwayCliServiceSchema,
   );
 }
@@ -130,7 +137,7 @@ async function addDatabaseVolume(
 
 async function deleteIncompleteDatabaseService(
   dbService: RailwayCliService,
-  volumeError: unknown,
+  setupError: unknown,
   options: {
     railwayExe: RailwayCliExe;
     waspProjectDir: WaspProjectDir;
@@ -151,7 +158,7 @@ async function deleteIncompleteDatabaseService(
       [
         `Wasp couldn't finish setting up Railway database service "${dbService.name}" (${dbService.id}).`,
         "Wasp also couldn't remove the incomplete service. Remove it from Railway before trying again.",
-        `Volume error: ${getErrorMessage(volumeError)}`,
+        `Setup error: ${getErrorMessage(setupError)}`,
         `Cleanup error: ${getErrorMessage(cleanupError)}`,
       ].join("\n"),
     );

--- a/waspc/data/packages/deploy/src/providers/railway/railwayService/serviceInstance.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayService/serviceInstance.ts
@@ -2,16 +2,18 @@ import * as z from "zod";
 import { WaspProjectDir } from "../../../common/brandedTypes.js";
 import { createCommandWithCwd, runJsonCommand } from "../../../common/zx.js";
 import { RailwayCliExe } from "../brandedTypes.js";
-import {
-  RailwayApiServiceInstanceDeployV2ResponseSchema,
-  RailwayApiServiceInstanceUpdateResponseSchema,
-} from "../jsonOutputSchemas.js";
 
 // Railway's name for a service in a specific environment.
 export type RailwayServiceInstance = {
   serviceId: string;
   environmentId: string;
 };
+
+const RailwayApiServiceInstanceUpdateResponseSchema = z.object({
+  data: z.object({
+    serviceInstanceUpdate: z.literal(true),
+  }),
+});
 
 export async function setServiceInstanceImage(
   serviceInstance: RailwayServiceInstance,
@@ -44,6 +46,12 @@ export async function setServiceInstanceImage(
     options,
   );
 }
+
+const RailwayApiServiceInstanceDeployV2ResponseSchema = z.object({
+  data: z.object({
+    serviceInstanceDeployV2: z.string(),
+  }),
+});
 
 export async function startServiceInstanceDeployment(
   serviceInstance: RailwayServiceInstance,

--- a/waspc/data/packages/deploy/src/providers/railway/railwayService/serviceInstance.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayService/serviceInstance.ts
@@ -1,0 +1,96 @@
+import * as z from "zod";
+import { WaspProjectDir } from "../../../common/brandedTypes.js";
+import { createCommandWithCwd, runJsonCommand } from "../../../common/zx.js";
+import { RailwayCliExe } from "../brandedTypes.js";
+import {
+  RailwayApiServiceInstanceDeployV2ResponseSchema,
+  RailwayApiServiceInstanceUpdateResponseSchema,
+} from "../jsonOutputSchemas.js";
+
+// Railway's name for a service in a specific environment.
+export type RailwayServiceInstance = {
+  serviceId: string;
+  environmentId: string;
+};
+
+export async function setServiceInstanceImage(
+  serviceInstance: RailwayServiceInstance,
+  image: string,
+  options: {
+    railwayExe: RailwayCliExe;
+    waspProjectDir: WaspProjectDir;
+  },
+): Promise<void> {
+  const serviceInstanceUpdateMutation = `
+    mutation ServiceInstanceUpdate(
+      $serviceId: String!
+      $environmentId: String
+      $input: ServiceInstanceUpdateInput!
+    ) {
+      serviceInstanceUpdate(
+        serviceId: $serviceId
+        environmentId: $environmentId
+        input: $input
+      )
+    }
+  `;
+
+  const imageSourceInput = JSON.stringify({ input: { source: { image } } });
+  await runServiceInstanceMutation(
+    serviceInstance,
+    serviceInstanceUpdateMutation,
+    ["--variables", imageSourceInput],
+    RailwayApiServiceInstanceUpdateResponseSchema,
+    options,
+  );
+}
+
+export async function startServiceInstanceDeployment(
+  serviceInstance: RailwayServiceInstance,
+  options: {
+    railwayExe: RailwayCliExe;
+    waspProjectDir: WaspProjectDir;
+  },
+): Promise<void> {
+  const serviceInstanceDeployV2Mutation = `
+    mutation ServiceInstanceDeployV2($serviceId: String!, $environmentId: String!) {
+      serviceInstanceDeployV2(serviceId: $serviceId, environmentId: $environmentId)
+    }
+  `;
+
+  await runServiceInstanceMutation(
+    serviceInstance,
+    serviceInstanceDeployV2Mutation,
+    [],
+    RailwayApiServiceInstanceDeployV2ResponseSchema,
+    options,
+  );
+}
+
+async function runServiceInstanceMutation<Schema extends z.ZodType>(
+  serviceInstance: RailwayServiceInstance,
+  mutation: string,
+  mutationArgs: string[],
+  responseSchema: Schema,
+  options: {
+    railwayExe: RailwayCliExe;
+    waspProjectDir: WaspProjectDir;
+  },
+): Promise<z.infer<Schema>> {
+  const railwayCli = createCommandWithCwd(
+    options.railwayExe,
+    options.waspProjectDir,
+  );
+
+  return runJsonCommand(
+    railwayCli,
+    [
+      "api",
+      mutation,
+      ...["--raw-var", `serviceId=${serviceInstance.serviceId}`],
+      ...["--raw-var", `environmentId=${serviceInstance.environmentId}`],
+      ...mutationArgs,
+    ],
+    responseSchema,
+  );
+}

--- a/waspc/data/packages/deploy/test/providers/railway/jsonOutputSchemas.test.ts
+++ b/waspc/data/packages/deploy/test/providers/railway/jsonOutputSchemas.test.ts
@@ -1,14 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
   RailwayCliDomainSchema,
-  RailwayCliProjectSchema,
   RailwayCliServiceStatusSchema,
-  RailwayProjectListSchema,
 } from "../../../src/providers/railway/jsonOutputSchemas.js";
-import {
-  cliProjectWithServices,
-  cliProjectWithoutServices,
-} from "./fixtures/railwayCliProject.js";
 
 describe("RailwayCliDomainSchema", () => {
   test("parses new format with domains array", () => {
@@ -35,20 +29,6 @@ describe("RailwayCliDomainSchema", () => {
   });
 });
 
-describe("RailwayCliProjectSchema", () => {
-  test("parses a project with services", () => {
-    const result = RailwayCliProjectSchema.parse(cliProjectWithServices);
-    expect(result.id).toBe(cliProjectWithServices.id);
-    expect(result.name).toBe(cliProjectWithServices.name);
-    expect(result.services.edges).toHaveLength(2);
-  });
-
-  test("parses a project with no services", () => {
-    const result = RailwayCliProjectSchema.parse(cliProjectWithoutServices);
-    expect(result.services.edges).toEqual([]);
-  });
-});
-
 describe("RailwayCliServiceStatusSchema", () => {
   test("treats a missing or unknown status as not ready", () => {
     expect(RailwayCliServiceStatusSchema.parse({}).status).toBeNull();
@@ -56,17 +36,5 @@ describe("RailwayCliServiceStatusSchema", () => {
       RailwayCliServiceStatusSchema.parse({ status: "BRAND_NEW_STATUS" })
         .status,
     ).toBeNull();
-  });
-});
-
-describe("RailwayProjectListSchema", () => {
-  test("parses a list of projects", () => {
-    const input = [cliProjectWithServices, cliProjectWithoutServices];
-    const result = RailwayProjectListSchema.parse(input);
-    expect(result).toHaveLength(2);
-  });
-
-  test("parses empty list", () => {
-    expect(RailwayProjectListSchema.parse([])).toEqual([]);
   });
 });

--- a/waspc/data/packages/deploy/test/providers/railway/railwayService/database.test.ts
+++ b/waspc/data/packages/deploy/test/providers/railway/railwayService/database.test.ts
@@ -4,11 +4,6 @@ import {
   DbServiceName,
   RailwayCliExe,
 } from "../../../../src/providers/railway/brandedTypes.js";
-import {
-  RailwayCliServiceListSchema,
-  RailwayCliServiceSchema,
-} from "../../../../src/providers/railway/jsonOutputSchemas.js";
-
 const mocks = vi.hoisted(() => ({
   railwayCli: vi.fn(),
   runJsonCommand: vi.fn(),
@@ -32,6 +27,7 @@ const dbVolumeMountPath = "/custom/postgresql/data";
 const dbServiceName = "Postgres" as DbServiceName;
 const dbImage = "postgres-image";
 const dbService = { id: "service-id", name: dbServiceName };
+const environmentId = "environment-id";
 const options = {
   railwayExe: "railway" as RailwayCliExe,
   waspProjectDir: "/app" as WaspProjectDir,
@@ -42,6 +38,7 @@ const createDatabaseServiceParams = {
     image: dbImage,
     volumeMountPath: dbVolumeMountPath,
   },
+  environmentId,
   ...options,
 };
 const volumeError = new Error("Failed to create volume");
@@ -52,49 +49,34 @@ beforeEach(() => {
 });
 
 describe("createDatabaseService", () => {
-  test("uses the configured mount path for PGDATA and the volume", async () => {
-    mocks.runJsonCommand.mockResolvedValueOnce(dbService);
+  test("uses the configured mount path for PGDATA and the volume, and the configured image", async () => {
+    mocks.runJsonCommand
+      .mockResolvedValueOnce(dbService)
+      .mockResolvedValueOnce({ data: { serviceInstanceUpdate: true } })
+      .mockResolvedValueOnce({ data: { serviceInstanceDeployV2: "depl-id" } });
     mocks.railwayCli.mockResolvedValueOnce({});
 
     await expect(
       createDatabaseService(createDatabaseServiceParams),
     ).resolves.toEqual(dbService);
 
-    expect(mocks.runJsonCommand).toHaveBeenCalledExactlyOnceWith(
+    expect(mocks.runJsonCommand).toHaveBeenNthCalledWith(
+      1,
       mocks.railwayCli,
-      [
-        "add",
-        "--service",
-        dbServiceName,
-        "--image",
-        dbImage,
-        "--variables",
-        "POSTGRES_DB=railway",
-        "--variables",
-        "POSTGRES_USER=postgres",
-        "--variables",
-        "POSTGRES_PASSWORD=${{secret()}}",
-        "--variables",
-        "PORT=5432",
-        "--variables",
-        `PGDATA=${dbVolumeMountPath}/pgdata`,
-        "--variables",
-        "DATABASE_URL=postgresql://${{POSTGRES_USER}}:${{POSTGRES_PASSWORD}}@${{RAILWAY_PRIVATE_DOMAIN}}:${{PORT}}/${{POSTGRES_DB}}",
-        "--json",
-      ],
-      RailwayCliServiceSchema,
+      expect.arrayContaining([`PGDATA=${dbVolumeMountPath}/pgdata`]),
+      expect.anything(),
     );
     expect(mocks.railwayCli).toHaveBeenCalledExactlyOnceWith(
-      [
-        "volume",
-        "--service",
-        dbService.id,
-        "add",
-        "--mount-path",
-        dbVolumeMountPath,
-        "--json",
-      ],
+      expect.arrayContaining(["--mount-path", dbVolumeMountPath]),
       { verbose: false },
+    );
+    expect(mocks.runJsonCommand).toHaveBeenNthCalledWith(
+      2,
+      mocks.railwayCli,
+      expect.arrayContaining([
+        JSON.stringify({ input: { source: { image: dbImage } } }),
+      ]),
+      expect.anything(),
     );
   });
 
@@ -107,6 +89,23 @@ describe("createDatabaseService", () => {
     await expect(
       createDatabaseService(createDatabaseServiceParams),
     ).rejects.toBe(volumeError);
+
+    expect(mocks.railwayCli).toHaveBeenLastCalledWith(
+      ["service", "delete", "--service", dbService.id, "--yes", "--json"],
+      { verbose: false },
+    );
+  });
+
+  test("deletes the incomplete service when setting the image fails", async () => {
+    const imageError = new Error("Failed to set image");
+    mocks.runJsonCommand
+      .mockResolvedValueOnce(dbService)
+      .mockRejectedValueOnce(imageError);
+    mocks.railwayCli.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+    await expect(
+      createDatabaseService(createDatabaseServiceParams),
+    ).rejects.toBe(imageError);
 
     expect(mocks.railwayCli).toHaveBeenLastCalledWith(
       ["service", "delete", "--service", dbService.id, "--yes", "--json"],
@@ -137,12 +136,6 @@ describe("assertDatabaseServiceHasVolume", () => {
     await expect(
       assertDatabaseServiceHasVolume(dbService, dbVolumeMountPath, options),
     ).resolves.toBeUndefined();
-
-    expect(mocks.runJsonCommand).toHaveBeenCalledExactlyOnceWith(
-      mocks.railwayCli,
-      ["service", "list", "--json"],
-      RailwayCliServiceListSchema,
-    );
   });
 
   test("throws when the service has no volume", async () => {


### PR DESCRIPTION
## Description

- `railway add --image` starts deploying immediately, before the volume attaches. The first deployment crashes and our wait logic could catch that crash and abort.
- Now we create the service empty, attach the volume, and only then set the image and deploy (via `railway api`). One deployment, volume attached from the start.
- Bumps the minimum Railway CLI to 5.28.0, which added `railway api`.
- The Railway CLI has no way to create a service with a volume attached, and no combination of its commands achieves this without going directly to the API. Submitted an issue with Railway about this: https://github.com/railwayapp/cli/issues/1101

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [x] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- The exact command sequence was verified live against Railway; the deploy CI test on this PR runs the full flow. -->

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change.
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Covered by the Railway deploy CI test. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
