### PR TITLE
Improve wording of `wasp new` CLI messages

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -34,7 +34,7 @@
 - The `OAuthData` type your auth hooks receive now properly includes the `slack` provider. ([#4655](https://github.com/wasp-lang/wasp/pull/4655))
 - Password reset now rejects an invalid or expired token before it looks at the new password, so someone without a valid reset link can no longer probe your app's password rules. ([#4657](https://github.com/wasp-lang/wasp/pull/4657))
 - `onBeforeSignup` now runs before `userSignupFields` on every signup method: email, username and password, and OAuth. ([#4659](https://github.com/wasp-lang/wasp/pull/4659))
-- Improved the wording of the `wasp new` CLI messages, e.g. it now says "Created a new Wasp app in `./my-app`." instead of "Created new Wasp app in ./my-app directory!". ([#4717](https://github.com/wasp-lang/wasp/pull/4717))
+- Improved the wording of some CLI messages. ([#4717](https://github.com/wasp-lang/wasp/pull/4717))
 
 ## 0.25.0
 

--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -34,6 +34,7 @@
 - The `OAuthData` type your auth hooks receive now properly includes the `slack` provider. ([#4655](https://github.com/wasp-lang/wasp/pull/4655))
 - Password reset now rejects an invalid or expired token before it looks at the new password, so someone without a valid reset link can no longer probe your app's password rules. ([#4657](https://github.com/wasp-lang/wasp/pull/4657))
 - `onBeforeSignup` now runs before `userSignupFields` on every signup method: email, username and password, and OAuth. ([#4659](https://github.com/wasp-lang/wasp/pull/4659))
+- Improved the wording of the `wasp new` CLI messages, e.g. it now says "Created a new Wasp app in `./my-app`." instead of "Created new Wasp app in ./my-app directory!". ([#4717](https://github.com/wasp-lang/wasp/pull/4717))
 
 ## 0.25.0
 

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject.hs
@@ -58,15 +58,15 @@ installDepsForNewProject absWaspProjectDir =
     Left _err ->
       putStrLn $
         Term.applyStyles [Term.Yellow] $
-          "Warning: Project created, but dependency installation failed.\n"
+          "Warning: The project was created, but dependency installation failed.\n"
             ++ "Run "
             ++ styleCode "wasp install"
-            ++ " in the project directory to install dependencies."
+            ++ " in the project directory to install the dependencies."
 
 -- | This function assumes that the project dir was created inside the current working directory.
 printGettingStartedInstructionsForProject :: NewProjectDescription -> IO ()
 printGettingStartedInstructionsForProject projectDescription = do
   let projectDirName = init . SP.toFilePath . SP.basename $ _absTemplateOutputDir projectDescription
   let instructions = getTemplateStartingInstructions projectDirName $ _template projectDescription
-  cliSendMessage $ Msg.Success $ "Created a new Wasp app in ./" ++ projectDirName ++ " directory!"
+  cliSendMessage $ Msg.Success $ "Created a new Wasp app in `./" ++ projectDirName ++ "`."
   putStrLn instructions

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
@@ -100,7 +100,7 @@ parseWaspProjectNameIntoAppName projectName
   | isValidWaspIdentifier appName = Right $ NewProjectAppName appName
   | otherwise =
       Left . intercalate "\n" $
-        [ "The project's name is not in the valid format! The project's name:",
+        [ "The project's name is not in a valid format! The project's name:",
           indent 2 "- must start with a letter or an underscore",
           indent 2 "- must contain only letters, numbers, dashes, or underscores",
           indent 2 "- must not be a Wasp keyword"
@@ -136,7 +136,7 @@ obtainAvailableTemplateOutputDirPath projectName = do
     ensureTemplateOutputDirDoesNotExist projectDirName absTemplateOutputDir = do
       whenM (doesDirExist $ toPathAbsDir absTemplateOutputDir) $
         throwProjectCreationError $
-          "Directory \"" ++ projectDirName ++ "\" is not empty."
+          "Directory \"./" ++ projectDirName ++ "\" already exists. Choose a different name or delete the directory first."
 
 mkNewProjectDescription :: String -> NewProjectAppName -> Path' Abs (Dir TemplateOutputDir) -> StarterTemplate -> NewProjectDescription
 mkNewProjectDescription projectName appName absTemplateOutputDir template =

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/ProjectDescription.hs
@@ -136,7 +136,9 @@ obtainAvailableTemplateOutputDirPath projectName = do
     ensureTemplateOutputDirDoesNotExist projectDirName absTemplateOutputDir = do
       whenM (doesDirExist $ toPathAbsDir absTemplateOutputDir) $
         throwProjectCreationError $
-          "Directory \"./" ++ projectDirName ++ "\" already exists. Choose a different name or delete the directory first."
+          "Directory `"
+            ++ projectDirName
+            ++ "` already exists. Choose a different name or delete the directory first."
 
 mkNewProjectDescription :: String -> NewProjectAppName -> Path' Abs (Dir TemplateOutputDir) -> StarterTemplate -> NewProjectDescription
 mkNewProjectDescription projectName appName absTemplateOutputDir template =

--- a/waspc/cli/src/Wasp/Cli/Interactive.hs
+++ b/waspc/cli/src/Wasp/Cli/Interactive.hs
@@ -95,7 +95,7 @@ askToChoose question options = do
 
     printErrorAndAskAgain :: IO o
     printErrorAndAskAgain = do
-      putStrLn $ Term.applyStyles [Term.Red] "Invalid selection, write the name or the index of the option."
+      putStrLn $ Term.applyStyles [Term.Red] "Invalid selection. Type the name or the index of the option."
       askToChoose question options
 
     showIndexedOptions :: String

--- a/web/docs/general/cli.md
+++ b/web/docs/general/cli.md
@@ -81,7 +81,7 @@ Choose a starter template
 
 🐝 --- Creating your project from the "basic" template... -------------------------
 
-Created new Wasp app in ./MyFirstProject directory!
+Created a new Wasp app in `./MyFirstProject`.
 
 To run your new app, do:
     cd MyFirstProject
@@ -96,7 +96,7 @@ $ wasp new MyFirstProject
 
 🐝 --- Creating your project from the "basic" template... -------------------------
 
-Created new Wasp app in ./MyFirstProject directory!
+Created a new Wasp app in `./MyFirstProject`.
 
 To run your new app, do:
 cd MyFirstProject

--- a/web/docs/project/starter-templates.md
+++ b/web/docs/project/starter-templates.md
@@ -26,7 +26,7 @@ Choose a starter template
 
 🐝 --- Creating your project from the "basic" template... -------------------------
 
-Created new Wasp app in ./MyFirstProject directory!
+Created a new Wasp app in `./MyFirstProject`.
 
 To run your new app, do:
     cd MyFirstProject

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -9587,7 +9587,7 @@ Choose a starter template
 
 🐝 --- Creating your project from the "basic" template... -------------------------
 
-Created new Wasp app in ./MyFirstProject directory!
+Created a new Wasp app in `./MyFirstProject`.
 
 To run your new app, do:
     cd MyFirstProject
@@ -15031,7 +15031,7 @@ Choose a starter template
 
 🐝 --- Creating your project from the "basic" template... -------------------------
 
-Created new Wasp app in ./MyFirstProject directory!
+Created a new Wasp app in `./MyFirstProject`.
 
 To run your new app, do:
     cd MyFirstProject
@@ -15046,7 +15046,7 @@ $ wasp new MyFirstProject
 
 🐝 --- Creating your project from the "basic" template... -------------------------
 
-Created new Wasp app in ./MyFirstProject directory!
+Created a new Wasp app in `./MyFirstProject`.
 
 To run your new app, do:
 cd MyFirstProject


### PR DESCRIPTION
## Description

Improves the wording and grammar of the messages printed by the `wasp new` command:

- `Created a new Wasp app in ./hello-app directory!` → `Created a new Wasp app in ` + "`" + `./hello-app` + "`" + `.` (backticks match the convention used for code in other CLI messages, e.g. in `DbConnectionEstablished` and `GeneratedApp`).
- `Warning: Project created, but dependency installation failed. ... to install dependencies.` → `Warning: The project was created, but dependency installation failed. ... to install the dependencies.`
- `Directory "hello-app" is not empty.` → `Directory ` + "`" + `hello-app` + "`" + ` already exists. Choose a different name or delete the directory first.` (the old message was misleading — the check is about the directory existing, not being empty).
- `The project's name is not in the valid format!` → `The project's name is not in a valid format!`
- `Invalid selection, write the name or the index of the option.` → `Invalid selection. Type the name or the index of the option.`

Also updated the corresponding docs in `web/docs/`.

Verified locally: built `waspc` with GHC 9.6.7 / cabal 3.16.1.0, ran `wasp-cli new` and confirmed the new messages are printed (both success and failure paths), and `cabal test wasp-cli-tests waspc-tests` passes (34 + 657 tests).

## Type of change

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
