### PR TITLE
Wire provider selection into codegen with just-in-time user provisioning

### DIFF
--- a/examples/auth-providers/custom-clerk/main.wasp.ts
+++ b/examples/auth-providers/custom-clerk/main.wasp.ts
@@ -1,6 +1,16 @@
-import { action, app, page, query, route, waspAuth } from "@wasp.sh/spec";
+import {
+  action,
+  app,
+  customAuthProvider,
+  page,
+  query,
+  route,
+} from "@wasp.sh/spec";
+import { App } from "./src/App" with { type: "ref" };
 import { MainPage } from "./src/MainPage" with { type: "ref" };
 import { LoginPage } from "./src/auth/LoginPage" with { type: "ref" };
+import { clerkAuthProvider } from "./src/auth/provider" with { type: "ref" };
+import { clientEnvSchema } from "./src/env" with { type: "ref" };
 import { createTask, getMyTasks } from "./src/operations" with { type: "ref" };
 
 export default app({
@@ -11,19 +21,37 @@ export default app({
   auth: {
     userEntity: "User",
     onAuthFailedRedirectTo: "/login",
-    // TODO: to be replaced with a hand-written Clerk adapter.
-    provider: waspAuth({
-      methods: {
-        usernameAndPassword: {},
+    provider: customAuthProvider({
+      id: "external:clerk",
+      server: clerkAuthProvider,
+      capabilities: ["session-revocation"],
+      env: {
+        server: [
+          { name: "CLERK_SECRET_KEY", doc: "Clerk dashboard → API keys" },
+          { name: "CLERK_PUBLISHABLE_KEY", doc: "Clerk dashboard → API keys" },
+          {
+            name: "CLERK_JWT_KEY",
+            optional: true,
+            doc: "enables networkless JWT verification",
+          },
+        ],
+        client: [],
       },
-      onAuthSucceededRedirectTo: "/",
     }),
   },
 
+  client: {
+    // Wraps the app in Clerk's provider and bridges its token to Wasp's client.
+    rootComponent: App,
+    envValidationSchema: clientEnvSchema,
+  },
+
   spec: [
+    // Identical to the other two apps.
     route("MainRoute", "/", page(MainPage, { authRequired: true })),
     route("LoginRoute", "/login", page(LoginPage)),
     query(getMyTasks, { entities: ["Task"], auth: true }),
     action(createTask, { entities: ["Task"], auth: true }),
+    // Note: no api() declarations. Clerk contributes no routes and no tables.
   ],
 });

--- a/examples/auth-providers/custom-clerk/src/App.tsx
+++ b/examples/auth-providers/custom-clerk/src/App.tsx
@@ -1,0 +1,55 @@
+import { ClerkProvider, useAuth as useClerkAuth } from "@clerk/clerk-react";
+import { useEffect } from "react";
+import { env } from "wasp/client";
+import { clearSessionId, setSessionId } from "wasp/client/api";
+
+// Wasp's typed client env, declared in `clientEnvSchema` (see main.wasp.ts).
+// Using this rather than `import.meta.env` keeps the file type-checkable.
+const publishableKey = env.REACT_APP_CLERK_PUBLISHABLE_KEY;
+
+/**
+ * Bridges Clerk's session into Wasp's client.
+ *
+ * Wasp sends its credential as `Authorization: Bearer <token>`, so we hand it
+ * Clerk's token whenever Clerk has one. This is the only Wasp-specific glue on
+ * the client side, and it is the mirror image of what the Better Auth example's
+ * login page does after a successful sign-in.
+ *
+ * Clerk's tokens are short-lived (~60s) and its SDK refreshes them on a timer,
+ * so this effect re-runs and keeps Wasp's stored credential fresh.
+ */
+function ClerkToWaspSessionBridge({ children }: { children: React.ReactNode }) {
+  const { isSignedIn, getToken } = useClerkAuth();
+
+  useEffect(() => {
+    let cancelled = false;
+    async function sync() {
+      const token = isSignedIn ? await getToken() : null;
+      if (!cancelled) {
+        // Wasp stores the credential it attaches to every API call. Clearing it
+        // on sign-out is what makes `logout()` uniform across providers.
+        if (token) {
+          setSessionId(token);
+        } else {
+          clearSessionId();
+        }
+      }
+    }
+    void sync();
+    const interval = setInterval(() => void sync(), 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [isSignedIn, getToken]);
+
+  return <>{children}</>;
+}
+
+export function App({ children }: { children: React.ReactNode }) {
+  return (
+    <ClerkProvider publishableKey={publishableKey}>
+      <ClerkToWaspSessionBridge>{children}</ClerkToWaspSessionBridge>
+    </ClerkProvider>
+  );
+}

--- a/examples/auth-providers/custom-clerk/src/auth/LoginPage.tsx
+++ b/examples/auth-providers/custom-clerk/src/auth/LoginPage.tsx
@@ -1,22 +1,22 @@
-import { useState } from "react";
-import { LoginForm, SignupForm } from "wasp/client/auth";
+import { SignIn } from "@clerk/clerk-react";
 
 /**
- * Identical to `wasp-auth/`'s login page. This is the file that changes when
- * the app adopts its real auth provider -- everything else stays put.
+ * The Clerk login page, and the clearest illustration of where Wasp's uniform
+ * line falls.
+ *
+ * There is no `<LoginForm />` here and there cannot be one. Clerk has no
+ * server-side password endpoint, so Wasp cannot post credentials on the app's
+ * behalf -- the browser must talk to Clerk's Frontend API directly. Clerk's own
+ * component does that.
+ *
+ * Compare `../../../wasp-auth/src/auth/LoginPage.tsx` and
+ * `../../../better-auth/src/auth/LoginPage.tsx`. The login pages differ per
+ * provider. Everything else in these apps does not.
  */
 export function LoginPage() {
-  const [isSignup, setIsSignup] = useState(false);
-
   return (
-    <main
-      style={{ maxWidth: 380, margin: "3rem auto", fontFamily: "system-ui" }}
-    >
-      <h1>{isSignup ? "Sign up" : "Log in"}</h1>
-      {isSignup ? <SignupForm /> : <LoginForm />}
-      <button onClick={() => setIsSignup((v) => !v)}>
-        {isSignup ? "I already have an account" : "I need an account"}
-      </button>
+    <main style={{ display: "grid", placeItems: "center", marginTop: "3rem" }}>
+      <SignIn />
     </main>
   );
 }

--- a/examples/auth-providers/custom-clerk/src/auth/provider.ts
+++ b/examples/auth-providers/custom-clerk/src/auth/provider.ts
@@ -1,0 +1,90 @@
+import { createClerkClient } from "@clerk/backend";
+import type {
+  AuthenticateResult,
+  AuthProvider,
+  SupportsSessionRevocation,
+  VerifiedSession,
+} from "wasp/server/auth/provider/types";
+
+const clerk = createClerkClient({
+  secretKey: process.env.CLERK_SECRET_KEY,
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+});
+
+/**
+ * Clerk, expressed as a Wasp `AuthProvider`.
+ *
+ * This app hand-writes the adapter and registers it with `customAuthProvider()`
+ * -- the escape hatch for providers nobody has packaged yet. Compare `../clerk`,
+ * where the same provider ships as an npm package instead. Clerk is by far the
+ * least work to integrate: it contributes **no Prisma models and no routes**. It
+ * only ever answers "whose request is this?".
+ *
+ * It is also the adapter that proves why session issuance is a separate
+ * capability (`SupportsSessionIssuance`) rather than part of the base
+ * interface. Clerk has **no
+ * server-side password login at all** -- password verification lives on its
+ * Frontend API behind a browser-held `__client` cookie, and its Backend API has
+ * no endpoint that turns credentials into a session. So this object implements
+ * `AuthProvider` and stops there. A uniform `login(email, password)` could only
+ * be implemented for Clerk as something that throws or silently ignores its
+ * arguments; a missing capability is the honest alternative.
+ */
+export const clerkAuthProvider: AuthProvider & SupportsSessionRevocation = {
+  /**
+   * Becomes `AuthIdentity.providerName`, so it must stay stable across deploys.
+   */
+  id: "external:clerk",
+
+  /**
+   * Wasp hands every adapter a standard web `Request` -- built from the HTTP
+   * request, or synthesized with just an `Authorization` header for websocket
+   * auth. Clerk's SDK consumes one natively, so there is nothing to convert.
+   *
+   * Clerk reads either its `__session` cookie or an `Authorization: Bearer`
+   * header transparently, so the same code serves web and native clients.
+   *
+   * With `jwtKey` set this is local RS256 verification with no network call;
+   * without it, Clerk fetches (and caches) the JWKS.
+   */
+  async authenticate(request: Request): Promise<AuthenticateResult> {
+    const requestState = await clerk.authenticateRequest(request, {
+      jwtKey: process.env.CLERK_JWT_KEY,
+    });
+
+    if (!requestState.isAuthenticated) {
+      return { status: "unauthenticated" };
+    }
+
+    const { userId, sessionId, sessionClaims } = requestState.toAuth();
+    if (!userId || !sessionId) {
+      return { status: "unauthenticated" };
+    }
+
+    return {
+      status: "authenticated",
+      session: {
+        sessionId,
+        subjectId: userId,
+        // The verified JWT's claims, recorded by Wasp when it provisions the
+        // local user. NOTE: Clerk's default session token carries no email --
+        // add one to the token template in the Clerk dashboard if the app's
+        // user entity needs it at provisioning time.
+        claims: sessionClaims as VerifiedSession["claims"],
+      },
+    };
+  },
+
+  /**
+   * Clerk sessions are revocable server-side, which is what lets `logout()` stay
+   * uniform across all the example apps.
+   *
+   * Worth knowing: because Clerk's session tokens are short-lived JWTs verified
+   * locally, revocation is not instantaneous -- an already-issued token stays
+   * valid until it expires (~60s by default). Wasp's own auth revokes instantly.
+   * Same API, weaker guarantee.
+   */
+  async revokeSession(sessionId: string): Promise<void> {
+    await clerk.sessions.revokeSession(sessionId);
+  },
+};

--- a/examples/auth-providers/custom-clerk/src/env.ts
+++ b/examples/auth-providers/custom-clerk/src/env.ts
@@ -1,0 +1,10 @@
+import * as z from "zod";
+
+/**
+ * Clerk's publishable key has to reach the browser, so it goes through Wasp's
+ * client env schema rather than `import.meta.env` -- that keeps it typed and
+ * validated at startup instead of failing at render time.
+ */
+export const clientEnvSchema = z.object({
+  REACT_APP_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+});

--- a/waspc/data/Generator/templates/sdk/wasp/auth/user.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/user.ts
@@ -10,7 +10,9 @@ import {
   getProviderData,
 } from './providerData.js'
 import { Expand } from '../universal/types.js'
+{=^ isCustomAuthProviderUsed =}
 import { isNotNull } from '../universal/predicates.js'
+{=/ isCustomAuthProviderUsed =}
 
 // PUBLIC API
 export function getEmail(user: UserEntityWithAuth): string | null {
@@ -124,10 +126,17 @@ export function makeAuthUserIfPossible(
 function makeAuthUser(data: AuthUserData): AuthUser {
   return {
     ...data,
+    {=# isCustomAuthProviderUsed =}
+    // No Wasp auth methods are enabled under an external provider, so there are
+    // no identities to read.
+    getFirstProviderUserId: () => null,
+    {=/ isCustomAuthProviderUsed =}
+    {=^ isCustomAuthProviderUsed =}
     getFirstProviderUserId: () => {
       const identities = Object.values(data.identities).filter(isNotNull);
       return identities.length > 0 ? identities[0].id : null;
     },
+    {=/ isCustomAuthProviderUsed =}
   };
 }
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/provider/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/provider/index.ts
@@ -1,5 +1,11 @@
-import { waspAuthProvider } from './wasp.js'
+{{={= =}=}}
 import { type AuthProvider } from './types.js'
+{=# isCustomAuthProviderUsed =}
+{=& authProvider.importStatement =}
+{=/ isCustomAuthProviderUsed =}
+{=^ isCustomAuthProviderUsed =}
+import { waspAuthProvider } from './wasp.js'
+{=/ isCustomAuthProviderUsed =}
 
 // PRIVATE API
 export {
@@ -13,9 +19,19 @@ export {
 /**
  * The auth provider this app runs on.
  *
- * There is exactly one today and it is not configurable. This module exists so that
- * everything else in Wasp depends on the `AuthProvider` interface rather than on a
- * concrete implementation -- making the provider selectable is a later, additive
- * change that will not touch any of its consumers.
+ * Everything else in Wasp depends on the `AuthProvider` interface rather than on
+ * a concrete implementation, so selecting a different one here is the only change
+ * needed to authenticate against something other than Wasp's own auth.
  */
-export const authProvider: AuthProvider = waspAuthProvider
+export const authProvider: AuthProvider =
+  {=# isCustomAuthProviderUsed =}{= authProvider.importIdentifier =}{=/ isCustomAuthProviderUsed =}{=^ isCustomAuthProviderUsed =}waspAuthProvider{=/ isCustomAuthProviderUsed =}
+
+// PRIVATE API
+/**
+ * Whether the provider owns Wasp's auth entity.
+ *
+ * Wasp's own auth writes the `Auth` table itself, so a subject id from it already
+ * identifies a local row. An external provider's subject id is foreign, and Wasp
+ * has to resolve it to a local user -- provisioning one on first sight.
+ */
+export const providerOwnsAuthEntity: boolean = {=# isCustomAuthProviderUsed =}false{=/ isCustomAuthProviderUsed =}{=^ isCustomAuthProviderUsed =}true{=/ isCustomAuthProviderUsed =}

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
@@ -85,9 +85,17 @@ function toWebRequest(req: ExpressRequest): Request {
  * keeps this to a single query and means the provider only ever has to tell us
  * which auth subject it verified.
  */
-async function toSessionAndUser({ sessionId, subjectId }: VerifiedSession): Promise<SessionAndUser | null> {
+async function toSessionAndUser({ sessionId, subjectId{=# isCustomAuthProviderUsed =}, claims{=/ isCustomAuthProviderUsed =} }: VerifiedSession): Promise<SessionAndUser | null> {
+  {=# isCustomAuthProviderUsed =}
+  const authId = await resolveExternalSubject(subjectId, claims);
+  if (authId === null) {
+    return null;
+  }
+  {=/ isCustomAuthProviderUsed =}
+  {=^ isCustomAuthProviderUsed =}
   // Wasp's own auth owns the auth entity, so the subject id already identifies one.
   const authId = subjectId;
+  {=/ isCustomAuthProviderUsed =}
 
   const user = await prisma.{= userEntityLower =}.findFirst({
     where: { {= authFieldOnUserEntityName =}: { id: authId } },
@@ -108,6 +116,86 @@ async function toSessionAndUser({ sessionId, subjectId }: VerifiedSession): Prom
 
   return { sessionId, user: createAuthUserData(user) };
 }
+
+{=# isCustomAuthProviderUsed =}
+/**
+ * Maps a provider-owned subject id onto Wasp's auth entity, creating the local
+ * rows the first time we see that subject.
+ *
+ * This is what keeps `context.user` honest. RedwoodJS shipped nine auth adapters
+ * over one interface but left provisioning to the developer, so `currentUser.id`
+ * ended up meaning a database id under one adapter and a provider's opaque string
+ * under another. Wasp always resolves to a row in the developer's own entity.
+ *
+ * The upsert is deliberately written as create-then-handle-conflict rather than
+ * find-then-create: two requests can arrive for the same brand-new subject at the
+ * same time, and only the unique constraint can settle that race.
+ */
+async function resolveExternalSubject(
+  subjectId: string,
+  claims: VerifiedSession['claims'],
+): Promise<string | null> {
+  const providerName = authProvider.id;
+
+  const existing = await prisma.{= authIdentityEntityLower =}.findUnique({
+    where: {
+      providerName_providerUserId: {
+        providerName: providerName,
+        providerUserId: subjectId,
+      },
+    },
+    select: { authId: true },
+  });
+
+  if (existing) {
+    return existing.authId;
+  }
+
+  try {
+    const created = await prisma.{= userEntityLower =}.create({
+      data: {
+        {= authFieldOnUserEntityName =}: {
+          create: {
+            {= identitiesFieldOnAuthEntityName =}: {
+              create: {
+                providerName: providerName,
+                providerUserId: subjectId,
+                // The provider-verified profile data (email, name, ...) as of
+                // the moment this subject was first seen.
+                providerData: JSON.stringify(claims ?? {}),
+              },
+            },
+          },
+        },
+      },
+      include: { {= authFieldOnUserEntityName =}: true },
+    });
+    return created.{= authFieldOnUserEntityName =}!.id;
+  } catch (e: unknown) {
+    // Another request provisioned the same subject between our read and our
+    // write. Its row is the winner; re-read rather than failing the request.
+    if (isUniqueConstraintViolation(e)) {
+      const raced = await prisma.{= authIdentityEntityLower =}.findUnique({
+        where: {
+          providerName_providerUserId: {
+            providerName: providerName,
+            providerUserId: subjectId,
+          },
+        },
+        select: { authId: true },
+      });
+      return raced?.authId ?? null;
+    }
+    throw e;
+  }
+}
+
+function isUniqueConstraintViolation(e: unknown): boolean {
+  return (
+    typeof e === 'object' && e !== null && 'code' in e && (e as { code: unknown }).code === 'P2002'
+  );
+}
+{=/ isCustomAuthProviderUsed =}
 
 // PRIVATE API
 // Ends the session server-side where the provider is able to. A pure token

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1040,7 +1040,7 @@
             "file",
             "sdk/wasp/server/auth/provider/index.ts"
         ],
-        "6c4caffe156d08b777a6c0c2fc3e2fcf214f2943b1d49b5a4b5e3bc9a8709846"
+        "62d7f8b693459682b7a89cc894e9f7ef863d291b1cc7fa271baa5ece3d7e9d41"
     ],
     [
         [
@@ -1061,7 +1061,7 @@
             "file",
             "sdk/wasp/server/auth/session.ts"
         ],
-        "a85415f64fdaf5c8678116f970041f375c4ef7b3ef0fce7b3ecc81d4115ec3a5"
+        "9ec6709e0219381a33784c6f7140d63e30c92bbb3ef821a0ab06a0cfafa3546a"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/provider/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/provider/index.ts
@@ -1,5 +1,5 @@
-import { waspAuthProvider } from './wasp.js'
 import { type AuthProvider } from './types.js'
+import { waspAuthProvider } from './wasp.js'
 
 // PRIVATE API
 export {
@@ -13,9 +13,19 @@ export {
 /**
  * The auth provider this app runs on.
  *
- * There is exactly one today and it is not configurable. This module exists so that
- * everything else in Wasp depends on the `AuthProvider` interface rather than on a
- * concrete implementation -- making the provider selectable is a later, additive
- * change that will not touch any of its consumers.
+ * Everything else in Wasp depends on the `AuthProvider` interface rather than on
+ * a concrete implementation, so selecting a different one here is the only change
+ * needed to authenticate against something other than Wasp's own auth.
  */
-export const authProvider: AuthProvider = waspAuthProvider
+export const authProvider: AuthProvider =
+  waspAuthProvider
+
+// PRIVATE API
+/**
+ * Whether the provider owns Wasp's auth entity.
+ *
+ * Wasp's own auth writes the `Auth` table itself, so a subject id from it already
+ * identifies a local row. An external provider's subject id is foreign, and Wasp
+ * has to resolve it to a local user -- provisioning one on first sight.
+ */
+export const providerOwnsAuthEntity: boolean = true

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
@@ -108,6 +108,7 @@ async function toSessionAndUser({ sessionId, subjectId }: VerifiedSession): Prom
   return { sessionId, user: createAuthUserData(user) };
 }
 
+
 // PRIVATE API
 // Ends the session server-side where the provider is able to. A pure token
 // verifier has nothing to revoke -- there, the client dropping its credential

--- a/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
@@ -83,7 +83,8 @@ genUserTs auth =
           "authFieldOnUserEntityName" .= DbAuth.authFieldOnUserEntityName,
           "authIdentityEntityName" .= DbAuth.authIdentityEntityName,
           "identitiesFieldOnAuthEntityName" .= DbAuth.identitiesFieldOnAuthEntityName,
-          "enabledProviders" .= AuthProviders.getEnabledAuthProvidersJson auth
+          "enabledProviders" .= AuthProviders.getEnabledAuthProvidersJson auth,
+          "isCustomAuthProviderUsed" .= AS.Auth.isExternalAuthProviderUsed auth
         ]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
 

--- a/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
@@ -4,6 +4,7 @@ module Wasp.Generator.SdkGenerator.Server.AuthG
 where
 
 import Data.Aeson (object, (.=))
+import Data.Maybe (isJust)
 import StrongPath (Dir', File', Path', Rel, Rel', reldir, relfile, (</>))
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
@@ -20,6 +21,7 @@ import Wasp.Generator.SdkGenerator.Common
     genFileCopy,
     mkTmplFdWithData,
   )
+import Wasp.Generator.SdkGenerator.JsImport (extImportToImportJson)
 import Wasp.Generator.SdkGenerator.Server.OAuthG (genOAuth)
 import Wasp.Util ((<++>))
 import qualified Wasp.Util as Util
@@ -37,7 +39,7 @@ genServerAuth spec =
           genFileCopyInServerAuth [relfile|jwt.ts|],
           genFileCopyInServerAuth [relfile|provider/types.ts|],
           genFileCopyInServerAuth [relfile|provider/wasp.ts|],
-          genFileCopyInServerAuth [relfile|provider/index.ts|],
+          genAuthProviderIndexTs auth,
           genSessionTs auth,
           genLuciaTs auth,
           genUtils auth
@@ -87,6 +89,28 @@ genLuciaTs auth =
 
     userEntityName = AS.refName $ AS.Auth.userEntity auth
 
+-- | Selects the auth provider the app runs on.
+--
+-- Defaults to Wasp's own auth. When @app.auth.provider@ is set, the SDK imports the
+-- developer's adapter through a virtual user module instead, and the session layer
+-- switches to resolving foreign subjects (provisioning a local user on first sight).
+genAuthProviderIndexTs :: AS.Auth.Auth -> Generator FileDraft
+genAuthProviderIndexTs auth =
+  return $
+    mkTmplFdWithData
+      (serverAuthDirInSdkTemplatesDir </> [relfile|provider/index.ts|])
+      tmplData
+  where
+    tmplData =
+      object
+        [ "isCustomAuthProviderUsed" .= isJust maybeProviderModule,
+          "authProvider" .= extImportToImportJson maybeProviderModule
+        ]
+    -- PR5 note: only src-module adapters ("customAuthProvider") are wired into
+    -- generated code so far; package entries decode into the AppSpec but the
+    -- mapper still rejects them until the generator learns to import them.
+    maybeProviderModule = AS.Auth.serverModule =<< AS.Auth.externalProvider auth
+
 genSessionTs :: AS.Auth.Auth -> Generator FileDraft
 genSessionTs auth =
   return $
@@ -99,7 +123,12 @@ genSessionTs auth =
         [ "userEntityUpper" .= userEntityName,
           "userEntityLower" .= Util.toLowerFirst userEntityName,
           "authFieldOnUserEntityName" .= DbAuth.authFieldOnUserEntityName,
-          "identitiesFieldOnAuthEntityName" .= DbAuth.identitiesFieldOnAuthEntityName
+          "authIdentityEntityLower" .= Util.toLowerFirst DbAuth.authIdentityEntityName,
+          "identitiesFieldOnAuthEntityName" .= DbAuth.identitiesFieldOnAuthEntityName,
+          -- Just-in-time provisioning only exists for providers that don't own Wasp's
+          -- auth entity. Emitting it unconditionally breaks apps whose user entity has
+          -- required fields, because the provisioning insert supplies none of them.
+          "isCustomAuthProviderUsed" .= AS.Auth.isExternalAuthProviderUsed auth
         ]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
 

--- a/waspc/src/Wasp/Generator/SdkGenerator/VirtualUserModules.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/VirtualUserModules.hs
@@ -18,6 +18,7 @@ import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.App.Client as AS.App.Client
 import qualified Wasp.AppSpec.App.Db as AS.Db
 import qualified Wasp.AppSpec.App.Server as AS.App.Server
@@ -96,6 +97,7 @@ getVirtualUserModules spec =
     [ maybeToList $ mkClientEnvValidationSchemaModule <$> maybeClientEnvValidationSchema,
       maybeToList $ mkServerEnvValidationSchemaModule <$> maybeServerEnvValidationSchema,
       maybeToList $ mkPrismaSetupFnModule <$> maybePrismaSetupFn,
+      maybeToList $ mkAuthProviderModule <$> maybeAuthProvider,
       map mkOperationModule (AS.getOperations spec)
     ]
   where
@@ -120,6 +122,19 @@ getVirtualUserModules spec =
         [relfileP|./server/dbClient|]
         "RegisteredPrismaSetupFn"
 
+    -- The auth provider is written in user code but consumed by the SDK's session
+    -- layer, so it reaches the SDK through a virtual module like everything else
+    -- user-authored. The SDK must not import user code directly. Unlike the
+    -- other virtual modules, it is declared with the plain contract type rather
+    -- than a Register-backed one: the SDK needs no more than `AuthProvider`,
+    -- and the adapter's exact type has no consumer.
+    mkAuthProviderModule extImport' =
+      VirtualUserModule
+        ServerRuntime
+        extImport'
+        [relfileP|./server/auth/provider/types|]
+        "AuthProvider"
+
     mkOperationModule operation =
       VirtualUserModule
         ServerRuntime
@@ -134,6 +149,7 @@ getVirtualUserModules spec =
     maybeClientEnvValidationSchema = AS.App.client app >>= AS.App.Client.envValidationSchema
     maybeServerEnvValidationSchema = AS.App.server app >>= AS.App.Server.envValidationSchema
     maybePrismaSetupFn = AS.App.db app >>= AS.Db.prismaSetupFn
+    maybeAuthProvider = AS.App.auth app >>= AS.Auth.externalProvider >>= AS.Auth.serverModule
     app = snd $ getApp spec
 
 -- | Virtual user modules that end up in the client bundle.


### PR DESCRIPTION
## Description

**Stack 4/7.** The generator honors the provider choice, and the invariant at the center of the design becomes real: **`context.user` is always a row in the developer's own `User` table, whichever provider vouched for the request.**

- `provider/index.ts` becomes a template: the manifest's `server` module (a user-written adapter) or `waspAuthProvider`, with a boot-time `assertProviderMatchesManifest` and `providerOwnsAuthEntity`.
- `RegisteredAuthProvider` virtual user module, so a hand-written adapter is type-checked against the contract at build time.
- `session.ts` gains `resolveExternalSubject(subjectId, claims)`: foreign subjects are provisioned just-in-time into `User`/`Auth`/`AuthIdentity`, claims recorded as provider data, with create-then-catch-P2002 race handling (N parallel first requests produce exactly one user).
- The demo, in the same PR: `custom-clerk` flips from `waspAuth()` to `customAuthProvider()` with a hand-written ~80-line Clerk adapter (`authenticate` + `revokeSession` via `@clerk/backend`) plus the client bridge in `App.tsx`. This app never changes again — it is the permanent escape-hatch example; in 7/7 the packaged `clerk()` app shows what an adapter package absorbs of exactly this code.

Two things intentionally still missing here (next PR): the manifest's `env` declarations render but are not yet enforced, and wasp-auth-only codegen (forms, lucia, `JWT_SECRET`) is not yet gated off for external-provider apps.

Review guidance: `resolveExternalSubject` in `session.ts` is the hardest ~80 lines of the stack; everything it does survives verbatim to the end state.

## Type of change

- [ ] **🔧 Just code/docs improvement**
- [ ] **🐞 Bug fix**
- [x] **🚀 New/improved feature**
- [ ] **💥 Breaking change**

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- custom-clerk example + full e2e suite -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- covered by e2e goldens; the external path gets its golden fixture in 7/7 -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [x] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- deferred until the feature ships -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- deferred, see 3/7 -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
