### PR TITLE
Gate wasp-auth-only codegen behind the provider and expose the active provider identity

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/auth/provider.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/provider.ts
@@ -1,0 +1,23 @@
+{{={= =}=}}
+// PUBLIC API
+/**
+ * The auth provider this app runs on, as a literal the type system narrows.
+ *
+ * Guard provider-specific code with it and TypeScript will tell you at compile
+ * time when the app switches providers:
+ *
+ * ```ts
+ * import { authProviderId } from 'wasp/auth/provider'
+ * ```
+ */
+export const authProviderId = "{= providerId =}" as const;
+
+// PUBLIC API
+export type AuthProviderId = typeof authProviderId;
+
+// PUBLIC API
+/**
+ * The capabilities the provider declared. An open set: adapters may declare
+ * capabilities newer than this version of Wasp knows about.
+ */
+export const authCapabilities = {=& capabilities =} as const;

--- a/waspc/data/Generator/templates/sdk/wasp/client/auth/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/auth/index.ts
@@ -1,5 +1,7 @@
 {{={= =}=}}
+{=^ isExternalAuthProviderUsed =}
 export * from './ui'
+{=/ isExternalAuthProviderUsed =}
 {=# isEmailAuthEnabled =}
 export * from './email'
 {=/ isEmailAuthEnabled =}

--- a/waspc/data/Generator/templates/sdk/wasp/client/env/schema.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/env/schema.ts
@@ -25,13 +25,30 @@ const serverUrlSchema =
     })
   )
 
+{=# isExternalAuthProviderUsed =}
+{=! Env vars the external auth provider's manifest declared for the client. =}
+const externalAuthProviderEnvSchema = z.object({
+  {=# externalAuthProviderClientEnvVars =}
+  "{= name =}": z.string({
+    error: {=& errorJson =},
+  }){=# isOptional =}.optional(){=/ isOptional =},
+  {=/ externalAuthProviderClientEnvVars =}
+});
+
+{=/ isExternalAuthProviderUsed =}
 const waspDevClientEnvSchema = z.object({
   "{= serverUrlEnvVarName =}": serverUrlSchema
     .default("{= defaultServerUrl =}"),
+{=# isExternalAuthProviderUsed =}
+  ...externalAuthProviderEnvSchema.shape,
+{=/ isExternalAuthProviderUsed =}
 });
 
 const waspProdClientEnvSchema = z.object({
   "{= serverUrlEnvVarName =}": serverUrlSchema,
+{=# isExternalAuthProviderUsed =}
+  ...externalAuthProviderEnvSchema.shape,
+{=/ isExternalAuthProviderUsed =}
 });
 
 const waspClientEnvSchema = import.meta.env.MODE === "production"

--- a/waspc/data/Generator/templates/sdk/wasp/package.json
+++ b/waspc/data/Generator/templates/sdk/wasp/package.json
@@ -63,6 +63,10 @@
       ===============================================================
     =}
     "./auth": "./dist/auth/index.js",
+    {=# isAuthEnabled =}
+    {=! Users: which auth provider the app runs on, as narrowable literals. =}
+    "./auth/provider": "./dist/auth/provider.js",
+    {=/ isAuthEnabled =}
     {=! FIXME: Documented only in example apps, not in docs. Also re-exported through `wasp/server/auth`.=}
     {=! FIXME: Candidate for removal? =}
     {=! Users: validators in custom auth actions. =}
@@ -116,10 +120,14 @@
       Internal server runtime API. Undocumented.
       ===============================================================
     =}
+    {=! Wasp-auth-only modules. Not generated under an external auth provider,
+        so their exports are dropped too and importing them is an error. =}
+    {=^ isCustomAuthProviderUsed =}
     "./server/auth/email": "./dist/server/auth/email/index.js",
     "./server/auth/email/utils": "./dist/server/auth/email/utils.js",
     "./server/auth/jwt": "./dist/server/auth/jwt.js",
     "./server/auth/password": "./dist/server/auth/password.js",
+    {=/ isCustomAuthProviderUsed =}
     {=! Server: the contract a custom auth provider implements. Adapters live in
         user code, so they need to import this as a normal module. =}
     "./server/auth/provider/types": "./dist/server/auth/provider/types.js",

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/index.ts
@@ -3,6 +3,14 @@ export {
   defineUserSignupFields,
 } from '../../auth/providers/types.js'
 
+{=# isCustomAuthProviderUsed =}
+{=! Under an external provider, `wasp/server/auth` keeps only what is
+    provider-independent: typing `userSignupFields` and the error helper the
+    generated code itself uses. Everything password- and hook-shaped belongs
+    to Wasp's own auth and is not generated at all. =}
+export { createInvalidCredentialsError } from './utils.js'
+{=/ isCustomAuthProviderUsed =}
+{=^ isCustomAuthProviderUsed =}
 export {
   createProviderId,
   sanitizeAndSerializeProviderData,
@@ -35,6 +43,7 @@ export type {
   InternalAuthHookParams,
   OAuthData,
 } from './hooks.js'
+{=/ isCustomAuthProviderUsed =}
 
 {=# isExternalAuthEnabled =}
 export * from './oauth/index.js'

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/provider/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/provider/index.ts
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import { type AuthProvider } from './types.js'
+import { {=# isCustomAuthProviderUsed =}canManageSessions as canProviderManagesSessions, canRevokeSessions as canProviderRevokeSessions, {=/ isCustomAuthProviderUsed =}type AuthProvider } from './types.js'
 {=# isCustomAuthProviderUsed =}
 {=& authProvider.importStatement =}
 {=/ isCustomAuthProviderUsed =}
@@ -11,8 +11,10 @@ import { waspAuthProvider } from './wasp.js'
 export {
   type AuthProvider,
   type SessionManagingAuthProvider,
+  type SupportsSessionRevocation,
   type VerifiedSession,
   canManageSessions,
+  canRevokeSessions,
 } from './types.js'
 
 // PRIVATE API
@@ -25,6 +27,56 @@ export {
  */
 export const authProvider: AuthProvider =
   {=# isCustomAuthProviderUsed =}{= authProvider.importIdentifier =}{=/ isCustomAuthProviderUsed =}{=^ isCustomAuthProviderUsed =}waspAuthProvider{=/ isCustomAuthProviderUsed =}
+{=# isCustomAuthProviderUsed =}
+
+/**
+ * The manifest in `main.wasp.ts` made compile-time claims about this provider
+ * (its id, its capabilities), and code was generated from them. Checking the
+ * claims against the adapter object at boot turns a wrong manifest into a
+ * loud startup failure instead of a subtly broken app.
+ */
+function assertProviderMatchesManifest(): void {
+  const manifestProviderId = "{= manifestProviderId =}";
+  const manifestCapabilities: string[] = {=& manifestCapabilities =};
+
+  const errors: string[] = [];
+
+  if (authProvider.id !== manifestProviderId) {
+    errors.push(
+      `the manifest declares id '${manifestProviderId}', but the adapter's id is '${authProvider.id}' -- ` +
+        `identities are recorded under the provider id, so the two must match`,
+    );
+  }
+
+  if (
+    manifestCapabilities.includes('issue-sessions') &&
+    !canProviderManagesSessions(authProvider)
+  ) {
+    errors.push(
+      `the manifest declares the 'issue-sessions' capability, but the adapter does not implement the full ` +
+        `issueSession/revokeSession/revokeAllSessions set Wasp requires for session management`,
+    );
+  }
+
+  if (
+    manifestCapabilities.includes('session-revocation') &&
+    !canProviderRevokeSessions(authProvider)
+  ) {
+    errors.push(
+      `the manifest declares the 'session-revocation' capability, but the adapter does not implement revokeSession`,
+    );
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `The auth provider adapter does not match its manifest ('${manifestProviderId}'):\n` +
+        errors.map((error) => `  - ${error}`).join('\n'),
+    );
+  }
+}
+
+assertProviderMatchesManifest()
+{=/ isCustomAuthProviderUsed =}
 
 // PRIVATE API
 /**

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
@@ -8,6 +8,12 @@ import { canManageSessions, canRevokeSessions, type VerifiedSession } from "./pr
 
 import { config, prisma } from '../index.js';
 import { createAuthUserData } from "../../auth/user.js";
+{=# isCustomAuthProviderUsed =}
+import { validateAndGetUserFields } from './utils.js';
+{=# externalUserSignupFields.isDefined =}
+{=& externalUserSignupFields.importStatement =}
+{=/ externalUserSignupFields.isDefined =}
+{=/ isCustomAuthProviderUsed =}
 
 /**
  * Wasp's session layer.
@@ -152,8 +158,19 @@ async function resolveExternalSubject(
   }
 
   try {
+    // The app's `userSignupFields` compute the new user's own fields from the
+    // claims the provider verified -- the only way a user entity with required
+    // columns can be provisioned at all.
+    const userFields = await validateAndGetUserFields(
+      { ...(claims ?? {}) },
+      {=# externalUserSignupFields.isDefined =}{= externalUserSignupFields.importIdentifier =}{=/ externalUserSignupFields.isDefined =}{=^ externalUserSignupFields.isDefined =}undefined{=/ externalUserSignupFields.isDefined =},
+    );
+
     const created = await prisma.{= userEntityLower =}.create({
       data: {
+        // Using `any` to defer validation of required-but-unset fields to
+        // Prisma, which reports them precisely.
+        ...(userFields as any),
         {= authFieldOnUserEntityName =}: {
           create: {
             {= identitiesFieldOnAuthEntityName =}: {

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -1,5 +1,7 @@
 {{={= =}=}}
+{=^ isCustomAuthProviderUsed =}
 import { hashPassword } from './password.js'
+{=/ isCustomAuthProviderUsed =}
 import { prisma, HttpError } from '../index.js'
 import { sleep } from '../utils.js'
 import {
@@ -57,6 +59,7 @@ export async function findAuthIdentity(providerId: ProviderId): Promise<{= authI
   });
 }
 
+{=^ isCustomAuthProviderUsed =}
 // PUBLIC API
 /**
  * Updates the provider data for the given auth identity.
@@ -86,6 +89,7 @@ export async function updateAuthIdentityProviderData<PN extends ProviderName>(
     data: { providerData: serializedProviderData },
   });
 }
+{=/ isCustomAuthProviderUsed =}
 
 // PRIVATE API
 export type FindAuthWithUserResult = {= authEntityUpper =} & {
@@ -237,6 +241,7 @@ export async function validateAndGetUserFields(
   return result;
 }
 
+{=^ isCustomAuthProviderUsed =}
 // PUBLIC API
 export async function sanitizeAndSerializeProviderData<PN extends ProviderName>(
   providerData: PossibleProviderData[PN],
@@ -262,6 +267,7 @@ async function ensurePasswordIsHashed<PN extends ProviderName>(
 
   return data;
 }
+{=/ isCustomAuthProviderUsed =}
 
 // PRIVATE API
 export function createInvalidCredentialsError(message?: string): HttpError {

--- a/waspc/data/Generator/templates/sdk/wasp/server/config.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/config.ts
@@ -12,11 +12,11 @@ type Config = {
   frontendUrl: string;
   serverUrl: string;
   allowedCORSOrigins: (string | RegExp)[];
-  {=# isAuthEnabled =}
+  {=# isWaspAuthUsed =}
   auth: {
     jwtSecret: string;
   }
-  {=/ isAuthEnabled =}
+  {=/ isWaspAuthUsed =}
 }
 
 const frontendUrl = stripTrailingSlash(env['{= clientUrlEnvVarName =}'])
@@ -36,11 +36,11 @@ const config: Config = {
   isDevelopment: env.NODE_ENV === 'development',
   port: env.PORT,
   databaseUrl: env.{= databaseUrlEnvVarName =},
-  {=# isAuthEnabled =}
+  {=# isWaspAuthUsed =}
   auth: {
     jwtSecret: env["{= jwtSecretEnvVarName =}"]
   }
-  {=/ isAuthEnabled =}
+  {=/ isWaspAuthUsed =}
 }
 
 // PUBLIC API

--- a/waspc/data/Generator/templates/sdk/wasp/server/env.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/env.ts
@@ -124,6 +124,14 @@ const waspCommonServerEnvSchema = z.object({
     error: getRequiredEnvVarErrorMessage('Microsoft auth provider', 'MICROSOFT_CLIENT_SECRET'),
   }),
   {=/ enabledAuthProviders.isMicrosoftAuthEnabled =}
+  {=! Env vars the external auth provider's manifest declared. Rendering them
+      here means a missing var fails at boot with the manifest's own
+      explanation, not at the first authenticated request. =}
+  {=# externalAuthProviderServerEnvVars =}
+  "{= name =}": z.string({
+    error: {=& errorJson =},
+  }){=# isOptional =}.optional(){=/ isOptional =},
+  {=/ externalAuthProviderServerEnvVars =}
   {=/ isAuthEnabled =}
 });
 
@@ -147,12 +155,12 @@ const clientUrlSchema =
     })
   )
 
-{=# isAuthEnabled =}
+{=# isWaspAuthUsed =}
 const jwtTokenSchema = z
   .string({
     error: '{= jwtSecretEnvVarName =} is required',
   })
-{=/ isAuthEnabled =}
+{=/ isWaspAuthUsed =}
 
 // In development, we provide default values for some environment variables
 // to make the development process easier.
@@ -162,19 +170,19 @@ const waspDevServerEnvSchema = z.object({
     .default("{= defaultServerUrl =}"),
   "{= clientUrlEnvVarName =}": clientUrlSchema
     .default("{= defaultClientUrl =}"),
-  {=# isAuthEnabled =}
+  {=# isWaspAuthUsed =}
   "{= jwtSecretEnvVarName =}": jwtTokenSchema
     .default("DEVJWTSECRET"),
-  {=/ isAuthEnabled =}
+  {=/ isWaspAuthUsed =}
 });
 
 const waspProdServerEnvSchema = z.object({
   NODE_ENV: z.literal("production"),
   "{= serverUrlEnvVarName =}": serverUrlSchema,
   "{= clientUrlEnvVarName =}": clientUrlSchema,
-  {=# isAuthEnabled =}
+  {=# isWaspAuthUsed =}
   "{= jwtSecretEnvVarName =}": jwtTokenSchema,
-  {=/ isAuthEnabled =}
+  {=/ isWaspAuthUsed =}
 });
 
 const waspServerEnvSchema = z.discriminatedUnion("NODE_ENV", [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
@@ -62,6 +62,7 @@ wasp-app/.wasp/out/sdk/wasp/auth/helpers/Slack.tsx
 wasp-app/.wasp/out/sdk/wasp/auth/helpers/user.ts
 wasp-app/.wasp/out/sdk/wasp/auth/index.ts
 wasp-app/.wasp/out/sdk/wasp/auth/logout.ts
+wasp-app/.wasp/out/sdk/wasp/auth/provider.ts
 wasp-app/.wasp/out/sdk/wasp/auth/providerData.ts
 wasp-app/.wasp/out/sdk/wasp/auth/providers/index.ts
 wasp-app/.wasp/out/sdk/wasp/auth/providers/types.ts
@@ -272,6 +273,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/auth/logout.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/auth/logout.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/auth/logout.js
 wasp-app/.wasp/out/sdk/wasp/dist/auth/logout.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/auth/provider.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/auth/provider.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/auth/provider.js
+wasp-app/.wasp/out/sdk/wasp/dist/auth/provider.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/auth/providerData.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/auth/providerData.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/auth/providerData.js

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -324,6 +324,13 @@
     [
         [
             "file",
+            "sdk/wasp/auth/provider.ts"
+        ],
+        "176579da976ad6eeb899b877d7b53d6b7616fb4973b515993882fafc68951ceb"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/auth/providerData.ts"
         ],
         "0325226f972b575d213046bafc16c3585c87c943a8da64679da773088fd9d77a"
@@ -872,7 +879,7 @@
             "file",
             "sdk/wasp/package.json"
         ],
-        "26b3bb6afcf7d414b62c96a84a49fe2310307c77b90e8f182f3b708e8fa4c47c"
+        "416e9dfe833dbfa9b1466818c5d9c9dd2caaaa1e47371b3ae37a57b755bd0dde"
     ],
     [
         [
@@ -1040,7 +1047,7 @@
             "file",
             "sdk/wasp/server/auth/provider/index.ts"
         ],
-        "62d7f8b693459682b7a89cc894e9f7ef863d291b1cc7fa271baa5ece3d7e9d41"
+        "9916d92ff4187ec09a9db74c2569cd39b704e11f97d6d72343575361bd5d9e5b"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/provider.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/provider.ts
@@ -1,0 +1,22 @@
+// PUBLIC API
+/**
+ * The auth provider this app runs on, as a literal the type system narrows.
+ *
+ * Guard provider-specific code with it and TypeScript will tell you at compile
+ * time when the app switches providers:
+ *
+ * ```ts
+ * import { authProviderId } from 'wasp/auth/provider'
+ * ```
+ */
+export const authProviderId = "wasp" as const;
+
+// PUBLIC API
+export type AuthProviderId = typeof authProviderId;
+
+// PUBLIC API
+/**
+ * The capabilities the provider declared. An open set: adapters may declare
+ * capabilities newer than this version of Wasp knows about.
+ */
+export const authCapabilities = ['issue-sessions', 'session-revocation'] as const;

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -41,6 +41,7 @@
   },
   "exports": {
     "./auth": "./dist/auth/index.js",
+    "./auth/provider": "./dist/auth/provider.js",
     "./auth/providers": "./dist/auth/providers/index.js",
     "./auth/providers/types": "./dist/auth/providers/types.js",
     "./auth/user": "./dist/auth/user.js",

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/provider/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/provider/index.ts
@@ -5,8 +5,10 @@ import { waspAuthProvider } from './wasp.js'
 export {
   type AuthProvider,
   type SessionManagingAuthProvider,
+  type SupportsSessionRevocation,
   type VerifiedSession,
   canManageSessions,
+  canRevokeSessions,
 } from './types.js'
 
 // PRIVATE API

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -4,6 +4,8 @@ module Wasp.AppSpec.Valid
   ( validateAppSpec,
     getApp,
     isAuthEnabled,
+    isWaspAuthUsed,
+    getExternalAuthProvider,
     doesUserEntityContainField,
     getIdFieldFromCrudEntity,
     getLowestNodeVersionUserAllows,
@@ -551,6 +553,18 @@ getApp spec = case takeDecls @App (AS.decls spec) of
 -- | This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).
 isAuthEnabled :: AppSpec -> Bool
 isAuthEnabled spec = isJust (App.auth $ snd $ getApp spec)
+
+-- | Whether the app authenticates through Wasp's own auth -- i.e. auth is
+-- enabled and no external provider is selected. Everything password-shaped
+-- (login routes, lucia, JWT_SECRET, auth forms) is generated only when this
+-- holds.
+isWaspAuthUsed :: AppSpec -> Bool
+isWaspAuthUsed spec = case App.auth (snd $ getApp spec) of
+  Nothing -> False
+  Just auth -> not (Auth.isExternalAuthProviderUsed auth)
+
+getExternalAuthProvider :: AppSpec -> Maybe Auth.ExternalAuthProviderSpec
+getExternalAuthProvider spec = App.auth (snd $ getApp spec) >>= Auth.externalProvider
 
 getValidDbSystem :: AppSpec -> AS.Db.DbSystem
 getValidDbSystem = getValidDbSystemFromPrismaSchema . AS.prismaSchema

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -189,6 +189,8 @@ genPackageJson spec = do
       [relfile|package.json|]
       ( object
           [ "sdkPackageName" .= C.sdkPackageName,
+            "isAuthEnabled" .= isAuthEnabled spec,
+            "isCustomAuthProviderUsed" .= isJust (AS.Valid.getExternalAuthProvider spec),
             "depsChunk" .= N.getDependenciesPackageJsonEntry (npmDepsForSdk spec),
             "devDepsChunk" .= N.getDevDependenciesPackageJsonEntry (npmDepsForSdk spec),
             "peerDepsChunk" .= N.getPeerDependenciesPackageJsonEntry (npmDepsForSdk spec)
@@ -288,6 +290,7 @@ genServerConfigFile spec = return $ C.mkTmplFdWithData [relfile|server/config.ts
     tmplData =
       object
         [ "isAuthEnabled" .= isAuthEnabled spec,
+          "isWaspAuthUsed" .= AS.Valid.isWaspAuthUsed spec,
           "clientUrlEnvVarName" .= Server.clientUrlEnvVarName,
           "serverUrlEnvVarName" .= Server.serverUrlEnvVarName,
           "jwtSecretEnvVarName" .= AuthG.jwtSecretEnvVarName,

--- a/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
@@ -35,6 +35,7 @@ genAuth spec =
       -- shared stuff
       sequence
         [ genUserTs auth,
+          genAuthProviderIdentity auth,
           genFileCopyInAuth [relfile|providerData.ts|],
           genFileCopyInAuth [relfile|validation.ts|],
           genIndexTs auth,
@@ -49,12 +50,39 @@ genAuth spec =
             genFileCopyInAuth [relfile|responseSchemas.ts|],
             genUseAuth auth
           ]
-        <++> genAuthForms auth
-        <++> genLocalAuth auth
-        <++> genOAuthAuth auth
-        <++> genEmailAuth auth
+        -- Wasp's own auth UI and flows. An external provider brings its own,
+        -- so under one these are not generated at all: importing `LoginForm`
+        -- is then a compile error, not a component that breaks at runtime.
+        <++> onlyUnderWaspAuth auth (genAuthForms auth)
+        <++> onlyUnderWaspAuth auth (genLocalAuth auth)
+        <++> onlyUnderWaspAuth auth (genOAuthAuth auth)
+        <++> onlyUnderWaspAuth auth (genEmailAuth auth)
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
+
+    onlyUnderWaspAuth auth gen
+      | AS.Auth.isExternalAuthProviderUsed auth = return []
+      | otherwise = gen
+
+-- | The one module that always answers "which auth provider is this app on":
+-- a literal the type system narrows, so provider-specific code can be guarded
+-- at compile time.
+genAuthProviderIdentity :: AS.Auth.Auth -> Generator FileDraft
+genAuthProviderIdentity auth =
+  return $
+    mkTmplFdWithData
+      (authDirInSdkTemplatesDir </> [relfile|provider.ts|])
+      tmplData
+  where
+    tmplData =
+      object
+        [ "providerId" .= providerId,
+          "capabilities" .= makeJsArrayFromHaskellList capabilities
+        ]
+    providerId = maybe "wasp" AS.Auth.providerId maybeExternalProvider
+    -- Wasp's own auth can mint and revoke sessions server-side.
+    capabilities = maybe ["issue-sessions", "session-revocation"] AS.Auth.capabilities maybeExternalProvider
+    maybeExternalProvider = AS.Auth.externalProvider auth
 
 -- | Generates React hook that Wasp developer can use in a component to get
 --   access to the currently logged in user (and check whether user is logged in

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/AuthG.hs
@@ -3,6 +3,8 @@ module Wasp.Generator.SdkGenerator.Client.AuthG
   )
 where
 
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
 import StrongPath (Dir', File', Path', Rel, Rel', reldir, relfile, (</>))
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
@@ -22,19 +24,24 @@ genClientAuth :: AppSpec -> Generator [FileDraft]
 genClientAuth spec =
   case maybeAuth of
     Nothing -> return []
-    Just auth ->
-      sequence
-        [ genAuthIndex auth,
-          genAuthUi auth
-        ]
-        <++> genAuthEmail auth
-        <++> genAuthUsername auth
-        <++> genAuthSlack auth
-        <++> genAuthDiscord auth
-        <++> genAuthGoogle auth
-        <++> genAuthKeycloak auth
-        <++> genAuthGitHub auth
-        <++> genAuthMicrosoft auth
+    Just auth
+      -- Under an external provider `wasp/client/auth` keeps only the uniform
+      -- surface (useAuth, logout); the provider's own UI comes from its
+      -- adapter package, not from Wasp's generated forms.
+      | AS.Auth.isExternalAuthProviderUsed auth -> sequence [genAuthIndex auth]
+      | otherwise ->
+          sequence
+            [ genAuthIndex auth,
+              genAuthUi auth
+            ]
+            <++> genAuthEmail auth
+            <++> genAuthUsername auth
+            <++> genAuthSlack auth
+            <++> genAuthDiscord auth
+            <++> genAuthGoogle auth
+            <++> genAuthKeycloak auth
+            <++> genAuthGitHub auth
+            <++> genAuthMicrosoft auth
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
 
@@ -45,7 +52,14 @@ genAuthIndex auth =
       (clientAuthDirInSdkTemplatesDir </> [relfile|index.ts|])
       tmplData
   where
-    tmplData = AuthProviders.getEnabledAuthProvidersJson auth
+    tmplData = case AuthProviders.getEnabledAuthProvidersJson auth of
+      Aeson.Object enabledProvidersFlags ->
+        Aeson.Object $
+          KeyMap.insert
+            "isExternalAuthProviderUsed"
+            (Aeson.toJSON $ AS.Auth.isExternalAuthProviderUsed auth)
+            enabledProvidersFlags
+      otherJson -> otherJson
 
 genAuthUi :: AS.Auth.Auth -> Generator FileDraft
 genAuthUi auth =

--- a/waspc/src/Wasp/Generator/SdkGenerator/EnvValidation.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/EnvValidation.hs
@@ -5,13 +5,18 @@ module Wasp.Generator.SdkGenerator.EnvValidation
 where
 
 import Data.Aeson (KeyValue ((.=)), object)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Text as Aeson.Text
 import Data.Maybe (isJust)
+import qualified Data.Text.Lazy as TL
 import StrongPath (relfile)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
+import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import qualified Wasp.AppSpec.App.Client as AS.App.Client
 import qualified Wasp.AppSpec.App.Server as AS.App.Server
 import Wasp.AppSpec.Valid (getApp)
+import qualified Wasp.AppSpec.Valid as AS.Valid
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
 import qualified Wasp.Generator.AuthProviders as AuthProviders
 import qualified Wasp.Generator.EmailSenders as EmailSenders
@@ -54,6 +59,9 @@ genServerEnv spec = return $ mkTmplFdWithData [relfile|server/env.ts|] tmplData
     tmplData =
       object
         [ "isAuthEnabled" .= isJust maybeAuth,
+          "isWaspAuthUsed" .= AS.Valid.isWaspAuthUsed spec,
+          "externalAuthProviderServerEnvVars"
+            .= (externalProviderEnvVarsTmplData (.server) <$> AS.Valid.getExternalAuthProvider spec),
           "clientUrlEnvVarName" .= Server.clientUrlEnvVarName,
           "serverUrlEnvVarName" .= Server.serverUrlEnvVarName,
           "jwtSecretEnvVarName" .= AuthG.jwtSecretEnvVarName,
@@ -79,10 +87,43 @@ genClientEnvSchema spec = return $ mkTmplFdWithData tmplPath tmplData
       object
         [ "serverUrlEnvVarName" .= WebApp.serverUrlEnvVarName,
           "defaultServerUrl" .= Server.defaultDevServerUrl,
+          "isExternalAuthProviderUsed" .= isJust maybeExternalProvider,
+          "externalAuthProviderClientEnvVars"
+            .= (externalProviderEnvVarsTmplData AS.Auth.client <$> maybeExternalProvider),
           "envValidationSchema" .= extImportToImportJson maybeEnvValidationSchema
         ]
+    maybeExternalProvider = AS.Valid.getExternalAuthProvider spec
     maybeEnvValidationSchema = AS.App.client app >>= AS.App.Client.envValidationSchema
     app = snd $ getApp spec
+
+-- | Env vars an external auth provider's manifest declared, rendered into the
+-- generated zod schemas so a missing var fails at boot with the manifest's own
+-- explanation.
+externalProviderEnvVarsTmplData ::
+  (AS.Auth.ExternalProviderEnvVars -> [AS.Auth.ExternalProviderEnvVar]) ->
+  AS.Auth.ExternalAuthProviderSpec ->
+  [Aeson.Value]
+externalProviderEnvVarsTmplData getVars extProvider =
+  toTmplData <$> getVars (AS.Auth.envVars extProvider)
+  where
+    toTmplData envVar =
+      object
+        [ "name" .= AS.Auth.name envVar,
+          "isOptional" .= (AS.Auth.optional envVar == Just True),
+          "errorJson" .= jsStringLiteral (errorMessage envVar)
+        ]
+
+    errorMessage envVar =
+      AS.Auth.name envVar
+        ++ " is required by the '"
+        ++ AS.Auth.providerId extProvider
+        ++ "' auth provider"
+        ++ maybe "." (": " ++) (AS.Auth.doc envVar)
+
+    -- Encoding the message as JSON yields a valid, correctly escaped JS string
+    -- literal, whatever characters the manifest's doc happens to contain.
+    jsStringLiteral :: String -> String
+    jsStringLiteral = TL.unpack . Aeson.Text.encodeToLazyText
 
 depsRequiredByEnvValidation :: [Npm.Dependency.Dependency]
 depsRequiredByEnvValidation =

--- a/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
@@ -12,6 +12,7 @@ import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
 import Wasp.AppSpec.Valid (getApp)
 import qualified Wasp.Generator.AuthProviders as AuthProviders
+import Wasp.Generator.Common (makeJsArrayFromHaskellList)
 import qualified Wasp.Generator.DbGenerator.Auth as DbAuth
 import Wasp.Generator.FileDraft (FileDraft)
 import Wasp.Generator.Monad (Generator)
@@ -30,23 +31,37 @@ genServerAuth :: AppSpec -> Generator [FileDraft]
 genServerAuth spec =
   case maybeAuth of
     Nothing -> return []
-    Just auth ->
-      sequence
-        [ genFileCopy [relfile|server/core/auth.ts|],
-          genAuthIndex auth,
-          genHooks auth,
-          genFileCopyInServerAuth [relfile|password.ts|],
-          genFileCopyInServerAuth [relfile|jwt.ts|],
-          genFileCopyInServerAuth [relfile|provider/types.ts|],
-          genFileCopyInServerAuth [relfile|provider/wasp.ts|],
-          genAuthProviderIndexTs auth,
-          genSessionTs auth,
-          genLuciaTs auth,
-          genUtils auth
-        ]
-        <++> genAuthEmail auth
-        <++> genAuthUsername auth
-        <++> genOAuth auth
+    -- Under an external provider only the provider seam and the session read
+    -- path exist. Everything password-shaped -- lucia, hashing, jwt, Wasp's own
+    -- provider -- is not generated, so it cannot be imported and its
+    -- dependencies are not installed.
+    Just auth
+      | AS.Auth.isExternalAuthProviderUsed auth ->
+          sequence
+            [ genFileCopy [relfile|server/core/auth.ts|],
+              genAuthIndex auth,
+              genFileCopyInServerAuth [relfile|provider/types.ts|],
+              genAuthProviderIndexTs auth,
+              genSessionTs auth,
+              genUtils auth
+            ]
+      | otherwise ->
+          sequence
+            [ genFileCopy [relfile|server/core/auth.ts|],
+              genAuthIndex auth,
+              genHooks auth,
+              genFileCopyInServerAuth [relfile|password.ts|],
+              genFileCopyInServerAuth [relfile|jwt.ts|],
+              genFileCopyInServerAuth [relfile|provider/types.ts|],
+              genFileCopyInServerAuth [relfile|provider/wasp.ts|],
+              genAuthProviderIndexTs auth,
+              genSessionTs auth,
+              genLuciaTs auth,
+              genUtils auth
+            ]
+            <++> genAuthEmail auth
+            <++> genAuthUsername auth
+            <++> genOAuth auth
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
 
@@ -60,7 +75,8 @@ genAuthIndex auth =
     tmplData =
       object
         [ "enabledProviders" .= AuthProviders.getEnabledAuthProvidersJson auth,
-          "isExternalAuthEnabled" .= isExternalAuthEnabled
+          "isExternalAuthEnabled" .= isExternalAuthEnabled,
+          "isCustomAuthProviderUsed" .= AS.Auth.isExternalAuthProviderUsed auth
         ]
     isExternalAuthEnabled = AS.Auth.isExternalAuthEnabled auth
 
@@ -104,12 +120,18 @@ genAuthProviderIndexTs auth =
     tmplData =
       object
         [ "isCustomAuthProviderUsed" .= isJust maybeProviderModule,
-          "authProvider" .= extImportToImportJson maybeProviderModule
+          "authProvider" .= extImportToImportJson maybeProviderModule,
+          -- The manifest's compile-time claims, checked against the runtime
+          -- adapter object at boot so a wrong manifest fails loudly instead of
+          -- generating a surface the adapter cannot back.
+          "manifestProviderId" .= (AS.Auth.providerId <$> maybeExternalProvider),
+          "manifestCapabilities" .= (makeJsArrayFromHaskellList . AS.Auth.capabilities <$> maybeExternalProvider)
         ]
-    -- PR5 note: only src-module adapters ("customAuthProvider") are wired into
+    -- NOTE: only src-module adapters ("customAuthProvider") are wired into
     -- generated code so far; package entries decode into the AppSpec but the
     -- mapper still rejects them until the generator learns to import them.
-    maybeProviderModule = AS.Auth.serverModule =<< AS.Auth.externalProvider auth
+    maybeProviderModule = AS.Auth.serverModule =<< maybeExternalProvider
+    maybeExternalProvider = AS.Auth.externalProvider auth
 
 genSessionTs :: AS.Auth.Auth -> Generator FileDraft
 genSessionTs auth =
@@ -128,7 +150,9 @@ genSessionTs auth =
           -- Just-in-time provisioning only exists for providers that don't own Wasp's
           -- auth entity. Emitting it unconditionally breaks apps whose user entity has
           -- required fields, because the provisioning insert supplies none of them.
-          "isCustomAuthProviderUsed" .= AS.Auth.isExternalAuthProviderUsed auth
+          "isCustomAuthProviderUsed" .= AS.Auth.isExternalAuthProviderUsed auth,
+          "externalUserSignupFields"
+            .= extImportToImportJson (AS.Auth.userSignupFieldsForExternalAuthProvider =<< AS.Auth.externalProvider auth)
         ]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
 
@@ -151,7 +175,8 @@ genUtils auth =
           "authFieldOnUserEntityName" .= (DbAuth.authFieldOnUserEntityName :: String),
           "identitiesFieldOnAuthEntityName" .= (DbAuth.identitiesFieldOnAuthEntityName :: String),
           "failureRedirectPath" .= AS.Auth.onAuthFailedRedirectTo auth,
-          "successRedirectPath" .= getOnAuthSucceededRedirectToOrDefault auth
+          "successRedirectPath" .= getOnAuthSucceededRedirectToOrDefault auth,
+          "isCustomAuthProviderUsed" .= AS.Auth.isExternalAuthProviderUsed auth
         ]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
 

--- a/waspc/src/Wasp/Generator/SdkGenerator/VirtualUserModules.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/VirtualUserModules.hs
@@ -98,6 +98,7 @@ getVirtualUserModules spec =
       maybeToList $ mkServerEnvValidationSchemaModule <$> maybeServerEnvValidationSchema,
       maybeToList $ mkPrismaSetupFnModule <$> maybePrismaSetupFn,
       maybeToList $ mkAuthProviderModule <$> maybeAuthProvider,
+      maybeToList $ mkAuthProviderUserSignupFieldsModule <$> maybeAuthProviderUserSignupFields,
       map mkOperationModule (AS.getOperations spec)
     ]
   where
@@ -135,6 +136,17 @@ getVirtualUserModules spec =
         [relfileP|./server/auth/provider/types|]
         "AuthProvider"
 
+    -- Feeds just-in-time provisioning under an external provider; consumed by
+    -- the SDK's session layer, so it goes through a virtual module too. Like
+    -- the auth provider module, it is declared with the plain contract type:
+    -- the session layer needs no more than `UserSignupFields`.
+    mkAuthProviderUserSignupFieldsModule extImport' =
+      VirtualUserModule
+        ServerRuntime
+        extImport'
+        [relfileP|./auth/providers/types|]
+        "UserSignupFields"
+
     mkOperationModule operation =
       VirtualUserModule
         ServerRuntime
@@ -150,6 +162,7 @@ getVirtualUserModules spec =
     maybeServerEnvValidationSchema = AS.App.server app >>= AS.App.Server.envValidationSchema
     maybePrismaSetupFn = AS.App.db app >>= AS.Db.prismaSetupFn
     maybeAuthProvider = AS.App.auth app >>= AS.Auth.externalProvider >>= AS.Auth.serverModule
+    maybeAuthProviderUserSignupFields = AS.App.auth app >>= AS.Auth.externalProvider >>= AS.Auth.userSignupFieldsForExternalAuthProvider
     app = snd $ getApp spec
 
 -- | Virtual user modules that end up in the client bundle.

--- a/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
@@ -132,7 +132,13 @@ genAuthHooks auth = return $ C.mkTmplFdWithData [relfile|src/auth/hooks.ts|] (Ju
     relPathToServerSrcDir = [reldirP|../|]
 
 depsRequiredByAuth :: AppSpec -> [Npm.Dependency.Dependency]
-depsRequiredByAuth spec = maybe [] (const authDeps) maybeAuth
+depsRequiredByAuth spec = case maybeAuth of
+  Nothing -> []
+  Just auth
+    -- An external provider brings its own session store; Wasp's lucia-backed
+    -- one is not generated, so its dependencies must not be installed either.
+    | AS.Auth.isExternalAuthProviderUsed auth -> []
+    | otherwise -> authDeps
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
     authDeps =


### PR DESCRIPTION
## Description

**Stack 5/7.** The negative space: under an external provider, Wasp's own auth surface disappears instead of lying around.

- `isWaspAuthUsed` gating: auth forms, per-method client modules, lucia/password/jwt server modules, their sdk `package.json` exports and npm deps are generated only under `waspAuth()`. Importing them under an external provider is a compile error, not a runtime surprise.
- `JWT_SECRET` is required only under wasp auth; instead, the manifest's declared env vars are rendered into the generated zod env schemas, so a missing `CLERK_SECRET_KEY` fails at boot with the adapter's own doc string as the error message.
- New `wasp/auth/provider` identity module: `authProviderId` and `capabilities` as narrowable literals.
- `userSignupFields` from the manifest feeds JIT provisioning through `validateAndGetUserFields` (a purely additive extension of 4/7's `resolveExternalSubject`).

One caveat, stated openly: the external-provider branch gets its end-to-end golden proof in 7/7, where the snapshot test lands together with the packaged Clerk fixture in its final form (landing it here would mean rewriting a 167-file golden dir one PR later).

## Type of change

- [ ] **🔧 Just code/docs improvement**
- [ ] **🐞 Bug fix**
- [x] **🚀 New/improved feature**
- [ ] **💥 Breaking change**

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- full e2e suite; kitchen-sink goldens show the wasp-auth branch unchanged -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- gating is proven by the 7/7 snapshot; wasp-auth branch by existing goldens -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- deferred until the feature ships -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- deferred, see 3/7 -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
