### PR TITLE
Teach codegen to consume adapter packages: serverPackage entries, setupFn, and manifest routes

### DIFF
--- a/waspc/data/Generator/libs/auth-contract/README.md
+++ b/waspc/data/Generator/libs/auth-contract/README.md
@@ -2,9 +2,10 @@
 
 The contract between Wasp and pluggable auth providers.
 
-An auth provider implements this contract to make an external auth solution
-(Better Auth, Clerk, WorkOS, ...) usable as a Wasp auth provider: `AuthProvider`,
-`VerifiedSession`, and the optional `SessionIssuingAuthProvider` capability.
+An auth adapter package implements this contract to make an external auth
+solution (Better Auth, Clerk, WorkOS, ...) usable as a Wasp auth provider:
+`AuthProvider`, `VerifiedSession`, `WaspServerRuntime`, and the
+`createServerAdapter` factory shape adapter packages must export.
 
 The package is copied into generated Wasp apps as a tarball (like the other libs
 in this directory) and installed via a `file:` dependency, so both generated code

--- a/waspc/data/Generator/libs/auth-contract/src/index.ts
+++ b/waspc/data/Generator/libs/auth-contract/src/index.ts
@@ -5,7 +5,14 @@
  * pages, `auth: true` operations, `context.user`, `useAuth()` -- so implementing it
  * is all it takes to make any auth solution (Better Auth, Clerk, WorkOS, ...) a
  * Wasp auth provider.
+ *
+ * An adapter package implements this contract in its server entry and exposes it
+ * as a named `createServerAdapter` export (see `ServerAdapterFactory`). Its
+ * client side, if it has one, ships as ordinary React exports on the package's
+ * own `/client` entry -- Wasp generates no client glue.
  */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 export type JsonValue =
   | string
@@ -199,3 +206,107 @@ export function canManageSessions(
     typeof p.revokeAllSessions === "function"
   );
 }
+
+/**
+ * Everything Wasp hands a server-side adapter about the app it runs in.
+ *
+ * This is the adapter's *only* window into the app: adapters must not import
+ * generated code (`wasp/...`) and must not read `process.env` themselves. Keeping
+ * the boundary here is what lets an adapter package typecheck and version
+ * independently of any particular Wasp app.
+ */
+export type WaspServerRuntime = {
+  /**
+   * The app's PrismaClient instance. Typed as `unknown` because the client's type
+   * is generated per app; adapters that need it narrow it themselves.
+   */
+  db: unknown;
+
+  /**
+   * The Prisma datasource provider of the app's database: `"sqlite"`,
+   * `"postgresql"`, ... Adapters that bring their own storage layer (Better
+   * Auth's prisma adapter, for one) need to know the dialect they are talking to.
+   */
+  dbProvider: string;
+
+  /**
+   * The server-side environment, already validated against the env vars the
+   * adapter's manifest declared.
+   */
+  env: Record<string, string | undefined>;
+
+  /** The URL the Wasp server is reachable at. */
+  serverUrl: string;
+
+  /** The URL the Wasp client is served from. Useful for trusted-origin checks. */
+  clientUrl: string;
+
+  /**
+   * Report that the provider just created one of its own users.
+   *
+   * For adapters that can observe their signup moment (in-process providers
+   * like Better Auth; a hosted provider cannot). Wasp provisions the
+   * corresponding local user eagerly, so it exists from signup rather than
+   * from the first authenticated request. Calling it is optional and always
+   * safe: provisioning is idempotent, and just-in-time provisioning on first
+   * request remains the backstop regardless.
+   */
+  onAuthUserCreated?(authUser: {
+    subjectId: string;
+    claims?: Record<string, JsonValue>;
+  }): Promise<void>;
+};
+
+/**
+ * What an adapter's server entry produces: the provider itself, plus, for
+ * providers that own HTTP endpoints of their own (Better Auth's `/sign-in` and
+ * friends), the handler Wasp should mount at the manifest's `basePath`.
+ *
+ * One factory returns both so they are guaranteed to share one configured
+ * instance -- a provider verifying against one configuration while its routes run
+ * another is a bug class this shape makes unrepresentable.
+ */
+export type ServerAdapter = {
+  provider: AuthProvider;
+
+  /**
+   * Node-style request handler for the provider's own routes. Wasp mounts it at
+   * the `basePath` the adapter's manifest declared, with the app's usual
+   * middleware around it (minus the JSON body parser when the manifest asked for
+   * raw bodies).
+   */
+  routeHandler?: (
+    req: IncomingMessage,
+    res: ServerResponse,
+  ) => void | Promise<void>;
+};
+
+/**
+ * User-code extensions Wasp delivers alongside the serializable options.
+ *
+ * `setupFn` follows the same convention as Wasp's `prismaSetupFn`: a user
+ * function the adapter calls with its integration configuration, whose return
+ * value becomes the configuration to use. It is the escape hatch for
+ * everything a manifest cannot carry -- functions, class instances, live
+ * values -- so the user can reach the underlying library's full surface
+ * (Better Auth's hooks, plugins and email callbacks, say) without giving up
+ * the packaged adapter. Adapters should re-assert the invariants their
+ * integration depends on (route base paths, required plugins, table name
+ * overrides) after applying it.
+ */
+export type ServerAdapterExtensions = {
+  setupFn?: (config: never) => unknown;
+};
+
+/**
+ * The required shape of an adapter package's server entry: a named
+ * `createServerAdapter` export of this type. `options` is the serializable
+ * configuration the adapter's spec helper captured in `main.wasp.ts`, delivered
+ * verbatim; `extensions` carries the user-code escape hatches referenced by the
+ * manifest.
+ */
+export type ServerAdapterFactory<Options = unknown> = (
+  runtime: WaspServerRuntime,
+  options: Options,
+  extensions?: ServerAdapterExtensions,
+) => ServerAdapter | Promise<ServerAdapter>;

--- a/waspc/data/Generator/templates/sdk/wasp/package.json
+++ b/waspc/data/Generator/templates/sdk/wasp/package.json
@@ -131,6 +131,11 @@
     {=! Server: the contract a custom auth provider implements. Adapters live in
         user code, so they need to import this as a normal module. =}
     "./server/auth/provider/types": "./dist/server/auth/provider/types.js",
+    {=# isCustomAuthProviderUsed =}
+    {=! Server: the selected provider and its route handler, for mounting the
+        provider's own routes. =}
+    "./server/auth/provider": "./dist/server/auth/provider/index.js",
+    {=/ isCustomAuthProviderUsed =}
     "./server/auth/session": "./dist/server/auth/session.js",
     "./server/auth/utils": "./dist/server/auth/utils.js",
     "./server/core/auth": "./dist/server/core/auth.js",

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/provider/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/provider/index.ts
@@ -1,7 +1,17 @@
 {{={= =}=}}
 import { {=# isCustomAuthProviderUsed =}canManageSessions as canProviderManagesSessions, canRevokeSessions as canProviderRevokeSessions, {=/ isCustomAuthProviderUsed =}type AuthProvider } from './types.js'
 {=# isCustomAuthProviderUsed =}
+{=# isPackageAuthProvider =}
+import { provisionAuthUser } from '../session.js'
+import { createServerAdapter } from '{= serverPackage =}'
+import { config, prisma } from '../../index.js'
+{=# externalSetupFn.isDefined =}
+{=& externalSetupFn.importStatement =}
+{=/ externalSetupFn.isDefined =}
+{=/ isPackageAuthProvider =}
+{=^ isPackageAuthProvider =}
 {=& authProvider.importStatement =}
+{=/ isPackageAuthProvider =}
 {=/ isCustomAuthProviderUsed =}
 {=^ isCustomAuthProviderUsed =}
 import { waspAuthProvider } from './wasp.js'
@@ -17,6 +27,38 @@ export {
   canRevokeSessions,
 } from './types.js'
 
+{=# isPackageAuthProvider =}
+/**
+ * The adapter package's server factory, called with everything it may know
+ * about the app. This runtime object is the adapter's *only* window into the
+ * app: adapters never import generated code and never read `process.env`
+ * themselves, which is what lets them version independently of any app.
+ */
+const serverAdapter = await Promise.resolve(
+  createServerAdapter(
+    {
+      db: prisma,
+      dbProvider: '{= dbProvider =}',
+      env: process.env,
+      serverUrl: config.serverUrl,
+      clientUrl: config.frontendUrl,
+      // The eager-provisioning channel: an in-process adapter reports its own
+      // signups, and the local user exists from that moment. Idempotent; JIT
+      // provisioning on first request remains the backstop.
+      onAuthUserCreated: async (authUser) => {
+        await provisionAuthUser(authUser.subjectId, authUser.claims)
+      },
+    },
+    {=& optionsJson =},
+    {
+      // The user's setup function for the adapter's underlying library; the
+      // adapter calls it with its integration config and uses the result.
+      setupFn: {=# externalSetupFn.isDefined =}{= externalSetupFn.importIdentifier =}{=/ externalSetupFn.isDefined =}{=^ externalSetupFn.isDefined =}undefined{=/ externalSetupFn.isDefined =},
+    },
+  ),
+)
+
+{=/ isPackageAuthProvider =}
 // PRIVATE API
 /**
  * The auth provider this app runs on.
@@ -26,7 +68,16 @@ export {
  * needed to authenticate against something other than Wasp's own auth.
  */
 export const authProvider: AuthProvider =
-  {=# isCustomAuthProviderUsed =}{= authProvider.importIdentifier =}{=/ isCustomAuthProviderUsed =}{=^ isCustomAuthProviderUsed =}waspAuthProvider{=/ isCustomAuthProviderUsed =}
+  {=# isCustomAuthProviderUsed =}{=# isPackageAuthProvider =}serverAdapter.provider{=/ isPackageAuthProvider =}{=^ isPackageAuthProvider =}{= authProvider.importIdentifier =}{=/ isPackageAuthProvider =}{=/ isCustomAuthProviderUsed =}{=^ isCustomAuthProviderUsed =}waspAuthProvider{=/ isCustomAuthProviderUsed =}
+{=# isPackageAuthProvider =}
+
+// PRIVATE API
+/**
+ * Node handler for the provider's own routes, if it brought any. The server
+ * mounts it at the basePath the manifest declared.
+ */
+export const authProviderRouteHandler = serverAdapter.routeHandler
+{=/ isPackageAuthProvider =}
 {=# isCustomAuthProviderUsed =}
 
 /**

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/provider/types.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/provider/types.ts
@@ -18,3 +18,14 @@ export {
   type SupportsSessionRevocation,
   type VerifiedSession,
 } from '@wasp.sh/auth-contract'
+
+// PRIVATE API
+/**
+ * The type the SDK expects of the user's `setupFn` for a packaged adapter's
+ * underlying library (the `prismaSetupFn` convention). The adapter package
+ * types its parameter precisely; the SDK only needs *a* function it can hand
+ * to the adapter's server factory.
+ */
+export type AuthProviderSetupFn = NonNullable<
+  import('@wasp.sh/auth-contract').ServerAdapterExtensions['setupFn']
+>

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
@@ -212,6 +212,20 @@ function isUniqueConstraintViolation(e: unknown): boolean {
     typeof e === 'object' && e !== null && 'code' in e && (e as { code: unknown }).code === 'P2002'
   );
 }
+
+// PRIVATE API
+/**
+ * Eager provisioning: the runtime channel an in-process adapter calls when it
+ * observes its own signup, so the local user exists from that moment instead
+ * of from the first authenticated request. Same code path as just-in-time
+ * provisioning, called sooner -- idempotent by the same unique constraint.
+ */
+export async function provisionAuthUser(
+  subjectId: string,
+  claims: VerifiedSession['claims'],
+): Promise<void> {
+  await resolveExternalSubject(subjectId, claims);
+}
 {=/ isCustomAuthProviderUsed =}
 
 // PRIVATE API

--- a/waspc/data/Generator/templates/server/src/routes/index.js
+++ b/waspc/data/Generator/templates/server/src/routes/index.js
@@ -5,6 +5,9 @@ import { globalMiddlewareConfigForExpress } from '../middleware/index.js'
 {=# isAuthEnabled =}
 import auth from './auth/index.js'
 {=/ isAuthEnabled =}
+{=# externalAuthProviderRoutes =}
+import { authProviderRouteHandler } from 'wasp/server/auth/provider'
+{=/ externalAuthProviderRoutes =}
 {=# areThereAnyCustomApiRoutes =}
 import apis from './apis/index.js'
 {=/ areThereAnyCustomApiRoutes =}
@@ -41,6 +44,25 @@ router.get('/', middleware,
 {=# isAuthEnabled =}
 router.use('/auth', middleware, auth)
 {=/ isAuthEnabled =}
+{=# externalAuthProviderRoutes =}
+// The external auth provider's own routes, mounted where its manifest asked.
+// The usual middleware stack applies{=# rawBody =}, minus the body parsers: the
+// provider's handler reads the raw request stream itself, and a body that was
+// already consumed would make every request to it hang{=/ rawBody =}.
+const authProviderMiddleware = globalMiddlewareConfigForExpress((middlewareConfig) => {
+  {=# rawBody =}
+  middlewareConfig.delete('express.json')
+  middlewareConfig.delete('express.urlencoded')
+  {=/ rawBody =}
+  return middlewareConfig
+})
+router.use('{= basePath =}', authProviderMiddleware, (req, res, next) => {
+  if (authProviderRouteHandler === undefined) {
+    return next(new Error('The auth provider manifest declares routes, but its server adapter returned no routeHandler.'))
+  }
+  return Promise.resolve(authProviderRouteHandler(req, res)).catch(next)
+})
+{=/ externalAuthProviderRoutes =}
 router.use('/{= operationsRouteInRootRouter =}', middleware, operations)
 {=# areThereAnyCrudRoutes =}
 router.use('/{= crudRouteInRootRouter =}', middleware, rootCrudRouter)

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz"
         ],
-        "2bba5c7c10f7a28b2f254287161be48fe51f9a5d1a4304771815f226f729330b"
+        "9f5d731409748beed6b99248e907b97aefc1c913028939b83c67ab6ad2f4bbfb"
     ],
     [
         [
@@ -1054,7 +1054,7 @@
             "file",
             "sdk/wasp/server/auth/provider/types.ts"
         ],
-        "772dc1b404468c930dcde08d56040d543075c8ec1a4e41d1e409d200b65a5bd7"
+        "fddcc716d39477ebd8e3379e8e01603636117a0a7f025677cb1a411d746df6e6"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/provider/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/provider/types.ts
@@ -18,3 +18,14 @@ export {
   type SupportsSessionRevocation,
   type VerifiedSession,
 } from '@wasp.sh/auth-contract'
+
+// PRIVATE API
+/**
+ * The type the SDK expects of the user's `setupFn` for a packaged adapter's
+ * underlying library (the `prismaSetupFn` convention). The adapter package
+ * types its parameter precisely; the SDK only needs *a* function it can hand
+ * to the adapter's server factory.
+ */
+export type AuthProviderSetupFn = NonNullable<
+  import('@wasp.sh/auth-contract').ServerAdapterExtensions['setupFn']
+>

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz"
         ],
-        "2bba5c7c10f7a28b2f254287161be48fe51f9a5d1a4304771815f226f729330b"
+        "9f5d731409748beed6b99248e907b97aefc1c913028939b83c67ab6ad2f4bbfb"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz"
         ],
-        "2bba5c7c10f7a28b2f254287161be48fe51f9a5d1a4304771815f226f729330b"
+        "9f5d731409748beed6b99248e907b97aefc1c913028939b83c67ab6ad2f4bbfb"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz"
         ],
-        "2bba5c7c10f7a28b2f254287161be48fe51f9a5d1a4304771815f226f729330b"
+        "9f5d731409748beed6b99248e907b97aefc1c913028939b83c67ab6ad2f4bbfb"
     ],
     [
         [

--- a/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
@@ -4,13 +4,15 @@ module Wasp.Generator.SdkGenerator.Server.AuthG
 where
 
 import Data.Aeson (object, (.=))
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import StrongPath (Dir', File', Path', Rel, Rel', reldir, relfile, (</>))
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.Auth
+import qualified Wasp.AppSpec.App.Db as AS.Db
 import Wasp.AppSpec.Valid (getApp)
+import qualified Wasp.AppSpec.Valid as AS.Valid
 import qualified Wasp.Generator.AuthProviders as AuthProviders
 import Wasp.Generator.Common (makeJsArrayFromHaskellList)
 import qualified Wasp.Generator.DbGenerator.Auth as DbAuth
@@ -41,7 +43,7 @@ genServerAuth spec =
             [ genFileCopy [relfile|server/core/auth.ts|],
               genAuthIndex auth,
               genFileCopyInServerAuth [relfile|provider/types.ts|],
-              genAuthProviderIndexTs auth,
+              genAuthProviderIndexTs spec auth,
               genSessionTs auth,
               genUtils auth
             ]
@@ -54,7 +56,7 @@ genServerAuth spec =
               genFileCopyInServerAuth [relfile|jwt.ts|],
               genFileCopyInServerAuth [relfile|provider/types.ts|],
               genFileCopyInServerAuth [relfile|provider/wasp.ts|],
-              genAuthProviderIndexTs auth,
+              genAuthProviderIndexTs spec auth,
               genSessionTs auth,
               genLuciaTs auth,
               genUtils auth
@@ -110,8 +112,8 @@ genLuciaTs auth =
 -- Defaults to Wasp's own auth. When @app.auth.provider@ is set, the SDK imports the
 -- developer's adapter through a virtual user module instead, and the session layer
 -- switches to resolving foreign subjects (provisioning a local user on first sight).
-genAuthProviderIndexTs :: AS.Auth.Auth -> Generator FileDraft
-genAuthProviderIndexTs auth =
+genAuthProviderIndexTs :: AppSpec -> AS.Auth.Auth -> Generator FileDraft
+genAuthProviderIndexTs spec auth =
   return $
     mkTmplFdWithData
       (serverAuthDirInSdkTemplatesDir </> [relfile|provider/index.ts|])
@@ -119,19 +121,29 @@ genAuthProviderIndexTs auth =
   where
     tmplData =
       object
-        [ "isCustomAuthProviderUsed" .= isJust maybeProviderModule,
+        [ "isCustomAuthProviderUsed" .= isJust maybeExternalProvider,
+          "isPackageAuthProvider" .= isJust maybeServerPackage,
+          "serverPackage" .= maybeServerPackage,
           "authProvider" .= extImportToImportJson maybeProviderModule,
+          -- The adapter's serializable options, spliced in verbatim -- the
+          -- mapper already proved the text is valid JSON.
+          "optionsJson" .= fromMaybe "undefined" (AS.Auth.optionsJson =<< maybeExternalProvider),
+          "dbProvider" .= prismaDbProviderName,
           -- The manifest's compile-time claims, checked against the runtime
           -- adapter object at boot so a wrong manifest fails loudly instead of
           -- generating a surface the adapter cannot back.
+          "externalSetupFn"
+            .= extImportToImportJson (AS.Auth.setupFn =<< maybeExternalProvider),
           "manifestProviderId" .= (AS.Auth.providerId <$> maybeExternalProvider),
           "manifestCapabilities" .= (makeJsArrayFromHaskellList . AS.Auth.capabilities <$> maybeExternalProvider)
         ]
-    -- NOTE: only src-module adapters ("customAuthProvider") are wired into
-    -- generated code so far; package entries decode into the AppSpec but the
-    -- mapper still rejects them until the generator learns to import them.
     maybeProviderModule = AS.Auth.serverModule =<< maybeExternalProvider
+    maybeServerPackage = AS.Auth.serverPackage =<< maybeExternalProvider
     maybeExternalProvider = AS.Auth.externalProvider auth
+    prismaDbProviderName :: String
+    prismaDbProviderName = case AS.Valid.getValidDbSystem spec of
+      AS.Db.PostgreSQL -> "postgresql"
+      AS.Db.SQLite -> "sqlite"
 
 genSessionTs :: AS.Auth.Auth -> Generator FileDraft
 genSessionTs auth =

--- a/waspc/src/Wasp/Generator/SdkGenerator/VirtualUserModules.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/VirtualUserModules.hs
@@ -99,6 +99,7 @@ getVirtualUserModules spec =
       maybeToList $ mkPrismaSetupFnModule <$> maybePrismaSetupFn,
       maybeToList $ mkAuthProviderModule <$> maybeAuthProvider,
       maybeToList $ mkAuthProviderUserSignupFieldsModule <$> maybeAuthProviderUserSignupFields,
+      maybeToList $ mkAuthProviderSetupFnModule <$> maybeAuthProviderSetupFn,
       map mkOperationModule (AS.getOperations spec)
     ]
   where
@@ -147,6 +148,17 @@ getVirtualUserModules spec =
         [relfileP|./auth/providers/types|]
         "UserSignupFields"
 
+    -- The user's setup function for the adapter's underlying library
+    -- (the prismaSetupFn convention); delivered to the adapter's server
+    -- factory. Declared with the plain contract type: the adapter package
+    -- types its parameter precisely, the SDK only needs *a* function.
+    mkAuthProviderSetupFnModule extImport' =
+      VirtualUserModule
+        ServerRuntime
+        extImport'
+        [relfileP|./server/auth/provider/types|]
+        "AuthProviderSetupFn"
+
     mkOperationModule operation =
       VirtualUserModule
         ServerRuntime
@@ -163,6 +175,7 @@ getVirtualUserModules spec =
     maybePrismaSetupFn = AS.App.db app >>= AS.Db.prismaSetupFn
     maybeAuthProvider = AS.App.auth app >>= AS.Auth.externalProvider >>= AS.Auth.serverModule
     maybeAuthProviderUserSignupFields = AS.App.auth app >>= AS.Auth.externalProvider >>= AS.Auth.userSignupFieldsForExternalAuthProvider
+    maybeAuthProviderSetupFn = AS.App.auth app >>= AS.Auth.externalProvider >>= AS.Auth.setupFn
     app = snd $ getApp spec
 
 -- | Virtual user modules that end up in the client bundle.

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -37,11 +37,13 @@ import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
+import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
 import qualified Wasp.AppSpec.App.Server as AS.App.Server
 import Wasp.AppSpec.ExternalFiles (SourceExternalCodeDir)
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
 import qualified Wasp.AppSpec.Util as AS.Util
 import Wasp.AppSpec.Valid (getApp, getLowestNodeVersionUserAllows, isAuthEnabled)
+import qualified Wasp.AppSpec.Valid as AS.Valid
 import Wasp.Env (envVarsToDotEnvContent)
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
 import Wasp.Generator.Common (ServerRootDir)
@@ -298,7 +300,17 @@ genRoutesIndex spec =
           "areThereAnyCustomApiRoutes" .= (not . null $ AS.getApis spec),
           "areThereAnyCrudRoutes" .= (not . null $ AS.getCruds spec),
           "isDevelopment" .= (AS.isDevelopment spec :: Bool),
-          "appName" .= (fst $ getApp spec :: String)
+          "appName" .= (fst $ getApp spec :: String),
+          "externalAuthProviderRoutes" .= (externalProviderRoutesTmplData <$> maybeExternalProviderRoutes)
+        ]
+
+    -- Routes an external auth provider brought along (Better Auth's own
+    -- endpoints), mounted at the basePath its manifest declared.
+    maybeExternalProviderRoutes = AS.Valid.getExternalAuthProvider spec >>= AS.App.Auth.routes
+    externalProviderRoutesTmplData providerRoutes =
+      object
+        [ "basePath" .= AS.App.Auth.basePath providerRoutes,
+          "rawBody" .= (AS.App.Auth.rawBody providerRoutes == Just True)
         ]
 
 operationsRouteInRootRouter :: String

--- a/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/AuthG.hs
@@ -56,15 +56,22 @@ genAuth spec = case maybeAuth of
       [ genAuthRoutesIndex auth,
         genFileCopy [relfile|routes/auth/me.ts|],
         genFileCopy [relfile|routes/auth/logout.ts|],
-        genProvidersIndex auth,
-        genAuthHooks auth
+        genProvidersIndex auth
       ]
+      -- Wasp's auth hooks only fire from Wasp's own signup and login flows, so
+      -- under an external provider the module (and the types it needs) do not
+      -- exist.
+      <++> onlyUnderWaspAuth auth (sequence [genAuthHooks auth])
       <++> genLocalAuth auth
       <++> genOAuthAuth auth
       <++> genEmailAuth spec auth
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
     genFileCopy = return . C.mkSrcTmplFd
+
+    onlyUnderWaspAuth auth gen
+      | AS.Auth.isExternalAuthProviderUsed auth = return []
+      | otherwise = gen
 
 genAuthRoutesIndex :: AS.Auth.Auth -> Generator FileDraft
 genAuthRoutesIndex auth = return $ C.mkTmplFdWithDstAndData tmplFile dstFile (Just tmplData)


### PR DESCRIPTION
## Description

**Stack 6/7.** Codegen learns to consume adapter *packages*, and the contract gains the adapter-package surface together with its consumers:

- `@wasp.sh/auth-contract` grows `WaspServerRuntime` (db, dbProvider, validated env, URLs — the adapter's only window into the app), `ServerAdapter`, `ServerAdapterExtensions { setupFn }` and `ServerAdapterFactory`. Adapters must not import generated code or read `process.env`; this boundary is what lets an adapter package typecheck and version independently of any app.
- `genAuthProviderIndexTs` final form: for `server: { package }` manifests it emits the `createServerAdapter(runtime, options, extensions)` call with the manifest's `options` delivered verbatim and the app's `setupFn` (the `prismaSetupFn`-convention escape hatch) passed through a new `RegisteredAuthProviderSetupFn` virtual module.
- The server mounts a package adapter's `routeHandler` at the manifest's declared `basePath`, with `rawBody: true` routes exempted from the JSON body parser (Better Auth reads its own stream).
- Wasp-auth-only hooks module suppressed under external providers.

No app in the repo uses a package entry until 7/7, so golden churn here is minimal; the shape is exercised by two real packages one PR later.

## Type of change

- [ ] **🔧 Just code/docs improvement**
- [ ] **🐞 Bug fix**
- [x] **🚀 New/improved feature**
- [ ] **💥 Breaking change**

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- full e2e suite; exercised end to end by 7/7's packages + snapshot -->

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- package-entry mapping is unit-tested since 3/7; codegen proven by 7/7's golden -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- deferred until the feature ships -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- deferred, see 3/7 -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
