### PR TITLE
Add the client half of the auth provider contract with generated wiring

### DIFF
--- a/examples/ask-the-documents/package-lock.json
+++ b/examples/ask-the-documents/package-lock.json
@@ -7481,7 +7481,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/auth-providers/better-auth/package-lock.json
+++ b/examples/auth-providers/better-auth/package-lock.json
@@ -4111,7 +4111,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/auth-providers/clerk/package-lock.json
+++ b/examples/auth-providers/clerk/package-lock.json
@@ -4043,7 +4043,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/auth-providers/custom-clerk/package-lock.json
+++ b/examples/auth-providers/custom-clerk/package-lock.json
@@ -4042,7 +4042,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/auth-providers/wasp-auth/package-lock.json
+++ b/examples/auth-providers/wasp-auth/package-lock.json
@@ -3944,7 +3944,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/kitchen-sink/package-lock.json
+++ b/examples/kitchen-sink/package-lock.json
@@ -4013,7 +4013,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/tutorials/TodoApp/package-lock.json
+++ b/examples/tutorials/TodoApp/package-lock.json
@@ -3838,7 +3838,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/tutorials/TodoAppTs/package-lock.json
+++ b/examples/tutorials/TodoAppTs/package-lock.json
@@ -3838,7 +3838,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/waspello/package-lock.json
+++ b/examples/waspello/package-lock.json
@@ -4190,7 +4190,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/examples/websockets-realtime-voting/package-lock.json
+++ b/examples/websockets-realtime-voting/package-lock.json
@@ -4957,7 +4957,7 @@
     "node_modules/@wasp.sh/auth-contract": {
       "version": "0.26.0",
       "resolved": "file:.wasp/out/libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz",
-      "integrity": "sha512-iO/ILJyPgtsZbdEmRbTfrtnTgYQyjNPBKc1dGzf/vJoYK8KZxCMgDbO0kbuhpXJ5k1PXlACAV5ZYUlUeW6pw9Q==",
+      "integrity": "sha512-5zBaT/DT7J2ACObgfnfmMSsTcO9bMfQW3540P/5iEZDQBe727zdh+3S6MR67puw0WVyzgsIkmkCEkflwSW/w+A==",
       "license": "MIT"
     },
     "node_modules/@wasp.sh/generated-server": {

--- a/waspc/data/Generator/libs/auth-contract/README.md
+++ b/waspc/data/Generator/libs/auth-contract/README.md
@@ -5,7 +5,9 @@ The contract between Wasp and pluggable auth providers.
 An auth adapter package implements this contract to make an external auth
 solution (Better Auth, Clerk, WorkOS, ...) usable as a Wasp auth provider:
 `AuthProvider`, `VerifiedSession`, `WaspServerRuntime`, and the
-`createServerAdapter` factory shape adapter packages must export.
+`createServerAdapter` factory shape adapter packages must export. The client-side
+half lives at `@wasp.sh/auth-contract/client`: `ClientAuthAdapter` and the
+`createClientAdapter` factory shape, for adapters with client-side needs.
 
 The package is copied into generated Wasp apps as a tarball (like the other libs
 in this directory) and installed via a `file:` dependency, so both generated code

--- a/waspc/data/Generator/libs/auth-contract/package-lock.json
+++ b/waspc/data/Generator/libs/auth-contract/package-lock.json
@@ -11,8 +11,18 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.5",
         "@types/node": "~22.12",
+        "@types/react": "^18.0.37",
+        "react": "^18.2.0",
         "tsdown": "^0.21.5",
         "typescript": "~6.0.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/generator": {
@@ -525,6 +535,24 @@
         "undici-types": "~6.20.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/ansis": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
@@ -612,6 +640,13 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/defu": {
       "version": "6.1.7",
@@ -712,6 +747,13 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -723,6 +765,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/obug": {
@@ -775,6 +830,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",

--- a/waspc/data/Generator/libs/auth-contract/package.json
+++ b/waspc/data/Generator/libs/auth-contract/package.json
@@ -22,6 +22,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "default": "./dist/client.js"
     }
   },
   "files": [
@@ -33,9 +37,19 @@
     "prepare": "npm run build",
     "test": "tsc --noEmit"
   },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.5",
     "@types/node": "~22.12",
+    "@types/react": "^18.0.37",
+    "react": "^18.2.0",
     "tsdown": "^0.21.5",
     "typescript": "~6.0.3"
   },

--- a/waspc/data/Generator/libs/auth-contract/src/client.ts
+++ b/waspc/data/Generator/libs/auth-contract/src/client.ts
@@ -1,0 +1,75 @@
+/**
+ * The client-side half of the auth provider contract.
+ *
+ * An adapter package with client-side needs (a React context to mount, a
+ * credential to attach to requests) implements this in its client entry and
+ * exposes it as a named `createClientAdapter` export (see
+ * {@link ClientAdapterFactory}). Wasp instantiates it and wires the pieces
+ * into the generated client; the app composes nothing by hand.
+ */
+
+import type { ComponentType, ReactNode } from "react";
+
+/**
+ * Everything Wasp hands a client-side adapter about the app it runs in. Like
+ * its server counterpart, this is the adapter's only window into the app.
+ */
+export type WaspClientRuntime = {
+  /** The URL the Wasp server is reachable at. */
+  apiUrl: string;
+
+  /**
+   * The client-side environment, already validated against the env vars the
+   * adapter's manifest declared.
+   */
+  env: Record<string, string | undefined>;
+};
+
+export type ClientAuthAdapter = {
+  /**
+   * Component Wasp composes around the app's tree, so every page renders
+   * inside it. This is where a provider's React context lives (Clerk's
+   * `ClerkProvider`, for one). It does not occupy the app's own
+   * `rootComponent` slot.
+   */
+  Wrapper?: ComponentType<{ children: ReactNode }>;
+
+  /**
+   * The credential to attach to the next request, or `null` when there is
+   * none.
+   *
+   * Pull-based on purpose: Wasp asks at each request rather than caching a
+   * pushed value, so a token that rotates under the adapter (short-lived
+   * JWTs) is always current. Implementations should resolve only once the
+   * provider's client is loaded, so the first authenticated request cannot
+   * race provider startup.
+   */
+  getCredential(): Promise<string | null>;
+
+  /**
+   * Subscribe to credential changes; returns an unsubscribe function.
+   *
+   * Wasp uses this to refresh the current user and re-authenticate live
+   * websocket connections after a login or logout that happened outside
+   * Wasp's own code -- inside a provider's sign-in component, for one.
+   */
+  onCredentialChange?(listener: () => void): () => void;
+
+  /**
+   * Called by Wasp's `logout()` before it revokes the session server-side:
+   * the adapter's chance to clear its own client-side state (Clerk's
+   * `signOut()`, a token store's `clear()`).
+   */
+  onLogout?(): Promise<void>;
+};
+
+/**
+ * The required shape of an adapter package's client entry: a named
+ * `createClientAdapter` export of this type. `options` is the serializable
+ * configuration the adapter's spec helper captured in `main.wasp.ts`,
+ * delivered verbatim.
+ */
+export type ClientAdapterFactory<Options = unknown> = (
+  runtime: WaspClientRuntime,
+  options: Options,
+) => ClientAuthAdapter;

--- a/waspc/data/Generator/libs/auth-contract/tsconfig.json
+++ b/waspc/data/Generator/libs/auth-contract/tsconfig.json
@@ -4,9 +4,10 @@
     "module": "NodeNext",
     "moduleResolution": "nodenext",
     "noEmit": true,
-    "types": ["node"],
+    "types": ["node", "react"],
     "strict": true,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/waspc/data/Generator/libs/auth-contract/tsdown.config.ts
+++ b/waspc/data/Generator/libs/auth-contract/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/client.ts"],
   outDir: "dist",
   clean: true,
 

--- a/waspc/data/Generator/templates/sdk/wasp/api/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/api/index.ts
@@ -1,4 +1,8 @@
+{{={= =}=}}
 import ky, { isHTTPError } from 'ky'
+{=# isClientAuthAdapterUsed =}
+import { clientAuthAdapter } from '../client/auth/provider.js'
+{=/ isClientAuthAdapterUsed =}
 import { config } from '../client/index.js'
 import { storage } from '../core/storage.js'
 import { apiEventsEmitter } from './events.js'
@@ -44,13 +48,26 @@ export const api = ky.extend({
   prefix: config.apiUrl,
   hooks: {
     beforeRequest: [
+      {=# isClientAuthAdapterUsed =}
+      // Pull-based on purpose: the adapter is asked at each request, so a
+      // token that rotates underneath (short-lived JWTs) is always current.
+      async ({ request }) => {
+        const credential = await clientAuthAdapter.getCredential()
+        if (credential !== null) {
+          request.headers.set('Authorization', `Bearer ${credential}`)
+        }
+      },
+      {=/ isClientAuthAdapterUsed =}
+      {=^ isClientAuthAdapterUsed =}
       ({ request }) => {
         const sessionId = getSessionId()
         if (sessionId !== null) {
           request.headers.set('Authorization', `Bearer ${sessionId}`)
         }
       },
+      {=/ isClientAuthAdapterUsed =}
     ],
+    {=^ isClientAuthAdapterUsed =}
     afterResponse: [
       ({ request, response }) => {
         if (response.status === 401) {
@@ -76,6 +93,7 @@ export const api = ky.extend({
         }
       },
     ],
+    {=/ isClientAuthAdapterUsed =}
   },
 })
 

--- a/waspc/data/Generator/templates/sdk/wasp/auth/logout.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/logout.ts
@@ -1,9 +1,18 @@
+{{={= =}=}}
 import { api, removeLocalUserData } from '../api/index.js'
+{=# isClientAuthAdapterUsed =}
+import { clientAuthAdapter } from '../client/auth/provider.js'
+{=/ isClientAuthAdapterUsed =}
 import { invalidateAndRemoveQueries } from '../client/operations/internal/resources.js'
 
 // PUBLIC API
 export default async function logout(): Promise<void> {
   try {
+    {=# isClientAuthAdapterUsed =}
+    // The adapter clears its own client-side state first (Clerk's signOut(),
+    // a token store's clear()), then Wasp revokes the session server-side.
+    await clientAuthAdapter.onLogout?.()
+    {=/ isClientAuthAdapterUsed =}
     await api.post('/auth/logout')
   } finally {
     // Even if the logout request fails, we still want to remove the local user data

--- a/waspc/data/Generator/templates/sdk/wasp/client/app/components/WaspApp.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/app/components/WaspApp.tsx
@@ -7,11 +7,23 @@ import { queryClientInitialized } from '../../operations/index'
 {=# areWebSocketsUsed =}
 import { WebSocketProvider } from '../../webSocket/WebSocketProvider'
 {=/ areWebSocketsUsed =}
+{=# isClientAuthAdapterUsed =}
+import { Fragment } from 'react'
+
+import { clientAuthAdapter } from '../../auth/provider'
+
+// The provider's React context (Clerk's ClerkProvider, for one) wraps the whole
+// app, outside the app's own rootComponent slot.
+const ClientAuthAdapterWrapper = clientAuthAdapter.Wrapper ?? Fragment
+{=/ isClientAuthAdapterUsed =}
 
 export function WaspApp({ children }: { children: ReactNode }) {
   const queryClient = use(queryClientInitialized)
 
   return (
+    {=# isClientAuthAdapterUsed =}
+    <ClientAuthAdapterWrapper>
+    {=/ isClientAuthAdapterUsed =}
     <QueryClientProvider client={queryClient}>
       {=# areWebSocketsUsed =}
       <WebSocketProvider>
@@ -22,5 +34,8 @@ export function WaspApp({ children }: { children: ReactNode }) {
       {children}
       {=/ areWebSocketsUsed =}
     </QueryClientProvider>
+    {=# isClientAuthAdapterUsed =}
+    </ClientAuthAdapterWrapper>
+    {=/ isClientAuthAdapterUsed =}
   )
 }

--- a/waspc/data/Generator/templates/sdk/wasp/client/auth/provider.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/auth/provider.ts
@@ -1,0 +1,30 @@
+{{={= =}=}}
+import type { ClientAuthAdapter } from '@wasp.sh/auth-contract/client'
+
+import { createClientAdapter } from '{= clientPackage =}'
+
+import { apiEventsEmitter } from '../../api/events.js'
+import { config } from '../config.js'
+import { env } from '../env.js'
+
+// PRIVATE API
+/**
+ * The client half of the app's auth provider, instantiated from the adapter
+ * package's client entry with the same runtime-window discipline as the
+ * server half: the adapter sees only what Wasp hands it here.
+ */
+export const clientAuthAdapter: ClientAuthAdapter = createClientAdapter(
+  {
+    apiUrl: config.apiUrl,
+    env,
+  },
+  {=# hasOptions =}{=& optionsJson =}{=/ hasOptions =}{=^ hasOptions =}undefined{=/ hasOptions =},
+)
+
+// Rebroadcast provider-side credential changes into Wasp's existing event
+// channel, so the current-user query and live websocket connections react to
+// token rotation and to logins/logouts that happen inside the provider's own
+// UI.
+clientAuthAdapter.onCredentialChange?.(() => {
+  apiEventsEmitter.emit('sessionId.set')
+})

--- a/waspc/data/Generator/templates/sdk/wasp/package.json
+++ b/waspc/data/Generator/templates/sdk/wasp/package.json
@@ -131,6 +131,10 @@
     {=! Server: the contract a custom auth provider implements. Adapters live in
         user code, so they need to import this as a normal module. =}
     "./server/auth/provider/types": "./dist/server/auth/provider/types.js",
+    {=# isClientAuthAdapterUsed =}
+    {=! Client: the instantiated client half of the auth provider. =}
+    "./client/auth/provider": "./dist/client/auth/provider.js",
+    {=/ isClientAuthAdapterUsed =}
     {=# isCustomAuthProviderUsed =}
     {=! Server: the selected provider and its route handler, for mounting the
         provider's own routes. =}

--- a/waspc/data/packages/spec/__tests__/spec/mapApp.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec/mapApp.unit.test.ts
@@ -495,6 +495,7 @@ describe("mapAuth", () => {
             >[0],
           ),
         },
+        clientPackage: undefined,
         routes: undefined,
         capabilities: provider.capabilities,
         envVars: {
@@ -539,6 +540,7 @@ describe("mapAuth", () => {
       provider: {
         ...getExternalProviderManifest(auth),
         server: { package: "@wasp.sh/auth-clerk/server" },
+        client: { package: "@wasp.sh/auth-clerk/client" },
       } as unknown as WaspSpec.Auth["provider"],
     };
     const ctx = makeMapperContext({ entityNames: [auth.userEntity] });
@@ -548,6 +550,7 @@ describe("mapAuth", () => {
     expect(result.provider).toMatchObject({
       kind: "external",
       server: { package: "@wasp.sh/auth-clerk/server" },
+      clientPackage: "@wasp.sh/auth-clerk/client",
     });
   });
 

--- a/waspc/data/packages/spec/src/appSpec.ts
+++ b/waspc/data/packages/spec/src/appSpec.ts
@@ -178,6 +178,7 @@ export type ExternalAuthProvider = {
 export type ExternalAuthProviderSpec = {
   providerId: string;
   server: { package: string } | { module: ExtImport };
+  clientPackage: Optional<string>;
   routes: Optional<ExternalProviderRoutes>;
   capabilities: string[];
   envVars: ExternalProviderEnvVars;

--- a/waspc/data/packages/spec/src/spec/mapper/app.ts
+++ b/waspc/data/packages/spec/src/spec/mapper/app.ts
@@ -138,6 +138,7 @@ function mapExternalAuthProvider(
             manifest.server as WaspSpec.Reference<AnyObject>,
           ),
         },
+    clientPackage: manifest.client?.package,
     routes: manifest.routes && {
       basePath: manifest.routes.basePath,
       rawBody: manifest.routes.rawBody,

--- a/waspc/data/packages/spec/src/spec/publicApi/waspSpec.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/waspSpec.ts
@@ -307,6 +307,12 @@ export interface ExternalAuthProviderManifest {
    */
   server: { package: string } | Reference<AnyObject>;
   /**
+   * Module specifier of an adapter package's client entry (which must export
+   * `createClientAdapter`). Wasp instantiates it and wires the client side --
+   * context wrapper, credential transport, logout -- automatically.
+   */
+  client?: { package: string };
+  /**
    * Routes the provider wants mounted on Wasp's server, for providers that
    * bring their own HTTP endpoints (Better Auth). `rawBody` mounts them
    * without the JSON body parser, for handlers that read the body themselves.

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -32,7 +32,7 @@
             "file",
             "libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz"
         ],
-        "9f5d731409748beed6b99248e907b97aefc1c913028939b83c67ab6ad2f4bbfb"
+        "3bd00e4d98c9eef49401fa75de51a33eabd4d0a8518e839367af1ee475d5e40d"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz"
         ],
-        "9f5d731409748beed6b99248e907b97aefc1c913028939b83c67ab6ad2f4bbfb"
+        "3bd00e4d98c9eef49401fa75de51a33eabd4d0a8518e839367af1ee475d5e40d"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz"
         ],
-        "9f5d731409748beed6b99248e907b97aefc1c913028939b83c67ab6ad2f4bbfb"
+        "3bd00e4d98c9eef49401fa75de51a33eabd4d0a8518e839367af1ee475d5e40d"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -25,7 +25,7 @@
             "file",
             "libs/auth-contract/wasp.sh-auth-contract-0.26.0.tgz"
         ],
-        "9f5d731409748beed6b99248e907b97aefc1c913028939b83c67ab6ad2f4bbfb"
+        "3bd00e4d98c9eef49401fa75de51a33eabd4d0a8518e839367af1ee475d5e40d"
     ],
     [
         [

--- a/waspc/src/Wasp/AppSpec/App/Auth.hs
+++ b/waspc/src/Wasp/AppSpec/App/Auth.hs
@@ -30,6 +30,7 @@ module Wasp.AppSpec.App.Auth
     serverPackage,
     serverModule,
     isExternalAuthProviderUsed,
+    isClientAuthAdapterUsed,
     isUsernameAndPasswordAuthEnabled,
     isExternalAuthEnabled,
     isSlackAuthEnabled,
@@ -138,6 +139,8 @@ data ExternalAuthProviderSpec = ExternalAuthProviderSpec
     providerId :: String,
     -- | Where the provider's implementation comes from.
     server :: ExternalProviderServer,
+    -- | Module specifier of an adapter package's client entry, if it has one.
+    clientPackage :: Maybe String,
     -- | Routes the provider wants mounted on Wasp's server, for providers that
     -- own HTTP endpoints of their own (Better Auth).
     routes :: Maybe ExternalProviderRoutes,
@@ -182,6 +185,10 @@ serverModule :: ExternalAuthProviderSpec -> Maybe ExtImport
 serverModule spec = case spec.server of
   ExternalProviderServer (Left _) -> Nothing
   ExternalProviderServer (Right extImport) -> Just extImport
+
+-- | Whether the selected external provider brings a client-side adapter entry.
+isClientAuthAdapterUsed :: Auth -> Bool
+isClientAuthAdapterUsed auth = isJust (externalProvider auth >>= clientPackage)
 
 data ExternalProviderRoutes = ExternalProviderRoutes
   { basePath :: String,

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -99,6 +99,19 @@ buildSdk generatedAppDir = do
   where
     sdkRootDir = generatedAppDir </> C.sdkRootDirInGeneratedAppDir
 
+-- | The client HTTP wrapper. Under a client auth adapter the credential is
+-- pulled from the adapter at each request instead of read from local storage.
+genApiIndexTs :: AppSpec -> Generator FileDraft
+genApiIndexTs spec =
+  return $
+    C.mkTmplFdWithData
+      [relfile|api/index.ts|]
+      (object ["isClientAuthAdapterUsed" .= isClientAdapterUsed spec])
+
+isClientAdapterUsed :: AppSpec -> Bool
+isClientAdapterUsed spec =
+  maybe False AS.App.Auth.isClientAuthAdapterUsed (AS.App.auth $ snd $ AS.Valid.getApp spec)
+
 genSdk :: AppSpec -> Generator [FileDraft]
 genSdk spec =
   sequence
@@ -108,7 +121,7 @@ genSdk spec =
       C.genFileCopy [relfile|scripts/copy-assets.js|],
       C.genFileCopy [relfile|types/index.ts|],
       C.genFileCopy [relfile|types/register.ts|],
-      C.genFileCopy [relfile|api/index.ts|],
+      genApiIndexTs spec,
       C.genFileCopy [relfile|api/events.ts|],
       C.genFileCopy [relfile|serialization/index.ts|],
       C.genFileCopy [relfile|core/storage.ts|],
@@ -191,6 +204,7 @@ genPackageJson spec = do
           [ "sdkPackageName" .= C.sdkPackageName,
             "isAuthEnabled" .= isAuthEnabled spec,
             "isCustomAuthProviderUsed" .= isJust (AS.Valid.getExternalAuthProvider spec),
+            "isClientAuthAdapterUsed" .= isClientAdapterUsed spec,
             "depsChunk" .= N.getDependenciesPackageJsonEntry (npmDepsForSdk spec),
             "devDepsChunk" .= N.getDevDependenciesPackageJsonEntry (npmDepsForSdk spec),
             "peerDepsChunk" .= N.getPeerDependenciesPackageJsonEntry (npmDepsForSdk spec)

--- a/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/AuthG.hs
@@ -46,7 +46,7 @@ genAuth spec =
         <++> sequence
           [ genFileCopyInAuth [relfile|helpers/user.ts|],
             genFileCopyInAuth [relfile|types.ts|],
-            genFileCopyInAuth [relfile|logout.ts|],
+            genLogoutTs auth,
             genFileCopyInAuth [relfile|responseSchemas.ts|],
             genUseAuth auth
           ]
@@ -96,6 +96,13 @@ genUseAuth auth =
   where
     tmplData = object ["entitiesGetMeDependsOn" .= makeJsArrayFromHaskellList [userEntityName]]
     userEntityName = AS.refName $ AS.Auth.userEntity auth
+
+genLogoutTs :: AS.Auth.Auth -> Generator FileDraft
+genLogoutTs auth =
+  return $
+    mkTmplFdWithData
+      (authDirInSdkTemplatesDir </> [relfile|logout.ts|])
+      (object ["isClientAuthAdapterUsed" .= AS.Auth.isClientAuthAdapterUsed auth])
 
 genUserTs :: AS.Auth.Auth -> Generator FileDraft
 genUserTs auth =

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/AppG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/AppG.hs
@@ -44,7 +44,11 @@ genWaspAppComponent spec =
   return $
     C.mkTmplFdWithData
       [relfile|client/app/components/WaspApp.tsx|]
-      (object ["areWebSocketsUsed" .= WS.areWebSocketsUsed spec])
+      ( object
+          [ "areWebSocketsUsed" .= WS.areWebSocketsUsed spec,
+            "isClientAuthAdapterUsed" .= maybe False AS.Auth.isClientAuthAdapterUsed (AS.App.auth $ snd $ getApp spec)
+          ]
+      )
 
 genAppComponents :: Generator [FileDraft]
 genAppComponents =

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/AuthG.hs
@@ -28,7 +28,10 @@ genClientAuth spec =
       -- Under an external provider `wasp/client/auth` keeps only the uniform
       -- surface (useAuth, logout); the provider's own UI comes from its
       -- adapter package, not from Wasp's generated forms.
-      | AS.Auth.isExternalAuthProviderUsed auth -> sequence [genAuthIndex auth]
+      | AS.Auth.isExternalAuthProviderUsed auth ->
+          sequence $
+            [genAuthIndex auth]
+              ++ [genClientAuthProviderTs auth | AS.Auth.isClientAuthAdapterUsed auth]
       | otherwise ->
           sequence
             [ genAuthIndex auth,
@@ -44,6 +47,24 @@ genClientAuth spec =
             <++> genAuthMicrosoft auth
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
+
+-- | The client half of the auth provider: instantiates the adapter package's
+-- client entry with the same runtime-window discipline as the server half.
+genClientAuthProviderTs :: AS.Auth.Auth -> Generator FileDraft
+genClientAuthProviderTs auth =
+  return $
+    mkTmplFdWithData
+      (clientAuthDirInSdkTemplatesDir </> [relfile|provider.ts|])
+      tmplData
+  where
+    tmplData =
+      Aeson.object
+        [ "clientPackage" Aeson..= clientPackage,
+          "hasOptions" Aeson..= maybe False (const True) maybeOptionsJson,
+          "optionsJson" Aeson..= maybeOptionsJson
+        ]
+    clientPackage = AS.Auth.externalProvider auth >>= AS.Auth.clientPackage
+    maybeOptionsJson = AS.Auth.externalProvider auth >>= AS.Auth.optionsJson
 
 genAuthIndex :: AS.Auth.Auth -> Generator FileDraft
 genAuthIndex auth =


### PR DESCRIPTION
## Description

**Stack 7/8** (between adapter codegen and the packages). The client half of the auth provider contract, landing together with its generated consumers.

The problem it solves: client integration was the design's weakest part — hand-written `App.tsx` glue per app, a push-based token bridge with a staleness window across Clerk's ~60s rotations, and `logout()` that didn't tell the provider's client.

- **Contract** (`@wasp.sh/auth-contract/client`): `ClientAuthAdapter { Wrapper?, getCredential(), onCredentialChange?, onLogout? }` + `WaspClientRuntime` + `ClientAdapterFactory`. `getCredential` is pull-based on purpose (asked at each request, rotating tokens always current) and doubles as the readiness gate (resolves only once the provider's client is loaded).
- **Manifest**: `client: { package }` entry, mapped to IR `clientPackage` — consumed this time, unlike its earlier deleted incarnation.
- **Generated wiring**: a `wasp/client/auth/provider` module instantiates `createClientAdapter(runtime, options)` with the manifest-validated client env; `WaspApp` composes `Wrapper` around the app (outside `rootComponent`); the api client's `beforeRequest` awaits `getCredential()` instead of reading stored state; `logout()` calls `onLogout()`; credential changes rebroadcast into the existing `sessionId` events so query invalidation and websockets react for free.

No package implements it in this PR (the shape is final; consumers of the *factory* arrive one PR later, same pattern as the server half in the previous PR).

Review guidance: the contract file and the generated `provider.ts` template are the substance; the api/logout/WaspApp edits are small conditional branches, inert for every app without a client adapter (kitchen-sink goldens prove it).

## Type of change

- [ ] **🔧 Just code/docs improvement**
- [ ] **🐞 Bug fix**
- [x] **🚀 New/improved feature**
- [ ] **💥 Breaking change**

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended. <!-- full e2e suite; exercised end to end by the Clerk package in the next PR -->

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- spec mapper test covers the client entry mapping -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- examples flip in the next PR, with the package that implements this -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- API snapshots regenerated; prose docs deferred until the feature ships -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- deferred, one entry when the stack ships -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
