### PR TITLE
Fix all HLint hints

### DIFF
--- a/waspc/.hlint.yaml
+++ b/waspc/.hlint.yaml
@@ -1,10 +1,16 @@
 - arguments:
     # NOTE: List of extensions below should reflect the list
-    #   of default extensions from package.yaml.
+    #   of default extensions from waspc.cabal.
+    - -XDisambiguateRecordFields
+    - -XFlexibleContexts
+    - -XLambdaCase
+    - -XMultiParamTypeClasses
+    - -XNamedFieldPuns
+    - -XOverloadedRecordDot
     - -XOverloadedStrings
-    - -XTemplateHaskell
     - -XQuasiQuotes
     - -XScopedTypeVariables
+    - -XTemplateHaskell
 
 - ignore: { name: Use camelCase } # We can decide this on our own.
 - ignore: { name: Eta reduce } # We can decide this on our own.

--- a/waspc/cli/exe/Main.hs
+++ b/waspc/cli/exe/Main.hs
@@ -10,7 +10,7 @@ import Main.Utf8 (withUtf8)
 import System.Environment (getArgs)
 import qualified System.Environment as Env
 import System.Exit (exitFailure)
-import System.IO (hPutStrLn, stderr, stdout)
+import System.IO (hPutStrLn, stderr)
 import Wasp.Cli.Command (runCommand)
 import Wasp.Cli.Command.BashCompletion (bashCompletion, printBashCompletionInstruction)
 import Wasp.Cli.Command.Build (build)
@@ -180,7 +180,7 @@ printUsage =
 
 printVersion :: IO ()
 printVersion = do
-  hPutStrLn stdout $ show waspVersion
+  print waspVersion
   hPutStrLn stderr $
     unlines
       [ "",

--- a/waspc/cli/src/Wasp/Cli/Command/Telemetry/Project.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Telemetry/Project.hs
@@ -110,7 +110,7 @@ initialCache = ProjectTelemetryCache {_lastCheckIn = Nothing, _lastCheckInBuild 
 -- * Project telemetry cache file.
 
 getTimeOfLastTelemetryDataSent :: ProjectTelemetryCache -> Maybe T.UTCTime
-getTimeOfLastTelemetryDataSent cache = maximum [_lastCheckIn cache, _lastCheckInBuild cache]
+getTimeOfLastTelemetryDataSent cache = max (_lastCheckIn cache) (_lastCheckInBuild cache)
 
 readProjectTelemetryCacheFile :: Path' Abs (Dir TelemetryCacheDir) -> ProjectHash -> IO (Maybe ProjectTelemetryCache)
 readProjectTelemetryCacheFile telemetryCacheDirPath projectHash =

--- a/waspc/e2e-tests/Tests/SdkPackageExportsTest.hs
+++ b/waspc/e2e-tests/Tests/SdkPackageExportsTest.hs
@@ -6,6 +6,7 @@ import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Aeson.KeyMap as AesonKeyMap
 import qualified Data.ByteString as BS
 import Data.List (isInfixOf, isSuffixOf, stripPrefix)
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import FileSystem (SnapshotType (Current), getSnapshotsDir, snapshotDirInSnapshotsDir)
 import StrongPath ((</>))
@@ -92,7 +93,7 @@ wildcardParentDir :: FilePath -> FilePath
 wildcardParentDir target = FP.dropTrailingPathSeparator $ takeWhile (/= '*') target
 
 dropPrefix :: String -> String -> String
-dropPrefix prefix value = maybe value id $ stripPrefix prefix value
+dropPrefix prefix value = fromMaybe value $ stripPrefix prefix value
 
 replaceSuffix :: String -> String -> String -> String
 replaceSuffix oldSuffix newSuffix value =

--- a/waspc/e2e-tests/Tests/WaspVersionTest.hs
+++ b/waspc/e2e-tests/Tests/WaspVersionTest.hs
@@ -10,7 +10,7 @@ waspVersionTest =
     "wasp-version"
     [ TestCase
         "match-waspc-version"
-        (return . (: []) $ (~| ("{ read ver; [ \"$ver\" = '" ++ show waspVersion ++ "' ]; }")) $ waspCliVersion)
+        (return . (: []) $ (~| ("{ read ver; [ \"$ver\" = '" ++ show waspVersion ++ "' ]; }")) waspCliVersion)
     ]
 
 waspCliVersion :: ShellCommand

--- a/waspc/src/Wasp/Analyzer/TypeChecker/Monad.hs
+++ b/waspc/src/Wasp/Analyzer/TypeChecker/Monad.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TupleSections #-}
+
 module Wasp.Analyzer.TypeChecker.Monad
   ( TypeChecker,
     lookupType,
@@ -45,7 +47,7 @@ run typeDefs = runWithBound bindings typeDefs
     enumValueBindings :: [(Identifier, Type)]
     enumValueBindings =
       concatMap
-        (\(TD.EnumType name variants) -> zip variants (repeat $ EnumType name))
+        (\(TD.EnumType name variants) -> map (,EnumType name) variants)
         $ TD.getEnumTypes typeDefs
 
     bindings :: Bindings

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -153,7 +153,7 @@ validateAppAuthIsSetIfAnyPageRequiresAuth spec =
   | anyPageRequiresAuth && not (isAuthEnabled spec)
   ]
   where
-    anyPageRequiresAuth = any ((== Just True) . Page.authRequired) (snd <$> AS.getPages spec)
+    anyPageRequiresAuth = any ((== Just True) . Page.authRequired . snd) (AS.getPages spec)
 
 validateOnlyEmailOrUsernameAndPasswordAuthIsUsed :: AppSpec -> [ValidationError]
 validateOnlyEmailOrUsernameAndPasswordAuthIsUsed spec =

--- a/waspc/src/Wasp/Generator/NpmInstall.hs
+++ b/waspc/src/Wasp/Generator/NpmInstall.hs
@@ -9,7 +9,6 @@ import Control.Concurrent.Async (concurrently)
 import Control.Monad (when)
 import Control.Monad.Except (MonadError (throwError), runExceptT)
 import Control.Monad.IO.Class (liftIO)
-import Data.Functor ((<&>))
 import qualified Data.Text as T
 import StrongPath (Abs, Dir, Path')
 import qualified StrongPath as SP
@@ -67,12 +66,11 @@ installNpmDependenciesWithInstallRecord spec dstDir = runExceptT $ do
 -- Installs npm dependencies from the user's package.json, by running `npm install` .
 installProjectNpmDependencies ::
   Chan JobMessage -> SP.Path SP.System Abs (Dir WaspProjectDir) -> IO (Either String ())
-installProjectNpmDependencies messagesChan projectDir =
-  handleProjectInstallMessages messagesChan `concurrently` installProjectDepsJob
-    <&> snd
-    <&> \case
-      ExitFailure code -> Left $ "Project setup failed with exit code " ++ show code ++ "."
-      _success -> Right ()
+installProjectNpmDependencies messagesChan projectDir = do
+  (_, installExitCode) <- handleProjectInstallMessages messagesChan `concurrently` installProjectDepsJob
+  return $ case installExitCode of
+    ExitFailure code -> Left $ "Project setup failed with exit code " ++ show code ++ "."
+    _success -> Right ()
   where
     installProjectDepsJob =
       installNpmDependenciesAndReport

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/AppG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/AppG.hs
@@ -81,8 +81,8 @@ genAuthPages spec =
     Nothing -> return []
     Just auth ->
       sequence $
-        [genCreateAuthRequiredPage auth]
-          ++ [genOAuthCallbackPage auth | AS.Auth.isExternalAuthEnabled auth]
+        genCreateAuthRequiredPage auth
+          : [genOAuthCallbackPage auth | AS.Auth.isExternalAuthEnabled auth]
   where
     maybeAuth = AS.App.auth $ snd $ getApp spec
 

--- a/waspc/src/Wasp/Generator/WriteFileDrafts.hs
+++ b/waspc/src/Wasp/Generator/WriteFileDrafts.hs
@@ -126,7 +126,7 @@ readChecksumFile dstDir = do
   return $ do
     contents <- maybeContents
     typeAndPathAndChecksums <- Aeson.decode contents :: Maybe [((String, FilePath), Checksum)]
-    sequence $ (\(typeAndPath, checksum) -> (,checksum) <$> fromTypeAndPathToSp typeAndPath) <$> typeAndPathAndChecksums
+    mapM (\(typeAndPath, checksum) -> (,checksum) <$> fromTypeAndPathToSp typeAndPath) typeAndPathAndChecksums
   where
     checksumFP = SP.fromAbsFile $ dstDir </> checksumFileInProjectRoot
 

--- a/waspc/src/Wasp/Project/Waspignore.hs
+++ b/waspc/src/Wasp/Project/Waspignore.hs
@@ -38,7 +38,7 @@ waspIgnorePathInWaspProjectDir = [relfile|.waspignore|]
 
 -- | These patterns are ignored by every 'WaspignoreFile'
 defaultIgnorePatterns :: [Pattern]
-defaultIgnorePatterns = map compile [".waspignore"]
+defaultIgnorePatterns = [compile ".waspignore"]
 
 -- | Parses a string to a 'WaspignoreFile'.
 --

--- a/waspc/src/Wasp/Psl/Ast/Schema.hs
+++ b/waspc/src/Wasp/Psl/Ast/Schema.hs
@@ -10,7 +10,7 @@ module Wasp.Psl.Ast.Schema
   )
 where
 
-import Data.Maybe (catMaybes)
+import Data.Maybe (mapMaybe)
 import Wasp.Psl.Ast.ConfigBlock (ConfigBlock)
 import qualified Wasp.Psl.Ast.ConfigBlock as Psl.ConfigBlock
 import Wasp.Psl.Ast.Enum (Enum)
@@ -63,7 +63,7 @@ getGenerators = extractBlockOfType $ \case
 
 extractBlockOfType :: (Block -> Maybe a) -> Schema -> [WithCtx a]
 extractBlockOfType extractFn (Schema blocksWithCtx) =
-  catMaybes $ extractBlockMaybe <$> blocksWithCtx
+  mapMaybe extractBlockMaybe blocksWithCtx
   where
     extractBlockMaybe (WithCtx block context) =
       (`WithCtx` context) <$> extractFn block

--- a/waspc/src/Wasp/SemanticVersion.hs
+++ b/waspc/src/Wasp/SemanticVersion.hs
@@ -44,7 +44,8 @@ import Wasp.SemanticVersion.VersionBound
   )
 
 {--
-# The `node-semver` implementation
+The `node-semver` implementation
+================================
 
 We implement the `node-semver` package differently from the original implementation.
 This comment explains:
@@ -52,7 +53,8 @@ This comment explains:
 - How can we implement this?
 - Which one did we pick and why?
 
-## How does the `node-semver` behave?
+How does the `node-semver` behave?
+----------------------------------
 
 The `node-semver` package implements three classes: `SemVer`, `Comparator`, and `Range`:
 - `SemvVer` class is an implementation of the semantic version.
@@ -88,7 +90,8 @@ This is a recurring issue with `node-semver`.
 Their documentation is not really written as a specification,
 which makes it hard to replicate the API behavior fully.
 
-## How can we implement this?
+How can we implement this?
+--------------------------
 
 So the important context is that `node-semver` has two separate domains:
 1. The core domain - `SemVer`, `Comparator`, and `Range`.
@@ -124,7 +127,8 @@ We can either:
      - The middle layer is hidden from the public API.
      - In the end, we would only differentiate on the `Comparator`, which isn't that bad.
 
-## Which one did we pick and why?
+Which one did we pick and why?
+------------------------------
 
 We picked the second option.
 


### PR DESCRIPTION
## Description

`./run hlint` was reporting 13 hints and 4 parse warnings; it now reports **No hints**. The bulk of it is mechanical (`maybe x id` → `fromMaybe x`, `catMaybes . map` → `mapMaybe`, `[x] ++ ys` → `x : ys`, and so on), all semantics-preserving; the only one where HLint's literal suggestion read worse than the original is the functor-law violation in `NpmInstall`, which I rewrote as a do block instead. Two changes are worth a closer look: `.hlint.yaml` still referenced the removed `package.yaml` and listed only 4 of the 10 default extensions in `waspc.cabal`, and the missing `OverloadedRecordDot` was making HLint parse `entry.id` as `entry . id` and report a bogus "Redundant id", so I synced the list; and the Markdown headings in the `SemanticVersion` doc comment are now setext style (`===` / `---` underlines) so HLint stops reading a leading `#` as a CPP directive. Verified with `./run hlint`, `./run check:ormolu`, a full `cabal build all`, and both unit suites (657 + 34 tests passing).

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- No functional change, so the existing suites are the test. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
