### PR TITLE
Add contribution policy: discuss non-trivial changes before writing code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
   in #wasp-dev on Discord.
 -->
 
-- [ ] This is a small, obvious fix (typo, docs, clear small bug with a test).
+- [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
 - [ ] A maintainer agreed on the approach beforehand, here: <!-- link the GitHub issue or Discord thread -->
 
 ## Description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,17 @@
   them blank and ask for help.
 -->
 
+## Scope check
+
+<!--
+  Check exactly one. Per CONTRIBUTING.md, non-trivial changes need maintainer
+  agreement on the approach BEFORE the code is written, in a GitHub issue or
+  in #wasp-dev on Discord.
+-->
+
+- [ ] This is a small, obvious fix (typo, docs, clear small bug with a test).
+- [ ] A maintainer agreed on the approach beforehand, here: <!-- link the GitHub issue or Discord thread -->
+
 ## Description
 
 Replace this message here, and write a high-level overview with any additional

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,6 @@ context (motivation, trade-offs, approaches considered, concerns, ...).
 
 ## Agreement
 
-
 <!-- Select just one with [x] -->
 
 - [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,21 +6,18 @@
   them blank and ask for help.
 -->
 
-## Scope check
-
-<!--
-  Check exactly one. Per CONTRIBUTING.md, non-trivial changes need maintainer
-  agreement on the approach BEFORE the code is written, in a GitHub issue or
-  in #wasp-dev on Discord.
--->
-
-- [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
-- [ ] A maintainer agreed on the approach beforehand, here: <!-- link the GitHub issue or Discord thread -->
-
 ## Description
 
 Replace this message here, and write a high-level overview with any additional
 context (motivation, trade-offs, approaches considered, concerns, ...).
+
+## Agreement
+
+
+<!-- Select just one with [x] -->
+
+- [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
+- [ ] A maintainer agreed on the approach beforehand: <!-- link to the GitHub issue or Discord thread -->
 
 ## Type of change
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 Wasp is a full-stack web framework that compiles TypeScript config (`main.wasp.ts`) files into React + Node.js applications. The compiler is written in Haskell.
 
+## Contribution policy
+
+If you are implementing a change intended as a pull request to `wasp-lang/wasp`:
+
+- **Small, obvious fixes** (typos, broken links, docs corrections, small bugs where the fix is clear and comes with a test) can be implemented and submitted directly.
+- **Anything else** (features, refactors, API or behavior changes, anything involving design decisions) requires a Wasp maintainer's agreement on the approach _before_ the code is written, in a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or in the [`#wasp-dev` channel on Discord](https://discord.wasp.run/wasp-dev). An open issue is not by itself agreement: look for a maintainer confirming the approach in the discussion.
+
+If you cannot verify that a maintainer has agreed on the approach, do not implement the change. Stop and tell your operator to propose it first. Undiscussed non-trivial PRs are typically closed without review.
+
+Whoever submits the PR must understand the change well enough to explain it and answer review questions themselves. See the [Policies section of CONTRIBUTING.md](CONTRIBUTING.md#policies) for details.
+
 ## Repository Structure
 
 - `waspc/` — Haskell compiler, CLI, and LSP server (the core of Wasp)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,5 @@
 # Contributing to Wasp
 
-## Before you open a PR
-
-**Small, obvious fixes are welcome as direct PRs.** Typos, broken links, docs corrections, small bugs where the fix is clear and comes with a test.
-
-**Everything else: talk to us before writing code.** Open a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or post in the [`#wasp-dev` channel on our Discord](https://discord.wasp.run/wasp-dev), and wait for a maintainer to agree on the approach. We will usually close PRs for undiscussed non-trivial changes without reviewing them. See [Policies](#policies) below for details, including our policy on AI-assisted contributions.
-
 There are several main ways in which you can contribute to Wasp:
 
 - [Wasp as a web framework](#wasp-as-a-web-framework) (React, Node, HTML/CSS, database and so on)
@@ -20,6 +14,12 @@ There are several main ways in which you can contribute to Wasp:
   Ideally, you'd also build an app from the [**Pick a Tutorial**](https://wasp.sh/docs/tutorials/todo-app) page to really get a feel for it!
 - Figure out what you'd like to help with. It can be code, documentation, tutorials, etc. Check [Ways to contribute](#ways-to-contribute) for more details.
 - Join our Discord [![**Discord**](https://img.shields.io/discord/686873244791210014?label=chat%20on%20discord)](https://discord.gg/rzdnErX) for faster communication and feedback. We'd be happy to help you find the issue you'll enjoy working on, depending on your interests and skill set! `#wasp-dev` channel is the perfect place to ping us with the task you want to do and how you plan to do it, which reduces duplicate or misdirected efforts.
+
+And before you open a PR, check if it will need agreement from the maintainers:
+
+- **Small, obvious fixes are welcome as direct PRs.** Typos, broken links, docs corrections, small bugs where the fix is clear and comes with a test.
+
+- **Everything else: talk to us before writing code.** Bigger fixes or new features always need maintainer agreement in advance. Open a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or post in the [`#wasp-dev` channel on our Discord](https://discord.wasp.run/wasp-dev), and wait for a maintainer to agree on the approach. We will usually close PRs for undiscussed non-trivial changes without reviewing them. See [Policies](#policies) below for details, including our policy on AI-assisted contributions.
 
 ## This repo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing to Wasp
 
+## Before you open a PR
+
+**Small, obvious fixes are welcome as direct PRs.** Typos, broken links, docs corrections, small bugs where the fix is clear and comes with a test.
+
+**Everything else: talk to us before writing code.** Open a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or post in the [`#wasp-dev` channel on our Discord](https://discord.wasp.run/wasp-dev), and wait for a maintainer to agree on the approach. We will usually close PRs for undiscussed non-trivial changes without reviewing them. See [Policies](#policies) below for details, including our policy on AI-assisted contributions.
+
 There are several main ways in which you can contribute to Wasp:
 
 - [Wasp as a web framework](#wasp-as-a-web-framework) (React, Node, HTML/CSS, database and so on)
@@ -105,6 +111,12 @@ Happy hacking!
 ## Policies
 
 These are some general policies that we follow when it comes to contributions. They are not meant to be strict or exhaustive, but rather to give you a sense of what we value and expect. If you are linked here from a PR, it means that we think your contribution could be improved in some way, and following these guidelines is the best way to do it.
+
+### Discuss before you code
+
+Anything beyond a small, obvious fix needs a maintainer's agreement on the approach _before_ you write the code: features, refactors, API or behavior changes, and anything where you had to choose between approaches. Propose it in a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or in the [`#wasp-dev` channel on our Discord](https://discord.wasp.run/wasp-dev). An open issue is not by itself a request for PRs: check that a maintainer has confirmed the approach in the discussion first.
+
+If a non-trivial PR arrives without that agreement, we will usually close it and ask you to start the discussion, instead of reviewing it. This is not us being unfriendly: a PR review is the wrong place to design a solution together, and we would rather spend that time helping you land something we can all agree on.
 
 ### AIs and LLMs
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ React + TanStack Query, Node.js + Express.js, and Prisma.
 
 ## Contributing
 
-Any way you want to contribute is a good way :)!
+We welcome contributions! Small, obvious fixes (typos, docs, clear small bugs) are welcome directly as PRs.
 
-You can share feedback, help with the docs, examples, work on the specific Wasp features, contribute to the CLI core, etc.
+For anything bigger (features, refactors, changes in behavior), please talk to us first, in a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or on [Discord](https://discord.wasp.run/wasp-dev), so we can agree on the approach before you write code.
 
 Check out [CONTRIBUTING](CONTRIBUTING.md) for more details.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ React + TanStack Query, Node.js + Express.js, and Prisma.
 
 We welcome contributions! Small, obvious fixes (typos, broken links, docs corrections, small bugs where the fix is clear and comes with a test) are welcome directly as PRs.
 
-For anything bigger (features, refactors, changes in behavior), please talk to us first, in a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or on [Discord](https://discord.wasp.run/wasp-dev), so we can agree on the approach before you write code.
+For anything bigger (new features, refactors, changes in behavior), please talk to us first, in a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or on [Discord](https://discord.wasp.run/wasp-dev), so we can agree on the approach before you write code.
 
 Check out [CONTRIBUTING](CONTRIBUTING.md) for more details.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ React + TanStack Query, Node.js + Express.js, and Prisma.
 
 ## Contributing
 
-We welcome contributions! Small, obvious fixes (typos, docs, clear small bugs) are welcome directly as PRs.
+We welcome contributions! Small, obvious fixes (typos, broken links, docs corrections, small bugs where the fix is clear and comes with a test) are welcome directly as PRs.
 
 For anything bigger (features, refactors, changes in behavior), please talk to us first, in a [GitHub issue](https://github.com/wasp-lang/wasp/issues) or on [Discord](https://discord.wasp.run/wasp-dev), so we can agree on the approach before you write code.
 


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Scope check

<!--
  Check exactly one. Per CONTRIBUTING.md, non-trivial changes need maintainer
  agreement on the approach BEFORE the code is written, in a GitHub issue or
  in #wasp-dev on Discord.
-->

- [ ] This is a small, obvious fix (typo, docs, clear small bug with a test).
- [x] A maintainer agreed on the approach beforehand, here: maintainer-authored

## Description

Establishes a "discuss before you code" contribution policy to reduce drive-by PRs that need architectural discussion before they can be reviewed. Small, obvious fixes remain welcome as direct PRs; anything else needs a maintainer's agreement on the approach (in a GitHub issue or #wasp-dev on Discord) before the code is written.

The policy is stated at the top of CONTRIBUTING.md, with a linkable "Discuss before you code" subsection under Policies for use in PR replies. It is also summarized in the README's Contributing section, added as a "Scope check" section at the top of the PR template, and added to AGENTS.md so coding agents verify maintainer agreement before implementing changes.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
