### PR TITLE
Make dev app component URLs take explicit ports

### DIFF
--- a/waspc/cli/src/Wasp/Cli/AppComponentUrls.hs
+++ b/waspc/cli/src/Wasp/Cli/AppComponentUrls.hs
@@ -1,25 +1,25 @@
 module Wasp.Cli.AppComponentUrls
-  ( makeDefaultUrls,
-    makeDefaultDevClientUrl,
-    defaultDevServerUrl,
+  ( makeDevUrls,
+    makeDevClientUrl,
+    makeDevServerUrl,
   )
 where
 
+import Network.Socket (PortNumber)
 import Wasp.AppComponentUrl (AppComponentUrl (..))
 import Wasp.AppSpec (AppSpec)
-import Wasp.Cli.AppComponentPorts (defaultDevClientPort, defaultDevServerPort)
 import qualified Wasp.Generator.WebAppGenerator.Common as WebAppG
 
-makeDefaultUrls :: AppSpec -> (AppComponentUrl, AppComponentUrl)
-makeDefaultUrls appSpec = (clientUrl, serverUrl)
+makeDevUrls :: AppSpec -> (PortNumber, PortNumber) -> (AppComponentUrl, AppComponentUrl)
+makeDevUrls appSpec (clientPort, serverPort) = (clientUrl, serverUrl)
   where
-    clientUrl = makeDefaultDevClientUrl appSpec
-    serverUrl = defaultDevServerUrl
+    clientUrl = makeDevClientUrl appSpec clientPort
+    serverUrl = makeDevServerUrl serverPort
 
-makeDefaultDevClientUrl :: AppSpec -> AppComponentUrl
-makeDefaultDevClientUrl spec =
-  Local {port = defaultDevClientPort, path = Just $ WebAppG.getBaseDir spec}
+makeDevClientUrl :: AppSpec -> PortNumber -> AppComponentUrl
+makeDevClientUrl spec port =
+  Local {port = port, path = Just $ WebAppG.getBaseDir spec}
 
-defaultDevServerUrl :: AppComponentUrl
-defaultDevServerUrl =
-  Local {port = defaultDevServerPort, path = Nothing}
+makeDevServerUrl :: PortNumber -> AppComponentUrl
+makeDevServerUrl port =
+  Local {port = port, path = Nothing}

--- a/waspc/cli/src/Wasp/Cli/Command/BuildStart/Config.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BuildStart/Config.hs
@@ -13,10 +13,9 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Char (toLower)
 import StrongPath ((</>))
 import qualified StrongPath as SP
-import qualified Wasp.AppComponentUrl as AppComponentUrl
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.Valid as ASV
-import Wasp.Cli.AppComponentUrls (defaultDevServerUrl, makeDefaultDevClientUrl)
+import Wasp.Cli.AppComponentUrls (makeDevUrls)
 import Wasp.Cli.Command (Command, CommandError (CommandError))
 import Wasp.Cli.Command.BuildStart.ArgumentsParser (BuildStartArgs (..), buildStartArgsParser)
 import Wasp.Cli.EnvVarWithCtx (addEnvVarsUniqueC)
@@ -49,10 +48,8 @@ makeBuildStartConfig appSpec args projectDir' = do
   userServerEnvVars <- liftIO $ concatMapM EnvVarWithCtx.readEnvVarArgument args.serverEnvVars
   userClientEnvVars <- liftIO $ concatMapM EnvVarWithCtx.readEnvVarArgument args.clientEnvVars
 
-  let clientUrl = (makeDefaultDevClientUrl appSpec) {AppComponentUrl.port = args.clientPort}
-      serverUrl = defaultDevServerUrl {AppComponentUrl.port = args.serverPort}
-
-      (baseClientRunConfig, baseServerRunConfig) = makeRunConfigs (clientUrl, serverUrl)
+  let (baseClientRunConfig, baseServerRunConfig) =
+        makeRunConfigs $ makeDevUrls appSpec (args.clientPort, args.serverPort)
 
   clientRunConfig' <- baseClientRunConfig `addEnvVarsUniqueC` userClientEnvVars
   serverRunConfig' <- baseServerRunConfig `addEnvVarsUniqueC` userServerEnvVars

--- a/waspc/cli/src/Wasp/Cli/Command/Db/Seed.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Db/Seed.hs
@@ -15,11 +15,13 @@ import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Db as AS.Db
 import qualified Wasp.AppSpec.ExtImport as AS.ExtImport
 import qualified Wasp.AppSpec.Valid as ASV
+import Wasp.Cli.AppComponentPorts (findAppComponentPorts)
+import Wasp.Cli.AppComponentUrls (makeDevUrls)
 import Wasp.Cli.Command (Command, CommandError (CommandError), require)
 import Wasp.Cli.Command.Compile (analyze)
 import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.Require.InWaspProject (InWaspProject (InWaspProject))
-import Wasp.Cli.RunConfigs (makeDefaultDevRunConfigs)
+import Wasp.Cli.RunConfigs (makeRunConfigs)
 import Wasp.Generator.DbGenerator.Operations (dbSeed)
 import qualified Wasp.Message as Msg
 import Wasp.Project.Common (generatedAppDirInWaspProjectDir)
@@ -30,7 +32,9 @@ seed maybeUserProvidedSeedName = do
   let genProjectDir = waspProjectDir </> generatedAppDirInWaspProjectDir
 
   appSpec <- analyze waspProjectDir
-  let (_, serverRunConfig) = makeDefaultDevRunConfigs appSpec
+
+  ports <- findAppComponentPorts (Nothing, Nothing)
+  let (_, serverRunConfig) = makeRunConfigs $ makeDevUrls appSpec ports
 
   nameOfSeedToRun <- obtainNameOfExistingSeedToRun maybeUserProvidedSeedName appSpec
 

--- a/waspc/cli/src/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start.hs
@@ -8,10 +8,8 @@ import Control.Concurrent.MVar (MVar, newMVar, tryTakeMVar)
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
 import StrongPath (Abs, Dir, Path', (</>))
-import Wasp.AppComponentUrl (AppComponentUrl (..))
-import Wasp.AppSpec (AppSpec)
 import Wasp.Cli.AppComponentPorts (findAppComponentPorts)
-import Wasp.Cli.AppComponentUrls (defaultDevServerUrl, makeDefaultDevClientUrl)
+import Wasp.Cli.AppComponentUrls (makeDevUrls)
 import Wasp.Cli.Command (Command, CommandError (..), require)
 import Wasp.Cli.Command.Call (Arguments)
 import Wasp.Cli.Command.Compile (compile, printWarningsAndErrorsIfAny)
@@ -57,8 +55,8 @@ start = withArguments "wasp start" startArgsParser $ \args -> withProjectLock $ 
 
   (warnings, appSpec) <- compile
 
-  appComponentUrls <- makeDevAppComponentUrls appSpec args
-  let runConfigs = makeRunConfigs appComponentUrls
+  ports <- findAppComponentPorts (args.clientPort, args.serverPort)
+  let runConfigs = makeRunConfigs $ makeDevUrls appSpec ports
   assertImplicitEnvVarsDontOverrideWaspEnvVars waspProjectDir runConfigs
 
   DbConnectionEstablished <- require
@@ -110,14 +108,6 @@ start = withArguments "wasp start" startArgsParser $ \args -> withProjectLock $ 
           putStrLn ""
           printWarningsAndErrorsIfAny (warnings, errors)
           putStrLn ""
-
-makeDevAppComponentUrls :: AppSpec -> StartArgs -> Command (AppComponentUrl, AppComponentUrl)
-makeDevAppComponentUrls appSpec args = do
-  (clientPort, serverPort) <- findAppComponentPorts (args.clientPort, args.serverPort)
-  return
-    ( (makeDefaultDevClientUrl appSpec) {port = clientPort},
-      defaultDevServerUrl {port = serverPort}
-    )
 
 -- | The web app and server have their own logic for reading environment
 -- variables autonomously, so we don't need to merge the different sources of

--- a/waspc/cli/src/Wasp/Cli/Command/Test.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Test.hs
@@ -9,13 +9,15 @@ import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
 import StrongPath (Abs, Dir, (</>))
 import StrongPath.Types (Path')
+import Wasp.Cli.AppComponentPorts (findAppComponentPorts)
+import Wasp.Cli.AppComponentUrls (makeDevUrls)
 import Wasp.Cli.Command (Command, CommandError (..), require)
 import Wasp.Cli.Command.Compile (compile)
 import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.Require.InWaspProject (InWaspProject (InWaspProject))
 import Wasp.Cli.Command.Watch (watch)
 import Wasp.Cli.ProjectLock (withProjectLock)
-import Wasp.Cli.RunConfigs (makeDefaultDevRunConfigs)
+import Wasp.Cli.RunConfigs (makeRunConfigs)
 import qualified Wasp.Generator
 import Wasp.Generator.WebAppGenerator.RunConfig (WebAppRunConfig)
 import qualified Wasp.Message as Msg
@@ -39,7 +41,9 @@ watchAndTest testRunner = withProjectLock $ do
   cliSendMessageC $ Msg.Start "Starting compilation and setup phase. Hold tight..."
 
   (warnings, appSpec) <- compile
-  let (clientRunConfig, _) = makeDefaultDevRunConfigs appSpec
+
+  ports <- findAppComponentPorts (Nothing, Nothing)
+  let (clientRunConfig, _) = makeRunConfigs $ makeDevUrls appSpec ports
 
   cliSendMessageC $ Msg.Start "Watching for file changes and running tests ..."
 

--- a/waspc/cli/src/Wasp/Cli/RunConfigs.hs
+++ b/waspc/cli/src/Wasp/Cli/RunConfigs.hs
@@ -1,21 +1,15 @@
 module Wasp.Cli.RunConfigs
-  ( makeDefaultDevRunConfigs,
-    makeRunConfigs,
+  ( makeRunConfigs,
     showRunConfigUrls,
   )
 where
 
 import Wasp.AppComponentUrl (AppComponentUrl (..))
 import qualified Wasp.AppComponentUrl as AppComponentUrl
-import Wasp.AppSpec (AppSpec)
-import Wasp.Cli.AppComponentUrls (makeDefaultUrls)
 import Wasp.Generator.ServerGenerator.RunConfig (ServerRunConfig, makeServerRunConfig)
 import qualified Wasp.Generator.ServerGenerator.RunConfig as ServerRunConfig
 import Wasp.Generator.WebAppGenerator.RunConfig (WebAppRunConfig, makeWebAppRunConfig)
 import qualified Wasp.Generator.WebAppGenerator.RunConfig as WebAppRunConfig
-
-makeDefaultDevRunConfigs :: AppSpec -> (WebAppRunConfig, ServerRunConfig)
-makeDefaultDevRunConfigs appSpec = makeRunConfigs $ makeDefaultUrls appSpec
 
 makeRunConfigs :: (AppComponentUrl, AppComponentUrl) -> (WebAppRunConfig, ServerRunConfig)
 makeRunConfigs (clientUrl, serverUrl) = (clientRunConfig, serverRunConfig)


### PR DESCRIPTION
## Description

Follow-up cleanup to the port-selection work in #4585/#4586. The dev URL helpers in `Wasp.Cli.AppComponentUrls` no longer bake in the default ports: `makeDevUrls`/`makeDevClientUrl`/`makeDevServerUrl` now take the ports as arguments, so every caller builds its URLs from the ports resolved by `findAppComponentPorts`. This removes `makeDefaultDevRunConfigs` and the record-update-the-port dance in `wasp start` and `wasp build start`, and it makes `wasp db seed` and `wasp test` resolve their ports the same way `wasp start` does instead of assuming 3000/3001. Marked as a code improvement since it's a refactor, but note the one behavioural consequence: with a `wasp start` already occupying 3000/3001, `wasp db seed` and `wasp test` will now pick the next free ports for the URLs they pass to the app (and will fail if no free port exists) rather than silently using the taken defaults.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
