### PR TITLE
Revert "Update GHC to 9.10.3 (#4741)"

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -150,7 +150,7 @@ url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/453012788"
 provenance = "github-attestations"
 
 [[tools."mise-cabal:hlint"]]
-version = "3.10"
+version = "3.8"
 backend = "mise-cabal:hlint"
 
 [[tools."mise-cabal:stan"]]
@@ -158,7 +158,7 @@ version = "0.2.1.0"
 backend = "mise-cabal:stan"
 
 [[tools."mise-ghcup:ghc"]]
-version = "9.10.3"
+version = "9.6.7"
 backend = "mise-ghcup:ghc"
 
 [[tools."mise-ghcup:hls"]]

--- a/mise.toml
+++ b/mise.toml
@@ -6,13 +6,23 @@ ghcup = "0.2.6.2"
 
 cabal = "3.16.1.0"
 
-"mise-ghcup:ghc" = "9.10.3"
+# Holding off GHC 9.10 since HLint doesn't work with it:
+# https://github.com/haskell/haskell-language-server/issues/4674
+"mise-ghcup:ghc" = "9.6.7"
 
-# We assume that this HLS version ships prebuilt binaries for the GHC version
-# above. When upgrading GHC or HLS, check
+# When upgrading the HLS version, we need to ensure compatibility with our GHC
+# version. You can see the compatibility table at:
 # https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html
-# to see which combination of GHC and HLS versions are compatible.
+# Check that the HLS version has a prebuilt binary for the GHC version we are
+# using by running the following command:
+# `type haskell-language-server-$(ghc --numeric-version)`
 "mise-ghcup:hls" = "2.14.0.0"
+
+# Use the same version as the one used inside the HLS binary above. You can run
+# the following command to find the plugin versions (incl. HLint) in the current
+# GHC+HLS combination:
+# `haskell-language-server-$(ghc --numeric-version) --list-plugins`
+"mise-cabal:hlint" = "3.8"
 
 # This should be equal to Wasp's lowest supported Node version.
 # Keep in sync with:
@@ -41,8 +51,6 @@ jq = "1.8.2"
 # https://github.com/jdx/mise/discussions/10828
 ormolu.version = "0.8.1.1"
 ormolu.os = ["linux/x64", "darwin", "windows/x64"]
-
-"mise-cabal:hlint" = "3.10"
 
 "mise-cabal:stan" = "0.2.1.0"
 

--- a/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Templating.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/CreateNewProject/StarterTemplates/Templating.hs
@@ -3,6 +3,7 @@ module Wasp.Cli.Command.CreateNewProject.StarterTemplates.Templating
   )
 where
 
+import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as T
 import StrongPath (Abs, Dir, File, Path')

--- a/waspc/src/Wasp/Util/Control/Monad.hs
+++ b/waspc/src/Wasp/Util/Control/Monad.hs
@@ -4,6 +4,8 @@ module Wasp.Util.Control.Monad
   )
 where
 
+import Data.List (foldl')
+
 -- | Analogous to "Data.Foldable.foldMap'", except that its result is encapsulated in a
 -- monad.
 --

--- a/waspc/src/Wasp/Util/Terminal.hs
+++ b/waspc/src/Wasp/Util/Terminal.hs
@@ -9,6 +9,8 @@ module Wasp.Util.Terminal
   )
 where
 
+import Data.List (foldl')
+
 -- | Applies the Wasp CLI standardized code styling to a string.
 styleCode :: String -> String
 styleCode "" = ""

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -151,7 +151,7 @@ library
     regex-tdfa ^>=1.3.2,
     split ^>=0.2.5,
     strong-path ^>=1.2.0,
-    template-haskell ^>=2.22.0,
+    template-haskell ^>=2.20.0,
     text ^>=2.1.3,
     time ^>=1.12.2,
     unliftio ^>=0.2.25,


### PR DESCRIPTION
This reverts https://github.com/wasp-lang/wasp/pull/4741.

HLS doesn't include HLint for GHC 9.10, as that combination of HLS+GHC has errors.
As such, in-editor hints didn't include HLint hints.

We undo the GHC 9.10 bump and improve the guidance in our `mise.toml` so that we know how to check for compatibility in the future.