### PR TITLE
Made mise docs in CONTRIBUTING.md more prescriptive / tailored.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,23 +33,29 @@ While this document captures the general instructions for the whole repo, make s
 
 We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haskell, Node, and code formatters). Mise is an all-in-one tool that makes it easy to set up and manage the development environment (tools, env vars, tasks) per project. Everything is declared in a single file ([`mise.toml`](mise.toml)), and every developer can use it to set up their environment in a consistent way. We also use it on our CI to ensure it uses the same versions of tools as well.
 
+> [!NOTE]
+> There are no hard dependencies on mise for local development, so if you prefer to use your own tooling, you can install each program separately, and use the versions specified in [`mise.toml`](mise.toml) as a reference. But then, you're in charge of making sure you have the right versions of the tools installed, and keeping them up-to-date as we upgrade them.
+
+#### Global Mise setup
+
 While you can use Mise explicitly, on demand, via `mise exec|run|en`, normally you don't want to deal with that but just have it work automatically in the background.
 Mise has detailed docs on this, but here is the summarized version of how you will most likely want to set it up:
 1. Of course, **install** `mise`.
 2. Set up automatic mise **activation** per dir for interactive shells by adding `eval "$($HOME/.local/bin/mise activate bash)"` to your `~/.bashrc` (If on Mac: `... zsh)"` to your `~/.zshrc`).
    With this, when in an interactive shell, mise will automatically keep the dev environment updated for that shell based on your current directory.
    It does so by updating its `PATH` and other env vars.
-3. Set up global mise **shims** by adding `eval "$($HOME/.local/bin/mise activate bash --shims)"` to your `~/.profile` (If on Mac: `... zsh --shims)"` to your `~/.zprofile`).
+3. Set up global mise **shims** by adding `eval "$($HOME/.local/bin/mise activate bash --shims)"` to your `~/.profile` or possibly `~/.bash_profile` (If on Mac: `... zsh --shims)"` to your `~/.zprofile`).
    This complements the *activate* by covering direct, non-interactive usage, which *activate* doesn't cover.
-   E.g. if a process calls `node` directly, and not from interactive shell, it will hit a mise shim which will, based on the process's working directory, provide it with the correct version of `node` (or just pass it to system `node` if there is no applicable mise config).
+   E.g. if a process calls `node` directly, and not from interactive shell, it will hit a mise shim which will, based on the calling process's working directory, provide it with the correct version of `node` (or just pass it to system `node` if there is no applicable mise config).
 4. Potentially install tool-specific mise integrations/plugins, e.g. a plugin for your editor, although in most cases *activation* + *shims* will already do the job and you don't have to bother with this.
 
 If you are wondering why both *activate* and *shims*: because they both serve different use cases and complement each other. *Activate* runs once per dir change / shell activation, but can't affect the non-interactive usage (e.g. your editor executing tools non-interactively). On the other hand, *shims* work even for non-interactive usage, but call mise on each tool call (although cheap) and also can't provide env vars for the shell (but do set them for that single tool call). Having both ensures you are well covered.
 
-Run `mise install` from the root of the repo to install all the required tools.
+Run `mise doctor` to validate that everything is setup correctly.
 
-> [!NOTE]
-> There are no hard dependencies on mise for local development, so if you prefer to use your own tooling, you can install each program separately, and use the versions specified in [`mise.toml`](mise.toml) as a reference. But then, you're in charge of making sure you have the right versions of the tools installed, and keeping them up-to-date as we upgrade them.
+#### Repo setup
+
+Run `mise install` from the root of the repo to install all the required tools.
 
 ### Basic commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,17 @@ We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haske
 
 While you can use Mise explicitly, on demand, via `mise exec|run|en`, normally you don't want to deal with that but just have it work automatically in the background.
 Mise has detailed docs on this, but here is the summarized version of how you will most likely want to set it up:
+
 1. Of course, **install** `mise`.
 2. Set up automatic mise **activation** per dir for interactive shells by adding `eval "$($HOME/.local/bin/mise activate bash)"` to your `~/.bashrc` (If on Mac: `... zsh)"` to your `~/.zshrc`).
    With this, when in an interactive shell, mise will automatically keep the dev environment updated for that shell based on your current directory.
    It does so by updating its `PATH` and other env vars.
 3. Set up global mise **shims** by adding `eval "$($HOME/.local/bin/mise activate bash --shims)"` to your `~/.profile` or possibly `~/.bash_profile` (If on Mac: `... zsh --shims)"` to your `~/.zprofile`).
-   This complements the *activate* by covering direct, non-interactive usage, which *activate* doesn't cover.
+   This complements the _activate_ by covering direct, non-interactive usage, which _activate_ doesn't cover.
    E.g. if a process calls `node` directly, and not from interactive shell, it will hit a mise shim which will, based on the calling process's working directory, provide it with the correct version of `node` (or just pass it to system `node` if there is no applicable mise config).
-4. Potentially install tool-specific mise integrations/plugins, e.g. a plugin for your editor, although in most cases *activation* + *shims* will already do the job and you don't have to bother with this.
+4. Potentially install tool-specific mise integrations/plugins, e.g. a plugin for your editor, although in most cases _activation_ + _shims_ will already do the job and you don't have to bother with this.
 
-If you are wondering why both *activate* and *shims*: because they both serve different use cases and complement each other. *Activate* runs once per dir change / shell activation, but can't affect the non-interactive usage (e.g. your editor executing tools non-interactively). On the other hand, *shims* work even for non-interactive usage, but call mise on each tool call (although cheap) and also can't provide env vars for the shell (but do set them for that single tool call). Having both ensures you are well covered.
+If you are wondering why both _activate_ and _shims_: because they both serve different use cases and complement each other. _Activate_ runs once per dir change / shell activation, but can't affect the non-interactive usage (e.g. your editor executing tools non-interactively). On the other hand, _shims_ work even for non-interactive usage, but call mise on each tool call (although cheap) and also can't provide env vars for the shell (but do set them for that single tool call). Having both ensures you are well covered.
 
 Run `mise doctor` to validate that everything is setup correctly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,11 @@ We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haske
 
 While you can use Mise explicitly, on demand, via `mise exec|run|en`, normally you don't want to deal with that but just have it work automatically in the background.
 Mise has detailed docs on this, but here is the summarized version of how you will most likely want to set it up:
-1. Of course, install `mise`.
-2. Set up automatic mise *activation* per dir for interactive shells by adding `eval "$($HOME/.local/bin/mise activate bash)"` to your `~/.bashrc` (If on Mac: `... zsh)"` to your `~/.zshrc`).
+1. Of course, **install** `mise`.
+2. Set up automatic mise **activation** per dir for interactive shells by adding `eval "$($HOME/.local/bin/mise activate bash)"` to your `~/.bashrc` (If on Mac: `... zsh)"` to your `~/.zshrc`).
    With this, when in an interactive shell, mise will automatically keep the dev environment updated for that shell based on your current directory.
    It does so by updating its `PATH` and other env vars.
-3. Set up global mise *shims* by adding `eval "$($HOME/.local/bin/mise activate bash --shims)"` to your `~/.profile` (If on Mac: `... zsh --shims)"` to your `~/.zprofile`).
+3. Set up global mise **shims** by adding `eval "$($HOME/.local/bin/mise activate bash --shims)"` to your `~/.profile` (If on Mac: `... zsh --shims)"` to your `~/.zprofile`).
    This complements the *activate* by covering direct, non-interactive usage, which *activate* doesn't cover.
    E.g. if a process calls `node` directly, and not from interactive shell, it will hit a mise shim which will, based on the process's working directory, provide it with the correct version of `node` (or just pass it to system `node` if there is no applicable mise config).
 4. Potentially install tool-specific mise integrations/plugins, e.g. a plugin for your editor, although in most cases *activation* + *shims* will already do the job and you don't have to bother with this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,19 +31,22 @@ While this document captures the general instructions for the whole repo, make s
 > [!NOTE]
 > **Developing on Windows?** Use the Bash shell bundled with [Git for Windows](https://git-scm.com/download/win) (often called "Git Bash"). Wasp's development scripts are Bash scripts and won't run in PowerShell or Command Prompt. If you develop inside WSL (Windows Subsystem for Linux), you are effectively on Linux, so follow the Linux instructions instead.
 
-We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haskell, Node, and code formatters). Mise is an all-in-one tool that makes it easy to set up and manage all the different tools needed for the Wasp repo. Everything is declared in a single file ([`mise.toml`](mise.toml)), and every developer can use it to set up their environment in a consistent way. We also use it on our CI to ensure it uses the same versions of tools as well.
+We use [mise](https://mise.jdx.dev/) to manage our development tools (e.g. Haskell, Node, and code formatters). Mise is an all-in-one tool that makes it easy to set up and manage the development environment (tools, env vars, tasks) per project. Everything is declared in a single file ([`mise.toml`](mise.toml)), and every developer can use it to set up their environment in a consistent way. We also use it on our CI to ensure it uses the same versions of tools as well.
 
-Run `mise install` from the root of the repo to install all the required tools. Then, you can access the mise-managed tools in different ways:
+While you can use Mise explicitly, on demand, via `mise exec|run|en`, normally you don't want to deal with that but just have it work automatically in the background.
+Mise has detailed docs on this, but here is the summarized version of how you will most likely want to set it up:
+1. Of course, install `mise`.
+2. Set up automatic mise *activation* per dir for interactive shells by adding `eval "$($HOME/.local/bin/mise activate bash)"` to your `~/.bashrc` (If on Mac: `... zsh)"` to your `~/.zshrc`).
+   With this, when in an interactive shell, mise will automatically keep the dev environment updated for that shell based on your current directory.
+   It does so by updating its `PATH` and other env vars.
+3. Set up global mise *shims* by adding `eval "$($HOME/.local/bin/mise activate bash --shims)"` to your `~/.profile` (If on Mac: `... zsh --shims)"` to your `~/.zprofile`).
+   This complements the *activate* by covering direct, non-interactive usage, which *activate* doesn't cover.
+   E.g. if a process calls `node` directly, and not from interactive shell, it will hit a mise shim which will, based on the process's working directory, provide it with the correct version of `node` (or just pass it to system `node` if there is no applicable mise config).
+4. Potentially install tool-specific mise integrations/plugins, e.g. a plugin for your editor, although in most cases *activation* + *shims* will already do the job and you don't have to bother with this.
 
-- **(Recommended for local development)** You can set up your shell to automatically call the `mise activate` script. This will make sure that the specified tools and versions are in your `PATH` when you go into the repo. Check their installation instructions at https://mise.jdx.dev/installing-mise.html#shells.
+If you are wondering why both *activate* and *shims*: because they both serve different use cases and complement each other. *Activate* runs once per dir change / shell activation, but can't affect the non-interactive usage (e.g. your editor executing tools non-interactively). On the other hand, *shims* work even for non-interactive usage, but call mise on each tool call (although cheap) and also can't provide env vars for the shell (but do set them for that single tool call). Having both ensures you are well covered.
 
-- You can also run [`mise en`](https://mise.jdx.dev/cli/en.html) to go into a one-off shell for the current project, similar to `nix-shell` or `virtualenv`.
-
-- If you don't want to add a shell hook, you can use the [Shims mode](https://mise.jdx.dev/dev-tools/shims.html), which lets you just add a single directory to your `PATH`, which will get populated with intelligent redirectors to the correct versions of the tools for the current working directory.
-
-- For one-off commands, you can use [the `mise exec` command](https://mise.jdx.dev/cli/exec.html) (or `mise x`) to run a specific command with the repo tools available, e.g. `mise x -- ghc --version`, `mise x -- node --version`, `mise x -- ./run build`, etc.
-
-You can learn more and install Mise by following the [official instructions](https://mise.jdx.dev/getting-started.html), then run `mise install` from the repo root to install the required tools.
+Run `mise install` from the root of the repo to install all the required tools.
 
 > [!NOTE]
 > There are no hard dependencies on mise for local development, so if you prefer to use your own tooling, you can install each program separately, and use the versions specified in [`mise.toml`](mise.toml) as a reference. But then, you're in charge of making sure you have the right versions of the tools installed, and keeping them up-to-date as we upgrade them.


### PR DESCRIPTION
I was setting them up for myself and went through quite some investigation to figure out what is really the best setup. Their docs are not bad, but they don't directly and simply explain how and when to use what kind of setup. I would say they go wide, but still don't make it super easy to decide what you actually need.

And in our instructions, we said to do activate, but presented shims as an alternative, while I believe now that they should also be sometihng we set up for the optimal experience.

So I modified the docs to make it clear one should do activate and shims both, deemphasized direct usage patterns since we normaly don't need those, and provided some reasoning so people can make their own decisions from there.