### PR TITLE
Route all identity reads and writes through one identity store, shared by wasp-auth and user-made providers

### DIFF
--- a/examples/kitchen-sink/src/features/auth/customSignup.ts
+++ b/examples/kitchen-sink/src/features/auth/customSignup.ts
@@ -3,8 +3,11 @@ import {
   ensureValidEmail,
   ensureValidPassword,
 } from "wasp/auth/validation";
-import { prisma } from "wasp/server";
-import { defineUserSignupFields, hashPassword } from "wasp/server/auth";
+import {
+  defineUserSignupFields,
+  getIdentityStore,
+  hashPassword,
+} from "wasp/server/auth";
 import { CustomSignup } from "wasp/server/operations";
 
 export const userSignupFields = defineUserSignupFields({
@@ -38,31 +41,22 @@ export const customSignup: CustomSignup<
   ensureValidPassword(args);
 
   try {
-    await prisma.auth.create({
-      data: {
-        user: {
-          create: {
-            address: args.address,
-          },
+    // The same identity store Wasp's own signup flow uses -- no raw table
+    // access needed. Hashing stays the caller's explicit job.
+    await getIdentityStore("email").createIdentity(
+      args.email,
+      {
+        data: {
+          isEmailVerified: true,
+          emailVerificationSentAt: null,
+          passwordResetSentAt: null,
         },
-        identities: {
-          create: {
-            providerName: "email",
-            providerUserId: args.email,
-            providerData: JSON.stringify({
-              isEmailVerified: true,
-              emailVerificationSentAt: null,
-              passwordResetSentAt: null,
-            }),
-            // Hashing is the caller's explicit job; the secret goes into its
-            // own column, which the Prisma client omits when reading.
-            providerSecrets: JSON.stringify({
-              hashedPassword: await hashPassword(args.password),
-            }),
-          },
+        secrets: {
+          hashedPassword: await hashPassword(args.password),
         },
       },
-    });
+      { address: args.address },
+    );
   } catch (e: any) {
     return {
       success: false,

--- a/examples/kitchen-sink/src/features/db/seeds.ts
+++ b/examples/kitchen-sink/src/features/db/seeds.ts
@@ -1,43 +1,22 @@
 import { type AuthUser } from "wasp/auth";
 import { type DbSeedFn, type PrismaClient } from "wasp/server";
-import { hashPassword } from "wasp/server/auth";
+import { getIdentityStore, hashPassword } from "wasp/server/auth";
 import { createTask } from "../operations/actions.js";
 
-async function createUser(prismaClient: PrismaClient, data: any) {
-  const newUser = await prismaClient.user.create({
-    data: {
-      auth: {
-        create: {
-          identities: {
-            create: {
-              providerName: "username",
-              providerUserId: data.username,
-              // Hashing is the caller's explicit job; the secret goes into its
-              // own column, which the Prisma client omits when reading.
-              providerSecrets: JSON.stringify({
-                hashedPassword: await hashPassword(data.password),
-              }),
-            },
-          },
-        },
+async function createUser(_prismaClient: PrismaClient, data: any) {
+  // The same identity store Wasp's own signup flow uses -- no raw table
+  // access needed. Hashing stays the caller's explicit job.
+  const createdUser = await getIdentityStore("username").createIdentity(
+    data.username,
+    {
+      secrets: {
+        hashedPassword: await hashPassword(data.password),
       },
     },
-    include: {
-      auth: {
-        select: {
-          id: true,
-          userId: true,
-          identities: true,
-        },
-        include: {
-          identities: true,
-        },
-      },
-    },
-  });
+  );
 
   return {
-    id: newUser.id,
+    id: createdUser.id,
   } as AuthUser;
 }
 

--- a/waspc/data/Generator/templates/sdk/wasp/package.json
+++ b/waspc/data/Generator/templates/sdk/wasp/package.json
@@ -140,6 +140,7 @@
         provider's own routes. =}
     "./server/auth/provider": "./dist/server/auth/provider/index.js",
     {=/ isCustomAuthProviderUsed =}
+    "./server/auth/identityStore": "./dist/server/auth/identityStore.js",
     "./server/auth/session": "./dist/server/auth/session.js",
     "./server/auth/utils": "./dist/server/auth/utils.js",
     "./server/core/auth": "./dist/server/core/auth.js",

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
@@ -2,12 +2,8 @@
 import { createJWT, TimeSpan } from '../jwt.js'
 import { emailSender } from '../../email/index.js';
 import { Email } from '../../email/core/types.js';
-import {
-  createProviderId,
-  updateAuthIdentityProviderData,
-  findAuthIdentity,
-  type EmailProviderData,
-} from '../utils.js';
+import { type EmailProviderData } from '../utils.js';
+import { getIdentityStore } from '../identityStore.js';
 import { config as waspServerConfig } from '../../index.js';
 import { type {= userEntityUpper =}, type {= authEntityUpper =} } from '../../../entities/index.js'
 
@@ -61,16 +57,16 @@ async function sendEmailAndSaveMetadata(
 ): Promise<void> {
   // Save the metadata (e.g. timestamp) first, and then send the email
   // so the user can't send multiple requests while the email is being sent.
-  const providerId = createProviderId("email", email);
-  const authIdentity = await findAuthIdentity(providerId);
+  const emailIdentities = getIdentityStore('email');
+  const identity = await emailIdentities.find(email);
 
-  if (!authIdentity) {
+  if (!identity) {
     throw new Error(`User with email: ${email} not found.`);
   }
 
   // A partial update of the non-secret column only -- the password hash is
   // neither read nor rewritten to store a timestamp.
-  await updateAuthIdentityProviderData<'email'>(providerId, metadata);
+  await emailIdentities.updateData(email, metadata);
 
   emailSender.send(content).catch((e) => {
     console.error('Failed to send email', e);

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/hooks.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/hooks.ts
@@ -1,6 +1,7 @@
 {{={= =}=}}
 import type { Request as ExpressRequest } from 'express'
-import { type ProviderId, type CreateUserResult, type FindAuthWithUserResult } from './utils.js'
+import { type ProviderId, type FindAuthWithUserResult } from './utils.js'
+import { type CreateUserResult } from './identityStore.js'
 import { prisma } from '../index.js'
 import { Expand } from '../../universal/types.js'
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/identityStore.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/identityStore.ts
@@ -1,0 +1,251 @@
+{{={= =}=}}
+import { prisma } from '../index.js'
+import {
+  type {= userEntityUpper =},
+  type {= authEntityUpper =},
+} from '../../entities/index.js'
+import {
+  normalizeProviderUserId,
+  type PossibleProviderData,
+  type PossibleProviderSecrets,
+  type ProviderName,
+} from '../../auth/providerData.js'
+import { type PossibleUserFields } from '../../auth/providers/types.js'
+
+/**
+ * Wasp's identity store: THE way to read and write auth identities, for Wasp's
+ * own auth and for user-made providers alike -- Wasp's auth flows go through the
+ * exact same facet a hand-written provider gets, with no privileged access.
+ *
+ * A facet is scoped to one `providerName` (Wasp's own auth multiplexes several:
+ * `email`, `username`, the OAuth providers; an external provider has exactly
+ * one, its manifest id). The facet's three data channels mirror the identity's
+ * three columns:
+ *
+ * - `claims`  -- what the provider asserted at login; written at creation,
+ *   read-only afterwards, so its provenance can be trusted.
+ * - `data`    -- non-secret working state; partial updates via `updateData`.
+ * - `secrets` -- secret material, in the column the Prisma client omits by
+ *   default. Read and written ONLY through `getSecrets`/`setSecrets`, and
+ *   stored as given: hashing is the caller's explicit job (see `hashPassword`
+ *   in `wasp/server/auth`), never a side effect of storage.
+ */
+
+// PUBLIC API
+export type Identity<Data extends object> = {
+  providerName: string;
+  providerUserId: string;
+  authId: string;
+  /** Non-secret working state (the `providerData` column, parsed). */
+  data: Data;
+  /** Provider-asserted, Wasp-recorded profile data (the `providerClaims` column, parsed). */
+  claims: Record<string, unknown>;
+}
+
+// PUBLIC API
+export type CreateUserResult = {= userEntityUpper =} & {
+  {= authFieldOnUserEntityName =}: {= authEntityUpper =} | null
+}
+
+// PUBLIC API
+export type IdentityStore<Data extends object, Secrets extends object> = {
+  /** Reads the identity (never its secrets). */
+  find(providerUserId: string): Promise<Identity<Data> | null>;
+
+  /**
+   * Creates the user with its auth identity in one atomic write. A duplicate
+   * identity surfaces as Prisma's unique-constraint error (P2002), same as any
+   * other conflicting write -- see `rethrowPossibleAuthError`.
+   */
+  createIdentity(
+    providerUserId: string,
+    identity?: {
+      claims?: Record<string, unknown>;
+      data?: Data;
+      secrets?: Secrets;
+    },
+    userFields?: PossibleUserFields,
+  ): Promise<CreateUserResult>;
+
+  /**
+   * Idempotent create: returns the existing identity's `authId` when the
+   * subject is already known, creates it otherwise. Two concurrent calls for
+   * the same brand-new subject are settled by the unique constraint -- the
+   * loser re-reads and returns the winner's row.
+   */
+  provision(
+    providerUserId: string,
+    identity?: {
+      claims?: Record<string, unknown>;
+      data?: Data;
+      secrets?: Secrets;
+    },
+    userFields?: PossibleUserFields,
+  ): Promise<{ authId: string } | null>;
+
+  /**
+   * Reads the identity's secret material -- the single opt-in into the column
+   * the Prisma client omits by default. Keep the result on the server.
+   */
+  getSecrets(providerUserId: string): Promise<Secrets | null>;
+
+  /** Replaces the identity's secret material. Expects it **already hashed**. */
+  setSecrets(providerUserId: string, secrets: Secrets): Promise<void>;
+
+  /** Merges the given updates into the identity's non-secret data. */
+  updateData(providerUserId: string, updates: Partial<Data>): Promise<void>;
+
+  /**
+   * Deletes the identity's whole user (cascading to its auth data and
+   * sessions). Returns whether anything was deleted.
+   */
+  deleteUser(providerUserId: string): Promise<boolean>;
+}
+
+// PUBLIC API
+/**
+ * The facet for one of Wasp's own auth methods, typed with its data shapes.
+ */
+export function getIdentityStore<PN extends ProviderName>(
+  providerName: PN,
+): IdentityStore<PossibleProviderData[PN], PossibleProviderSecrets[PN]>
+// PUBLIC API
+/**
+ * The facet for a user-made provider (e.g. an `external:*` id): same powers
+ * Wasp's own auth uses, with untyped data shapes -- the provider owns them.
+ */
+export function getIdentityStore(
+  providerName: string,
+): IdentityStore<Record<string, unknown>, Record<string, unknown>>
+export function getIdentityStore(
+  providerName: string,
+): IdentityStore<Record<string, unknown>, Record<string, unknown>> {
+  // Unknown provider names pass through normalization unchanged (its default
+  // branch), so the cast only widens the accepted names.
+  const normalize = (providerUserId: string) =>
+    normalizeProviderUserId(providerName as ProviderName, providerUserId);
+
+  const whereIdentity = (providerUserId: string) => ({
+    providerName_providerUserId: {
+      providerName,
+      providerUserId: normalize(providerUserId),
+    },
+  });
+
+  return {
+    async find(providerUserId) {
+      const identity = await prisma.{= authIdentityEntityLower =}.findUnique({
+        where: whereIdentity(providerUserId),
+      });
+      if (identity === null) {
+        return null;
+      }
+      return {
+        providerName: identity.providerName,
+        providerUserId: identity.providerUserId,
+        authId: identity.authId,
+        data: JSON.parse(identity.providerData),
+        claims: JSON.parse(identity.providerClaims),
+      };
+    },
+
+    async createIdentity(providerUserId, identity, userFields) {
+      return prisma.{= userEntityLower =}.create({
+        data: {
+          // Using any here to prevent type errors when userFields are not
+          // defined. We want Prisma to throw an error in that case.
+          ...(userFields ?? {} as any),
+          {= authFieldOnUserEntityName =}: {
+            create: {
+              {= identitiesFieldOnAuthEntityName =}: {
+                create: {
+                  providerName,
+                  providerUserId: normalize(providerUserId),
+                  providerClaims: JSON.stringify(identity?.claims ?? {}),
+                  providerData: JSON.stringify(identity?.data ?? {}),
+                  providerSecrets: JSON.stringify(identity?.secrets ?? {}),
+                },
+              },
+            }
+          },
+        },
+        // We need to include the Auth entity here because we need `authId`
+        // to be able to create a session.
+        include: {
+          {= authFieldOnUserEntityName =}: true,
+        },
+      })
+    },
+
+    async provision(providerUserId, identity, userFields) {
+      const existing = await this.find(providerUserId);
+      if (existing !== null) {
+        return { authId: existing.authId };
+      }
+      try {
+        const created = await this.createIdentity(providerUserId, identity, userFields);
+        return { authId: created.{= authFieldOnUserEntityName =}!.id };
+      } catch (e: unknown) {
+        // Another request provisioned the same subject between our read and
+        // our write. Its row is the winner; re-read rather than failing.
+        if (isUniqueConstraintViolation(e)) {
+          const raced = await this.find(providerUserId);
+          return raced === null ? null : { authId: raced.authId };
+        }
+        throw e;
+      }
+    },
+
+    async getSecrets(providerUserId) {
+      const identity = await prisma.{= authIdentityEntityLower =}.findUnique({
+        where: whereIdentity(providerUserId),
+        omit: { providerSecrets: false },
+      });
+      return identity === null ? null : JSON.parse(identity.providerSecrets);
+    },
+
+    async setSecrets(providerUserId, secrets) {
+      await prisma.{= authIdentityEntityLower =}.update({
+        where: whereIdentity(providerUserId),
+        data: { providerSecrets: JSON.stringify(secrets) },
+      });
+    },
+
+    async updateData(providerUserId, updates) {
+      const identity = await prisma.{= authIdentityEntityLower =}.findUnique({
+        where: whereIdentity(providerUserId),
+        select: { providerData: true },
+      });
+      if (identity === null) {
+        throw new Error('Auth identity not found.');
+      }
+      const newData = { ...JSON.parse(identity.providerData), ...updates };
+      await prisma.{= authIdentityEntityLower =}.update({
+        where: whereIdentity(providerUserId),
+        data: { providerData: JSON.stringify(newData) },
+      });
+    },
+
+    async deleteUser(providerUserId) {
+      const { count } = await prisma.{= userEntityLower =}.deleteMany({
+        where: {
+          {= authFieldOnUserEntityName =}: {
+            {= identitiesFieldOnAuthEntityName =}: {
+              some: {
+                providerName,
+                providerUserId: normalize(providerUserId),
+              },
+            },
+          },
+        },
+      });
+      return count > 0;
+    },
+  };
+}
+
+function isUniqueConstraintViolation(e: unknown): boolean {
+  return (
+    typeof e === 'object' && e !== null && 'code' in e && (e as { code: unknown }).code === 'P2002'
+  );
+}

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/index.ts
@@ -3,11 +3,21 @@ export {
   defineUserSignupFields,
 } from '../../auth/providers/types.js'
 
+// The identity store: the one channel for reading and writing auth
+// identities. Wasp's own auth flows use the exact same facet a user-made
+// provider gets -- no privileged access.
+export {
+  getIdentityStore,
+  type Identity,
+  type IdentityStore,
+  type CreateUserResult,
+} from './identityStore.js'
+
 {=# isCustomAuthProviderUsed =}
-{=! Under an external provider, `wasp/server/auth` keeps only what is
-    provider-independent: typing `userSignupFields` and the error helper the
-    generated code itself uses. Everything password- and hook-shaped belongs
-    to Wasp's own auth and is not generated at all. =}
+{=! Under an external provider, `wasp/server/auth` keeps what is
+    provider-independent: the identity store, typing `userSignupFields`, and
+    the error helper the generated code itself uses. Everything password- and
+    hook-shaped belongs to Wasp's own auth and is not generated at all. =}
 export { createInvalidCredentialsError } from './utils.js'
 {=/ isCustomAuthProviderUsed =}
 {=^ isCustomAuthProviderUsed =}
@@ -15,13 +25,6 @@ export {
   createProviderId,
   parseProviderData,
   parseProviderSecrets,
-  updateAuthIdentityProviderData,
-  setAuthIdentitySecrets,
-  findAuthIdentity,
-  findAuthIdentitySecrets,
-  createUser,
-  type AuthIdentityWithoutSecrets,
-  type CreateUserResult,
   type ProviderId,
   type ProviderName,
   type EmailProviderData,

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
@@ -10,6 +10,7 @@ import * as sessionStore from "./sessionStore.js";
 import { prisma } from '../index.js';
 import { createAuthUserData } from "../../auth/user.js";
 {=# isCustomAuthProviderUsed =}
+import { getIdentityStore } from './identityStore.js';
 import { validateAndGetUserFields } from './utils.js';
 {=# externalUserSignupFields.isDefined =}
 {=& externalUserSignupFields.importStatement =}
@@ -155,77 +156,37 @@ async function resolveExternalSubject(
   subjectId: string,
   claims: VerifiedSession['claims'],
 ): Promise<string | null> {
-  const providerName = authProvider.id;
+  const identities = getIdentityStore(authProvider.id);
 
-  const existing = await prisma.{= authIdentityEntityLower =}.findUnique({
-    where: {
-      providerName_providerUserId: {
-        providerName: providerName,
-        providerUserId: subjectId,
-      },
-    },
-    select: { authId: true },
-  });
-
+  const existing = await identities.find(subjectId);
   if (existing) {
     return existing.authId;
   }
 
-  try {
-    // The app's `userSignupFields` compute the new user's own fields from the
-    // claims the provider verified -- the only way a user entity with required
-    // columns can be provisioned at all.
-    const userFields = await validateAndGetUserFields(
-      { ...(claims ?? {}) },
-      {=# externalUserSignupFields.isDefined =}{= externalUserSignupFields.importIdentifier =}{=/ externalUserSignupFields.isDefined =}{=^ externalUserSignupFields.isDefined =}undefined{=/ externalUserSignupFields.isDefined =},
-    );
-
-    const created = await prisma.{= userEntityLower =}.create({
-      data: {
-        // Using `any` to defer validation of required-but-unset fields to
-        // Prisma, which reports them precisely.
-        ...(userFields as any),
-        {= authFieldOnUserEntityName =}: {
-          create: {
-            {= identitiesFieldOnAuthEntityName =}: {
-              create: {
-                providerName: providerName,
-                providerUserId: subjectId,
-                // The provider-verified profile data (email, name, ...) as of
-                // the moment this subject was first seen. Wasp-written and
-                // read-only afterwards, so its provenance can be trusted.
-                providerClaims: JSON.stringify(claims ?? {}),
-              },
-            },
-          },
-        },
-      },
-      include: { {= authFieldOnUserEntityName =}: true },
-    });
-    return created.{= authFieldOnUserEntityName =}!.id;
-  } catch (e: unknown) {
-    // Another request provisioned the same subject between our read and our
-    // write. Its row is the winner; re-read rather than failing the request.
-    if (isUniqueConstraintViolation(e)) {
-      const raced = await prisma.{= authIdentityEntityLower =}.findUnique({
-        where: {
-          providerName_providerUserId: {
-            providerName: providerName,
-            providerUserId: subjectId,
-          },
-        },
-        select: { authId: true },
-      });
-      return raced?.authId ?? null;
-    }
-    throw e;
-  }
-}
-
-function isUniqueConstraintViolation(e: unknown): boolean {
-  return (
-    typeof e === 'object' && e !== null && 'code' in e && (e as { code: unknown }).code === 'P2002'
+  // The app's `userSignupFields` compute the new user's own fields from the
+  // claims the provider verified -- the only way a user entity with required
+  // columns can be provisioned at all. Computed only for brand-new subjects.
+  const userFields = await validateAndGetUserFields(
+    { ...(claims ?? {}) },
+    {=# externalUserSignupFields.isDefined =}{= externalUserSignupFields.importIdentifier =}{=/ externalUserSignupFields.isDefined =}{=^ externalUserSignupFields.isDefined =}undefined{=/ externalUserSignupFields.isDefined =},
   );
+
+  // `provision` is the store's idempotent create: a concurrent request for the
+  // same brand-new subject is settled by the unique constraint, and the loser
+  // returns the winner's row.
+  const provisioned = await identities.provision(
+    subjectId,
+    {
+      // The provider-verified profile data (email, name, ...) as of the moment
+      // this subject was first seen. Wasp-written and read-only afterwards, so
+      // its provenance can be trusted.
+      claims: { ...(claims ?? {}) },
+    },
+    // Using `any` to defer validation of required-but-unset fields to Prisma,
+    // which reports them precisely.
+    userFields as any,
+  );
+  return provisioned?.authId ?? null;
 }
 
 // PRIVATE API

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -4,24 +4,12 @@ import { sleep } from '../utils.js'
 import {
   type {= userEntityUpper =},
   type {= authEntityUpper =},
-  type {= authIdentityEntityUpper =},
 } from '../../entities/index.js'
 import { Prisma } from '@prisma/client';
 
 import { throwValidationError } from '../../auth/validation.js'
 
-import {
-  type ProviderId,
-  type ProviderName,
-  type PossibleProviderData,
-  type PossibleProviderSecrets,
-  parseProviderData,
-  parseProviderSecrets,
-  serializeProviderData,
-  serializeProviderSecrets,
-} from '../../auth/providerData.js'
-
-import { type UserSignupFields, type PossibleUserFields } from '../../auth/providers/types.js'
+import { type UserSignupFields } from '../../auth/providers/types.js'
 
 // Runtime-agnostic provider data code, re-exported here because it's part of
 // the server-side auth API surface (e.g. through `wasp/server/auth`).
@@ -55,93 +43,6 @@ export const authConfig = {
   successRedirectPath: "{= successRedirectPath =}",
 }
 
-// PUBLIC API
-/**
- * The auth identity as everything outside auth internals sees it: the secret
- * column does not exist here -- the Prisma client omits it by default, and only
- * `findAuthIdentitySecrets` opts back in.
- */
-export type AuthIdentityWithoutSecrets = Omit<{= authIdentityEntityUpper =}, 'providerSecrets'>
-
-// PUBLIC API
-export async function findAuthIdentity(providerId: ProviderId): Promise<AuthIdentityWithoutSecrets | null> {
-  return prisma.{= authIdentityEntityLower =}.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    }
-  });
-}
-
-{=^ isCustomAuthProviderUsed =}
-// PUBLIC API
-/**
- * Reads the auth identity's secret material (e.g. the password hash). This is
- * the single place that opts back into the `providerSecrets` column the Prisma
- * client omits by default -- keep the result on the server.
- */
-export async function findAuthIdentitySecrets<PN extends ProviderName>(
-  providerId: ProviderId,
-): Promise<PossibleProviderSecrets[PN] | null> {
-  const identity = await prisma.{= authIdentityEntityLower =}.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    omit: { providerSecrets: false },
-  });
-  return identity === null ? null : parseProviderSecrets<PN>(identity.providerSecrets);
-}
-
-// PUBLIC API
-/**
- * Merges the given updates into the auth identity's non-secret provider data.
- * Secrets have their own column and their own writer (`setAuthIdentitySecrets`),
- * so this update can never touch them.
- */
-export async function updateAuthIdentityProviderData<PN extends ProviderName>(
-  providerId: ProviderId,
-  providerDataUpdates: Partial<PossibleProviderData[PN]>,
-): Promise<AuthIdentityWithoutSecrets> {
-  const identity = await prisma.{= authIdentityEntityLower =}.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    select: { providerData: true },
-  });
-  if (identity === null) {
-    throw new Error('Auth identity not found.');
-  }
-  const newProviderData = {
-    ...parseProviderData<PN>(identity.providerData),
-    ...providerDataUpdates,
-  }
-  return prisma.{= authIdentityEntityLower =}.update({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    data: { providerData: serializeProviderData<PN>(newProviderData) },
-  });
-}
-
-// PUBLIC API
-/**
- * Replaces the auth identity's secret material. Expects secrets to arrive
- * **already hashed** -- hashing is the flow's explicit responsibility (see
- * `hashPassword` in `wasp/server/auth/password`), never an implicit side effect
- * of storage.
- */
-export async function setAuthIdentitySecrets<PN extends ProviderName>(
-  providerId: ProviderId,
-  secrets: PossibleProviderSecrets[PN],
-): Promise<AuthIdentityWithoutSecrets> {
-  return prisma.{= authIdentityEntityLower =}.update({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    data: { providerSecrets: serializeProviderSecrets<PN>(secrets) },
-  });
-}
-{=/ isCustomAuthProviderUsed =}
-
 // PRIVATE API
 export type FindAuthWithUserResult = {= authEntityUpper =} & {
   {= userFieldOnAuthEntityName =}: {= userEntityUpper =}
@@ -162,58 +63,6 @@ export async function findAuthWithUserBy(
   }
 
   return { ...result, user: result.user };
-}
-
-// PUBLIC API
-export type CreateUserResult = {= userEntityUpper =} & {
-  auth: {= authEntityUpper =} | null
-}
-
-// PUBLIC API
-/**
- * Creates the user with its auth identity in one atomic write. `data` is the
- * provider's non-secret state, `secrets` its secret material -- `secrets` must
- * arrive already hashed (see `setAuthIdentitySecrets`).
- */
-export async function createUser<PN extends ProviderName>(
-  providerId: ProviderId,
-  identity?: {
-    data?: PossibleProviderData[PN];
-    secrets?: PossibleProviderSecrets[PN];
-  },
-  userFields?: PossibleUserFields,
-): Promise<CreateUserResult> {
-  return prisma.{= userEntityLower =}.create({
-    data: {
-      // Using any here to prevent type errors when userFields are not
-      // defined. We want Prisma to throw an error in that case.
-      ...(userFields ?? {} as any),
-      {= authFieldOnUserEntityName =}: {
-        create: {
-          {= identitiesFieldOnAuthEntityName =}: {
-              create: {
-                  providerName: providerId.providerName,
-                  providerUserId: providerId.providerUserId,
-                  providerData: serializeProviderData<PN>(identity?.data ?? ({} as PossibleProviderData[PN])),
-                  providerSecrets: serializeProviderSecrets<PN>(identity?.secrets ?? ({} as PossibleProviderSecrets[PN])),
-              },
-          },
-        }
-      },
-    },
-    // We need to include the Auth entity here because we need `authId`
-    // to be able to create a session.
-    include: {
-      {= authFieldOnUserEntityName =}: true,
-    },
-  })
-}
-
-// PRIVATE API
-export async function deleteUserByAuthId(authId: string): Promise<{ count: number }> {
-  return prisma.{= userEntityLower =}.deleteMany({ where: { auth: {
-    id: authId,
-  } } })
 }
 
 // PRIVATE API

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/login.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/login.ts
@@ -3,11 +3,9 @@ import { createInvalidCredentialsError } from 'wasp/server/auth/utils'
 import { verifyPassword } from 'wasp/server/auth/password'
 import {
     createProviderId,
-    findAuthIdentity,
-    findAuthIdentitySecrets,
     findAuthWithUserBy,
-    parseProviderData,
 } from 'wasp/server/auth/utils'
+import { getIdentityStore } from 'wasp/server/auth/identityStore'
 import { createSession } from 'wasp/server/auth/session'
 import { ensureValidEmail, ensurePasswordIsPresent } from 'wasp/auth/validation'
 import { onBeforeLoginHook, onAfterLoginHook } from '../../hooks.js';
@@ -20,17 +18,17 @@ export function getLoginRoute() {
         const fields = req.body ?? {}
         ensureValidArgs(fields)
 
+        const emailIdentities = getIdentityStore('email')
         const providerId = createProviderId("email", fields.email)
-        const authIdentity = await findAuthIdentity(providerId)
-        if (!authIdentity) {
+        const identity = await emailIdentities.find(fields.email)
+        if (!identity) {
             throw createInvalidCredentialsError()
         }
-        const providerData = parseProviderData<'email'>(authIdentity.providerData)
-        if (!providerData.isEmailVerified) {
+        if (!identity.data.isEmailVerified) {
             throw createInvalidCredentialsError()
         }
         // The secret column is read explicitly and only here in this flow.
-        const secrets = await findAuthIdentitySecrets<'email'>(providerId)
+        const secrets = await emailIdentities.getSecrets(fields.email)
         if (secrets === null) {
             throw createInvalidCredentialsError()
         }
@@ -40,7 +38,7 @@ export function getLoginRoute() {
             throw createInvalidCredentialsError()
         }
     
-        const auth = await findAuthWithUserBy({ id: authIdentity.authId })
+        const auth = await findAuthWithUserBy({ id: identity.authId })
 
         if (auth === null) {
             throw createInvalidCredentialsError()

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/requestPasswordReset.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/requestPasswordReset.ts
@@ -1,10 +1,6 @@
 import { Request, Response } from 'express';
-import {
-    createProviderId,
-    findAuthIdentity,
-    doFakeWork,
-    parseProviderData,
-} from 'wasp/server/auth/utils';
+import { doFakeWork } from 'wasp/server/auth/utils';
+import { getIdentityStore } from 'wasp/server/auth/identityStore';
 import {
     createPasswordResetLink,
     sendPasswordResetEmail,
@@ -31,9 +27,8 @@ export function getRequestPasswordResetRoute({
         const args = req.body ?? {};
         ensureValidEmail(args);
 
-        const authIdentity = await findAuthIdentity(
-            createProviderId("email", args.email),
-        );
+        const emailIdentities = getIdentityStore('email');
+        const identity = await emailIdentities.find(args.email);
 
         /**
          * By doing fake work, we make it harder to enumerate users by measuring
@@ -41,21 +36,20 @@ export function getRequestPasswordResetRoute({
          * could measure the time it takes to respond and figure out if the user exists.
          */
 
-        if (!authIdentity) {
+        if (!identity) {
             await doFakeWork();
             res.json({ success: true });
             return
         }
 
-        const providerData = parseProviderData<'email'>(authIdentity.providerData);
-        const { isResendAllowed, timeLeft } = isEmailResendAllowed(providerData, 'passwordResetSentAt');
+        const { isResendAllowed, timeLeft } = isEmailResendAllowed(identity.data, 'passwordResetSentAt');
         if (!isResendAllowed) {
             throw new HttpError(400, `Please wait ${timeLeft} secs before trying again.`);
         }
 
         const passwordResetLink = await createPasswordResetLink(args.email, clientRoute);
         try {
-            const email = authIdentity.providerUserId
+            const email = identity.providerUserId
             await sendPasswordResetEmail(
                 email,
                 {

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/resetPassword.ts
@@ -1,10 +1,5 @@
 import { Request, Response } from 'express';
-import {
-    createProviderId,
-    findAuthIdentity,
-    setAuthIdentitySecrets,
-    updateAuthIdentityProviderData,
-} from 'wasp/server/auth/utils';
+import { getIdentityStore } from 'wasp/server/auth/identityStore';
 import { hashPassword } from 'wasp/server/auth/password';
 import { validateJWT } from 'wasp/server/auth/jwt'
 import { invalidateAllSessionsForAuthId } from 'wasp/server/auth/session'
@@ -28,24 +23,24 @@ export async function resetPassword(
 
     ensureValidPasswordArg(args);
 
-    const providerId = createProviderId('email', email);
-    const authIdentity = await findAuthIdentity(providerId);
-    if (!authIdentity) {
+    const emailIdentities = getIdentityStore('email');
+    const identity = await emailIdentities.find(email);
+    if (!identity) {
         throw new HttpError(400, "Password reset failed, invalid token");
     }
 
     // Hashing is the flow's explicit job -- storage never hashes.
-    await setAuthIdentitySecrets<'email'>(providerId, {
+    await emailIdentities.setSecrets(email, {
         hashedPassword: await hashPassword(password),
     });
-    await updateAuthIdentityProviderData<'email'>(providerId, {
+    await emailIdentities.updateData(email, {
         // The act of resetting the password verifies the email
         isEmailVerified: true,
     });
 
     // Changing the password invalidates all the existing sessions, so that
     // somebody who got hold of a session can't keep using it.
-    await invalidateAllSessionsForAuthId(authIdentity.authId);
+    await invalidateAllSessionsForAuthId(identity.authId);
 
     res.json({ success: true });
 };

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/signup.ts
@@ -2,14 +2,11 @@ import { Request, Response } from 'express'
 import type { UserSignupFields } from 'wasp/auth/providers/types'
 import {
   createProviderId,
-  createUser,
-  deleteUserByAuthId,
   doFakeWork,
-  findAuthIdentity,
-  parseProviderData,
   rethrowPossibleAuthError,
   validateAndGetUserFields,
 } from 'wasp/server/auth/utils'
+import { getIdentityStore } from 'wasp/server/auth/identityStore'
 import { hashPassword } from 'wasp/server/auth/password'
 import {
   ensurePasswordIsPresent,
@@ -46,8 +43,9 @@ export function getSignupRoute({
     const fields = req.body
     ensureValidArgs(fields)
 
+    const emailIdentities = getIdentityStore('email')
     const providerId = createProviderId('email', fields.email)
-    const existingAuthIdentity = await findAuthIdentity(providerId)
+    const existingIdentity = await emailIdentities.find(fields.email)
 
     /**
      *
@@ -73,15 +71,12 @@ export function getSignupRoute({
      *     else's email address and therefore permanently making that email
      *     address unavailable for later account creation (by real owner).
      */
-    if (existingAuthIdentity) {
-      const providerData = parseProviderData<'email'>(
-        existingAuthIdentity.providerData,
-      )
+    if (existingIdentity) {
 
       // TOOD: faking work makes sense if the time spent on faking the work matches the time
       // it would take to send the email. Atm, the fake work takes obviously longer than sending
       // the email!
-      if (providerData.isEmailVerified) {
+      if (existingIdentity.data.isEmailVerified) {
         await doFakeWork()
         res.json({ success: true })
         return
@@ -90,7 +85,7 @@ export function getSignupRoute({
       // TODO: we are still leaking information here since when we are faking work
       // we are not checking if the email was sent or not!
       const { isResendAllowed, timeLeft } = isEmailResendAllowed(
-        providerData,
+        existingIdentity.data,
         'emailVerificationSentAt',
       )
       if (!isResendAllowed) {
@@ -101,7 +96,7 @@ export function getSignupRoute({
       }
 
       try {
-        await deleteUserByAuthId(existingAuthIdentity.authId)
+        await emailIdentities.deleteUser(fields.email)
       } catch (e: unknown) {
         rethrowPossibleAuthError(e)
       }
@@ -118,8 +113,8 @@ export function getSignupRoute({
     const userFields = await validateAndGetUserFields(fields, userSignupFields)
 
     try {
-      const user = await createUser<'email'>(
-        providerId,
+      const user = await emailIdentities.createIdentity(
+        fields.email,
         {
           data: {
             isEmailVerified: isEmailAutoVerified ? true : false,

--- a/waspc/data/Generator/templates/server/src/auth/providers/email/verifyEmail.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/email/verifyEmail.ts
@@ -2,11 +2,9 @@ import { Request, Response } from 'express';
 import { validateJWT } from 'wasp/server/auth/jwt';
 import {
   createInvalidCredentialsError,
-  createProviderId,
-  findAuthIdentity,
   findAuthWithUserBy,
-  updateAuthIdentityProviderData,
 } from 'wasp/server/auth/utils';
+import { getIdentityStore } from 'wasp/server/auth/identityStore';
 import { HttpError } from 'wasp/server';
 import { onAfterEmailVerifiedHook } from '../../hooks.js';
 
@@ -21,20 +19,20 @@ export async function verifyEmail(
             throw new HttpError(400, "Email verification failed, invalid token");
         });
 
-    const providerId = createProviderId('email', email);
-    const authIdentity = await findAuthIdentity(providerId);
-    if (!authIdentity) {
+    const emailIdentities = getIdentityStore('email');
+    const identity = await emailIdentities.find(email);
+    if (!identity) {
         throw new HttpError(400, "Email verification failed, invalid token");
     }
 
     // A partial update of the non-secret column only -- flipping the flag can
     // no longer race another writer into losing fields, and the password hash
     // is never even read.
-    await updateAuthIdentityProviderData<'email'>(providerId, {
+    await emailIdentities.updateData(email, {
         isEmailVerified: true,
     });
 
-    const auth = await findAuthWithUserBy({ id: authIdentity.authId })
+    const auth = await findAuthWithUserBy({ id: identity.authId })
 
     if (auth === null) {
         throw createInvalidCredentialsError();

--- a/waspc/data/Generator/templates/server/src/auth/providers/oauth/user.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/oauth/user.ts
@@ -2,13 +2,12 @@
 import { Request as ExpressRequest } from 'express'
 import {
   type ProviderId,
-  createUser,
   validateAndGetUserFields,
   createProviderId,
   findAuthWithUserBy,
 } from 'wasp/server/auth/utils'
+import { getIdentityStore } from 'wasp/server/auth/identityStore'
 import { type {= authEntityUpper =} } from 'wasp/entities'
-import { prisma } from 'wasp/server'
 import { type UserSignupFields, type ProviderConfig } from 'wasp/auth/providers/types'
 import { type OAuthData } from 'wasp/server/auth'
 import { getRedirectUriForOneTimeCode, tokenStore } from 'wasp/server/auth'
@@ -64,21 +63,11 @@ async function getAuthIdFromProviderDetails({
   req: ExpressRequest;
   oauth: OAuthData;
 }): Promise<{= authEntityUpper =}['id']> {
-  const existingAuthIdentity = await prisma.{= authIdentityEntityLower =}.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    include: {
-      {= authFieldOnAuthIdentityEntityName =}: {
-        include: {
-          {= userFieldOnAuthEntityName =}: true
-        }
-      }
-    }
-  })
+  const identities = getIdentityStore(providerId.providerName)
+  const existingIdentity = await identities.find(providerId.providerUserId)
 
-  if (existingAuthIdentity) {
-    const authId = existingAuthIdentity.{= authFieldOnAuthIdentityEntityName =}.id
+  if (existingIdentity) {
+    const authId = existingIdentity.authId
 
     // NOTE: Fetching the user to pass it to the login hooks - it's a bit wasteful
     // but we wanted to keep the onAfterLoginHook params consistent for all auth providers.
@@ -120,8 +109,8 @@ async function getAuthIdFromProviderDetails({
     )
 
     // For now, we don't store any data or secrets for the oauth providers.
-    const user = await createUser(
-      providerId,
+    const user = await identities.createIdentity(
+      providerId.providerUserId,
       {},
       // Using any here because we want to avoid TypeScript errors and
       // rely on Prisma to validate the data.
@@ -134,6 +123,6 @@ async function getAuthIdFromProviderDetails({
       oauth,
     })
 
-    return user.auth.id
+    return user.auth!.id
   }
 }

--- a/waspc/data/Generator/templates/server/src/auth/providers/username/login.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/username/login.ts
@@ -5,10 +5,9 @@ import { verifyPassword } from 'wasp/server/auth/password'
 
 import {
   createProviderId,
-  findAuthIdentity,
-  findAuthIdentitySecrets,
   findAuthWithUserBy,
 } from 'wasp/server/auth/utils'
+import { getIdentityStore } from 'wasp/server/auth/identityStore'
 import { createSession } from 'wasp/server/auth/session'
 import { ensureValidUsername, ensurePasswordIsPresent } from 'wasp/auth/validation'
 import { onBeforeLoginHook, onAfterLoginHook } from '../../hooks.js';
@@ -17,15 +16,16 @@ export default defineHandler(async (req, res) => {
   const fields = req.body ?? {}
   ensureValidArgs(fields)
 
+  const usernameIdentities = getIdentityStore('username')
   const providerId = createProviderId('username', fields.username)
-  const authIdentity = await findAuthIdentity(providerId)
-  if (!authIdentity) {
+  const identity = await usernameIdentities.find(fields.username)
+  if (!identity) {
     throw createInvalidCredentialsError()
   }
 
   try {
     // The secret column is read explicitly and only here in this flow.
-    const secrets = await findAuthIdentitySecrets<'username'>(providerId)
+    const secrets = await usernameIdentities.getSecrets(fields.username)
     if (secrets === null) {
       throw createInvalidCredentialsError()
     }
@@ -35,7 +35,7 @@ export default defineHandler(async (req, res) => {
   }
 
   const auth = await findAuthWithUserBy({
-    id: authIdentity.authId
+    id: identity.authId
   })
 
   if (auth === null) {

--- a/waspc/data/Generator/templates/server/src/auth/providers/username/signup.ts
+++ b/waspc/data/Generator/templates/server/src/auth/providers/username/signup.ts
@@ -2,9 +2,9 @@
 import { defineHandler } from 'wasp/server/utils'
 import {
   createProviderId,
-  createUser,
   rethrowPossibleAuthError,
 } from 'wasp/server/auth/utils'
+import { getIdentityStore } from 'wasp/server/auth/identityStore'
 import { hashPassword } from 'wasp/server/auth/password'
 import {
   ensureValidUsername,
@@ -40,8 +40,8 @@ export function getSignupRoute({
     );
 
     try {
-      const user = await createUser<'username'>(
-        providerId,
+      const user = await getIdentityStore('username').createIdentity(
+        fields.username,
         {
           // Hashing is the flow's explicit job -- storage never hashes.
           secrets: {

--- a/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/snapshot-file-list.manifest
@@ -398,6 +398,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/_types/taggedEntities.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/_types/taggedEntities.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/_types/taggedEntities.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/_types/taggedEntities.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/auth/identityStore.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/auth/identityStore.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/auth/identityStore.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/auth/identityStore.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/index.js
@@ -525,6 +529,7 @@ wasp-app/.wasp/out/sdk/wasp/serialization/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/HttpError.ts
 wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
+wasp-app/.wasp/out/sdk/wasp/server/auth/identityStore.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/lucia.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/provider/index.ts

--- a/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/.waspchecksums
@@ -550,7 +550,7 @@
             "file",
             "sdk/wasp/package.json"
         ],
-        "51a8a6354c263b355d9049e60945ffdf10ff46070bcd5f71de6b7b86d33a61b3"
+        "2609a3cff1f4f73ca96ac7910eebd78d32b305e440b0a43b0bdb3c4ae35022cd"
     ],
     [
         [
@@ -597,9 +597,16 @@
     [
         [
             "file",
+            "sdk/wasp/server/auth/identityStore.ts"
+        ],
+        "caa077beb9eeef4a1853e8c7a884d72a8d6a5292172239ebb444d8fd77d01f73"
+    ],
+    [
+        [
+            "file",
             "sdk/wasp/server/auth/index.ts"
         ],
-        "99758be6a86317b72fe22b3f0c0869fe6859f753e93feb30d33103c3f236e7ff"
+        "bd4c4fefc89f2d04c03a1867f4ff0225714f1c742ae20d6d3513ca614136743c"
     ],
     [
         [
@@ -627,7 +634,7 @@
             "file",
             "sdk/wasp/server/auth/session.ts"
         ],
-        "fb235b0ff39c3c120522ef96c455ae30f9fec47e968a760493fda5aa022f057a"
+        "3c1519f6879325c447321a07c097741284a58f8b96b5c084376bade7e4b8e29b"
     ],
     [
         [
@@ -641,7 +648,7 @@
             "file",
             "sdk/wasp/server/auth/utils.ts"
         ],
-        "bedf8cef4fbb9dd5584cc9c60f2b7b05369e70bca6522fe8ca27ff176f849d77"
+        "ae8c23abf8ff3024b1ad0e0f1b4392e1965caea517885689c06a4ac537c651db"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -61,6 +61,7 @@
     "./server": "./dist/server/index.js",
     "./server/api": "./dist/server/api/index.js",
     "./server/auth": "./dist/server/auth/index.js",
+    "./server/auth/identityStore": "./dist/server/auth/identityStore.js",
     "./server/auth/provider": "./dist/server/auth/provider/index.js",
     "./server/auth/provider/types": "./dist/server/auth/provider/types.js",
     "./server/auth/session": "./dist/server/auth/session.js",

--- a/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/identityStore.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/identityStore.ts
@@ -1,0 +1,250 @@
+import { prisma } from '../index.js'
+import {
+  type User,
+  type Auth,
+} from '../../entities/index.js'
+import {
+  normalizeProviderUserId,
+  type PossibleProviderData,
+  type PossibleProviderSecrets,
+  type ProviderName,
+} from '../../auth/providerData.js'
+import { type PossibleUserFields } from '../../auth/providers/types.js'
+
+/**
+ * Wasp's identity store: THE way to read and write auth identities, for Wasp's
+ * own auth and for user-made providers alike -- Wasp's auth flows go through the
+ * exact same facet a hand-written provider gets, with no privileged access.
+ *
+ * A facet is scoped to one `providerName` (Wasp's own auth multiplexes several:
+ * `email`, `username`, the OAuth providers; an external provider has exactly
+ * one, its manifest id). The facet's three data channels mirror the identity's
+ * three columns:
+ *
+ * - `claims`  -- what the provider asserted at login; written at creation,
+ *   read-only afterwards, so its provenance can be trusted.
+ * - `data`    -- non-secret working state; partial updates via `updateData`.
+ * - `secrets` -- secret material, in the column the Prisma client omits by
+ *   default. Read and written ONLY through `getSecrets`/`setSecrets`, and
+ *   stored as given: hashing is the caller's explicit job (see `hashPassword`
+ *   in `wasp/server/auth`), never a side effect of storage.
+ */
+
+// PUBLIC API
+export type Identity<Data extends object> = {
+  providerName: string;
+  providerUserId: string;
+  authId: string;
+  /** Non-secret working state (the `providerData` column, parsed). */
+  data: Data;
+  /** Provider-asserted, Wasp-recorded profile data (the `providerClaims` column, parsed). */
+  claims: Record<string, unknown>;
+}
+
+// PUBLIC API
+export type CreateUserResult = User & {
+  auth: Auth | null
+}
+
+// PUBLIC API
+export type IdentityStore<Data extends object, Secrets extends object> = {
+  /** Reads the identity (never its secrets). */
+  find(providerUserId: string): Promise<Identity<Data> | null>;
+
+  /**
+   * Creates the user with its auth identity in one atomic write. A duplicate
+   * identity surfaces as Prisma's unique-constraint error (P2002), same as any
+   * other conflicting write -- see `rethrowPossibleAuthError`.
+   */
+  createIdentity(
+    providerUserId: string,
+    identity?: {
+      claims?: Record<string, unknown>;
+      data?: Data;
+      secrets?: Secrets;
+    },
+    userFields?: PossibleUserFields,
+  ): Promise<CreateUserResult>;
+
+  /**
+   * Idempotent create: returns the existing identity's `authId` when the
+   * subject is already known, creates it otherwise. Two concurrent calls for
+   * the same brand-new subject are settled by the unique constraint -- the
+   * loser re-reads and returns the winner's row.
+   */
+  provision(
+    providerUserId: string,
+    identity?: {
+      claims?: Record<string, unknown>;
+      data?: Data;
+      secrets?: Secrets;
+    },
+    userFields?: PossibleUserFields,
+  ): Promise<{ authId: string } | null>;
+
+  /**
+   * Reads the identity's secret material -- the single opt-in into the column
+   * the Prisma client omits by default. Keep the result on the server.
+   */
+  getSecrets(providerUserId: string): Promise<Secrets | null>;
+
+  /** Replaces the identity's secret material. Expects it **already hashed**. */
+  setSecrets(providerUserId: string, secrets: Secrets): Promise<void>;
+
+  /** Merges the given updates into the identity's non-secret data. */
+  updateData(providerUserId: string, updates: Partial<Data>): Promise<void>;
+
+  /**
+   * Deletes the identity's whole user (cascading to its auth data and
+   * sessions). Returns whether anything was deleted.
+   */
+  deleteUser(providerUserId: string): Promise<boolean>;
+}
+
+// PUBLIC API
+/**
+ * The facet for one of Wasp's own auth methods, typed with its data shapes.
+ */
+export function getIdentityStore<PN extends ProviderName>(
+  providerName: PN,
+): IdentityStore<PossibleProviderData[PN], PossibleProviderSecrets[PN]>
+// PUBLIC API
+/**
+ * The facet for a user-made provider (e.g. an `external:*` id): same powers
+ * Wasp's own auth uses, with untyped data shapes -- the provider owns them.
+ */
+export function getIdentityStore(
+  providerName: string,
+): IdentityStore<Record<string, unknown>, Record<string, unknown>>
+export function getIdentityStore(
+  providerName: string,
+): IdentityStore<Record<string, unknown>, Record<string, unknown>> {
+  // Unknown provider names pass through normalization unchanged (its default
+  // branch), so the cast only widens the accepted names.
+  const normalize = (providerUserId: string) =>
+    normalizeProviderUserId(providerName as ProviderName, providerUserId);
+
+  const whereIdentity = (providerUserId: string) => ({
+    providerName_providerUserId: {
+      providerName,
+      providerUserId: normalize(providerUserId),
+    },
+  });
+
+  return {
+    async find(providerUserId) {
+      const identity = await prisma.authIdentity.findUnique({
+        where: whereIdentity(providerUserId),
+      });
+      if (identity === null) {
+        return null;
+      }
+      return {
+        providerName: identity.providerName,
+        providerUserId: identity.providerUserId,
+        authId: identity.authId,
+        data: JSON.parse(identity.providerData),
+        claims: JSON.parse(identity.providerClaims),
+      };
+    },
+
+    async createIdentity(providerUserId, identity, userFields) {
+      return prisma.user.create({
+        data: {
+          // Using any here to prevent type errors when userFields are not
+          // defined. We want Prisma to throw an error in that case.
+          ...(userFields ?? {} as any),
+          auth: {
+            create: {
+              identities: {
+                create: {
+                  providerName,
+                  providerUserId: normalize(providerUserId),
+                  providerClaims: JSON.stringify(identity?.claims ?? {}),
+                  providerData: JSON.stringify(identity?.data ?? {}),
+                  providerSecrets: JSON.stringify(identity?.secrets ?? {}),
+                },
+              },
+            }
+          },
+        },
+        // We need to include the Auth entity here because we need `authId`
+        // to be able to create a session.
+        include: {
+          auth: true,
+        },
+      })
+    },
+
+    async provision(providerUserId, identity, userFields) {
+      const existing = await this.find(providerUserId);
+      if (existing !== null) {
+        return { authId: existing.authId };
+      }
+      try {
+        const created = await this.createIdentity(providerUserId, identity, userFields);
+        return { authId: created.auth!.id };
+      } catch (e: unknown) {
+        // Another request provisioned the same subject between our read and
+        // our write. Its row is the winner; re-read rather than failing.
+        if (isUniqueConstraintViolation(e)) {
+          const raced = await this.find(providerUserId);
+          return raced === null ? null : { authId: raced.authId };
+        }
+        throw e;
+      }
+    },
+
+    async getSecrets(providerUserId) {
+      const identity = await prisma.authIdentity.findUnique({
+        where: whereIdentity(providerUserId),
+        omit: { providerSecrets: false },
+      });
+      return identity === null ? null : JSON.parse(identity.providerSecrets);
+    },
+
+    async setSecrets(providerUserId, secrets) {
+      await prisma.authIdentity.update({
+        where: whereIdentity(providerUserId),
+        data: { providerSecrets: JSON.stringify(secrets) },
+      });
+    },
+
+    async updateData(providerUserId, updates) {
+      const identity = await prisma.authIdentity.findUnique({
+        where: whereIdentity(providerUserId),
+        select: { providerData: true },
+      });
+      if (identity === null) {
+        throw new Error('Auth identity not found.');
+      }
+      const newData = { ...JSON.parse(identity.providerData), ...updates };
+      await prisma.authIdentity.update({
+        where: whereIdentity(providerUserId),
+        data: { providerData: JSON.stringify(newData) },
+      });
+    },
+
+    async deleteUser(providerUserId) {
+      const { count } = await prisma.user.deleteMany({
+        where: {
+          auth: {
+            identities: {
+              some: {
+                providerName,
+                providerUserId: normalize(providerUserId),
+              },
+            },
+          },
+        },
+      });
+      return count > 0;
+    },
+  };
+}
+
+function isUniqueConstraintViolation(e: unknown): boolean {
+  return (
+    typeof e === 'object' && e !== null && 'code' in e && (e as { code: unknown }).code === 'P2002'
+  );
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/index.ts
@@ -2,6 +2,16 @@ export {
   defineUserSignupFields,
 } from '../../auth/providers/types.js'
 
+// The identity store: the one channel for reading and writing auth
+// identities. Wasp's own auth flows use the exact same facet a user-made
+// provider gets -- no privileged access.
+export {
+  getIdentityStore,
+  type Identity,
+  type IdentityStore,
+  type CreateUserResult,
+} from './identityStore.js'
+
 export { createInvalidCredentialsError } from './utils.js'
 
 

--- a/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
@@ -8,6 +8,7 @@ import * as sessionStore from "./sessionStore.js";
 
 import { prisma } from '../index.js';
 import { createAuthUserData } from "../../auth/user.js";
+import { getIdentityStore } from './identityStore.js';
 import { validateAndGetUserFields } from './utils.js';
 
 /**
@@ -148,77 +149,37 @@ async function resolveExternalSubject(
   subjectId: string,
   claims: VerifiedSession['claims'],
 ): Promise<string | null> {
-  const providerName = authProvider.id;
+  const identities = getIdentityStore(authProvider.id);
 
-  const existing = await prisma.authIdentity.findUnique({
-    where: {
-      providerName_providerUserId: {
-        providerName: providerName,
-        providerUserId: subjectId,
-      },
-    },
-    select: { authId: true },
-  });
-
+  const existing = await identities.find(subjectId);
   if (existing) {
     return existing.authId;
   }
 
-  try {
-    // The app's `userSignupFields` compute the new user's own fields from the
-    // claims the provider verified -- the only way a user entity with required
-    // columns can be provisioned at all.
-    const userFields = await validateAndGetUserFields(
-      { ...(claims ?? {}) },
-      undefined,
-    );
-
-    const created = await prisma.user.create({
-      data: {
-        // Using `any` to defer validation of required-but-unset fields to
-        // Prisma, which reports them precisely.
-        ...(userFields as any),
-        auth: {
-          create: {
-            identities: {
-              create: {
-                providerName: providerName,
-                providerUserId: subjectId,
-                // The provider-verified profile data (email, name, ...) as of
-                // the moment this subject was first seen. Wasp-written and
-                // read-only afterwards, so its provenance can be trusted.
-                providerClaims: JSON.stringify(claims ?? {}),
-              },
-            },
-          },
-        },
-      },
-      include: { auth: true },
-    });
-    return created.auth!.id;
-  } catch (e: unknown) {
-    // Another request provisioned the same subject between our read and our
-    // write. Its row is the winner; re-read rather than failing the request.
-    if (isUniqueConstraintViolation(e)) {
-      const raced = await prisma.authIdentity.findUnique({
-        where: {
-          providerName_providerUserId: {
-            providerName: providerName,
-            providerUserId: subjectId,
-          },
-        },
-        select: { authId: true },
-      });
-      return raced?.authId ?? null;
-    }
-    throw e;
-  }
-}
-
-function isUniqueConstraintViolation(e: unknown): boolean {
-  return (
-    typeof e === 'object' && e !== null && 'code' in e && (e as { code: unknown }).code === 'P2002'
+  // The app's `userSignupFields` compute the new user's own fields from the
+  // claims the provider verified -- the only way a user entity with required
+  // columns can be provisioned at all. Computed only for brand-new subjects.
+  const userFields = await validateAndGetUserFields(
+    { ...(claims ?? {}) },
+    undefined,
   );
+
+  // `provision` is the store's idempotent create: a concurrent request for the
+  // same brand-new subject is settled by the unique constraint, and the loser
+  // returns the winner's row.
+  const provisioned = await identities.provision(
+    subjectId,
+    {
+      // The provider-verified profile data (email, name, ...) as of the moment
+      // this subject was first seen. Wasp-written and read-only afterwards, so
+      // its provenance can be trusted.
+      claims: { ...(claims ?? {}) },
+    },
+    // Using `any` to defer validation of required-but-unset fields to Prisma,
+    // which reports them precisely.
+    userFields as any,
+  );
+  return provisioned?.authId ?? null;
 }
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/auth-provider-external-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/utils.ts
@@ -3,24 +3,12 @@ import { sleep } from '../utils.js'
 import {
   type User,
   type Auth,
-  type AuthIdentity,
 } from '../../entities/index.js'
 import { Prisma } from '@prisma/client';
 
 import { throwValidationError } from '../../auth/validation.js'
 
-import {
-  type ProviderId,
-  type ProviderName,
-  type PossibleProviderData,
-  type PossibleProviderSecrets,
-  parseProviderData,
-  parseProviderSecrets,
-  serializeProviderData,
-  serializeProviderSecrets,
-} from '../../auth/providerData.js'
-
-import { type UserSignupFields, type PossibleUserFields } from '../../auth/providers/types.js'
+import { type UserSignupFields } from '../../auth/providers/types.js'
 
 // Runtime-agnostic provider data code, re-exported here because it's part of
 // the server-side auth API surface (e.g. through `wasp/server/auth`).
@@ -54,24 +42,6 @@ export const authConfig = {
   successRedirectPath: "/",
 }
 
-// PUBLIC API
-/**
- * The auth identity as everything outside auth internals sees it: the secret
- * column does not exist here -- the Prisma client omits it by default, and only
- * `findAuthIdentitySecrets` opts back in.
- */
-export type AuthIdentityWithoutSecrets = Omit<AuthIdentity, 'providerSecrets'>
-
-// PUBLIC API
-export async function findAuthIdentity(providerId: ProviderId): Promise<AuthIdentityWithoutSecrets | null> {
-  return prisma.authIdentity.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    }
-  });
-}
-
-
 // PRIVATE API
 export type FindAuthWithUserResult = Auth & {
   user: User
@@ -92,58 +62,6 @@ export async function findAuthWithUserBy(
   }
 
   return { ...result, user: result.user };
-}
-
-// PUBLIC API
-export type CreateUserResult = User & {
-  auth: Auth | null
-}
-
-// PUBLIC API
-/**
- * Creates the user with its auth identity in one atomic write. `data` is the
- * provider's non-secret state, `secrets` its secret material -- `secrets` must
- * arrive already hashed (see `setAuthIdentitySecrets`).
- */
-export async function createUser<PN extends ProviderName>(
-  providerId: ProviderId,
-  identity?: {
-    data?: PossibleProviderData[PN];
-    secrets?: PossibleProviderSecrets[PN];
-  },
-  userFields?: PossibleUserFields,
-): Promise<CreateUserResult> {
-  return prisma.user.create({
-    data: {
-      // Using any here to prevent type errors when userFields are not
-      // defined. We want Prisma to throw an error in that case.
-      ...(userFields ?? {} as any),
-      auth: {
-        create: {
-          identities: {
-              create: {
-                  providerName: providerId.providerName,
-                  providerUserId: providerId.providerUserId,
-                  providerData: serializeProviderData<PN>(identity?.data ?? ({} as PossibleProviderData[PN])),
-                  providerSecrets: serializeProviderSecrets<PN>(identity?.secrets ?? ({} as PossibleProviderSecrets[PN])),
-              },
-          },
-        }
-      },
-    },
-    // We need to include the Auth entity here because we need `authId`
-    // to be able to create a session.
-    include: {
-      auth: true,
-    },
-  })
-}
-
-// PRIVATE API
-export async function deleteUserByAuthId(authId: string): Promise<{ count: number }> {
-  return prisma.user.deleteMany({ where: { auth: {
-    id: authId,
-  } } })
 }
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/snapshot-file-list.manifest
@@ -614,6 +614,10 @@ wasp-app/.wasp/out/sdk/wasp/dist/server/auth/hooks.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/hooks.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/hooks.js
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/hooks.js.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/auth/identityStore.d.ts
+wasp-app/.wasp/out/sdk/wasp/dist/server/auth/identityStore.d.ts.map
+wasp-app/.wasp/out/sdk/wasp/dist/server/auth/identityStore.js
+wasp-app/.wasp/out/sdk/wasp/dist/server/auth/identityStore.js.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/index.d.ts
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/index.d.ts.map
 wasp-app/.wasp/out/sdk/wasp/dist/server/auth/index.js
@@ -865,6 +869,7 @@ wasp-app/.wasp/out/sdk/wasp/server/api/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/email/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/email/utils.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/hooks.ts
+wasp-app/.wasp/out/sdk/wasp/server/auth/identityStore.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/index.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/jwt.ts
 wasp-app/.wasp/out/sdk/wasp/server/auth/lucia.ts

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -879,7 +879,7 @@
             "file",
             "sdk/wasp/package.json"
         ],
-        "416e9dfe833dbfa9b1466818c5d9c9dd2caaaa1e47371b3ae37a57b755bd0dde"
+        "f2c34b8f74f627656083260918eb471cc8f92a5f84d582b7f24849be97bd4b94"
     ],
     [
         [
@@ -942,21 +942,28 @@
             "file",
             "sdk/wasp/server/auth/email/utils.ts"
         ],
-        "1a031a4b6b880e46d9bd375056ea020a095502cd065cb67720ab0d3179e25be5"
+        "18f17e156ca7c4d35ba487b35fea0ee997baff67310271bc15e4f04d23112c3c"
     ],
     [
         [
             "file",
             "sdk/wasp/server/auth/hooks.ts"
         ],
-        "9ce8ef2582a86b3bc4301f26b7327f38952fc3b4fec7c4930440cac2484475d8"
+        "043b4a6719103691a65ce301a0dbcdfcaa40224c4de9400140493b2d1020a288"
+    ],
+    [
+        [
+            "file",
+            "sdk/wasp/server/auth/identityStore.ts"
+        ],
+        "caa077beb9eeef4a1853e8c7a884d72a8d6a5292172239ebb444d8fd77d01f73"
     ],
     [
         [
             "file",
             "sdk/wasp/server/auth/index.ts"
         ],
-        "5ec574bbc356dbc9bb58a62e409b5a6a2e960bda96835ffa2a0c9bee6a87bfda"
+        "74f3bc318f5632fd9e286aa9be47a33b6660ab4e7b1c8ee053957b051b55b557"
     ],
     [
         [
@@ -1082,7 +1089,7 @@
             "file",
             "sdk/wasp/server/auth/utils.ts"
         ],
-        "1c07d75ee5ecd4cdd6d4ad3d4d9fb838dc8764715de72a10312bfc4a2eeaf997"
+        "ae8c23abf8ff3024b1ad0e0f1b4392e1965caea517885689c06a4ac537c651db"
     ],
     [
         [
@@ -1621,35 +1628,35 @@
             "file",
             "server/src/auth/providers/email/login.ts"
         ],
-        "028dfcfce88493ccbd39799a43cd1a86a02d452526fd571484ac88e46a0fd194"
+        "f78d908424ec441b6f09b25a08458183eb90673fdc23d16f8a98069cac8f2ac0"
     ],
     [
         [
             "file",
             "server/src/auth/providers/email/requestPasswordReset.ts"
         ],
-        "ad5aafedce765072b3292d019a5ba70201e6dc3592a4998b65319fde86ae3c52"
+        "dfbf47dddf47f09d117dff176d446dca7d78cdaa0d76d2527f469ea955f5fbe3"
     ],
     [
         [
             "file",
             "server/src/auth/providers/email/resetPassword.ts"
         ],
-        "9a2d5bc1ebb39bb556869f9e662b16ebefa6c078ad816d5b51f16934c138f95e"
+        "1be2c7b1472ed2c36f24dbcd949105e29463f74d4521297e9eeedc071b823539"
     ],
     [
         [
             "file",
             "server/src/auth/providers/email/signup.ts"
         ],
-        "41881930b0fd855b106f06af1055dbcfe7b9b7a830bdc36d8c59526fcfde0f60"
+        "9b6a51328aa7b9762934cfb0a2ec56f54280b4316ae77d6276c5dcad521df0d4"
     ],
     [
         [
             "file",
             "server/src/auth/providers/email/verifyEmail.ts"
         ],
-        "a33683c2ff2889fd05382e26b2d717572eeca563ada102673f68408d76b31744"
+        "7188c71d42ed74e08bcf20449ef339e3eb712a175cb305e307b3831267a2a925"
     ],
     [
         [
@@ -1705,7 +1712,7 @@
             "file",
             "server/src/auth/providers/oauth/user.ts"
         ],
-        "735f59f0cf30f44c9b14c9d26f30cf5c0e182b2587e4feae17c9db420f2da5d5"
+        "c8495a96f9acde8d5a8a41953570b11c1f5b5829968c2ecdb4ab606d7105e5d5"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -68,6 +68,7 @@
     "./server/auth": "./dist/server/auth/index.js",
     "./server/auth/email": "./dist/server/auth/email/index.js",
     "./server/auth/email/utils": "./dist/server/auth/email/utils.js",
+    "./server/auth/identityStore": "./dist/server/auth/identityStore.js",
     "./server/auth/jwt": "./dist/server/auth/jwt.js",
     "./server/auth/password": "./dist/server/auth/password.js",
     "./server/auth/provider/types": "./dist/server/auth/provider/types.js",

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/email/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/email/utils.ts
@@ -1,12 +1,8 @@
 import { createJWT, TimeSpan } from '../jwt.js'
 import { emailSender } from '../../email/index.js';
 import { Email } from '../../email/core/types.js';
-import {
-  createProviderId,
-  updateAuthIdentityProviderData,
-  findAuthIdentity,
-  type EmailProviderData,
-} from '../utils.js';
+import { type EmailProviderData } from '../utils.js';
+import { getIdentityStore } from '../identityStore.js';
 import { config as waspServerConfig } from '../../index.js';
 import { type User, type Auth } from '../../../entities/index.js'
 
@@ -60,16 +56,16 @@ async function sendEmailAndSaveMetadata(
 ): Promise<void> {
   // Save the metadata (e.g. timestamp) first, and then send the email
   // so the user can't send multiple requests while the email is being sent.
-  const providerId = createProviderId("email", email);
-  const authIdentity = await findAuthIdentity(providerId);
+  const emailIdentities = getIdentityStore('email');
+  const identity = await emailIdentities.find(email);
 
-  if (!authIdentity) {
+  if (!identity) {
     throw new Error(`User with email: ${email} not found.`);
   }
 
   // A partial update of the non-secret column only -- the password hash is
   // neither read nor rewritten to store a timestamp.
-  await updateAuthIdentityProviderData<'email'>(providerId, metadata);
+  await emailIdentities.updateData(email, metadata);
 
   emailSender.send(content).catch((e) => {
     console.error('Failed to send email', e);

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/hooks.ts
@@ -1,5 +1,6 @@
 import type { Request as ExpressRequest } from 'express'
-import { type ProviderId, type CreateUserResult, type FindAuthWithUserResult } from './utils.js'
+import { type ProviderId, type FindAuthWithUserResult } from './utils.js'
+import { type CreateUserResult } from './identityStore.js'
 import { prisma } from '../index.js'
 import { Expand } from '../../universal/types.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/identityStore.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/identityStore.ts
@@ -1,0 +1,250 @@
+import { prisma } from '../index.js'
+import {
+  type User,
+  type Auth,
+} from '../../entities/index.js'
+import {
+  normalizeProviderUserId,
+  type PossibleProviderData,
+  type PossibleProviderSecrets,
+  type ProviderName,
+} from '../../auth/providerData.js'
+import { type PossibleUserFields } from '../../auth/providers/types.js'
+
+/**
+ * Wasp's identity store: THE way to read and write auth identities, for Wasp's
+ * own auth and for user-made providers alike -- Wasp's auth flows go through the
+ * exact same facet a hand-written provider gets, with no privileged access.
+ *
+ * A facet is scoped to one `providerName` (Wasp's own auth multiplexes several:
+ * `email`, `username`, the OAuth providers; an external provider has exactly
+ * one, its manifest id). The facet's three data channels mirror the identity's
+ * three columns:
+ *
+ * - `claims`  -- what the provider asserted at login; written at creation,
+ *   read-only afterwards, so its provenance can be trusted.
+ * - `data`    -- non-secret working state; partial updates via `updateData`.
+ * - `secrets` -- secret material, in the column the Prisma client omits by
+ *   default. Read and written ONLY through `getSecrets`/`setSecrets`, and
+ *   stored as given: hashing is the caller's explicit job (see `hashPassword`
+ *   in `wasp/server/auth`), never a side effect of storage.
+ */
+
+// PUBLIC API
+export type Identity<Data extends object> = {
+  providerName: string;
+  providerUserId: string;
+  authId: string;
+  /** Non-secret working state (the `providerData` column, parsed). */
+  data: Data;
+  /** Provider-asserted, Wasp-recorded profile data (the `providerClaims` column, parsed). */
+  claims: Record<string, unknown>;
+}
+
+// PUBLIC API
+export type CreateUserResult = User & {
+  auth: Auth | null
+}
+
+// PUBLIC API
+export type IdentityStore<Data extends object, Secrets extends object> = {
+  /** Reads the identity (never its secrets). */
+  find(providerUserId: string): Promise<Identity<Data> | null>;
+
+  /**
+   * Creates the user with its auth identity in one atomic write. A duplicate
+   * identity surfaces as Prisma's unique-constraint error (P2002), same as any
+   * other conflicting write -- see `rethrowPossibleAuthError`.
+   */
+  createIdentity(
+    providerUserId: string,
+    identity?: {
+      claims?: Record<string, unknown>;
+      data?: Data;
+      secrets?: Secrets;
+    },
+    userFields?: PossibleUserFields,
+  ): Promise<CreateUserResult>;
+
+  /**
+   * Idempotent create: returns the existing identity's `authId` when the
+   * subject is already known, creates it otherwise. Two concurrent calls for
+   * the same brand-new subject are settled by the unique constraint -- the
+   * loser re-reads and returns the winner's row.
+   */
+  provision(
+    providerUserId: string,
+    identity?: {
+      claims?: Record<string, unknown>;
+      data?: Data;
+      secrets?: Secrets;
+    },
+    userFields?: PossibleUserFields,
+  ): Promise<{ authId: string } | null>;
+
+  /**
+   * Reads the identity's secret material -- the single opt-in into the column
+   * the Prisma client omits by default. Keep the result on the server.
+   */
+  getSecrets(providerUserId: string): Promise<Secrets | null>;
+
+  /** Replaces the identity's secret material. Expects it **already hashed**. */
+  setSecrets(providerUserId: string, secrets: Secrets): Promise<void>;
+
+  /** Merges the given updates into the identity's non-secret data. */
+  updateData(providerUserId: string, updates: Partial<Data>): Promise<void>;
+
+  /**
+   * Deletes the identity's whole user (cascading to its auth data and
+   * sessions). Returns whether anything was deleted.
+   */
+  deleteUser(providerUserId: string): Promise<boolean>;
+}
+
+// PUBLIC API
+/**
+ * The facet for one of Wasp's own auth methods, typed with its data shapes.
+ */
+export function getIdentityStore<PN extends ProviderName>(
+  providerName: PN,
+): IdentityStore<PossibleProviderData[PN], PossibleProviderSecrets[PN]>
+// PUBLIC API
+/**
+ * The facet for a user-made provider (e.g. an `external:*` id): same powers
+ * Wasp's own auth uses, with untyped data shapes -- the provider owns them.
+ */
+export function getIdentityStore(
+  providerName: string,
+): IdentityStore<Record<string, unknown>, Record<string, unknown>>
+export function getIdentityStore(
+  providerName: string,
+): IdentityStore<Record<string, unknown>, Record<string, unknown>> {
+  // Unknown provider names pass through normalization unchanged (its default
+  // branch), so the cast only widens the accepted names.
+  const normalize = (providerUserId: string) =>
+    normalizeProviderUserId(providerName as ProviderName, providerUserId);
+
+  const whereIdentity = (providerUserId: string) => ({
+    providerName_providerUserId: {
+      providerName,
+      providerUserId: normalize(providerUserId),
+    },
+  });
+
+  return {
+    async find(providerUserId) {
+      const identity = await prisma.authIdentity.findUnique({
+        where: whereIdentity(providerUserId),
+      });
+      if (identity === null) {
+        return null;
+      }
+      return {
+        providerName: identity.providerName,
+        providerUserId: identity.providerUserId,
+        authId: identity.authId,
+        data: JSON.parse(identity.providerData),
+        claims: JSON.parse(identity.providerClaims),
+      };
+    },
+
+    async createIdentity(providerUserId, identity, userFields) {
+      return prisma.user.create({
+        data: {
+          // Using any here to prevent type errors when userFields are not
+          // defined. We want Prisma to throw an error in that case.
+          ...(userFields ?? {} as any),
+          auth: {
+            create: {
+              identities: {
+                create: {
+                  providerName,
+                  providerUserId: normalize(providerUserId),
+                  providerClaims: JSON.stringify(identity?.claims ?? {}),
+                  providerData: JSON.stringify(identity?.data ?? {}),
+                  providerSecrets: JSON.stringify(identity?.secrets ?? {}),
+                },
+              },
+            }
+          },
+        },
+        // We need to include the Auth entity here because we need `authId`
+        // to be able to create a session.
+        include: {
+          auth: true,
+        },
+      })
+    },
+
+    async provision(providerUserId, identity, userFields) {
+      const existing = await this.find(providerUserId);
+      if (existing !== null) {
+        return { authId: existing.authId };
+      }
+      try {
+        const created = await this.createIdentity(providerUserId, identity, userFields);
+        return { authId: created.auth!.id };
+      } catch (e: unknown) {
+        // Another request provisioned the same subject between our read and
+        // our write. Its row is the winner; re-read rather than failing.
+        if (isUniqueConstraintViolation(e)) {
+          const raced = await this.find(providerUserId);
+          return raced === null ? null : { authId: raced.authId };
+        }
+        throw e;
+      }
+    },
+
+    async getSecrets(providerUserId) {
+      const identity = await prisma.authIdentity.findUnique({
+        where: whereIdentity(providerUserId),
+        omit: { providerSecrets: false },
+      });
+      return identity === null ? null : JSON.parse(identity.providerSecrets);
+    },
+
+    async setSecrets(providerUserId, secrets) {
+      await prisma.authIdentity.update({
+        where: whereIdentity(providerUserId),
+        data: { providerSecrets: JSON.stringify(secrets) },
+      });
+    },
+
+    async updateData(providerUserId, updates) {
+      const identity = await prisma.authIdentity.findUnique({
+        where: whereIdentity(providerUserId),
+        select: { providerData: true },
+      });
+      if (identity === null) {
+        throw new Error('Auth identity not found.');
+      }
+      const newData = { ...JSON.parse(identity.providerData), ...updates };
+      await prisma.authIdentity.update({
+        where: whereIdentity(providerUserId),
+        data: { providerData: JSON.stringify(newData) },
+      });
+    },
+
+    async deleteUser(providerUserId) {
+      const { count } = await prisma.user.deleteMany({
+        where: {
+          auth: {
+            identities: {
+              some: {
+                providerName,
+                providerUserId: normalize(providerUserId),
+              },
+            },
+          },
+        },
+      });
+      return count > 0;
+    },
+  };
+}
+
+function isUniqueConstraintViolation(e: unknown): boolean {
+  return (
+    typeof e === 'object' && e !== null && 'code' in e && (e as { code: unknown }).code === 'P2002'
+  );
+}

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/index.ts
@@ -2,17 +2,20 @@ export {
   defineUserSignupFields,
 } from '../../auth/providers/types.js'
 
+// The identity store: the one channel for reading and writing auth
+// identities. Wasp's own auth flows use the exact same facet a user-made
+// provider gets -- no privileged access.
+export {
+  getIdentityStore,
+  type Identity,
+  type IdentityStore,
+  type CreateUserResult,
+} from './identityStore.js'
+
 export {
   createProviderId,
   parseProviderData,
   parseProviderSecrets,
-  updateAuthIdentityProviderData,
-  setAuthIdentitySecrets,
-  findAuthIdentity,
-  findAuthIdentitySecrets,
-  createUser,
-  type AuthIdentityWithoutSecrets,
-  type CreateUserResult,
   type ProviderId,
   type ProviderName,
   type EmailProviderData,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/utils.ts
@@ -3,24 +3,12 @@ import { sleep } from '../utils.js'
 import {
   type User,
   type Auth,
-  type AuthIdentity,
 } from '../../entities/index.js'
 import { Prisma } from '@prisma/client';
 
 import { throwValidationError } from '../../auth/validation.js'
 
-import {
-  type ProviderId,
-  type ProviderName,
-  type PossibleProviderData,
-  type PossibleProviderSecrets,
-  parseProviderData,
-  parseProviderSecrets,
-  serializeProviderData,
-  serializeProviderSecrets,
-} from '../../auth/providerData.js'
-
-import { type UserSignupFields, type PossibleUserFields } from '../../auth/providers/types.js'
+import { type UserSignupFields } from '../../auth/providers/types.js'
 
 // Runtime-agnostic provider data code, re-exported here because it's part of
 // the server-side auth API surface (e.g. through `wasp/server/auth`).
@@ -54,91 +42,6 @@ export const authConfig = {
   successRedirectPath: "/",
 }
 
-// PUBLIC API
-/**
- * The auth identity as everything outside auth internals sees it: the secret
- * column does not exist here -- the Prisma client omits it by default, and only
- * `findAuthIdentitySecrets` opts back in.
- */
-export type AuthIdentityWithoutSecrets = Omit<AuthIdentity, 'providerSecrets'>
-
-// PUBLIC API
-export async function findAuthIdentity(providerId: ProviderId): Promise<AuthIdentityWithoutSecrets | null> {
-  return prisma.authIdentity.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    }
-  });
-}
-
-// PUBLIC API
-/**
- * Reads the auth identity's secret material (e.g. the password hash). This is
- * the single place that opts back into the `providerSecrets` column the Prisma
- * client omits by default -- keep the result on the server.
- */
-export async function findAuthIdentitySecrets<PN extends ProviderName>(
-  providerId: ProviderId,
-): Promise<PossibleProviderSecrets[PN] | null> {
-  const identity = await prisma.authIdentity.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    omit: { providerSecrets: false },
-  });
-  return identity === null ? null : parseProviderSecrets<PN>(identity.providerSecrets);
-}
-
-// PUBLIC API
-/**
- * Merges the given updates into the auth identity's non-secret provider data.
- * Secrets have their own column and their own writer (`setAuthIdentitySecrets`),
- * so this update can never touch them.
- */
-export async function updateAuthIdentityProviderData<PN extends ProviderName>(
-  providerId: ProviderId,
-  providerDataUpdates: Partial<PossibleProviderData[PN]>,
-): Promise<AuthIdentityWithoutSecrets> {
-  const identity = await prisma.authIdentity.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    select: { providerData: true },
-  });
-  if (identity === null) {
-    throw new Error('Auth identity not found.');
-  }
-  const newProviderData = {
-    ...parseProviderData<PN>(identity.providerData),
-    ...providerDataUpdates,
-  }
-  return prisma.authIdentity.update({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    data: { providerData: serializeProviderData<PN>(newProviderData) },
-  });
-}
-
-// PUBLIC API
-/**
- * Replaces the auth identity's secret material. Expects secrets to arrive
- * **already hashed** -- hashing is the flow's explicit responsibility (see
- * `hashPassword` in `wasp/server/auth/password`), never an implicit side effect
- * of storage.
- */
-export async function setAuthIdentitySecrets<PN extends ProviderName>(
-  providerId: ProviderId,
-  secrets: PossibleProviderSecrets[PN],
-): Promise<AuthIdentityWithoutSecrets> {
-  return prisma.authIdentity.update({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    data: { providerSecrets: serializeProviderSecrets<PN>(secrets) },
-  });
-}
-
 // PRIVATE API
 export type FindAuthWithUserResult = Auth & {
   user: User
@@ -159,58 +62,6 @@ export async function findAuthWithUserBy(
   }
 
   return { ...result, user: result.user };
-}
-
-// PUBLIC API
-export type CreateUserResult = User & {
-  auth: Auth | null
-}
-
-// PUBLIC API
-/**
- * Creates the user with its auth identity in one atomic write. `data` is the
- * provider's non-secret state, `secrets` its secret material -- `secrets` must
- * arrive already hashed (see `setAuthIdentitySecrets`).
- */
-export async function createUser<PN extends ProviderName>(
-  providerId: ProviderId,
-  identity?: {
-    data?: PossibleProviderData[PN];
-    secrets?: PossibleProviderSecrets[PN];
-  },
-  userFields?: PossibleUserFields,
-): Promise<CreateUserResult> {
-  return prisma.user.create({
-    data: {
-      // Using any here to prevent type errors when userFields are not
-      // defined. We want Prisma to throw an error in that case.
-      ...(userFields ?? {} as any),
-      auth: {
-        create: {
-          identities: {
-              create: {
-                  providerName: providerId.providerName,
-                  providerUserId: providerId.providerUserId,
-                  providerData: serializeProviderData<PN>(identity?.data ?? ({} as PossibleProviderData[PN])),
-                  providerSecrets: serializeProviderSecrets<PN>(identity?.secrets ?? ({} as PossibleProviderSecrets[PN])),
-              },
-          },
-        }
-      },
-    },
-    // We need to include the Auth entity here because we need `authId`
-    // to be able to create a session.
-    include: {
-      auth: true,
-    },
-  })
-}
-
-// PRIVATE API
-export async function deleteUserByAuthId(authId: string): Promise<{ count: number }> {
-  return prisma.user.deleteMany({ where: { auth: {
-    id: authId,
-  } } })
 }
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/login.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/login.ts
@@ -3,11 +3,9 @@ import { createInvalidCredentialsError } from 'wasp/server/auth/utils'
 import { verifyPassword } from 'wasp/server/auth/password'
 import {
     createProviderId,
-    findAuthIdentity,
-    findAuthIdentitySecrets,
     findAuthWithUserBy,
-    parseProviderData,
 } from 'wasp/server/auth/utils'
+import { getIdentityStore } from 'wasp/server/auth/identityStore'
 import { createSession } from 'wasp/server/auth/session'
 import { ensureValidEmail, ensurePasswordIsPresent } from 'wasp/auth/validation'
 import { onBeforeLoginHook, onAfterLoginHook } from '../../hooks.js';
@@ -20,17 +18,17 @@ export function getLoginRoute() {
         const fields = req.body ?? {}
         ensureValidArgs(fields)
 
+        const emailIdentities = getIdentityStore('email')
         const providerId = createProviderId("email", fields.email)
-        const authIdentity = await findAuthIdentity(providerId)
-        if (!authIdentity) {
+        const identity = await emailIdentities.find(fields.email)
+        if (!identity) {
             throw createInvalidCredentialsError()
         }
-        const providerData = parseProviderData<'email'>(authIdentity.providerData)
-        if (!providerData.isEmailVerified) {
+        if (!identity.data.isEmailVerified) {
             throw createInvalidCredentialsError()
         }
         // The secret column is read explicitly and only here in this flow.
-        const secrets = await findAuthIdentitySecrets<'email'>(providerId)
+        const secrets = await emailIdentities.getSecrets(fields.email)
         if (secrets === null) {
             throw createInvalidCredentialsError()
         }
@@ -40,7 +38,7 @@ export function getLoginRoute() {
             throw createInvalidCredentialsError()
         }
     
-        const auth = await findAuthWithUserBy({ id: authIdentity.authId })
+        const auth = await findAuthWithUserBy({ id: identity.authId })
 
         if (auth === null) {
             throw createInvalidCredentialsError()

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/requestPasswordReset.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/requestPasswordReset.ts
@@ -1,10 +1,6 @@
 import { Request, Response } from 'express';
-import {
-    createProviderId,
-    findAuthIdentity,
-    doFakeWork,
-    parseProviderData,
-} from 'wasp/server/auth/utils';
+import { doFakeWork } from 'wasp/server/auth/utils';
+import { getIdentityStore } from 'wasp/server/auth/identityStore';
 import {
     createPasswordResetLink,
     sendPasswordResetEmail,
@@ -31,9 +27,8 @@ export function getRequestPasswordResetRoute({
         const args = req.body ?? {};
         ensureValidEmail(args);
 
-        const authIdentity = await findAuthIdentity(
-            createProviderId("email", args.email),
-        );
+        const emailIdentities = getIdentityStore('email');
+        const identity = await emailIdentities.find(args.email);
 
         /**
          * By doing fake work, we make it harder to enumerate users by measuring
@@ -41,21 +36,20 @@ export function getRequestPasswordResetRoute({
          * could measure the time it takes to respond and figure out if the user exists.
          */
 
-        if (!authIdentity) {
+        if (!identity) {
             await doFakeWork();
             res.json({ success: true });
             return
         }
 
-        const providerData = parseProviderData<'email'>(authIdentity.providerData);
-        const { isResendAllowed, timeLeft } = isEmailResendAllowed(providerData, 'passwordResetSentAt');
+        const { isResendAllowed, timeLeft } = isEmailResendAllowed(identity.data, 'passwordResetSentAt');
         if (!isResendAllowed) {
             throw new HttpError(400, `Please wait ${timeLeft} secs before trying again.`);
         }
 
         const passwordResetLink = await createPasswordResetLink(args.email, clientRoute);
         try {
-            const email = authIdentity.providerUserId
+            const email = identity.providerUserId
             await sendPasswordResetEmail(
                 email,
                 {

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/resetPassword.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/resetPassword.ts
@@ -1,10 +1,5 @@
 import { Request, Response } from 'express';
-import {
-    createProviderId,
-    findAuthIdentity,
-    setAuthIdentitySecrets,
-    updateAuthIdentityProviderData,
-} from 'wasp/server/auth/utils';
+import { getIdentityStore } from 'wasp/server/auth/identityStore';
 import { hashPassword } from 'wasp/server/auth/password';
 import { validateJWT } from 'wasp/server/auth/jwt'
 import { invalidateAllSessionsForAuthId } from 'wasp/server/auth/session'
@@ -28,24 +23,24 @@ export async function resetPassword(
 
     ensureValidPasswordArg(args);
 
-    const providerId = createProviderId('email', email);
-    const authIdentity = await findAuthIdentity(providerId);
-    if (!authIdentity) {
+    const emailIdentities = getIdentityStore('email');
+    const identity = await emailIdentities.find(email);
+    if (!identity) {
         throw new HttpError(400, "Password reset failed, invalid token");
     }
 
     // Hashing is the flow's explicit job -- storage never hashes.
-    await setAuthIdentitySecrets<'email'>(providerId, {
+    await emailIdentities.setSecrets(email, {
         hashedPassword: await hashPassword(password),
     });
-    await updateAuthIdentityProviderData<'email'>(providerId, {
+    await emailIdentities.updateData(email, {
         // The act of resetting the password verifies the email
         isEmailVerified: true,
     });
 
     // Changing the password invalidates all the existing sessions, so that
     // somebody who got hold of a session can't keep using it.
-    await invalidateAllSessionsForAuthId(authIdentity.authId);
+    await invalidateAllSessionsForAuthId(identity.authId);
 
     res.json({ success: true });
 };

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/signup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/signup.ts
@@ -2,14 +2,11 @@ import { Request, Response } from 'express'
 import type { UserSignupFields } from 'wasp/auth/providers/types'
 import {
   createProviderId,
-  createUser,
-  deleteUserByAuthId,
   doFakeWork,
-  findAuthIdentity,
-  parseProviderData,
   rethrowPossibleAuthError,
   validateAndGetUserFields,
 } from 'wasp/server/auth/utils'
+import { getIdentityStore } from 'wasp/server/auth/identityStore'
 import { hashPassword } from 'wasp/server/auth/password'
 import {
   ensurePasswordIsPresent,
@@ -46,8 +43,9 @@ export function getSignupRoute({
     const fields = req.body
     ensureValidArgs(fields)
 
+    const emailIdentities = getIdentityStore('email')
     const providerId = createProviderId('email', fields.email)
-    const existingAuthIdentity = await findAuthIdentity(providerId)
+    const existingIdentity = await emailIdentities.find(fields.email)
 
     /**
      *
@@ -73,15 +71,12 @@ export function getSignupRoute({
      *     else's email address and therefore permanently making that email
      *     address unavailable for later account creation (by real owner).
      */
-    if (existingAuthIdentity) {
-      const providerData = parseProviderData<'email'>(
-        existingAuthIdentity.providerData,
-      )
+    if (existingIdentity) {
 
       // TOOD: faking work makes sense if the time spent on faking the work matches the time
       // it would take to send the email. Atm, the fake work takes obviously longer than sending
       // the email!
-      if (providerData.isEmailVerified) {
+      if (existingIdentity.data.isEmailVerified) {
         await doFakeWork()
         res.json({ success: true })
         return
@@ -90,7 +85,7 @@ export function getSignupRoute({
       // TODO: we are still leaking information here since when we are faking work
       // we are not checking if the email was sent or not!
       const { isResendAllowed, timeLeft } = isEmailResendAllowed(
-        providerData,
+        existingIdentity.data,
         'emailVerificationSentAt',
       )
       if (!isResendAllowed) {
@@ -101,7 +96,7 @@ export function getSignupRoute({
       }
 
       try {
-        await deleteUserByAuthId(existingAuthIdentity.authId)
+        await emailIdentities.deleteUser(fields.email)
       } catch (e: unknown) {
         rethrowPossibleAuthError(e)
       }
@@ -118,8 +113,8 @@ export function getSignupRoute({
     const userFields = await validateAndGetUserFields(fields, userSignupFields)
 
     try {
-      const user = await createUser<'email'>(
-        providerId,
+      const user = await emailIdentities.createIdentity(
+        fields.email,
         {
           data: {
             isEmailVerified: isEmailAutoVerified ? true : false,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/verifyEmail.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/email/verifyEmail.ts
@@ -2,11 +2,9 @@ import { Request, Response } from 'express';
 import { validateJWT } from 'wasp/server/auth/jwt';
 import {
   createInvalidCredentialsError,
-  createProviderId,
-  findAuthIdentity,
   findAuthWithUserBy,
-  updateAuthIdentityProviderData,
 } from 'wasp/server/auth/utils';
+import { getIdentityStore } from 'wasp/server/auth/identityStore';
 import { HttpError } from 'wasp/server';
 import { onAfterEmailVerifiedHook } from '../../hooks.js';
 
@@ -21,20 +19,20 @@ export async function verifyEmail(
             throw new HttpError(400, "Email verification failed, invalid token");
         });
 
-    const providerId = createProviderId('email', email);
-    const authIdentity = await findAuthIdentity(providerId);
-    if (!authIdentity) {
+    const emailIdentities = getIdentityStore('email');
+    const identity = await emailIdentities.find(email);
+    if (!identity) {
         throw new HttpError(400, "Email verification failed, invalid token");
     }
 
     // A partial update of the non-secret column only -- flipping the flag can
     // no longer race another writer into losing fields, and the password hash
     // is never even read.
-    await updateAuthIdentityProviderData<'email'>(providerId, {
+    await emailIdentities.updateData(email, {
         isEmailVerified: true,
     });
 
-    const auth = await findAuthWithUserBy({ id: authIdentity.authId })
+    const auth = await findAuthWithUserBy({ id: identity.authId })
 
     if (auth === null) {
         throw createInvalidCredentialsError();

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/user.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/src/auth/providers/oauth/user.ts
@@ -1,13 +1,12 @@
 import { Request as ExpressRequest } from 'express'
 import {
   type ProviderId,
-  createUser,
   validateAndGetUserFields,
   createProviderId,
   findAuthWithUserBy,
 } from 'wasp/server/auth/utils'
+import { getIdentityStore } from 'wasp/server/auth/identityStore'
 import { type Auth } from 'wasp/entities'
-import { prisma } from 'wasp/server'
 import { type UserSignupFields, type ProviderConfig } from 'wasp/auth/providers/types'
 import { type OAuthData } from 'wasp/server/auth'
 import { getRedirectUriForOneTimeCode, tokenStore } from 'wasp/server/auth'
@@ -63,21 +62,11 @@ async function getAuthIdFromProviderDetails({
   req: ExpressRequest;
   oauth: OAuthData;
 }): Promise<Auth['id']> {
-  const existingAuthIdentity = await prisma.authIdentity.findUnique({
-    where: {
-      providerName_providerUserId: providerId,
-    },
-    include: {
-      auth: {
-        include: {
-          user: true
-        }
-      }
-    }
-  })
+  const identities = getIdentityStore(providerId.providerName)
+  const existingIdentity = await identities.find(providerId.providerUserId)
 
-  if (existingAuthIdentity) {
-    const authId = existingAuthIdentity.auth.id
+  if (existingIdentity) {
+    const authId = existingIdentity.authId
 
     // NOTE: Fetching the user to pass it to the login hooks - it's a bit wasteful
     // but we wanted to keep the onAfterLoginHook params consistent for all auth providers.
@@ -119,8 +108,8 @@ async function getAuthIdFromProviderDetails({
     )
 
     // For now, we don't store any data or secrets for the oauth providers.
-    const user = await createUser(
-      providerId,
+    const user = await identities.createIdentity(
+      providerId.providerUserId,
       {},
       // Using any here because we want to avoid TypeScript errors and
       // rely on Prisma to validate the data.
@@ -133,6 +122,6 @@ async function getAuthIdFromProviderDetails({
       oauth,
     })
 
-    return user.auth.id
+    return user.auth!.id
   }
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/features/auth/customSignup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/features/auth/customSignup.ts
@@ -3,8 +3,11 @@ import {
   ensureValidEmail,
   ensureValidPassword,
 } from "wasp/auth/validation";
-import { prisma } from "wasp/server";
-import { defineUserSignupFields, hashPassword } from "wasp/server/auth";
+import {
+  defineUserSignupFields,
+  getIdentityStore,
+  hashPassword,
+} from "wasp/server/auth";
 import { CustomSignup } from "wasp/server/operations";
 
 export const userSignupFields = defineUserSignupFields({
@@ -38,31 +41,22 @@ export const customSignup: CustomSignup<
   ensureValidPassword(args);
 
   try {
-    await prisma.auth.create({
-      data: {
-        user: {
-          create: {
-            address: args.address,
-          },
+    // The same identity store Wasp's own signup flow uses -- no raw table
+    // access needed. Hashing stays the caller's explicit job.
+    await getIdentityStore("email").createIdentity(
+      args.email,
+      {
+        data: {
+          isEmailVerified: true,
+          emailVerificationSentAt: null,
+          passwordResetSentAt: null,
         },
-        identities: {
-          create: {
-            providerName: "email",
-            providerUserId: args.email,
-            providerData: JSON.stringify({
-              isEmailVerified: true,
-              emailVerificationSentAt: null,
-              passwordResetSentAt: null,
-            }),
-            // Hashing is the caller's explicit job; the secret goes into its
-            // own column, which the Prisma client omits when reading.
-            providerSecrets: JSON.stringify({
-              hashedPassword: await hashPassword(args.password),
-            }),
-          },
+        secrets: {
+          hashedPassword: await hashPassword(args.password),
         },
       },
-    });
+      { address: args.address },
+    );
   } catch (e: any) {
     return {
       success: false,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/features/db/seeds.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/src/features/db/seeds.ts
@@ -1,43 +1,22 @@
 import { type AuthUser } from "wasp/auth";
 import { type DbSeedFn, type PrismaClient } from "wasp/server";
-import { hashPassword } from "wasp/server/auth";
+import { getIdentityStore, hashPassword } from "wasp/server/auth";
 import { createTask } from "../operations/actions.js";
 
-async function createUser(prismaClient: PrismaClient, data: any) {
-  const newUser = await prismaClient.user.create({
-    data: {
-      auth: {
-        create: {
-          identities: {
-            create: {
-              providerName: "username",
-              providerUserId: data.username,
-              // Hashing is the caller's explicit job; the secret goes into its
-              // own column, which the Prisma client omits when reading.
-              providerSecrets: JSON.stringify({
-                hashedPassword: await hashPassword(data.password),
-              }),
-            },
-          },
-        },
+async function createUser(_prismaClient: PrismaClient, data: any) {
+  // The same identity store Wasp's own signup flow uses -- no raw table
+  // access needed. Hashing stays the caller's explicit job.
+  const createdUser = await getIdentityStore("username").createIdentity(
+    data.username,
+    {
+      secrets: {
+        hashedPassword: await hashPassword(data.password),
       },
     },
-    include: {
-      auth: {
-        select: {
-          id: true,
-          userId: true,
-          identities: true,
-        },
-        include: {
-          identities: true,
-        },
-      },
-    },
-  });
+  );
 
   return {
-    id: newUser.id,
+    id: createdUser.id,
   } as AuthUser;
 }
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -431,7 +431,7 @@
             "file",
             "sdk/wasp/package.json"
         ],
-        "b3012ae4d52cb9ac6eca36a1d1bd7a41d495bef0aa587e0c782ee25c31385db1"
+        "dc8a36320753ba72c78dc01e41305198ff445441664b628ff8253d231e64eaad"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -59,6 +59,7 @@
     "./server/auth": "./dist/server/auth/index.js",
     "./server/auth/email": "./dist/server/auth/email/index.js",
     "./server/auth/email/utils": "./dist/server/auth/email/utils.js",
+    "./server/auth/identityStore": "./dist/server/auth/identityStore.js",
     "./server/auth/jwt": "./dist/server/auth/jwt.js",
     "./server/auth/password": "./dist/server/auth/password.js",
     "./server/auth/provider/types": "./dist/server/auth/provider/types.js",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -431,7 +431,7 @@
             "file",
             "sdk/wasp/package.json"
         ],
-        "b3012ae4d52cb9ac6eca36a1d1bd7a41d495bef0aa587e0c782ee25c31385db1"
+        "dc8a36320753ba72c78dc01e41305198ff445441664b628ff8253d231e64eaad"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -59,6 +59,7 @@
     "./server/auth": "./dist/server/auth/index.js",
     "./server/auth/email": "./dist/server/auth/email/index.js",
     "./server/auth/email/utils": "./dist/server/auth/email/utils.js",
+    "./server/auth/identityStore": "./dist/server/auth/identityStore.js",
     "./server/auth/jwt": "./dist/server/auth/jwt.js",
     "./server/auth/password": "./dist/server/auth/password.js",
     "./server/auth/provider/types": "./dist/server/auth/provider/types.js",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -438,7 +438,7 @@
             "file",
             "sdk/wasp/package.json"
         ],
-        "b3012ae4d52cb9ac6eca36a1d1bd7a41d495bef0aa587e0c782ee25c31385db1"
+        "dc8a36320753ba72c78dc01e41305198ff445441664b628ff8253d231e64eaad"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/package.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/package.json
@@ -59,6 +59,7 @@
     "./server/auth": "./dist/server/auth/index.js",
     "./server/auth/email": "./dist/server/auth/email/index.js",
     "./server/auth/email/utils": "./dist/server/auth/email/utils.js",
+    "./server/auth/identityStore": "./dist/server/auth/identityStore.js",
     "./server/auth/jwt": "./dist/server/auth/jwt.js",
     "./server/auth/password": "./dist/server/auth/password.js",
     "./server/auth/provider/types": "./dist/server/auth/provider/types.js",

--- a/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Server/AuthG.hs
@@ -50,6 +50,7 @@ genServerAuth spec =
               genAuthProviderIndexTs spec auth,
               genSessionTs auth,
               genSessionStoreTs auth,
+              genIdentityStoreTs auth,
               genLuciaTs auth,
               genUtils auth
             ]
@@ -65,6 +66,7 @@ genServerAuth spec =
               genAuthProviderIndexTs spec auth,
               genSessionTs auth,
               genSessionStoreTs auth,
+              genIdentityStoreTs auth,
               genLuciaTs auth,
               genUtils auth
             ]
@@ -97,6 +99,24 @@ genHooks auth =
       tmplData
   where
     tmplData = object ["enabledProviders" .= AuthProviders.getEnabledAuthProvidersJson auth]
+
+genIdentityStoreTs :: AS.Auth.Auth -> Generator FileDraft
+genIdentityStoreTs auth =
+  return $
+    mkTmplFdWithData
+      (serverAuthDirInSdkTemplatesDir </> [relfile|identityStore.ts|])
+      tmplData
+  where
+    tmplData =
+      object
+        [ "userEntityUpper" .= (userEntityName :: String),
+          "userEntityLower" .= (Util.toLowerFirst userEntityName :: String),
+          "authEntityUpper" .= (DbAuth.authEntityName :: String),
+          "authIdentityEntityLower" .= (Util.toLowerFirst DbAuth.authIdentityEntityName :: String),
+          "authFieldOnUserEntityName" .= (DbAuth.authFieldOnUserEntityName :: String),
+          "identitiesFieldOnAuthEntityName" .= (DbAuth.identitiesFieldOnAuthEntityName :: String)
+        ]
+    userEntityName = AS.refName $ AS.Auth.userEntity auth
 
 genSessionStoreTs :: AS.Auth.Auth -> Generator FileDraft
 genSessionStoreTs _ =


### PR DESCRIPTION
Part of the pluggable auth provider stack (on top of #4768). Second of the "wasp-auth fully behind the auth interface" series: identity storage now has exactly one door, and Wasp's own auth walks through it like everyone else.

## Description

New module `wasp/server/auth/identityStore`: **the** way to read and write auth identities. `getIdentityStore(providerName)` returns a facet scoped to one provider namespace, with the three data channels mirroring the identity's three columns:

- `find` — the identity with parsed `data` and `claims`, never secrets
- `createIdentity` — atomic User → Auth → AuthIdentity create
- `provision` — idempotent create for JIT/eager provisioning (create-then-catch-P2002; the race loser returns the winner's row)
- `getSecrets` / `setSecrets` — the **only** opt-in into the Prisma-omitted secrets column; stored as given, hashing stays the caller's explicit job
- `updateData` — partial merge into non-secret data
- `deleteUser` — cascading delete by identity

Typing is two-tier: `getIdentityStore('email')` (a known Wasp method) is fully typed with that provider's data/secrets shapes; `getIdentityStore('external:anything')` returns the untyped facet — the provider owns its shapes.

**No cheating**: every wasp-auth flow now goes through the facet — email signup/login/verify/request-reset/reset (plus the verification-email metadata write), username signup/login, the OAuth callback (which also loses its one direct-prisma bypass of the helpers), and external JIT provisioning in `session.ts`. `grep` for the old primitives (`findAuthIdentity`, `createUser`, `updateAuthIdentityProviderData`, `setAuthIdentitySecrets`, `deleteUserByAuthId`) over templates and examples returns nothing. `providerUserId` normalization now happens inside the store, closing the old bypassability of `createProviderId`.

Public API (`wasp/server/auth`): the storage primitives removed in favor of `getIdentityStore` + `Identity`/`IdentityStore`/`CreateUserResult` types — exported under external providers too, since the store is exactly what a hand-written `customAuthProvider` needs for its own credential storage (the custom-password example lands in the next PR). Kitchen-sink's `customSignup.ts` and `seeds.ts` are ported and are the reference migration: both now create users through the same facet Wasp's signup flow uses, with no raw table access.

What deliberately stays outside the store: `findAuthWithUserBy` (an Auth→User read, not identity data), `contextWithUserEntity` (the documented user-entity grant), and Prisma error mapping at the flows (`rethrowPossibleAuthError`, unchanged behavior — a duplicate identity still surfaces as P2002 → 422).

## Type of change

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [x] **💥 Breaking change** <!-- removes public storage primitives in favor of the identity store -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- Behavior is pinned by the kitchen-sink e2e suite (incl. the logout and password-reset specs added in the previous PR), re-run green on this refactor in both dev and build modes. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [x] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- Covered by the previous PR's new specs, re-run against this refactor. -->
  - [x] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- No starter template uses the removed primitives. -->
  - [x] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- Lands with the stack's release docs. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- Deferred to the stack's release. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`. <!-- Ships with the release docs; the kitchen-sink ports show the mechanical mapping. -->
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
