### PR TITLE
Free up as much user's typescript config as possible

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -23,6 +23,7 @@
 - Now Wasp fails more gracefully when multiple commands are running in the same project. ([#4504](https://github.com/wasp-lang/wasp/pull/4504))
 - Added a `wasp show spec [--json]` command that prints an overview of your app as Wasp sees it: routes, pages, queries, actions, APIs, CRUDs, and jobs. ([#4451](https://github.com/wasp-lang/wasp/pull/4451))
 - Added the `wasp show build [--json]` command to print information about the last build. ([#4625](https://github.com/wasp-lang/wasp/pull/4625))
+- You can now customize your `tsconfig.src.json` more freely: options like `strict`, `target`, and `lib` are no longer locked, `include` and `exclude` allow extra entries, etc. Wasp still requires the options it needs to compile and bundle your project. ([#4772](https://github.com/wasp-lang/wasp/pull/4772))
 
 ### 🐞 Bug fixes
 

--- a/waspc/data/Cli/starters/skeleton/tsconfig.src.json
+++ b/waspc/data/Cli/starters/skeleton/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
+++ b/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
@@ -16,11 +16,8 @@
 
     /* Strictness and type checking */
     /*
-       User code was compiled using `"strict": true`, so we know we can use it
-       here as well. We override some of strict's options because parts of the SDK
-       code don't respect them. This only makes the SDK ruleset more permissive than
-       the user's ruleset. Therefore, we can sefely include users code inside the
-       SDK without casuing errors during the SDK build step.
+       We keep the SDK strict, but override some of strict's options
+       because parts of the SDK code don't respect them.
        Reference: https://github.com/wasp-lang/wasp/issues/1938
     */
     "strict": true,
@@ -28,8 +25,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     /*
-       The following two properties are disabled because we don't
-       yet want to force user code to use them.
+       We haven't adopted the following two properties yet.
        Reference: https://github.com/wasp-lang/wasp/issues/2655
     */
     "noUncheckedIndexedAccess": false,

--- a/waspc/data/Generator/templates/server/tsconfig.json
+++ b/waspc/data/Generator/templates/server/tsconfig.json
@@ -5,18 +5,8 @@
     // Overriding this until we implement more complete TypeScript support.
     "strict": false,
     "allowJs": true,
-
-    // This property currently doesn't matter because we haven't been running
-    // TSC on server code since https://github.com/wasp-lang/wasp/pull/1714.
-    //
-    // When we start running TSC again (after we fix all current errors and
-    // make project references work for the TS config), then I believe the
-    // correct configuration is "rootDir": "." (the project reference should
-    // take care of the user code), but we should double-check.
-    //
-    // Before changing this property, ensure you're aware of the implications:
-    //  - https://github.com/wasp-lang/wasp/pull/1584#discussion_r1404019301
-    //  - https://github.com/wasp-lang/wasp/pull/1713/files#diff-58191eecd9cc55f71c73de89420df8b1866dce38ad35f4ef0f6f8874616eda77R32
+    // The project reference takes care of the user project,
+    // so `rootDir` only needs to include the server files.
     "rootDir": ".",
     // Enable source map for debugging
     "sourceMap": true,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -2139,7 +2139,7 @@
             "file",
             "server/tsconfig.json"
         ],
-        "9f63354105e0b98df7a0d54f27798a97dd92f66cbea2f4fd67b9f73243fe8c01"
+        "9acba4a5ce9c3e21a9794485c8e26f152747e1fa670776fbc111d85253669aa7"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1278,7 +1278,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "18da980b9549422f0750fa8d4f90fe2614f2a5aa6ef8e6828abdc257fe22266f"
+        "029a4aca9060b5937b82167ab57cdf181bcb3eb73a71cecef3683482f066a1cd"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -16,11 +16,8 @@
 
     /* Strictness and type checking */
     /*
-       User code was compiled using `"strict": true`, so we know we can use it
-       here as well. We override some of strict's options because parts of the SDK
-       code don't respect them. This only makes the SDK ruleset more permissive than
-       the user's ruleset. Therefore, we can sefely include users code inside the
-       SDK without casuing errors during the SDK build step.
+       We keep the SDK strict, but override some of strict's options
+       because parts of the SDK code don't respect them.
        Reference: https://github.com/wasp-lang/wasp/issues/1938
     */
     "strict": true,
@@ -28,8 +25,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     /*
-       The following two properties are disabled because we don't
-       yet want to force user code to use them.
+       We haven't adopted the following two properties yet.
        Reference: https://github.com/wasp-lang/wasp/issues/2655
     */
     "noUncheckedIndexedAccess": false,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/server/tsconfig.json
@@ -4,18 +4,8 @@
     // Overriding this until we implement more complete TypeScript support.
     "strict": false,
     "allowJs": true,
-
-    // This property currently doesn't matter because we haven't been running
-    // TSC on server code since https://github.com/wasp-lang/wasp/pull/1714.
-    //
-    // When we start running TSC again (after we fix all current errors and
-    // make project references work for the TS config), then I believe the
-    // correct configuration is "rootDir": "." (the project reference should
-    // take care of the user code), but we should double-check.
-    //
-    // Before changing this property, ensure you're aware of the implications:
-    //  - https://github.com/wasp-lang/wasp/pull/1584#discussion_r1404019301
-    //  - https://github.com/wasp-lang/wasp/pull/1713/files#diff-58191eecd9cc55f71c73de89420df8b1866dce38ad35f4ef0f6f8874616eda77R32
+    // The project reference takes care of the user project,
+    // so `rootDir` only needs to include the server files.
     "rootDir": ".",
     // Enable source map for debugging
     "sourceMap": true,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -571,7 +571,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "18da980b9549422f0750fa8d4f90fe2614f2a5aa6ef8e6828abdc257fe22266f"
+        "029a4aca9060b5937b82167ab57cdf181bcb3eb73a71cecef3683482f066a1cd"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -746,7 +746,7 @@
             "file",
             "server/tsconfig.json"
         ],
-        "9f63354105e0b98df7a0d54f27798a97dd92f66cbea2f4fd67b9f73243fe8c01"
+        "9acba4a5ce9c3e21a9794485c8e26f152747e1fa670776fbc111d85253669aa7"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -16,11 +16,8 @@
 
     /* Strictness and type checking */
     /*
-       User code was compiled using `"strict": true`, so we know we can use it
-       here as well. We override some of strict's options because parts of the SDK
-       code don't respect them. This only makes the SDK ruleset more permissive than
-       the user's ruleset. Therefore, we can sefely include users code inside the
-       SDK without casuing errors during the SDK build step.
+       We keep the SDK strict, but override some of strict's options
+       because parts of the SDK code don't respect them.
        Reference: https://github.com/wasp-lang/wasp/issues/1938
     */
     "strict": true,
@@ -28,8 +25,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     /*
-       The following two properties are disabled because we don't
-       yet want to force user code to use them.
+       We haven't adopted the following two properties yet.
        Reference: https://github.com/wasp-lang/wasp/issues/2655
     */
     "noUncheckedIndexedAccess": false,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/server/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/server/tsconfig.json
@@ -4,18 +4,8 @@
     // Overriding this until we implement more complete TypeScript support.
     "strict": false,
     "allowJs": true,
-
-    // This property currently doesn't matter because we haven't been running
-    // TSC on server code since https://github.com/wasp-lang/wasp/pull/1714.
-    //
-    // When we start running TSC again (after we fix all current errors and
-    // make project references work for the TS config), then I believe the
-    // correct configuration is "rootDir": "." (the project reference should
-    // take care of the user code), but we should double-check.
-    //
-    // Before changing this property, ensure you're aware of the implications:
-    //  - https://github.com/wasp-lang/wasp/pull/1584#discussion_r1404019301
-    //  - https://github.com/wasp-lang/wasp/pull/1713/files#diff-58191eecd9cc55f71c73de89420df8b1866dce38ad35f4ef0f6f8874616eda77R32
+    // The project reference takes care of the user project,
+    // so `rootDir` only needs to include the server files.
     "rootDir": ".",
     // Enable source map for debugging
     "sourceMap": true,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/tsconfig.src.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/web-app/build/assets/200.js
@@ -255,13 +255,12 @@ function getSessionIdFromAuthorizationHeader(header) {
 //#endregion
 //#region .wasp/out/sdk/wasp/dist/client/operations/queryClient.js
 var defaultQueryClientConfig = {};
-var queryClientConfig;
 var resolveQueryClientInitialized;
 var queryClientInitialized = new Promise((resolve) => {
 	resolveQueryClientInitialized = resolve;
 });
 function initializeQueryClient() {
-	const queryClient = new QueryClient(queryClientConfig ?? defaultQueryClientConfig);
+	const queryClient = new QueryClient(defaultQueryClientConfig);
 	resolveQueryClientInitialized(queryClient);
 }
 //#endregion

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/tsconfig.src.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -571,7 +571,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "18da980b9549422f0750fa8d4f90fe2614f2a5aa6ef8e6828abdc257fe22266f"
+        "029a4aca9060b5937b82167ab57cdf181bcb3eb73a71cecef3683482f066a1cd"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -753,7 +753,7 @@
             "file",
             "server/tsconfig.json"
         ],
-        "9f63354105e0b98df7a0d54f27798a97dd92f66cbea2f4fd67b9f73243fe8c01"
+        "9acba4a5ce9c3e21a9794485c8e26f152747e1fa670776fbc111d85253669aa7"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -16,11 +16,8 @@
 
     /* Strictness and type checking */
     /*
-       User code was compiled using `"strict": true`, so we know we can use it
-       here as well. We override some of strict's options because parts of the SDK
-       code don't respect them. This only makes the SDK ruleset more permissive than
-       the user's ruleset. Therefore, we can sefely include users code inside the
-       SDK without casuing errors during the SDK build step.
+       We keep the SDK strict, but override some of strict's options
+       because parts of the SDK code don't respect them.
        Reference: https://github.com/wasp-lang/wasp/issues/1938
     */
     "strict": true,
@@ -28,8 +25,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     /*
-       The following two properties are disabled because we don't
-       yet want to force user code to use them.
+       We haven't adopted the following two properties yet.
        Reference: https://github.com/wasp-lang/wasp/issues/2655
     */
     "noUncheckedIndexedAccess": false,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/server/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/server/tsconfig.json
@@ -4,18 +4,8 @@
     // Overriding this until we implement more complete TypeScript support.
     "strict": false,
     "allowJs": true,
-
-    // This property currently doesn't matter because we haven't been running
-    // TSC on server code since https://github.com/wasp-lang/wasp/pull/1714.
-    //
-    // When we start running TSC again (after we fix all current errors and
-    // make project references work for the TS config), then I believe the
-    // correct configuration is "rootDir": "." (the project reference should
-    // take care of the user code), but we should double-check.
-    //
-    // Before changing this property, ensure you're aware of the implications:
-    //  - https://github.com/wasp-lang/wasp/pull/1584#discussion_r1404019301
-    //  - https://github.com/wasp-lang/wasp/pull/1713/files#diff-58191eecd9cc55f71c73de89420df8b1866dce38ad35f4ef0f6f8874616eda77R32
+    // The project reference takes care of the user project,
+    // so `rootDir` only needs to include the server files.
     "rootDir": ".",
     // Enable source map for debugging
     "sourceMap": true,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/tsconfig.src.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -760,7 +760,7 @@
             "file",
             "server/tsconfig.json"
         ],
-        "9f63354105e0b98df7a0d54f27798a97dd92f66cbea2f4fd67b9f73243fe8c01"
+        "9acba4a5ce9c3e21a9794485c8e26f152747e1fa670776fbc111d85253669aa7"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -578,7 +578,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "18da980b9549422f0750fa8d4f90fe2614f2a5aa6ef8e6828abdc257fe22266f"
+        "029a4aca9060b5937b82167ab57cdf181bcb3eb73a71cecef3683482f066a1cd"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -16,11 +16,8 @@
 
     /* Strictness and type checking */
     /*
-       User code was compiled using `"strict": true`, so we know we can use it
-       here as well. We override some of strict's options because parts of the SDK
-       code don't respect them. This only makes the SDK ruleset more permissive than
-       the user's ruleset. Therefore, we can sefely include users code inside the
-       SDK without casuing errors during the SDK build step.
+       We keep the SDK strict, but override some of strict's options
+       because parts of the SDK code don't respect them.
        Reference: https://github.com/wasp-lang/wasp/issues/1938
     */
     "strict": true,
@@ -28,8 +25,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     /*
-       The following two properties are disabled because we don't
-       yet want to force user code to use them.
+       We haven't adopted the following two properties yet.
        Reference: https://github.com/wasp-lang/wasp/issues/2655
     */
     "noUncheckedIndexedAccess": false,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/server/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/server/tsconfig.json
@@ -4,18 +4,8 @@
     // Overriding this until we implement more complete TypeScript support.
     "strict": false,
     "allowJs": true,
-
-    // This property currently doesn't matter because we haven't been running
-    // TSC on server code since https://github.com/wasp-lang/wasp/pull/1714.
-    //
-    // When we start running TSC again (after we fix all current errors and
-    // make project references work for the TS config), then I believe the
-    // correct configuration is "rootDir": "." (the project reference should
-    // take care of the user code), but we should double-check.
-    //
-    // Before changing this property, ensure you're aware of the implications:
-    //  - https://github.com/wasp-lang/wasp/pull/1584#discussion_r1404019301
-    //  - https://github.com/wasp-lang/wasp/pull/1713/files#diff-58191eecd9cc55f71c73de89420df8b1866dce38ad35f4ef0f6f8874616eda77R32
+    // The project reference takes care of the user project,
+    // so `rootDir` only needs to include the server files.
     "rootDir": ".",
     // Enable source map for debugging
     "sourceMap": true,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/tsconfig.src.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-new-golden/wasp-app/tsconfig.src.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-new-golden/wasp-app/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/waspc/src/Wasp/ExternalConfig/TsConfig.hs
+++ b/waspc/src/Wasp/ExternalConfig/TsConfig.hs
@@ -43,6 +43,7 @@ data CompilerOptions = CompilerOptions
     moduleResolution :: !(Maybe String),
     moduleDetection :: !(Maybe String),
     isolatedModules :: !(Maybe Bool),
+    verbatimModuleSyntax :: !(Maybe Bool),
     jsx :: !(Maybe String),
     strict :: !(Maybe Bool),
     esModuleInterop :: !(Maybe Bool),

--- a/waspc/src/Wasp/ExternalConfig/TsConfig.hs
+++ b/waspc/src/Wasp/ExternalConfig/TsConfig.hs
@@ -43,7 +43,6 @@ data CompilerOptions = CompilerOptions
     moduleResolution :: !(Maybe String),
     moduleDetection :: !(Maybe String),
     isolatedModules :: !(Maybe Bool),
-    verbatimModuleSyntax :: !(Maybe Bool),
     jsx :: !(Maybe String),
     strict :: !(Maybe Bool),
     esModuleInterop :: !(Maybe Bool),

--- a/waspc/src/Wasp/Project/ExternalConfig/SrcTsConfig.hs
+++ b/waspc/src/Wasp/Project/ExternalConfig/SrcTsConfig.hs
@@ -43,6 +43,11 @@ srcTsConfigValidator =
           -- stay bundler-friendly.
           V.inField ("module", T._module) $ V.oneOfJust ["esnext", "preserve"],
           V.inField ("moduleResolution", T.moduleResolution) $ V.eqJust "bundler",
+          -- Without `moduleDetection: force`, TypeScript treats files with no
+          -- imports or exports as global scripts, while the bundler treats them
+          -- as modules. Code relying on such globals type checks but breaks at
+          -- runtime after bundling.
+          V.inField ("moduleDetection", T.moduleDetection) $ V.eqJust "force",
           isolatedModulesValidator,
           -- Both options match the automatic JSX transform esbuild applies when
           -- bundling.

--- a/waspc/src/Wasp/Project/ExternalConfig/SrcTsConfig.hs
+++ b/waspc/src/Wasp/Project/ExternalConfig/SrcTsConfig.hs
@@ -19,6 +19,10 @@ parseAndValidateSrcTsConfig ::
   IO (Validation [CompileError] T.TsConfig)
 parseAndValidateSrcTsConfig = parseAndValidateTsConfigFile srcTsConfigValidator
 
+-- Wasp only requires the options it needs to compile and bundle the project.
+-- Everything else (strictness, target, lib, ...) is the user's choice.
+-- We ensure proper defaults through starter templates.
+--
 -- References for understanding the required compiler options:
 --   - The comments in templates/sdk/wasp/tsconfig.json
 --   - https://www.typescriptlang.org/docs/handbook/modules/introduction.html
@@ -27,38 +31,47 @@ parseAndValidateSrcTsConfig = parseAndValidateTsConfigFile srcTsConfigValidator
 srcTsConfigValidator :: V.Validator T.TsConfig
 srcTsConfigValidator =
   V.all
-    [ V.inField ("include", T.include) $ V.eqJust ["src", ".wasp/out/types/app"],
-      V.inField ("exclude", T.exclude) $ V.eqJust ["**/*.wasp.ts"],
+    [ V.inField ("include", T.include) $ V.required $ V.containsAll ["src", ".wasp/out/types/app"],
+      V.inField ("exclude", T.exclude) $ V.required $ V.containsAll ["**/*.wasp.ts"],
       V.inField ("compilerOptions", T.compilerOptions) $ V.required compilerOptionsValidator
     ]
   where
     compilerOptionsValidator :: V.Validator T.CompilerOptions
     compilerOptionsValidator =
       V.all
-        [ V.inField ("module", T._module) $ V.eqJust "esnext",
-          V.inField ("target", T.target) $ V.eqJust "esnext",
-          -- Since Wasp ends up bundling the user code, `bundler` is the most
-          -- appropriate `moduleResolution` option.
+        [ -- Since Wasp ends up bundling the user code, the module options must
+          -- stay bundler-friendly.
+          V.inField ("module", T._module) $ V.oneOfJust ["esnext", "preserve"],
           V.inField ("moduleResolution", T.moduleResolution) $ V.eqJust "bundler",
-          V.inField ("moduleDetection", T.moduleDetection) $ V.eqJust "force",
-          -- `isolatedModules` prevents users from using features that don't work
-          -- with transpilers and would fail when Wasp bundles the code with rollup
-          -- (e.g., const enums)
-          V.inField ("isolatedModules", T.isolatedModules) $ V.eqJust True,
-          V.inField ("jsx", T.jsx) $ V.eqJust "preserve",
-          V.inField ("strict", T.strict) $ V.eqJust True,
+          isolatedModulesValidator,
+          -- Both options match the automatic JSX transform esbuild applies when
+          -- bundling.
+          V.inField ("jsx", T.jsx) $ V.oneOfJust ["preserve", "react-jsx"],
+          -- Bundlers emulate `esModuleInterop` behavior at runtime, so type
+          -- checking must assume it too.
           V.inField ("esModuleInterop", T.esModuleInterop) $ V.eqJust True,
-          V.inField ("lib", T.lib) $ V.eqJust ["dom", "dom.iterable", "esnext"],
           -- From TypeScript 6 onwards, we need to manually specify which
           -- packages' globals we want to load.
           V.inField ("types", T.types) $ V.required $ V.containsAll ["react", "node"],
-          V.inField ("allowJs", T.allowJs) $ V.eqJust True,
           -- Wasp internally uses TypeScript's project references to compile the
           -- code. Referenced projects may not disable emit, so we must specify an
-          -- `outDir`.
+          -- `outDir` and keep `noEmit` off.
           V.inField ("outDir", T.outDir) $ V.eqJust ".wasp/out/user",
+          V.inField ("noEmit", T.noEmit) $ V.ifJust $ V.eq False,
           -- The composite flag is required because Wasp uses project references
           -- (i.e., web app and server reference user code as a subproject)
           V.inField ("composite", T.composite) $ V.eqJust True,
           V.inField ("skipLibCheck", T.skipLibCheck) $ V.eqJust True
         ]
+
+    -- `isolatedModules` prevents users from using features that don't work with
+    -- single-file transpilers and would fail at runtime after Wasp bundles the code
+    -- (e.g., const enums).
+    -- `verbatimModuleSyntax` is a stricter alternative that gives the same guarantee.
+    isolatedModulesValidator :: V.Validator T.CompilerOptions
+    isolatedModulesValidator compilerOptions
+      | T.isolatedModules compilerOptions == Just True = V.success
+      | T.verbatimModuleSyntax compilerOptions == Just True = V.success
+      | otherwise =
+          V.withFieldName "isolatedModules" $
+            V.failure "Expected \"isolatedModules\" (or the stricter \"verbatimModuleSyntax\") to be true."

--- a/waspc/src/Wasp/Project/ExternalConfig/SrcTsConfig.hs
+++ b/waspc/src/Wasp/Project/ExternalConfig/SrcTsConfig.hs
@@ -40,15 +40,19 @@ srcTsConfigValidator =
     compilerOptionsValidator =
       V.all
         [ -- Since Wasp ends up bundling the user code, the module options must
-          -- stay bundler-friendly.
-          V.inField ("module", T._module) $ V.oneOfJust ["esnext", "preserve"],
+          -- stay bundler-friendly. `esnext` also rejects CommonJS import syntax
+          -- that would end up as an unresolved `require` in the ESM bundle.
+          V.inField ("module", T._module) $ V.eqJust "esnext",
           V.inField ("moduleResolution", T.moduleResolution) $ V.eqJust "bundler",
           -- Without `moduleDetection: force`, TypeScript treats files with no
           -- imports or exports as global scripts, while the bundler treats them
           -- as modules. Code relying on such globals type checks but breaks at
           -- runtime after bundling.
           V.inField ("moduleDetection", T.moduleDetection) $ V.eqJust "force",
-          isolatedModulesValidator,
+          -- `isolatedModules` prevents users from using features that don't work
+          -- with single-file transpilers and would fail at runtime after Wasp
+          -- bundles the code (e.g., const enums).
+          V.inField ("isolatedModules", T.isolatedModules) $ V.eqJust True,
           -- Both options match the automatic JSX transform esbuild applies when
           -- bundling.
           V.inField ("jsx", T.jsx) $ V.oneOfJust ["preserve", "react-jsx"],
@@ -68,15 +72,3 @@ srcTsConfigValidator =
           V.inField ("composite", T.composite) $ V.eqJust True,
           V.inField ("skipLibCheck", T.skipLibCheck) $ V.eqJust True
         ]
-
-    -- `isolatedModules` prevents users from using features that don't work with
-    -- single-file transpilers and would fail at runtime after Wasp bundles the code
-    -- (e.g., const enums).
-    -- `verbatimModuleSyntax` is a stricter alternative that gives the same guarantee.
-    isolatedModulesValidator :: V.Validator T.CompilerOptions
-    isolatedModulesValidator compilerOptions
-      | T.isolatedModules compilerOptions == Just True = V.success
-      | T.verbatimModuleSyntax compilerOptions == Just True = V.success
-      | otherwise =
-          V.withFieldName "isolatedModules" $
-            V.failure "Expected \"isolatedModules\" (or the stricter \"verbatimModuleSyntax\") to be true."

--- a/waspc/src/Wasp/Validator.hs
+++ b/waspc/src/Wasp/Validator.hs
@@ -76,14 +76,27 @@ failure message' =
         fileName = Nothing
       }
 
--- | Validates that the value exists and is equal to the expected value.
-eqJust :: (Eq a, Show a) => a -> Validator (Maybe a)
-eqJust expected (Just actual)
+-- | Validates that the value is equal to the expected value.
+eq :: (Eq a, Show a) => a -> Validator a
+eq expected actual
   | actual == expected = success
   | otherwise =
       failure $ "Expected " ++ show expected ++ " but got " ++ show actual ++ "."
+
+-- | Validates that the value exists and is equal to the expected value.
+eqJust :: (Eq a, Show a) => a -> Validator (Maybe a)
+eqJust expected (Just actual) = eq expected actual
 eqJust expected Nothing =
   failure $ "Missing value, expected " ++ show expected ++ "."
+
+-- | Validates that the value exists and is one of the allowed values.
+oneOfJust :: (Eq a, Show a) => [a] -> Validator (Maybe a)
+oneOfJust allowed (Just actual)
+  | actual `elem` allowed = success
+  | otherwise =
+      failure $ "Expected one of " ++ show allowed ++ " but got " ++ show actual ++ "."
+oneOfJust allowed Nothing =
+  failure $ "Missing value, expected one of " ++ show allowed ++ "."
 
 -- | Validates that the list contains all of the expected elements. Additional
 -- elements are allowed. Combine with 'required' or 'ifJust' to validate an

--- a/waspc/src/Wasp/Validator.hs
+++ b/waspc/src/Wasp/Validator.hs
@@ -83,20 +83,22 @@ eq expected actual
   | otherwise =
       failure $ "Expected " ++ show expected ++ " but got " ++ show actual ++ "."
 
--- | Validates that the value exists and is equal to the expected value.
-eqJust :: (Eq a, Show a) => a -> Validator (Maybe a)
-eqJust expected (Just actual) = eq expected actual
-eqJust expected Nothing =
-  failure $ "Missing value, expected " ++ show expected ++ "."
-
--- | Validates that the value exists and is one of the allowed values.
-oneOfJust :: (Eq a, Show a) => [a] -> Validator (Maybe a)
-oneOfJust allowed (Just actual)
+-- | Validates that the value is one of the allowed values.
+oneOf :: (Eq a, Show a) => [a] -> Validator a
+oneOf allowed actual
   | actual `elem` allowed = success
   | otherwise =
       failure $ "Expected one of " ++ show allowed ++ " but got " ++ show actual ++ "."
-oneOfJust allowed Nothing =
-  failure $ "Missing value, expected one of " ++ show allowed ++ "."
+
+-- | Validates that the value exists and is equal to the expected value.
+eqJust :: (Eq a, Show a) => a -> Validator (Maybe a)
+eqJust expected =
+  requiredWith ("Missing value, expected " ++ show expected ++ ".") (eq expected)
+
+-- | Validates that the value exists and is one of the allowed values.
+oneOfJust :: (Eq a, Show a) => [a] -> Validator (Maybe a)
+oneOfJust allowed =
+  requiredWith ("Missing value, expected one of " ++ show allowed ++ ".") (oneOf allowed)
 
 -- | Validates that the list contains all of the expected elements. Additional
 -- elements are allowed. Combine with 'required' or 'ifJust' to validate an
@@ -112,11 +114,15 @@ containsAll expected actual
 ifJust :: Validator a -> Validator (Maybe a)
 ifJust = maybe success
 
--- | Requires the value to be Just, then runs the inner validator on the
--- unwrapped value. If the value is Nothing, the validation fails.
+-- | Validates that the value exists, then runs the inner validator on it.
 required :: Validator a -> Validator (Maybe a)
-required _ Nothing = failure "Missing required value."
-required innerValidator (Just value) = innerValidator value
+required = requiredWith "Missing required value."
+
+-- | Validates that the value exists, then runs the inner validator on it.
+-- Reports the given message when the value is missing.
+requiredWith :: String -> Validator a -> Validator (Maybe a)
+requiredWith missingValueMessage _ Nothing = failure missingValueMessage
+requiredWith _ innerValidator (Just value) = innerValidator value
 
 instance Show ValidationError where
   show

--- a/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
@@ -48,10 +48,6 @@ spec_SrcTsConfig = do
       validate (validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.types = Just ["react", "node", "vite/client"]})})
         `shouldBe` []
 
-    it "accepts module preserve" $
-      validate (validTsConfig {T.compilerOptions = Just (validCompilerOptions {T._module = Just "preserve"})})
-        `shouldBe` []
-
     it "returns an error when module is not bundler-friendly" $
       assertReturnsValidationErrorMentioningField "module" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T._module = Just "commonjs"})}
@@ -64,16 +60,7 @@ spec_SrcTsConfig = do
       assertReturnsValidationErrorMentioningField "jsx" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.jsx = Just "react"})}
 
-    it "accepts verbatimModuleSyntax as an alternative to isolatedModules" $
-      validate
-        ( validTsConfig
-            { T.compilerOptions =
-                Just (validCompilerOptions {T.isolatedModules = Nothing, T.verbatimModuleSyntax = Just True})
-            }
-        )
-        `shouldBe` []
-
-    it "returns an error when both isolatedModules and verbatimModuleSyntax are off" $
+    it "returns an error when isolatedModules is off" $
       assertReturnsValidationErrorMentioningField "isolatedModules" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.isolatedModules = Just False})}
 
@@ -128,7 +115,6 @@ validCompilerOptions =
       T.moduleResolution = Just "bundler",
       T.moduleDetection = Just "force",
       T.isolatedModules = Just True,
-      T.verbatimModuleSyntax = Nothing,
       T.jsx = Just "preserve",
       T.strict = Just True,
       T.esModuleInterop = Just True,

--- a/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
@@ -13,20 +13,28 @@ spec_SrcTsConfig = do
       validate validTsConfig `shouldBe` []
 
     it "returns an error when a compilerOption has a wrong value" $
-      assertReturnsValidationErrorMentioningField "strict" $
-        validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.strict = Just False})}
+      assertReturnsValidationErrorMentioningField "moduleResolution" $
+        validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.moduleResolution = Just "nodenext"})}
 
     it "returns an error when a compilerOption is missing" $
       assertReturnsValidationErrorMentioningField "jsx" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.jsx = Nothing})}
 
-    it "returns an error when include is wrong" $
+    it "returns an error when include is missing a required entry" $
       assertReturnsValidationErrorMentioningField "include" $
         validTsConfig {T.include = Just ["lib"]}
 
-    it "returns an error when exclude is wrong" $
+    it "accepts extra entries in include" $
+      validate (validTsConfig {T.include = Just ["src", ".wasp/out/types/app", "lib"]})
+        `shouldBe` []
+
+    it "returns an error when exclude is missing" $
       assertReturnsValidationErrorMentioningField "exclude" $
         validTsConfig {T.exclude = Nothing}
+
+    it "accepts extra entries in exclude" $
+      validate (validTsConfig {T.exclude = Just ["**/*.wasp.ts", "scripts"]})
+        `shouldBe` []
 
     it "returns an error when types is missing a required entry" $
       assertReturnsValidationErrorMentioningField "types" $
@@ -38,6 +46,56 @@ spec_SrcTsConfig = do
 
     it "accepts extra entries in types as long as react and node are present" $
       validate (validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.types = Just ["react", "node", "vite/client"]})})
+        `shouldBe` []
+
+    it "accepts module preserve" $
+      validate (validTsConfig {T.compilerOptions = Just (validCompilerOptions {T._module = Just "preserve"})})
+        `shouldBe` []
+
+    it "returns an error when module is not bundler-friendly" $
+      assertReturnsValidationErrorMentioningField "module" $
+        validTsConfig {T.compilerOptions = Just (validCompilerOptions {T._module = Just "commonjs"})}
+
+    it "accepts jsx react-jsx" $
+      validate (validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.jsx = Just "react-jsx"})})
+        `shouldBe` []
+
+    it "returns an error when jsx does not match the bundler's transform" $
+      assertReturnsValidationErrorMentioningField "jsx" $
+        validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.jsx = Just "react"})}
+
+    it "accepts verbatimModuleSyntax as an alternative to isolatedModules" $
+      validate
+        ( validTsConfig
+            { T.compilerOptions =
+                Just (validCompilerOptions {T.isolatedModules = Nothing, T.verbatimModuleSyntax = Just True})
+            }
+        )
+        `shouldBe` []
+
+    it "returns an error when both isolatedModules and verbatimModuleSyntax are off" $
+      assertReturnsValidationErrorMentioningField "isolatedModules" $
+        validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.isolatedModules = Just False})}
+
+    it "returns an error when noEmit is true" $
+      assertReturnsValidationErrorMentioningField "noEmit" $
+        validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.noEmit = Just True})}
+
+    it "accepts any values for the options Wasp doesn't require" $
+      validate
+        ( validTsConfig
+            { T.compilerOptions =
+                Just
+                  ( validCompilerOptions
+                      { T.strict = Just False,
+                        T.target = Just "es2020",
+                        T.lib = Just ["esnext"],
+                        T.allowJs = Nothing,
+                        T.moduleDetection = Nothing
+                      }
+                  )
+            }
+        )
         `shouldBe` []
 
 validate :: T.TsConfig -> [String]
@@ -67,6 +125,7 @@ validCompilerOptions =
       T.moduleResolution = Just "bundler",
       T.moduleDetection = Just "force",
       T.isolatedModules = Just True,
+      T.verbatimModuleSyntax = Nothing,
       T.jsx = Just "preserve",
       T.strict = Just True,
       T.esModuleInterop = Just True,

--- a/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
@@ -77,6 +77,10 @@ spec_SrcTsConfig = do
       assertReturnsValidationErrorMentioningField "isolatedModules" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.isolatedModules = Just False})}
 
+    it "returns an error when moduleDetection is not force" $
+      assertReturnsValidationErrorMentioningField "moduleDetection" $
+        validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.moduleDetection = Nothing})}
+
     it "returns an error when noEmit is true" $
       assertReturnsValidationErrorMentioningField "noEmit" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.noEmit = Just True})}
@@ -90,8 +94,7 @@ spec_SrcTsConfig = do
                       { T.strict = Just False,
                         T.target = Just "es2020",
                         T.lib = Just ["esnext"],
-                        T.allowJs = Nothing,
-                        T.moduleDetection = Nothing
+                        T.allowJs = Nothing
                       }
                   )
             }

--- a/waspc/tests/Project/ExternalConfig/WaspTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/WaspTsConfigTest.hs
@@ -83,7 +83,6 @@ validCompilerOptions =
       T.moduleResolution = Just "bundler",
       T.moduleDetection = Just "force",
       T.isolatedModules = Just True,
-      T.verbatimModuleSyntax = Nothing,
       T.jsx = Just "preserve",
       T.strict = Just True,
       T.esModuleInterop = Nothing,

--- a/waspc/tests/Project/ExternalConfig/WaspTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/WaspTsConfigTest.hs
@@ -83,6 +83,7 @@ validCompilerOptions =
       T.moduleResolution = Just "bundler",
       T.moduleDetection = Just "force",
       T.isolatedModules = Just True,
+      T.verbatimModuleSyntax = Nothing,
       T.jsx = Just "preserve",
       T.strict = Just True,
       T.esModuleInterop = Nothing,


### PR DESCRIPTION
## Description

Solves https://github.com/wasp-lang/wasp/issues/835

Frees as much of user's typescript configuration as possible.

User project is still being bundles as part of server/client so we can't fully free it.
The configuration must be bundler friendly.

Changes:

| Option | Freed how much |
|---|---|
| `strict` | Fully (check removed) |
| `target` | Fully (check removed) |
| `lib` | Fully (check removed) |
| `allowJs` | Fully (check removed) |
| `jsx` | 1 more value: `react-jsx` (besides `preserve`) |
| `include` | Extra entries allowed (must still contain `src`, `.wasp/out/types/app`) |
| `exclude` | Extra entries allowed (must still contain `**/*.wasp.ts`) |
| `types` | Unchanged behavior, extra entries were already allowed (must contain `react`, `node`) |
| `noEmit` | Tightened, not freed: new check that it isn't `true` (was unvalidated, failed later with a cryptic tsc error) |

Everything not listed in the validator was already unvalidated and stays free.

Note: does not solve path aliases which is a separate issue: https://github.com/wasp-lang/wasp/issues/2518


## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
