### PR TITLE
Cleanup leftover SDK<->user comments, update examples to follow new no comment template

### DIFF
--- a/examples/ask-the-documents/tsconfig.src.json
+++ b/examples/ask-the-documents/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/examples/ask-the-documents/tsconfig.wasp.json
+++ b/examples/ask-the-documents/tsconfig.wasp.json
@@ -4,17 +4,14 @@
     "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
-
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,
-
     "lib": ["ES2025"],
     "types": ["node"]
   },

--- a/examples/kitchen-sink/tsconfig.src.json
+++ b/examples/kitchen-sink/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/examples/kitchen-sink/tsconfig.wasp.json
+++ b/examples/kitchen-sink/tsconfig.wasp.json
@@ -4,17 +4,14 @@
     "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
-
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,
-
     "lib": ["ES2025"],
     "types": ["node"]
   },

--- a/examples/tutorials/TodoApp/tsconfig.src.json
+++ b/examples/tutorials/TodoApp/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/examples/tutorials/TodoApp/tsconfig.wasp.json
+++ b/examples/tutorials/TodoApp/tsconfig.wasp.json
@@ -4,17 +4,14 @@
     "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
-
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,
-
     "lib": ["ES2025"],
     "types": ["node"]
   },

--- a/examples/tutorials/TodoAppTs/tsconfig.src.json
+++ b/examples/tutorials/TodoAppTs/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/examples/tutorials/TodoAppTs/tsconfig.wasp.json
+++ b/examples/tutorials/TodoAppTs/tsconfig.wasp.json
@@ -4,17 +4,14 @@
     "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
-
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,
-
     "lib": ["ES2025"],
     "types": ["node"]
   },

--- a/examples/waspello/tsconfig.src.json
+++ b/examples/waspello/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/examples/waspello/tsconfig.wasp.json
+++ b/examples/waspello/tsconfig.wasp.json
@@ -4,17 +4,14 @@
     "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
-
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,
-
     "lib": ["ES2025"],
     "types": ["node"]
   },

--- a/examples/waspleau/tsconfig.src.json
+++ b/examples/waspleau/tsconfig.src.json
@@ -1,26 +1,11 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",
-    // Needed because this is used as a project reference.
     "composite": true,
     "target": "esnext",
-    // We're bundling all code in the end so this is the most appropriate option,
-    // it's also important for autocomplete to work properly.
     "moduleResolution": "bundler",
-    // JSX support
     "jsx": "preserve",
     "strict": true,
-    // Allow default imports.
     "esModuleInterop": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/examples/waspleau/tsconfig.wasp.json
+++ b/examples/waspleau/tsconfig.wasp.json
@@ -4,17 +4,14 @@
     "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
-
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,
-
     "lib": ["ES2025"],
     "types": ["node"]
   },

--- a/examples/websockets-realtime-voting/tsconfig.src.json
+++ b/examples/websockets-realtime-voting/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/examples/websockets-realtime-voting/tsconfig.wasp.json
+++ b/examples/websockets-realtime-voting/tsconfig.wasp.json
@@ -4,17 +4,14 @@
     "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
-
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,
-
     "lib": ["ES2025"],
     "types": ["node"]
   },

--- a/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
+++ b/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
@@ -39,22 +39,18 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // TODO: Enable this once we enable it for users:
-    // https://github.com/wasp-lang/wasp/issues/2654
+    // We haven't adopted this yet.
+    // Reference: https://github.com/wasp-lang/wasp/issues/2654
     "resolveJsonModule": false,
     /*
        The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers:
-         - The user code must enable it because Wasp bundles user code when bundling
-        server code and web app code (which directly import the user code).
-         - The SDK code must disable it because parts of the SDK code rely on
-        such features. Since we build the SDK with TSC before bundling it,
-        these features don't cause problems.
-      More details in https://github.com/wasp-lang/wasp/issues/2150
+       doesn't work with bundlers. We disable it because parts of the SDK code
+       rely on such features. Since we build the SDK with TSC before bundling
+       it, these features don't cause problems.
+       More details in https://github.com/wasp-lang/wasp/issues/2150
     */
     "isolatedModules": false,
-    // `verbatimModuleSyntax` is disabled because we don't yet want to
-    // force user code into using `type` imports.
+    // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
@@ -62,8 +58,7 @@
       - We want users to import stuff from the SDK with `wasp/something`, and we
         don't want to do extra processing on those imports (for now).
 
-      These requirements force us to bundle user code and, because we copy user
-      code into the SDK code, they force us to bundle the SDK too.
+      These requirements force us to bundle the SDK.
 
       We currently bundle the SDK in a very hacky way (indirectly while bundling
       the server and client): https://github.com/wasp-lang/wasp/issues/2150

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -1285,7 +1285,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "029a4aca9060b5937b82167ab57cdf181bcb3eb73a71cecef3683482f066a1cd"
+        "2666354463bcaebc95c0971b618746b44e04856d7f61b06261c6f367dcdb1505"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -39,22 +39,18 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // TODO: Enable this once we enable it for users:
-    // https://github.com/wasp-lang/wasp/issues/2654
+    // We haven't adopted this yet.
+    // Reference: https://github.com/wasp-lang/wasp/issues/2654
     "resolveJsonModule": false,
     /*
        The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers:
-         - The user code must enable it because Wasp bundles user code when bundling
-        server code and web app code (which directly import the user code).
-         - The SDK code must disable it because parts of the SDK code rely on
-        such features. Since we build the SDK with TSC before bundling it,
-        these features don't cause problems.
-      More details in https://github.com/wasp-lang/wasp/issues/2150
+       doesn't work with bundlers. We disable it because parts of the SDK code
+       rely on such features. Since we build the SDK with TSC before bundling
+       it, these features don't cause problems.
+       More details in https://github.com/wasp-lang/wasp/issues/2150
     */
     "isolatedModules": false,
-    // `verbatimModuleSyntax` is disabled because we don't yet want to
-    // force user code into using `type` imports.
+    // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
@@ -62,8 +58,7 @@
       - We want users to import stuff from the SDK with `wasp/something`, and we
         don't want to do extra processing on those imports (for now).
 
-      These requirements force us to bundle user code and, because we copy user
-      code into the SDK code, they force us to bundle the SDK too.
+      These requirements force us to bundle the SDK.
 
       We currently bundle the SDK in a very hacky way (indirectly while bundling
       the server and client): https://github.com/wasp-lang/wasp/issues/2150

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/tsconfig.src.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/tsconfig.src.json
@@ -1,13 +1,3 @@
-// =============================== IMPORTANT =================================
-// This file is mainly used for Wasp IDE support.
-//
-// Wasp will compile your code with slightly different (less strict) compilerOptions.
-// You can increase the configuration's strictness (e.g., by adding
-// "noUncheckedIndexedAccess": true), but you shouldn't reduce it (e.g., by
-// adding "strict": false). Just keep in mind that this will only affect your
-// IDE support, not the actual compilation.
-//
-// Full TypeScript configurability is coming very soon :)
 {
   "compilerOptions": {
     "module": "esnext",

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/tsconfig.wasp.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/tsconfig.wasp.json
@@ -4,17 +4,14 @@
     "target": "ES2025",
     "isolatedModules": true,
     "moduleDetection": "force",
-
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     "module": "esnext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
     "allowJs": true,
     "noEmit": true,
-
     "lib": ["ES2025"],
     "types": ["node"]
   },

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -571,7 +571,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "029a4aca9060b5937b82167ab57cdf181bcb3eb73a71cecef3683482f066a1cd"
+        "2666354463bcaebc95c0971b618746b44e04856d7f61b06261c6f367dcdb1505"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -39,22 +39,18 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // TODO: Enable this once we enable it for users:
-    // https://github.com/wasp-lang/wasp/issues/2654
+    // We haven't adopted this yet.
+    // Reference: https://github.com/wasp-lang/wasp/issues/2654
     "resolveJsonModule": false,
     /*
        The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers:
-         - The user code must enable it because Wasp bundles user code when bundling
-        server code and web app code (which directly import the user code).
-         - The SDK code must disable it because parts of the SDK code rely on
-        such features. Since we build the SDK with TSC before bundling it,
-        these features don't cause problems.
-      More details in https://github.com/wasp-lang/wasp/issues/2150
+       doesn't work with bundlers. We disable it because parts of the SDK code
+       rely on such features. Since we build the SDK with TSC before bundling
+       it, these features don't cause problems.
+       More details in https://github.com/wasp-lang/wasp/issues/2150
     */
     "isolatedModules": false,
-    // `verbatimModuleSyntax` is disabled because we don't yet want to
-    // force user code into using `type` imports.
+    // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
@@ -62,8 +58,7 @@
       - We want users to import stuff from the SDK with `wasp/something`, and we
         don't want to do extra processing on those imports (for now).
 
-      These requirements force us to bundle user code and, because we copy user
-      code into the SDK code, they force us to bundle the SDK too.
+      These requirements force us to bundle the SDK.
 
       We currently bundle the SDK in a very hacky way (indirectly while bundling
       the server and client): https://github.com/wasp-lang/wasp/issues/2150

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -571,7 +571,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "029a4aca9060b5937b82167ab57cdf181bcb3eb73a71cecef3683482f066a1cd"
+        "2666354463bcaebc95c0971b618746b44e04856d7f61b06261c6f367dcdb1505"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -39,22 +39,18 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // TODO: Enable this once we enable it for users:
-    // https://github.com/wasp-lang/wasp/issues/2654
+    // We haven't adopted this yet.
+    // Reference: https://github.com/wasp-lang/wasp/issues/2654
     "resolveJsonModule": false,
     /*
        The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers:
-         - The user code must enable it because Wasp bundles user code when bundling
-        server code and web app code (which directly import the user code).
-         - The SDK code must disable it because parts of the SDK code rely on
-        such features. Since we build the SDK with TSC before bundling it,
-        these features don't cause problems.
-      More details in https://github.com/wasp-lang/wasp/issues/2150
+       doesn't work with bundlers. We disable it because parts of the SDK code
+       rely on such features. Since we build the SDK with TSC before bundling
+       it, these features don't cause problems.
+       More details in https://github.com/wasp-lang/wasp/issues/2150
     */
     "isolatedModules": false,
-    // `verbatimModuleSyntax` is disabled because we don't yet want to
-    // force user code into using `type` imports.
+    // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
@@ -62,8 +58,7 @@
       - We want users to import stuff from the SDK with `wasp/something`, and we
         don't want to do extra processing on those imports (for now).
 
-      These requirements force us to bundle user code and, because we copy user
-      code into the SDK code, they force us to bundle the SDK too.
+      These requirements force us to bundle the SDK.
 
       We currently bundle the SDK in a very hacky way (indirectly while bundling
       the server and client): https://github.com/wasp-lang/wasp/issues/2150

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -578,7 +578,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "029a4aca9060b5937b82167ab57cdf181bcb3eb73a71cecef3683482f066a1cd"
+        "2666354463bcaebc95c0971b618746b44e04856d7f61b06261c6f367dcdb1505"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -39,22 +39,18 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // TODO: Enable this once we enable it for users:
-    // https://github.com/wasp-lang/wasp/issues/2654
+    // We haven't adopted this yet.
+    // Reference: https://github.com/wasp-lang/wasp/issues/2654
     "resolveJsonModule": false,
     /*
        The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers:
-         - The user code must enable it because Wasp bundles user code when bundling
-        server code and web app code (which directly import the user code).
-         - The SDK code must disable it because parts of the SDK code rely on
-        such features. Since we build the SDK with TSC before bundling it,
-        these features don't cause problems.
-      More details in https://github.com/wasp-lang/wasp/issues/2150
+       doesn't work with bundlers. We disable it because parts of the SDK code
+       rely on such features. Since we build the SDK with TSC before bundling
+       it, these features don't cause problems.
+       More details in https://github.com/wasp-lang/wasp/issues/2150
     */
     "isolatedModules": false,
-    // `verbatimModuleSyntax` is disabled because we don't yet want to
-    // force user code into using `type` imports.
+    // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
@@ -62,8 +58,7 @@
       - We want users to import stuff from the SDK with `wasp/something`, and we
         don't want to do extra processing on those imports (for now).
 
-      These requirements force us to bundle user code and, because we copy user
-      code into the SDK code, they force us to bundle the SDK too.
+      These requirements force us to bundle the SDK.
 
       We currently bundle the SDK in a very hacky way (indirectly while bundling
       the server and client): https://github.com/wasp-lang/wasp/issues/2150

--- a/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
@@ -79,8 +79,8 @@ spec_SrcTsConfig = do
             { T.compilerOptions =
                 Just
                   ( validCompilerOptions
-                      -- These are deliberately set to values different than the ones we have in starter templates.
-                      { T.strict = Just False,
+                      { -- These are deliberately set to values different than the ones we have in starter templates.
+                        T.strict = Just False,
                         T.target = Just "es2020",
                         T.lib = Just ["esnext"],
                         T.allowJs = Nothing

--- a/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
+++ b/waspc/tests/Project/ExternalConfig/SrcTsConfigTest.hs
@@ -20,55 +20,56 @@ spec_SrcTsConfig = do
       assertReturnsValidationErrorMentioningField "jsx" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.jsx = Nothing})}
 
-    it "returns an error when include is missing a required entry" $
+    it "returns an error when `include` is missing a required entry" $
       assertReturnsValidationErrorMentioningField "include" $
         validTsConfig {T.include = Just ["lib"]}
 
-    it "accepts extra entries in include" $
+    it "accepts extra entries in `include`" $
       validate (validTsConfig {T.include = Just ["src", ".wasp/out/types/app", "lib"]})
         `shouldBe` []
 
-    it "returns an error when exclude is missing" $
+    it "returns an error when `exclude` is missing" $
       assertReturnsValidationErrorMentioningField "exclude" $
         validTsConfig {T.exclude = Nothing}
 
-    it "accepts extra entries in exclude" $
+    it "accepts extra entries in `exclude`" $
       validate (validTsConfig {T.exclude = Just ["**/*.wasp.ts", "scripts"]})
         `shouldBe` []
 
-    it "returns an error when types is missing a required entry" $
+    it "returns an error when `types` is missing a required entry" $
       assertReturnsValidationErrorMentioningField "types" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.types = Just ["node"]})}
 
-    it "returns an error when types is missing" $
+    it "returns an error when `types` is missing" $
       assertReturnsValidationErrorMentioningField "types" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.types = Nothing})}
 
-    it "accepts extra entries in types as long as react and node are present" $
+    it "accepts extra entries in `types` as long as `react` and `node` are present" $
       validate (validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.types = Just ["react", "node", "vite/client"]})})
         `shouldBe` []
 
-    it "returns an error when module is not bundler-friendly" $
+    it "returns an error when `module` is not bundler-friendly" $
       assertReturnsValidationErrorMentioningField "module" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T._module = Just "commonjs"})}
 
-    it "accepts jsx react-jsx" $
-      validate (validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.jsx = Just "react-jsx"})})
-        `shouldBe` []
+    it "accepts every `jsx` value matching the bundler's transform" $
+      let validateWithJsx jsx =
+            validate (validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.jsx = Just jsx})})
+       in map validateWithJsx ["preserve", "react-jsx"] `shouldBe` [[], []]
 
-    it "returns an error when jsx does not match the bundler's transform" $
+    it "returns an error when `jsx` does not match the bundler's transform" $
       assertReturnsValidationErrorMentioningField "jsx" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.jsx = Just "react"})}
 
-    it "returns an error when isolatedModules is off" $
+    it "returns an error when `isolatedModules` is off" $
       assertReturnsValidationErrorMentioningField "isolatedModules" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.isolatedModules = Just False})}
 
-    it "returns an error when moduleDetection is not force" $
+    it "returns an error when `moduleDetection` is not `force`" $
       assertReturnsValidationErrorMentioningField "moduleDetection" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.moduleDetection = Nothing})}
 
-    it "returns an error when noEmit is true" $
+    it "returns an error when `noEmit` is `true`" $
       assertReturnsValidationErrorMentioningField "noEmit" $
         validTsConfig {T.compilerOptions = Just (validCompilerOptions {T.noEmit = Just True})}
 
@@ -78,6 +79,7 @@ spec_SrcTsConfig = do
             { T.compilerOptions =
                 Just
                   ( validCompilerOptions
+                      -- These are deliberately set to values different than the ones we have in starter templates.
                       { T.strict = Just False,
                         T.target = Just "es2020",
                         T.lib = Just ["esnext"],


### PR DESCRIPTION
## Description

Follow-up to #4772, which freed up as much of the user's TypeScript config as possible. That PR updated the starter skeleton but but didn't update existing examples.

While it did clean up some old SDK comments along the way, it did not clean up everything, so this PR continues after it.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- Comments and example configs only; no behavior to unit test. Existing 668 unit tests pass. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed.
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- Already correct as of #4772; this PR brings the examples up to match them. -->
  - [x] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa). <!-- The tutorial docs don't show tsconfig contents. -->

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- #4772's entry already covers this release and stays accurate. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Already bumped to 0.26.0 on main. -->

## Testing

E2E goldens regenerated with `./run build && ./run test:waspc:e2e:accept-all`. Snapshot churn is `sdk/wasp/tsconfig.json` and `.waspchecksums` across all four goldens, plus kitchen-sink's two user-side tsconfigs.

- 668 unit tests pass
- 934 e2e tests pass
- `ormolu` clean
