### PR TITLE
Enable stricter tsconfig flags in the SDK

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/auth/user.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/user.ts
@@ -28,7 +28,7 @@ export function getFirstProviderUserId(user?: UserEntityWithAuth): string | null
     return null;
   }
 
-  return user.auth.identities[0].providerUserId ?? null;
+  return user.auth.identities[0]?.providerUserId ?? null;
 }
 
 // PUBLIC API
@@ -126,7 +126,7 @@ function makeAuthUser(data: AuthUserData): AuthUser {
     ...data,
     getFirstProviderUserId: () => {
       const identities = Object.values(data.identities).filter(isNotNull);
-      return identities.length > 0 ? identities[0].id : null;
+      return identities[0]?.id ?? null;
     },
   };
 }

--- a/waspc/data/Generator/templates/sdk/wasp/client/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/index.ts
@@ -11,7 +11,7 @@ export enum HttpMethod {
 export type Route = { method: HttpMethod; path: string }
 
 // PUBLIC API
-export { ClientConfig, config } from './config';
+export { type ClientConfig, config } from './config';
 
 // PUBLIC API
 export { env } from './env';

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -30,7 +30,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      const userModulePath = clientVirtualUserModuleMap[id];
+      const userModulePath = Object.hasOwn(clientVirtualUserModuleMap, id)
+        ? clientVirtualUserModuleMap[id]
+        : undefined;
       if (userModulePath !== undefined) {
         const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -30,8 +30,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      if (Object.hasOwn(clientVirtualUserModuleMap, id)) {
-        const absPath = path.resolve(clientRootDir, clientVirtualUserModuleMap[id]);
+      const userModulePath = clientVirtualUserModuleMap[id];
+      if (userModulePath !== undefined) {
+        const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });
       }
       return null;

--- a/waspc/data/Generator/templates/sdk/wasp/server/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/index.ts
@@ -9,7 +9,7 @@ export { type ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { MiddlewareConfigFn } from './middleware/index.js'
+export { type MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
+++ b/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
@@ -24,12 +24,8 @@
     "useUnknownInCatchVariables": false,
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
-    /*
-       We haven't adopted the following two properties yet.
-       Reference: https://github.com/wasp-lang/wasp/issues/2655
-    */
-    "noUncheckedIndexedAccess": false,
-    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
 
     /* DX */
     "declaration": true, // Allows users to consume the SDK as a library, enables autocomplete
@@ -39,32 +35,21 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // We haven't adopted this yet.
-    // Reference: https://github.com/wasp-lang/wasp/issues/2654
-    "resolveJsonModule": false,
-    /*
-       The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers. We disable it because parts of the SDK code
-       rely on such features. Since we build the SDK with TSC before bundling
-       it, these features don't cause problems.
-       More details in https://github.com/wasp-lang/wasp/issues/2150
-    */
-    "isolatedModules": false,
+    "resolveJsonModule": true,
+    // `isolatedModules` rejects code that single-file transpilers (like esbuild)
+    // can't handle. The SDK gets bundled, so it must not rely on such code.
+    "isolatedModules": true,
     // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
-      - We want to allow users to use extensionless and directory imports.
-      - We want users to import stuff from the SDK with `wasp/something`, and we
-        don't want to do extra processing on those imports (for now).
+      The SDK code uses extensionless relative imports and imports its own
+      modules through the `wasp/*` package exports. TSC emits those imports
+      as-is, and only a bundler can resolve them at runtime.
 
-      These requirements force us to bundle the SDK.
-
-      We currently bundle the SDK in a very hacky way (indirectly while bundling
-      the server and client): https://github.com/wasp-lang/wasp/issues/2150
-      Regardless of how we do it, the SDK code is eventually bundled, so this
-      `tsconfig.json` file must reflect that (which means `moduleResolution:
-      bundler`).
+      The SDK output is never run directly: it's bundled into the server and
+      the client (https://github.com/wasp-lang/wasp/issues/2150), so this
+      `tsconfig.json` must resolve modules the way a bundler does.
     */
     "moduleResolution": "bundler",
     /*

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -746,7 +746,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "6f31e187576958151fc269bc5924b93714dd0f8d8e40fadf079a73e392f7ce7b"
+        "3a17c4a54a21024550e115199f9c668b48cfd35aaadca1327b16a5a1d4e823e3"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -368,7 +368,7 @@
             "file",
             "sdk/wasp/auth/user.ts"
         ],
-        "ebe4ea85e345c70544ea69031616396bcc56e49893e45a7ce350d6dbe2a2775a"
+        "89eab5d82f24bbb85cefbc2188a93d4113b6be1d826610ed7858ed28e04f9ccb"
     ],
     [
         [
@@ -571,7 +571,7 @@
             "file",
             "sdk/wasp/client/index.ts"
         ],
-        "07647fefe4b9ae39febd371ad5ea8b93ac47d5e7033c1b2895ebc19c38fb3748"
+        "2c587febd5931faba120a4cf796c5d66bbbf7c054a29468534e7260f777f0244"
     ],
     [
         [
@@ -746,7 +746,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "7adfcc09494f75c2fa87cfeb6b7fc88089ab1a33ecede3125c6b892eea20a8e1"
+        "6f31e187576958151fc269bc5924b93714dd0f8d8e40fadf079a73e392f7ce7b"
     ],
     [
         [
@@ -1138,7 +1138,7 @@
             "file",
             "sdk/wasp/server/index.ts"
         ],
-        "8c8ad2b3979c6940d2ab90b789ff847c1af1c1bc8d8541438cd9d210f6ff6e25"
+        "a0d0ff1c97a4bc52f78d0fac37d1470690984b5dc2284f37b65244e633608cd8"
     ],
     [
         [
@@ -1285,7 +1285,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "2666354463bcaebc95c0971b618746b44e04856d7f61b06261c6f367dcdb1505"
+        "77c89a888d80cb15e8f7497dca2e9070c2bcc2bc167ad8823537117bf6995646"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/user.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/user.ts
@@ -27,7 +27,7 @@ export function getFirstProviderUserId(user?: UserEntityWithAuth): string | null
     return null;
   }
 
-  return user.auth.identities[0].providerUserId ?? null;
+  return user.auth.identities[0]?.providerUserId ?? null;
 }
 
 // PUBLIC API
@@ -107,7 +107,7 @@ function makeAuthUser(data: AuthUserData): AuthUser {
     ...data,
     getFirstProviderUserId: () => {
       const identities = Object.values(data.identities).filter(isNotNull);
-      return identities.length > 0 ? identities[0].id : null;
+      return identities[0]?.id ?? null;
     },
   };
 }

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/index.ts
@@ -11,7 +11,7 @@ export enum HttpMethod {
 export type Route = { method: HttpMethod; path: string }
 
 // PUBLIC API
-export { ClientConfig, config } from './config';
+export { type ClientConfig, config } from './config';
 
 // PUBLIC API
 export { env } from './env';

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -27,8 +27,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      if (Object.hasOwn(clientVirtualUserModuleMap, id)) {
-        const absPath = path.resolve(clientRootDir, clientVirtualUserModuleMap[id]);
+      const userModulePath = clientVirtualUserModuleMap[id];
+      if (userModulePath !== undefined) {
+        const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });
       }
       return null;

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -27,7 +27,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      const userModulePath = clientVirtualUserModuleMap[id];
+      const userModulePath = Object.hasOwn(clientVirtualUserModuleMap, id)
+        ? clientVirtualUserModuleMap[id]
+        : undefined;
       if (userModulePath !== undefined) {
         const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
@@ -9,7 +9,7 @@ export { type ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { MiddlewareConfigFn } from './middleware/index.js'
+export { type MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -24,12 +24,8 @@
     "useUnknownInCatchVariables": false,
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
-    /*
-       We haven't adopted the following two properties yet.
-       Reference: https://github.com/wasp-lang/wasp/issues/2655
-    */
-    "noUncheckedIndexedAccess": false,
-    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
 
     /* DX */
     "declaration": true, // Allows users to consume the SDK as a library, enables autocomplete
@@ -39,32 +35,21 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // We haven't adopted this yet.
-    // Reference: https://github.com/wasp-lang/wasp/issues/2654
-    "resolveJsonModule": false,
-    /*
-       The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers. We disable it because parts of the SDK code
-       rely on such features. Since we build the SDK with TSC before bundling
-       it, these features don't cause problems.
-       More details in https://github.com/wasp-lang/wasp/issues/2150
-    */
-    "isolatedModules": false,
+    "resolveJsonModule": true,
+    // `isolatedModules` rejects code that single-file transpilers (like esbuild)
+    // can't handle. The SDK gets bundled, so it must not rely on such code.
+    "isolatedModules": true,
     // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
-      - We want to allow users to use extensionless and directory imports.
-      - We want users to import stuff from the SDK with `wasp/something`, and we
-        don't want to do extra processing on those imports (for now).
+      The SDK code uses extensionless relative imports and imports its own
+      modules through the `wasp/*` package exports. TSC emits those imports
+      as-is, and only a bundler can resolve them at runtime.
 
-      These requirements force us to bundle the SDK.
-
-      We currently bundle the SDK in a very hacky way (indirectly while bundling
-      the server and client): https://github.com/wasp-lang/wasp/issues/2150
-      Regardless of how we do it, the SDK code is eventually bundled, so this
-      `tsconfig.json` file must reflect that (which means `moduleResolution:
-      bundler`).
+      The SDK output is never run directly: it's bundled into the server and
+      the client (https://github.com/wasp-lang/wasp/issues/2150), so this
+      `tsconfig.json` must resolve modules the way a bundler does.
     */
     "moduleResolution": "bundler",
     /*

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "sdk/wasp/client/index.ts"
         ],
-        "07647fefe4b9ae39febd371ad5ea8b93ac47d5e7033c1b2895ebc19c38fb3748"
+        "2c587febd5931faba120a4cf796c5d66bbbf7c054a29468534e7260f777f0244"
     ],
     [
         [
@@ -319,7 +319,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "1b3926387257ed4e1b45bd10fc6e490cead654d494376d61ee8af6ff4fd4e4ae"
+        "07f799d8b4ef282cbc5bd40474170c31da92c56460cdfcde86d59b487bb22958"
     ],
     [
         [
@@ -494,7 +494,7 @@
             "file",
             "sdk/wasp/server/index.ts"
         ],
-        "8c8ad2b3979c6940d2ab90b789ff847c1af1c1bc8d8541438cd9d210f6ff6e25"
+        "a0d0ff1c97a4bc52f78d0fac37d1470690984b5dc2284f37b65244e633608cd8"
     ],
     [
         [
@@ -571,7 +571,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "2666354463bcaebc95c0971b618746b44e04856d7f61b06261c6f367dcdb1505"
+        "77c89a888d80cb15e8f7497dca2e9070c2bcc2bc167ad8823537117bf6995646"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -319,7 +319,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "07f799d8b4ef282cbc5bd40474170c31da92c56460cdfcde86d59b487bb22958"
+        "db4acaf6e01de4ad53a9c7fb75bff5da1809b99f88b4296a5a180ac3a9ef844f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/index.ts
@@ -11,7 +11,7 @@ export enum HttpMethod {
 export type Route = { method: HttpMethod; path: string }
 
 // PUBLIC API
-export { ClientConfig, config } from './config';
+export { type ClientConfig, config } from './config';
 
 // PUBLIC API
 export { env } from './env';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -26,8 +26,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      if (Object.hasOwn(clientVirtualUserModuleMap, id)) {
-        const absPath = path.resolve(clientRootDir, clientVirtualUserModuleMap[id]);
+      const userModulePath = clientVirtualUserModuleMap[id];
+      if (userModulePath !== undefined) {
+        const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });
       }
       return null;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -26,7 +26,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      const userModulePath = clientVirtualUserModuleMap[id];
+      const userModulePath = Object.hasOwn(clientVirtualUserModuleMap, id)
+        ? clientVirtualUserModuleMap[id]
+        : undefined;
       if (userModulePath !== undefined) {
         const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
@@ -9,7 +9,7 @@ export { type ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { MiddlewareConfigFn } from './middleware/index.js'
+export { type MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -24,12 +24,8 @@
     "useUnknownInCatchVariables": false,
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
-    /*
-       We haven't adopted the following two properties yet.
-       Reference: https://github.com/wasp-lang/wasp/issues/2655
-    */
-    "noUncheckedIndexedAccess": false,
-    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
 
     /* DX */
     "declaration": true, // Allows users to consume the SDK as a library, enables autocomplete
@@ -39,32 +35,21 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // We haven't adopted this yet.
-    // Reference: https://github.com/wasp-lang/wasp/issues/2654
-    "resolveJsonModule": false,
-    /*
-       The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers. We disable it because parts of the SDK code
-       rely on such features. Since we build the SDK with TSC before bundling
-       it, these features don't cause problems.
-       More details in https://github.com/wasp-lang/wasp/issues/2150
-    */
-    "isolatedModules": false,
+    "resolveJsonModule": true,
+    // `isolatedModules` rejects code that single-file transpilers (like esbuild)
+    // can't handle. The SDK gets bundled, so it must not rely on such code.
+    "isolatedModules": true,
     // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
-      - We want to allow users to use extensionless and directory imports.
-      - We want users to import stuff from the SDK with `wasp/something`, and we
-        don't want to do extra processing on those imports (for now).
+      The SDK code uses extensionless relative imports and imports its own
+      modules through the `wasp/*` package exports. TSC emits those imports
+      as-is, and only a bundler can resolve them at runtime.
 
-      These requirements force us to bundle the SDK.
-
-      We currently bundle the SDK in a very hacky way (indirectly while bundling
-      the server and client): https://github.com/wasp-lang/wasp/issues/2150
-      Regardless of how we do it, the SDK code is eventually bundled, so this
-      `tsconfig.json` file must reflect that (which means `moduleResolution:
-      bundler`).
+      The SDK output is never run directly: it's bundled into the server and
+      the client (https://github.com/wasp-lang/wasp/issues/2150), so this
+      `tsconfig.json` must resolve modules the way a bundler does.
     */
     "moduleResolution": "bundler",
     /*

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "sdk/wasp/client/index.ts"
         ],
-        "07647fefe4b9ae39febd371ad5ea8b93ac47d5e7033c1b2895ebc19c38fb3748"
+        "2c587febd5931faba120a4cf796c5d66bbbf7c054a29468534e7260f777f0244"
     ],
     [
         [
@@ -319,7 +319,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "1b3926387257ed4e1b45bd10fc6e490cead654d494376d61ee8af6ff4fd4e4ae"
+        "07f799d8b4ef282cbc5bd40474170c31da92c56460cdfcde86d59b487bb22958"
     ],
     [
         [
@@ -494,7 +494,7 @@
             "file",
             "sdk/wasp/server/index.ts"
         ],
-        "8c8ad2b3979c6940d2ab90b789ff847c1af1c1bc8d8541438cd9d210f6ff6e25"
+        "a0d0ff1c97a4bc52f78d0fac37d1470690984b5dc2284f37b65244e633608cd8"
     ],
     [
         [
@@ -571,7 +571,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "2666354463bcaebc95c0971b618746b44e04856d7f61b06261c6f367dcdb1505"
+        "77c89a888d80cb15e8f7497dca2e9070c2bcc2bc167ad8823537117bf6995646"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -319,7 +319,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "07f799d8b4ef282cbc5bd40474170c31da92c56460cdfcde86d59b487bb22958"
+        "db4acaf6e01de4ad53a9c7fb75bff5da1809b99f88b4296a5a180ac3a9ef844f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/index.ts
@@ -11,7 +11,7 @@ export enum HttpMethod {
 export type Route = { method: HttpMethod; path: string }
 
 // PUBLIC API
-export { ClientConfig, config } from './config';
+export { type ClientConfig, config } from './config';
 
 // PUBLIC API
 export { env } from './env';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -26,8 +26,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      if (Object.hasOwn(clientVirtualUserModuleMap, id)) {
-        const absPath = path.resolve(clientRootDir, clientVirtualUserModuleMap[id]);
+      const userModulePath = clientVirtualUserModuleMap[id];
+      if (userModulePath !== undefined) {
+        const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });
       }
       return null;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -26,7 +26,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      const userModulePath = clientVirtualUserModuleMap[id];
+      const userModulePath = Object.hasOwn(clientVirtualUserModuleMap, id)
+        ? clientVirtualUserModuleMap[id]
+        : undefined;
       if (userModulePath !== undefined) {
         const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
@@ -9,7 +9,7 @@ export { type ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { MiddlewareConfigFn } from './middleware/index.js'
+export { type MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -24,12 +24,8 @@
     "useUnknownInCatchVariables": false,
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
-    /*
-       We haven't adopted the following two properties yet.
-       Reference: https://github.com/wasp-lang/wasp/issues/2655
-    */
-    "noUncheckedIndexedAccess": false,
-    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
 
     /* DX */
     "declaration": true, // Allows users to consume the SDK as a library, enables autocomplete
@@ -39,32 +35,21 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // We haven't adopted this yet.
-    // Reference: https://github.com/wasp-lang/wasp/issues/2654
-    "resolveJsonModule": false,
-    /*
-       The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers. We disable it because parts of the SDK code
-       rely on such features. Since we build the SDK with TSC before bundling
-       it, these features don't cause problems.
-       More details in https://github.com/wasp-lang/wasp/issues/2150
-    */
-    "isolatedModules": false,
+    "resolveJsonModule": true,
+    // `isolatedModules` rejects code that single-file transpilers (like esbuild)
+    // can't handle. The SDK gets bundled, so it must not rely on such code.
+    "isolatedModules": true,
     // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
-      - We want to allow users to use extensionless and directory imports.
-      - We want users to import stuff from the SDK with `wasp/something`, and we
-        don't want to do extra processing on those imports (for now).
+      The SDK code uses extensionless relative imports and imports its own
+      modules through the `wasp/*` package exports. TSC emits those imports
+      as-is, and only a bundler can resolve them at runtime.
 
-      These requirements force us to bundle the SDK.
-
-      We currently bundle the SDK in a very hacky way (indirectly while bundling
-      the server and client): https://github.com/wasp-lang/wasp/issues/2150
-      Regardless of how we do it, the SDK code is eventually bundled, so this
-      `tsconfig.json` file must reflect that (which means `moduleResolution:
-      bundler`).
+      The SDK output is never run directly: it's bundled into the server and
+      the client (https://github.com/wasp-lang/wasp/issues/2150), so this
+      `tsconfig.json` must resolve modules the way a bundler does.
     */
     "moduleResolution": "bundler",
     /*

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -144,7 +144,7 @@
             "file",
             "sdk/wasp/client/index.ts"
         ],
-        "07647fefe4b9ae39febd371ad5ea8b93ac47d5e7033c1b2895ebc19c38fb3748"
+        "2c587febd5931faba120a4cf796c5d66bbbf7c054a29468534e7260f777f0244"
     ],
     [
         [
@@ -319,7 +319,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "1b3926387257ed4e1b45bd10fc6e490cead654d494376d61ee8af6ff4fd4e4ae"
+        "07f799d8b4ef282cbc5bd40474170c31da92c56460cdfcde86d59b487bb22958"
     ],
     [
         [
@@ -501,7 +501,7 @@
             "file",
             "sdk/wasp/server/index.ts"
         ],
-        "8c8ad2b3979c6940d2ab90b789ff847c1af1c1bc8d8541438cd9d210f6ff6e25"
+        "a0d0ff1c97a4bc52f78d0fac37d1470690984b5dc2284f37b65244e633608cd8"
     ],
     [
         [
@@ -578,7 +578,7 @@
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "2666354463bcaebc95c0971b618746b44e04856d7f61b06261c6f367dcdb1505"
+        "77c89a888d80cb15e8f7497dca2e9070c2bcc2bc167ad8823537117bf6995646"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -319,7 +319,7 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "07f799d8b4ef282cbc5bd40474170c31da92c56460cdfcde86d59b487bb22958"
+        "db4acaf6e01de4ad53a9c7fb75bff5da1809b99f88b4296a5a180ac3a9ef844f"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/index.ts
@@ -11,7 +11,7 @@ export enum HttpMethod {
 export type Route = { method: HttpMethod; path: string }
 
 // PUBLIC API
-export { ClientConfig, config } from './config';
+export { type ClientConfig, config } from './config';
 
 // PUBLIC API
 export { env } from './env';

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -26,8 +26,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      if (Object.hasOwn(clientVirtualUserModuleMap, id)) {
-        const absPath = path.resolve(clientRootDir, clientVirtualUserModuleMap[id]);
+      const userModulePath = clientVirtualUserModuleMap[id];
+      if (userModulePath !== undefined) {
+        const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });
       }
       return null;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -26,7 +26,9 @@ export function virtualUserModules(): Plugin {
       clientRootDir = config.root;
     },
     async resolveId(id, importer, options) {
-      const userModulePath = clientVirtualUserModuleMap[id];
+      const userModulePath = Object.hasOwn(clientVirtualUserModuleMap, id)
+        ? clientVirtualUserModuleMap[id]
+        : undefined;
       if (userModulePath !== undefined) {
         const absPath = path.resolve(clientRootDir, userModulePath);
         return this.resolve(absPath, importer, { ...options, skipSelf: true });

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
@@ -9,7 +9,7 @@ export { type ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { MiddlewareConfigFn } from './middleware/index.js'
+export { type MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -24,12 +24,8 @@
     "useUnknownInCatchVariables": false,
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
-    /*
-       We haven't adopted the following two properties yet.
-       Reference: https://github.com/wasp-lang/wasp/issues/2655
-    */
-    "noUncheckedIndexedAccess": false,
-    "noImplicitOverride": false,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
 
     /* DX */
     "declaration": true, // Allows users to consume the SDK as a library, enables autocomplete
@@ -39,32 +35,21 @@
     /* Modules */
     "module": "esnext",
     "esModuleInterop": true,
-    // We haven't adopted this yet.
-    // Reference: https://github.com/wasp-lang/wasp/issues/2654
-    "resolveJsonModule": false,
-    /*
-       The `isolatedModules` flag tells typescript to throw errors on code that
-       doesn't work with bundlers. We disable it because parts of the SDK code
-       rely on such features. Since we build the SDK with TSC before bundling
-       it, these features don't cause problems.
-       More details in https://github.com/wasp-lang/wasp/issues/2150
-    */
-    "isolatedModules": false,
+    "resolveJsonModule": true,
+    // `isolatedModules` rejects code that single-file transpilers (like esbuild)
+    // can't handle. The SDK gets bundled, so it must not rely on such code.
+    "isolatedModules": true,
     // We haven't adopted `verbatimModuleSyntax` yet.
     "verbatimModuleSyntax": false,
     "moduleDetection": "force", // Assume all files are modules
     /*
-      - We want to allow users to use extensionless and directory imports.
-      - We want users to import stuff from the SDK with `wasp/something`, and we
-        don't want to do extra processing on those imports (for now).
+      The SDK code uses extensionless relative imports and imports its own
+      modules through the `wasp/*` package exports. TSC emits those imports
+      as-is, and only a bundler can resolve them at runtime.
 
-      These requirements force us to bundle the SDK.
-
-      We currently bundle the SDK in a very hacky way (indirectly while bundling
-      the server and client): https://github.com/wasp-lang/wasp/issues/2150
-      Regardless of how we do it, the SDK code is eventually bundled, so this
-      `tsconfig.json` file must reflect that (which means `moduleResolution:
-      bundler`).
+      The SDK output is never run directly: it's bundled into the server and
+      the client (https://github.com/wasp-lang/wasp/issues/2150), so this
+      `tsconfig.json` must resolve modules the way a bundler does.
     */
     "moduleResolution": "bundler",
     /*


### PR DESCRIPTION
## Description

Turns on four `tsconfig.json` flags in the generated SDK that were marked as "not adopted yet" and fixes the handful of places that violated them:

- `noUncheckedIndexedAccess` (3 fixes: two `identities[0]` reads in `auth/user.ts`, one map lookup in the virtual user modules Vite plugin)
- `noImplicitOverride` (no code changes needed)
- `resolveJsonModule` (no code changes needed)
- `isolatedModules` (2 fixes: type re-exports in `client/index.ts` and `server/index.ts` now use `export type`). The user side already enforces this flag through the `tsconfig.src.json` validation, so the SDK is now consistent with it.

Also rewrites two outdated comments in the SDK `tsconfig.json`:

- The `moduleResolution: bundler` comment said the SDK depends on user code. It doesn't anymore. The real reason is that the SDK's own code uses extensionless relative imports and `wasp/*` self imports, and its output is only ever consumed by a bundler.
- The `isolatedModules` comment said parts of the SDK relied on non-isolated features. The only violations were the two re-exports above.

`verbatimModuleSyntax` is left off on purpose. It needs `import type` in 55 places across 32 files and is done in a follow-up PR.

Verified by running `tsc --noEmit` on the kitchen-sink SDK with the new config (0 errors) and by regenerating the e2e snapshots.

## Agreement

<!-- Select just one with [x] -->

- [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
- [x] A maintainer agreed on the approach beforehand: authored by a maintainer

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- Config and comment change, covered by the e2e snapshots. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
