### PR TITLE
Enable verbatimModuleSyntax in the SDK

### DIFF
--- a/waspc/data/Generator/templates/sdk/wasp/api/events.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/api/events.ts
@@ -1,4 +1,5 @@
-import mitt, { Emitter } from 'mitt';
+import mitt from 'mitt';
+import type { Emitter } from 'mitt';
 
 type ApiEvents = {
   // key: Event name

--- a/waspc/data/Generator/templates/sdk/wasp/auth/email/actions/signup.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/email/actions/signup.ts
@@ -2,7 +2,7 @@
 import { api, handleApiError } from '../../../api/index.js';
 import { SuccessResponseSchema } from '../../responseSchemas';
 {=# isEmailUserSignupFieldsDefined =}
-import { type UserEmailSignupFields } from '../../providers'
+import type { UserEmailSignupFields } from '../../providers'
 {=/ isEmailUserSignupFieldsDefined =}
 
 type EmailSignupData = {

--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/Auth.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/Auth.tsx
@@ -5,10 +5,10 @@ import styles from './Auth.module.css'
 import './internal/auth-styles.css'
 import { tokenObjToCSSVars } from "./internal/util"
 
-import {
-  type State,
-  type CustomizationOptions,
-  type AdditionalSignupFields,
+import type {
+  State,
+  CustomizationOptions,
+  AdditionalSignupFields,
 } from './types'
 import { LoginSignupForm } from './internal/common/LoginSignupForm'
 import { MessageError, MessageSuccess } from './internal/Message'

--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/Form.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/Form.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from "react";
 import styles from "./Form.module.css";
 import "./auth-styles.css";
 import { clsx } from "./util";

--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/Message.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/Message.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from "react";
 import styles from "./Message.module.css";
 import "./auth-styles.css";
 import { clsx } from "./util";

--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import { useForm, UseFormReturn } from 'react-hook-form'
+import { useForm, type UseFormReturn } from 'react-hook-form'
 import styles from './LoginSignupForm.module.css'
 import '../auth-styles.css'
 import { config } from '../../../../client/index.js'

--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/social/SocialButton.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/social/SocialButton.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from "react";
 import "../auth-styles.css";
 import { clsx } from "../util";
 import styles from "./SocialButton.module.css";

--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/util.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/internal/util.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from "react"
+import type { CSSProperties } from "react"
 
 export const clsx = (...classes: (string | undefined)[]) => {
   return classes.filter(Boolean).join(" ");

--- a/waspc/data/Generator/templates/sdk/wasp/auth/forms/types.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/forms/types.ts
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import { UseFormReturn, RegisterOptions } from 'react-hook-form'
+import type { UseFormReturn, RegisterOptions } from 'react-hook-form'
 import type { LoginSignupFormFields } from './internal/common/LoginSignupForm'
 
 // PRIVATE API

--- a/waspc/data/Generator/templates/sdk/wasp/auth/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/index.ts
@@ -6,4 +6,4 @@ export {
 } from './user.js'
 
 // PUBLIC API
-export { type AuthUser } from './user.js'
+export type { AuthUser } from './user.js'

--- a/waspc/data/Generator/templates/sdk/wasp/auth/useAuth.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/useAuth.ts
@@ -6,7 +6,7 @@ import { api, handleApiError } from '../api/index.js'
 import { HttpMethod } from '../client/index.js'
 import type { AuthUser, AuthUserData } from './user.js'
 import { makeAuthUserIfPossible } from './user.js'
-import { UseQueryResult } from '@tanstack/react-query'
+import type { UseQueryResult } from '@tanstack/react-query'
 
 // PUBLIC API
 export const getMe: Query<void, AuthUser | null> = createUserGetter()

--- a/waspc/data/Generator/templates/sdk/wasp/auth/user.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/user.ts
@@ -1,15 +1,15 @@
 {{={= =}=}}
-import {
-  type {= userEntityName =},
-  type {= authEntityName =},
-  type {= authIdentityEntityName =},
+import type {
+  {= userEntityName =},
+  {= authEntityName =},
+  {= authIdentityEntityName =},
 } from '../entities/index.js'
 import {
   type PossibleProviderData,
   type ProviderName,
   getProviderData,
 } from './providerData.js'
-import { Expand } from '../universal/types.js'
+import type { Expand } from '../universal/types.js'
 import { isNotNull } from '../universal/predicates.js'
 
 // PUBLIC API

--- a/waspc/data/Generator/templates/sdk/wasp/auth/username/actions/signup.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/auth/username/actions/signup.ts
@@ -1,7 +1,7 @@
 {{={= =}=}}
 import { api, handleApiError } from '../../../api/index.js'
 {=# isUsernameAndPasswordUserSignupFieldsDefined =}
-import { type UserUsernameAndPasswordSignupFields } from '../../providers'
+import type { UserUsernameAndPasswordSignupFields } from '../../providers'
 {=/ isUsernameAndPasswordUserSignupFieldsDefined =}
 
 type UsernameSignupData = {

--- a/waspc/data/Generator/templates/sdk/wasp/client/crud/operationsHelpers.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/crud/operationsHelpers.ts
@@ -1,9 +1,9 @@
-import { _Awaited, _ReturnType } from "../../universal/types";
+import type { _Awaited, _ReturnType } from "../../universal/types";
 import { useAction, useQuery } from "../operations";
 import type { ActionFor } from "../operations/actions/core";
 import type { ActionOptions } from "../operations/hooks";
 import type { QueryFor } from "../operations/queries/core";
-import { GenericBackendOperation } from "../operations/rpc";
+import type { GenericBackendOperation } from "../operations/rpc";
 
 // PRIVATE API
 export type UseQueryFor<Operation extends GenericBackendOperation> = (

--- a/waspc/data/Generator/templates/sdk/wasp/client/env.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/env.ts
@@ -1,6 +1,6 @@
 import type * as z from "zod";
 import { ensureEnvSchema } from "../env/validation";
-import { CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
+import { type CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
 
 // PUBLIC API
 export const env: z.infer<CompleteClientEnvSchema> = ensureEnvSchema(

--- a/waspc/data/Generator/templates/sdk/wasp/client/env/schema.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/env/schema.ts
@@ -1,6 +1,6 @@
 {{={= =}=}}
 import * as z from "zod"
-import { FromRegister } from "../../types/register";
+import type { FromRegister } from "../../types/register";
 {=# envValidationSchema.isDefined =}
 {=& envValidationSchema.importStatement =}
 {=/ envValidationSchema.isDefined =}

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/hooks.ts
@@ -1,14 +1,14 @@
 import {
-  QueryClient,
-  QueryKey,
+  type QueryClient,
+  type QueryKey,
   useQuery as rqUseQuery,
   useMutation,
-  UseMutationOptions,
+  type UseMutationOptions,
   useQueryClient,
-  UseQueryResult,
+  type UseQueryResult,
 } from "@tanstack/react-query";
 import { makeQueryCacheKey } from "./queries/core";
-import { Action, Query } from "./rpc";
+import type { Action, Query } from "./rpc";
 export { configureQueryClient } from "./queryClient";
 
 // PUBLIC API

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/index.ts
@@ -21,7 +21,7 @@ export {
     queryClientInitialized
 } from './queryClient'
 
-export {
+export type {
     // PUBLIC API
-    type QueryMetadata,
+    QueryMetadata,
 } from './rpc'

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/queries/core.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/queries/core.ts
@@ -1,4 +1,4 @@
-import { Route } from '../../index.js'
+import type { Route } from '../../index.js'
 import type { _Awaited, _ReturnType } from '../../../universal/types.js'
 import type {
   GenericBackendOperation,

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient, type QueryClientConfig } from '@tanstack/react-query'
 
 const defaultQueryClientConfig = {};
 

--- a/waspc/data/Generator/templates/sdk/wasp/client/operations/rpc.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/operations/rpc.ts
@@ -3,7 +3,7 @@ import type {
   _Awaited,
   _ReturnType
 } from "../../universal/types";
-import { type Route } from "../index";
+import type { Route } from "../index";
 
 // PRIVATE API (for SDK, should maybe be public, users define values of this
 // type).

--- a/waspc/data/Generator/templates/sdk/wasp/client/router/Link.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/router/Link.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Link as RouterLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterLinkProps = Parameters<typeof RouterLink>[0]
 

--- a/waspc/data/Generator/templates/sdk/wasp/client/router/NavLink.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/router/NavLink.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { NavLink as RouterNavLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterNavLinkProps = Parameters<typeof RouterNavLink>[0]
 

--- a/waspc/data/Generator/templates/sdk/wasp/client/test/vitest/helpers.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/test/vitest/helpers.tsx
@@ -1,12 +1,12 @@
-import { ReactElement, ReactNode } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { http, type HttpResponseResolver, type RequestHandler } from 'msw'
 import { setupServer, type SetupServer } from 'msw/node'
 import { BrowserRouter as Router } from 'react-router'
-import { render, RenderResult, cleanup } from '@testing-library/react'
+import { render, type RenderResult, cleanup } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeAll, afterEach, afterAll } from 'vitest'
-import { Query } from '../../operations/rpc.js'
-import { config, HttpMethod, Route } from '../../index.js'
+import type { Query } from '../../operations/rpc.js'
+import { config, HttpMethod, type Route } from '../../index.js'
 import { serialize } from '../../../core/serialization/index.js'
 
 // PRIVATE API

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import path from 'path'
 
 export function detectServerImports(): Plugin {

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/envFile.ts
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import { type Plugin, type UserConfig } from 'vite'
+import type { Plugin, UserConfig } from 'vite'
 import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,6 +1,6 @@
 {{={= =}=}}
 import path from "node:path";
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 import {
   getClientEntryTsxContent,
   getRoutesTsxContent,

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/wasp.ts
@@ -1,6 +1,7 @@
 {{={= =}=}}
-import { type PluginOption } from "vite";
-import react, { type Options as ReactOptions } from "@vitejs/plugin-react";
+import type { PluginOption } from "vite";
+import react from "@vitejs/plugin-react";
+import type { Options as ReactOptions } from "@vitejs/plugin-react";
 import ssr from "@wasp.sh/lib-vite-ssr";
 import { validateEnv } from "./validateEnv.js";
 import { envFile } from "./envFile.js";

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,6 +1,6 @@
 {{={= =}=}}
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import type { PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.

--- a/waspc/data/Generator/templates/sdk/wasp/client/webSocket/WebSocketProvider.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/webSocket/WebSocketProvider.tsx
@@ -1,6 +1,6 @@
 {{={= =}=}}
-import { createContext, useState, useEffect, Context, ReactNode } from 'react'
-import { io, Socket } from 'socket.io-client'
+import { createContext, useState, useEffect, type Context, type ReactNode } from 'react'
+import { io, type Socket } from 'socket.io-client'
 
 import { getSessionId } from '../../api/index.js'
 import { apiEventsEmitter } from '../../api/events.js'

--- a/waspc/data/Generator/templates/sdk/wasp/client/webSocket/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/webSocket/index.ts
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react'
-import { WebSocketContext, WebSocketContextValue } from './WebSocketProvider'
+import { WebSocketContext, type WebSocketContextValue } from './WebSocketProvider'
 import type {
   ClientToServerEvents,
   ServerToClientEvents,

--- a/waspc/data/Generator/templates/sdk/wasp/core/serialization/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/core/serialization/index.ts
@@ -1,6 +1,6 @@
 {{={= =}=}}
 import { deserialize, serialize } from "superjson"
-import { CustomSerializableJSONValue } from "./custom-register"
+import type { CustomSerializableJSONValue } from "./custom-register"
 
 {=# entitiesExist =}
 import "./prisma"

--- a/waspc/data/Generator/templates/sdk/wasp/entities/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/entities/index.ts
@@ -1,17 +1,17 @@
 {{={= =}=}}
-import {
+import type {
   {=# entities =}
-  type {= name =},
+  {= name =},
   {=/ entities =}
 } from "@prisma/client"
 
-export {
+export type {
   {=# entities =}
-  type {= name =},
+  {= name =},
   {=/ entities =}
   {=# isAuthEnabled =}
-  type {= authEntityName =},
-  type {= authIdentityEntityName =},
+  {= authEntityName =},
+  {= authIdentityEntityName =},
   {=/ isAuthEnabled =}
 } from "@prisma/client"
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/_types/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/_types/index.ts
@@ -1,16 +1,16 @@
 {{={= =}=}}
-import { type Expand } from '../../universal/types.js'
-import { type Request, type Response } from 'express'
-import {
-  type ParamsDictionary as ExpressParams,
-  type Query as ExpressQuery,
+import type { Expand } from '../../universal/types.js'
+import type { Request, Response } from 'express'
+import type {
+  ParamsDictionary as ExpressParams,
+  Query as ExpressQuery,
 } from 'express-serve-static-core'
 import { prisma } from '../index.js'
 {=# isAuthEnabled =}
-import { type AuthUser } from '../../auth/user.js'
+import type { AuthUser } from '../../auth/user.js'
 {=/ isAuthEnabled =}
-import { type _Entity } from './taggedEntities'
-import { type Payload } from '../../core/serialization/index.js'
+import type { _Entity } from './taggedEntities'
+import type { Payload } from '../../core/serialization/index.js'
 
 export * from "./taggedEntities"
 export * from "../../core/serialization/index.js"

--- a/waspc/data/Generator/templates/sdk/wasp/server/_types/taggedEntities.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/_types/taggedEntities.ts
@@ -4,11 +4,11 @@
 //
 // We must explicitly tag all entities with their name to avoid issues with
 // structural typing. See https://github.com/wasp-lang/wasp/pull/982 for details.
-import { 
-  type Entity, 
-  type EntityName,
+import type { 
+  Entity, 
+  EntityName,
   {=# entities =}
-  type {= name =},
+  {= name =},
   {=/ entities =}
 } from '../../entities/index.js'
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/api/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/api/index.ts
@@ -1,16 +1,16 @@
 {{={= =}=}}
 
-import { type ParamsDictionary as ExpressParams, type Query as ExpressQuery } from 'express-serve-static-core'
+import type { ParamsDictionary as ExpressParams, Query as ExpressQuery } from 'express-serve-static-core'
 
-import {
+import type {
   {=# allEntities =}
-  type {= internalTypeName =},
+  {= internalTypeName =},
   {=/ allEntities =}
   {=# shouldImportNonAuthenticatedApi =}
-  type Api,
+  Api,
   {=/ shouldImportNonAuthenticatedApi =}
   {=# shouldImportAuthenticatedApi =}
-  type AuthenticatedApi,
+  AuthenticatedApi,
   {=/ shouldImportAuthenticatedApi =}
 } from '../_types'
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/email/utils.ts
@@ -1,7 +1,7 @@
 {{={= =}=}}
 import { createJWT, TimeSpan } from '../jwt.js'
 import { emailSender } from '../../email/index.js';
-import { Email } from '../../email/core/types.js';
+import type { Email } from '../../email/core/types.js';
 import {
   createProviderId,
   updateAuthIdentityProviderData,
@@ -10,7 +10,7 @@ import {
   type EmailProviderData,
 } from '../utils.js';
 import { config as waspServerConfig } from '../../index.js';
-import { type {= userEntityUpper =}, type {= authEntityUpper =} } from '../../../entities/index.js'
+import type { {= userEntityUpper =}, {= authEntityUpper =} } from '../../../entities/index.js'
 
 // PUBLIC API
 export async function createEmailVerificationLink(

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/hooks.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/hooks.ts
@@ -1,8 +1,8 @@
 {{={= =}=}}
 import type { Request as ExpressRequest } from 'express'
-import { type ProviderId, type CreateUserResult, type FindAuthWithUserResult } from './utils.js'
+import type { ProviderId, CreateUserResult, FindAuthWithUserResult } from './utils.js'
 import { prisma } from '../index.js'
-import { Expand } from '../../universal/types.js'
+import type { Expand } from '../../universal/types.js'
 
 // PUBLIC API
 export type OnBeforeSignupHook = (

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/lucia.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/lucia.ts
@@ -2,7 +2,7 @@
 import { Lucia } from "lucia";
 import { PrismaAdapter } from "@lucia-auth/adapter-prisma";
 import { prisma } from '../index.js'
-import { type {= userEntityUpper =} } from "../../entities/index.js"
+import type { {= userEntityUpper =} } from "../../entities/index.js"
 
 const prismaAdapter = new PrismaAdapter(
   prisma.{= sessionEntityLower =},

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/oauth/provider.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/oauth/provider.ts
@@ -1,4 +1,4 @@
-import { OAuth2Provider, OAuth2ProviderWithPKCE } from "arctic";
+import type { OAuth2Provider, OAuth2ProviderWithPKCE } from "arctic";
 
 export function defineProvider<
   OAuthClient extends OAuth2Provider | OAuth2ProviderWithPKCE,

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/session.ts
@@ -1,8 +1,8 @@
 {{={= =}=}}
-import { Request as ExpressRequest } from "express";
+import type { Request as ExpressRequest } from "express";
 
-import { type {= userEntityUpper =} } from '../../entities/index.js';
-import { type AuthUserData } from '../../auth/user.js';
+import type { {= userEntityUpper =} } from '../../entities/index.js';
+import type { AuthUserData } from '../../auth/user.js';
 
 import { auth } from "./lucia.js";
 import type { Session } from "lucia";

--- a/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/auth/utils.ts
@@ -2,10 +2,10 @@
 import { hashPassword } from './password.js'
 import { prisma, HttpError } from '../index.js'
 import { sleep } from '../utils.js'
-import {
-  type {= userEntityUpper =},
-  type {= authEntityUpper =},
-  type {= authIdentityEntityUpper =},
+import type {
+  {= userEntityUpper =},
+  {= authEntityUpper =},
+  {= authIdentityEntityUpper =},
 } from '../../entities/index.js'
 import { Prisma } from '@prisma/client';
 
@@ -18,7 +18,7 @@ import {
   providerDataHasPasswordField,
 } from '../../auth/providerData.js'
 
-import { type UserSignupFields, type PossibleUserFields } from '../../auth/providers/types.js'
+import type { UserSignupFields, PossibleUserFields } from '../../auth/providers/types.js'
 
 // Runtime-agnostic provider data code, re-exported here because it's part of
 // the server-side auth API surface (e.g. through `wasp/server/auth`).

--- a/waspc/data/Generator/templates/sdk/wasp/server/email/core/helpers.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/email/core/helpers.ts
@@ -1,5 +1,5 @@
 {{={= =}=}}
-import { EmailFromField } from "./types";
+import type { EmailFromField } from "./types";
 
 // PRIVATE API
 // Formats an email address and an optional name into a string that can be used

--- a/waspc/data/Generator/templates/sdk/wasp/server/email/core/providers/dummy.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/email/core/providers/dummy.ts
@@ -1,5 +1,5 @@
 import { getDefaultFromField } from "../helpers.js";
-import { DummyEmailProvider, EmailSender } from "../types";
+import type { DummyEmailProvider, EmailSender } from "../types";
 
 import { colorize } from "../../../../universal/ansiColors.js";
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/email/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/email/index.ts
@@ -1,7 +1,7 @@
 {{={= =}=}}
 import { env } from '../env.js';
 import { initEmailSender } from "./core/index.js";
-import { EmailSender } from "./core/types.js";
+import type { EmailSender } from "./core/types.js";
 
 {=# isSmtpProviderEnabled =}
 const emailProvider = { 

--- a/waspc/data/Generator/templates/sdk/wasp/server/env.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/env.ts
@@ -1,7 +1,7 @@
 {{={= =}=}}
 import * as z from "zod"
 import { ensureEnvSchema } from "../env/validation"
-import { FromRegister } from "../types/register";
+import type { FromRegister } from "../types/register";
 {=# envValidationSchema.isDefined =}
 {=& envValidationSchema.importStatement =}
 {=/ envValidationSchema.isDefined =}

--- a/waspc/data/Generator/templates/sdk/wasp/server/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/index.ts
@@ -5,11 +5,11 @@ export { default as config } from './config.js'
 // PUBLIC API
 export { default as prisma, type PrismaClient } from './dbClient.js'
 // PUBLIC API
-export { type ServerSetupFn } from './types/index.js'
+export type { ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { type MiddlewareConfigFn } from './middleware/index.js'
+export type { MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/index.ts
@@ -1,3 +1,3 @@
-export { type JobFn } from './types'
+export type { JobFn } from './types'
 export { registerJob, createJobDefinition } from './pgBossJob.js'
 export { startPgBoss } from './pgBoss.js'

--- a/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/pgBossJob.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/pgBossJob.ts
@@ -2,7 +2,7 @@ import PgBoss from 'pg-boss'
 import { pgBossStarted } from './pgBoss.js'
 import { Job, SubmittedJob } from '../job.js'
 import type { JSONValue, JSONObject } from '../../../../core/serialization/index.js'
-import { PrismaDelegate } from '../../../_types/index.js'
+import type { PrismaDelegate } from '../../../_types/index.js'
 import type { JobFn } from './types.js'
 
 export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')

--- a/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/types.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/jobs/core/pgBoss/types.ts
@@ -1,4 +1,4 @@
-import { PrismaDelegate } from '../../../_types/index.js'
+import type { PrismaDelegate } from '../../../_types/index.js'
 import type { JSONValue, JSONObject } from '../../../../core/serialization/index.js'
 
 // PRIVATE API

--- a/waspc/data/Generator/templates/sdk/wasp/server/middleware/globalMiddleware.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/middleware/globalMiddleware.ts
@@ -1,4 +1,4 @@
-import { type RequestHandler } from 'express'
+import type { RequestHandler } from 'express'
 
 // PUBLIC API
 export type MiddlewareConfigFn = (middlewareConfig: MiddlewareConfig) => MiddlewareConfig

--- a/waspc/data/Generator/templates/sdk/wasp/server/operations/actions/types.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/operations/actions/types.ts
@@ -1,17 +1,17 @@
 {{={= =}=}}
 {=! TODO: This template is exactly the same at the moment as one for query
           types, consider whether it makes sense to address this in the future. =}
-import {
+import type {
   {=# allEntities =}
-  type {= internalTypeName =},
+  {= internalTypeName =},
   {=/ allEntities =}
   {=# shouldImportNonAuthenticatedOperation =}
-  type UnauthenticatedActionDefinition,
+  UnauthenticatedActionDefinition,
   {=/ shouldImportNonAuthenticatedOperation =}
   {=# shouldImportAuthenticatedOperation =}
-  type AuthenticatedActionDefinition,
+  AuthenticatedActionDefinition,
   {=/ shouldImportAuthenticatedOperation =}
-  type Payload,
+  Payload,
 } from '../../_types/index.js'
 
 {=# operations =}

--- a/waspc/data/Generator/templates/sdk/wasp/server/operations/queries/types.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/operations/queries/types.ts
@@ -2,17 +2,17 @@
 {=! TODO: This template is exactly the same at the moment as one for action
           types, consider whether it makes sense to address this in the future. =}
 
-import {
+import type {
   {=# allEntities =}
-  type {= internalTypeName =},
+  {= internalTypeName =},
   {=/ allEntities =}
   {=# shouldImportNonAuthenticatedOperation =}
-  type UnauthenticatedQueryDefinition,
+  UnauthenticatedQueryDefinition,
   {=/ shouldImportNonAuthenticatedOperation =}
   {=# shouldImportAuthenticatedOperation =}
-  type AuthenticatedQueryDefinition,
+  AuthenticatedQueryDefinition,
   {=/ shouldImportAuthenticatedOperation =}
-  type Payload,
+  Payload,
 } from '../../_types/index.js'
 
 {=# operations =}

--- a/waspc/data/Generator/templates/sdk/wasp/server/operations/wrappers.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/operations/wrappers.ts
@@ -1,10 +1,10 @@
 {{={= =}=}}
-import { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
+import type { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
 
 {=# isAuthEnabled =}
-import { type AuthUser } from '../../auth/user.js'
+import type { AuthUser } from '../../auth/user.js'
 {=/ isAuthEnabled =}
-import {
+import type {
   _Entity,
   {=# isAuthEnabled =}
   AuthenticatedOperationDefinition,

--- a/waspc/data/Generator/templates/sdk/wasp/server/types/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/types/index.ts
@@ -1,5 +1,5 @@
-import { type Application } from 'express'
-import { Server } from 'http'
+import type { Application } from 'express'
+import type { Server } from 'http'
 
 // PUBLIC API
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>

--- a/waspc/data/Generator/templates/sdk/wasp/server/utils.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/utils.ts
@@ -1,8 +1,8 @@
 {{={= =}=}}
-import { Response, RequestHandler } from 'express'
+import type { Response, RequestHandler } from 'express'
 
 {=# isAuthEnabled =}
-import { type AuthUserData } from '../auth/user.js'
+import type { AuthUserData } from '../auth/user.js'
 {=/ isAuthEnabled =}
 
 // This is explicitly how Express expects extensions to their

--- a/waspc/data/Generator/templates/sdk/wasp/server/webSocket/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/webSocket/index.ts
@@ -1,12 +1,12 @@
 {{={= =}=}}
 
-import { Server } from 'socket.io'
-import { EventsMap, DefaultEventsMap } from '@socket.io/component-emitter'
+import type { Server } from 'socket.io'
+import type { EventsMap, DefaultEventsMap } from '@socket.io/component-emitter'
 
-import { prisma } from '../index'
+import type { prisma } from '../index'
 import type { FromRegister } from '../../types/register'
 {=# isAuthEnabled =}
-import { type AuthUser } from '../../auth/user.js'
+import type { AuthUser } from '../../auth/user.js'
 {=/ isAuthEnabled =}
 
 

--- a/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
+++ b/waspc/data/Generator/templates/sdk/wasp/tsconfig.json
@@ -39,8 +39,9 @@
     // `isolatedModules` rejects code that single-file transpilers (like esbuild)
     // can't handle. The SDK gets bundled, so it must not rely on such code.
     "isolatedModules": true,
-    // We haven't adopted `verbatimModuleSyntax` yet.
-    "verbatimModuleSyntax": false,
+    // `verbatimModuleSyntax` makes type-only imports explicit, so single-file
+    // transpilers can drop them without having to know what they refer to.
+    "verbatimModuleSyntax": true,
     "moduleDetection": "force", // Assume all files are modules
     /*
       The SDK code uses extensionless relative imports and imports its own

--- a/waspc/data/Generator/templates/sdk/wasp/types/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/types/index.ts
@@ -1,1 +1,1 @@
-export { type Register } from "./register";
+export type { Register } from "./register";

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/.waspchecksums
@@ -46,7 +46,7 @@
             "file",
             "sdk/wasp/api/events.ts"
         ],
-        "91ec1889f649b608ca81cab8f048538b9dcc70f49444430b1e5b572af2a4970a"
+        "a49e9e7d605b95e741720fd26bfc264e5930ff148a6b5d0739019b32dc441935"
     ],
     [
         [
@@ -74,7 +74,7 @@
             "file",
             "sdk/wasp/auth/email/actions/signup.ts"
         ],
-        "7269867432c12155e9d61039d62f6e55a36baf8da9e08d36e62574323e15510b"
+        "ef1dff6c381802c434657bbef3c8386aba0cb343be5d1f420c7c8268360974dc"
     ],
     [
         [
@@ -102,7 +102,7 @@
             "file",
             "sdk/wasp/auth/forms/Auth.tsx"
         ],
-        "785bac055550f92ce94b9457dd157a2a59e298081791ccff98b11c29162408e9"
+        "3a516c4b84f0e825dc173b4852c0b7fe9e27ad1480b6564cf24d4e844b33eb59"
     ],
     [
         [
@@ -151,7 +151,7 @@
             "file",
             "sdk/wasp/auth/forms/internal/Form.tsx"
         ],
-        "5978aa2474e051a44f5bd0de00daf1ecb2b324e42b40e6d0c01223dbaa7f394e"
+        "40614345f7bf97c5e26aeabec0a7dda3bcccdb9169dbc31703760740042cbd2c"
     ],
     [
         [
@@ -165,7 +165,7 @@
             "file",
             "sdk/wasp/auth/forms/internal/Message.tsx"
         ],
-        "97bfac81743b6a042d89dfda961c0a2a2e18732e34446d7acd4b7d2bf68bc766"
+        "783cdd46b94766d80867105c95514aadeb0fc7d1495f2cea07d78d67df132e37"
     ],
     [
         [
@@ -186,7 +186,7 @@
             "file",
             "sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx"
         ],
-        "2accd8d7e5f95f9374f86f0bfd30c3576e7e55c7a544248fb528451a8dea45fa"
+        "7fbf5b5371bd0e0154732de5719c86da23691315601c10667bd1050c41baaf40"
     ],
     [
         [
@@ -235,7 +235,7 @@
             "file",
             "sdk/wasp/auth/forms/internal/social/SocialButton.tsx"
         ],
-        "9ababf450d1b711d96a336e9f55fcda99d45d0e9eb02bec246a8099228fc3f3e"
+        "3fb787cceaa352783ab6a4f6451e7eca9213ad6aca647eaeaa08376dc5062552"
     ],
     [
         [
@@ -256,14 +256,14 @@
             "file",
             "sdk/wasp/auth/forms/internal/util.ts"
         ],
-        "fa426b618af2e95dd5dc1e5646cc302d85b04128db07b8c0f66aa75eaa227e27"
+        "e46a06159653ed13cb40f929b1bb55be06f2c0d0ea7f93fe6a436b896571b68d"
     ],
     [
         [
             "file",
             "sdk/wasp/auth/forms/types.ts"
         ],
-        "4cc8525de62fe00cdb13b6609556c9fc29693baaf75d707a37585e0f2bf5a407"
+        "5eed85b0c8504495a86e0a84a03b7e372a294b2942fb4dff22dbcc5bd809c26d"
     ],
     [
         [
@@ -312,7 +312,7 @@
             "file",
             "sdk/wasp/auth/index.ts"
         ],
-        "90f6f7d09ae61b0cd0c4cc8ef11b459effaea28f01bc2a01b37055abe8533633"
+        "318a6569cf9622966c0a918736d24733d54b6db70653d34e1358d53a5dab99fa"
     ],
     [
         [
@@ -361,14 +361,14 @@
             "file",
             "sdk/wasp/auth/useAuth.ts"
         ],
-        "92b1c488d23c4793c1f6b25c7508f53b7afcb197b43dcf10d04ca628f25a99ec"
+        "4921218cee38ed738c3e1738e6cf2ca147f30e57ce3a0f02aa0e00aafa50a16a"
     ],
     [
         [
             "file",
             "sdk/wasp/auth/user.ts"
         ],
-        "89eab5d82f24bbb85cefbc2188a93d4113b6be1d826610ed7858ed28e04f9ccb"
+        "4e9595a5b04039a7674dcd4ef50da477ad7c8474d05a0b5d68e0d0a54dd37e6c"
     ],
     [
         [
@@ -529,7 +529,7 @@
             "file",
             "sdk/wasp/client/crud/operationsHelpers.ts"
         ],
-        "0ddc2233bcb6f8bd9e35538051483e870a74f74af3065fcc7d6d4201bd34311f"
+        "0492a79b164046a8a303a1e6959ae52df55d57d31fc83582185af6650e556879"
     ],
     [
         [
@@ -550,14 +550,14 @@
             "file",
             "sdk/wasp/client/env.ts"
         ],
-        "376a0376f927458a3052eee04d5ac0f4c6ace0daaa4f4016900df382839fdf59"
+        "a802c9a4d7cf15d376de7e7dbb8fd54094f946e822105f1d09c202f85f2049ab"
     ],
     [
         [
             "file",
             "sdk/wasp/client/env/schema.ts"
         ],
-        "1a16dc0140ac369f9effdfc7ddbbc701c8f486e876199b0effca8b921e88d970"
+        "9a7a95fdf48290d8fde2feff991f5ad143c8cee7f1c88aa1f172cf99a560b8a8"
     ],
     [
         [
@@ -592,14 +592,14 @@
             "file",
             "sdk/wasp/client/operations/hooks.ts"
         ],
-        "d2016f949fb6915b1b05e96020f4aba285f5e48bbcd6a4b26462b1f93302c8d2"
+        "9c22f453fb7abaeca08f48c7fdf7650b23610cfa16038b86851d4117bb6f46ad"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "c96965e460ada3ad0369ed17a0dc8ebce623781ba02ab8059e61856024d12df2"
+        "751e3c6788618cc77c412b3b0f2fb6f4f856d6d2d297484a75c95abf4a9cffd2"
     ],
     [
         [
@@ -627,7 +627,7 @@
             "file",
             "sdk/wasp/client/operations/queries/core.ts"
         ],
-        "63e324b622637513d40c0e3404c42cfbee665d7804a8f459036efeaa376f21d6"
+        "cf0cbee66bea7789d5eeac5798495c7f22f15868400bf0b6bab9c95d31bfe2ff"
     ],
     [
         [
@@ -641,28 +641,28 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "c32437fb349592ee41ab8d85aa0a92174e6eb7bf831cc63a0c3719c9cecd6343"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/rpc.ts"
         ],
-        "3b2c5f4ed90150f21da899cccc23c0aef42030db2f0171e56f28f0f016e25bc9"
+        "746c76905061b5d066cd3909a6cf7699cd57aa8ee17d04e3bad3d67e8c57483a"
     ],
     [
         [
             "file",
             "sdk/wasp/client/router/Link.tsx"
         ],
-        "d1a6f48d96f50b2900324f221f1fafa70a04bc9b5bba7d1dc78ffebfb7d2704b"
+        "504c73de9596bcf394d91b5bf3fc9078af5e461713b716a3155a918c9da03069"
     ],
     [
         [
             "file",
             "sdk/wasp/client/router/NavLink.tsx"
         ],
-        "22f7b0a0000fc53091f7a281feb025ea80f8a279bf2d21a2be3531d0c5b202ab"
+        "bcedb44395e0dced4009e5e4a8dffa18660b4bb81dec106a33407c454dedb991"
     ],
     [
         [
@@ -704,7 +704,7 @@
             "file",
             "sdk/wasp/client/test/vitest/helpers.tsx"
         ],
-        "f13f830a28370dc6038a5f69ce61b371530f776a407210b513daccb327bb8257"
+        "aafd398af585df12a06cb8f5ec5eb09a2f5db2deed01b257177566d43a42f704"
     ],
     [
         [
@@ -718,21 +718,21 @@
             "file",
             "sdk/wasp/client/vite/plugins/detectServerImports.ts"
         ],
-        "93885302fbb1758384e990fb6a7eac52fa03459f4df66a2b59eb8ac7b3e5c14a"
+        "af2157c5a71b7409055dd53094bdf33646ba2284fd3aaffad830489fecb06d79"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/envFile.ts"
         ],
-        "0fafefac0b8c9ecfa0cac06f13e084ac8e1661d8fbead6e2d8b2bc7a08c9b035"
+        "3bb6ae4f102a9fd9638669bac42e3c01d69bf9a6a26685d2debd9c4f19ce1af3"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
+        "1a144dffe58e7eab72b88edb64dd44220b63b09b902d51f1b6f92331fe3089e7"
     ],
     [
         [
@@ -746,28 +746,28 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "3a17c4a54a21024550e115199f9c668b48cfd35aaadca1327b16a5a1d4e823e3"
+        "fe4042c620847a52e52412cc9e71ad5af566fe5b427eed6ac16283d33dbbec20"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualWaspModules.ts"
         ],
-        "4aede5b77417f38713a8f8b72b119d8a060e1ef1984945ceca249119b528b38a"
+        "7988c7fa950d788a355cd82ad1a4577d43853aef7b302e81341e83e01d83c6ef"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "40bc5a0bef08825ad32026a8639e4f84d994e45ffc6ef81f0474038b0570d1e4"
+        "397b9226a3e28e6e6e3fff4e5a019f8f30ccf4b59f42f0bc52dc7928bf4703d9"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "e8fb2bdec48dc07ca7d01dd800adef26b6caee924dd0600662aa191f7f3e24ef"
+        "7e63f5649c418c88d69204313b0a31d40dce6a6037394dde01cf806d2b672eab"
     ],
     [
         [
@@ -809,14 +809,14 @@
             "file",
             "sdk/wasp/client/webSocket/WebSocketProvider.tsx"
         ],
-        "b89c0fb456aea6b6d48dc2f4f9ecf7fb17ddc1440290857082bd5dfa5d15b915"
+        "7bbbf383104dac926e3d14cc2dc03f4b6d2aa4438cd75d945bc898cd2d4b9eb3"
     ],
     [
         [
             "file",
             "sdk/wasp/client/webSocket/index.ts"
         ],
-        "a48ec69ffbaf2040158bb5ff6d2a687b6a7337c4587f73c7c2c0d3ec1d0218b0"
+        "a56613e84d1aad09e452b56263899a46d5627ccc4fd7ffd675496b5eff36f1da"
     ],
     [
         [
@@ -830,7 +830,7 @@
             "file",
             "sdk/wasp/core/serialization/index.ts"
         ],
-        "daaf6d88944b11969bcf278b84409b3ca81dc2f3cc97037df3ebc7f293381a74"
+        "329b29145a4e13a1278295fccc2f0c293b4b9975a10e2fb00423d288c9e89984"
     ],
     [
         [
@@ -851,7 +851,7 @@
             "file",
             "sdk/wasp/entities/index.ts"
         ],
-        "298f7b575e383e5d8876251525bc6e260368d41e4a77c37f3280ec45ef85c475"
+        "a2b7958d5f56751ef0d23e0fa0d63ade50529357890276253137dbf43a6e0fa2"
     ],
     [
         [
@@ -907,21 +907,21 @@
             "file",
             "sdk/wasp/server/_types/index.ts"
         ],
-        "fe2cf43274c573c351eb2fb6b377bea7a3ee3f244393f75687309d22042c602b"
+        "9e763458901936f7aea5e3450fca826d46827bd0ebf49689a82c61ed333227ab"
     ],
     [
         [
             "file",
             "sdk/wasp/server/_types/taggedEntities.ts"
         ],
-        "843840cc3556364d96272ccc45b73cf0ae30e2e787307b2c31928dbfea85c8cc"
+        "c0d607cf701a2f63c3e1db5fd9ece79e9c06c1f8f6586368825361d7d8fcf4a1"
     ],
     [
         [
             "file",
             "sdk/wasp/server/api/index.ts"
         ],
-        "e65877814b7326bb5abaa6f6f0f72ab21577188b861121722e6c595024d76265"
+        "854265daab2c2ac31ba4cf2ee031e898578b889b4fa3574c673c8b48625d8df9"
     ],
     [
         [
@@ -935,14 +935,14 @@
             "file",
             "sdk/wasp/server/auth/email/utils.ts"
         ],
-        "fbfb680c1cfb964be0893f681a7c72150d97631ce1c19bd0543df6903e22b5da"
+        "daa2a6d2f6d8bfc76d772796b96c43825b7dbe31253fbd14a39eaeb17b16bf4c"
     ],
     [
         [
             "file",
             "sdk/wasp/server/auth/hooks.ts"
         ],
-        "9ce8ef2582a86b3bc4301f26b7327f38952fc3b4fec7c4930440cac2484475d8"
+        "679a83b558778fae3685a3694193199454ba31687c7daa1b0bd00f892ee5c1f1"
     ],
     [
         [
@@ -963,7 +963,7 @@
             "file",
             "sdk/wasp/server/auth/lucia.ts"
         ],
-        "2d517314735c150c0928a38eaf47329bb9c5b4b4e4d7b5deb6ee8f14fc97422c"
+        "b734bbf7137131e6786f69afddf5941f9947b8c2cae617203a208255f01f8c9b"
     ],
     [
         [
@@ -984,7 +984,7 @@
             "file",
             "sdk/wasp/server/auth/oauth/provider.ts"
         ],
-        "5b913ae922e7a2b409c06e84687786ade16694522b85b36a1ca11d365414f6bc"
+        "a2571df5a40ebaa55f620aa0293fedb36af2115f4f003c76e4a0a301a89a706f"
     ],
     [
         [
@@ -1040,14 +1040,14 @@
             "file",
             "sdk/wasp/server/auth/session.ts"
         ],
-        "eef71ef3254da456d6c27c0307a0d382d281ec6c7c56503f78c02d0980da478e"
+        "a92ada66d570e566fbc9f8e9e19310029e4bb326c9c7913e9b9c37765adc9f47"
     ],
     [
         [
             "file",
             "sdk/wasp/server/auth/utils.ts"
         ],
-        "5b9841dab9d3247727b5c7c74c5a0b11ac29a419e7571211483af1200fe825bc"
+        "1eba2f9bd32b7bad8d1ee2f8ea6c58d5790163fdf7c39b8e16ede426db3cf0a2"
     ],
     [
         [
@@ -1096,7 +1096,7 @@
             "file",
             "sdk/wasp/server/email/core/helpers.ts"
         ],
-        "089df47a3b576925954fe07c60e5d98fbc55db40f0c6f561a9c0445459c54c1c"
+        "2debda50d7fd3e784460bde21075ce1f917a6a4745c0d3f7844206aec1acf25d"
     ],
     [
         [
@@ -1124,21 +1124,21 @@
             "file",
             "sdk/wasp/server/email/index.ts"
         ],
-        "5815f706767a91c23ef4d889a4a4ab322e9bad0c31bdc39bf51668b5745e7b0e"
+        "7256d9a0a432e173f2614dfd30c6b166b5f3cc907e5efb3c660f5d6f5575fcd3"
     ],
     [
         [
             "file",
             "sdk/wasp/server/env.ts"
         ],
-        "a9d7f86795e9e3db31f77e2690137f47928eeefb7c2db716bed9c15257757876"
+        "2065edeea102329ac346f01bdc8155453aa9d400bf71e6678a9d37132240888a"
     ],
     [
         [
             "file",
             "sdk/wasp/server/index.ts"
         ],
-        "a0d0ff1c97a4bc52f78d0fac37d1470690984b5dc2284f37b65244e633608cd8"
+        "1436713aa5119623c6384d8b399da9ee19c29a2441974cf5c6f9d674446581de"
     ],
     [
         [
@@ -1152,7 +1152,7 @@
             "file",
             "sdk/wasp/server/jobs/core/pgBoss/index.ts"
         ],
-        "ba33f9b0680dd2a6fdea55c2eb8f8163ad60f4ebbac8b459d5c1a2a708524bec"
+        "1755f90efa9a3e2f6b4ed892a77aa60f68e51a57b424342c61e3c3d1f1de2f75"
     ],
     [
         [
@@ -1166,14 +1166,14 @@
             "file",
             "sdk/wasp/server/jobs/core/pgBoss/pgBossJob.ts"
         ],
-        "5e8b2278584065be0d0b42bb311d00158cc72a96520eafcb77b60b53ba16a76f"
+        "3b1e3f1f3f2d345a10a043e9d637987755b5a79c51ccce85e0d2d1220023cceb"
     ],
     [
         [
             "file",
             "sdk/wasp/server/jobs/core/pgBoss/types.ts"
         ],
-        "4f3342c859170b73b6973374722781d711094159a7e9401b1e768bc2264a933e"
+        "7db5d1e42543a68f413bfc0c7770812b0b926ecb96a2b227d4b97393e9363cda"
     ],
     [
         [
@@ -1208,7 +1208,7 @@
             "file",
             "sdk/wasp/server/middleware/globalMiddleware.ts"
         ],
-        "53f258be83ca6de653b6b645253ce573e3c177e88017eb2adb17f5d3cebb36c3"
+        "ab20883dd155b8a66f8535a4ad1f532c2d89702fa750b3cd91ad79bc76a780c7"
     ],
     [
         [
@@ -1229,7 +1229,7 @@
             "file",
             "sdk/wasp/server/operations/actions/types.ts"
         ],
-        "c039716c099edfdab89b3ffde5cff73326aaaa652994cecaef62374407740f35"
+        "464460c8e258f7d40ff74106a5e157e5dadba0fa9020c716e454212e6ad3cbba"
     ],
     [
         [
@@ -1250,49 +1250,49 @@
             "file",
             "sdk/wasp/server/operations/queries/types.ts"
         ],
-        "8628743fcad9b0b8ebb210439efe3039d9b7987cff3b3d32b99bb5c374f221d7"
+        "706169ea75c2b60aec702e6f5ab2cee3ed9a44b5987b866880f0e88a15d2e6b1"
     ],
     [
         [
             "file",
             "sdk/wasp/server/operations/wrappers.ts"
         ],
-        "d432a04339fd8f26de89613fbd0661153b2b87e29b7e85a2e0cd4cf730cedfcc"
+        "4625b9308cbb21408a534a3cdddc437a01ca241a234b55ad2f5a702bedc51a0e"
     ],
     [
         [
             "file",
             "sdk/wasp/server/types/index.ts"
         ],
-        "0f2ffdfdd76c92084bd0ba270b674628ec907da0d047de6c8a9912e415462d97"
+        "0999c392608eb58a61adff654975e6b930f55bcf1f94a1c66618c2376f6fc23e"
     ],
     [
         [
             "file",
             "sdk/wasp/server/utils.ts"
         ],
-        "94c40a06e9fa1975720538e5444ebf2db3feaf394bedd4c44888594918c35f23"
+        "f9f55d4702ac173287d4af17327546cee87e039f03ddfad41343565f20f71ec1"
     ],
     [
         [
             "file",
             "sdk/wasp/server/webSocket/index.ts"
         ],
-        "2f77950c04e7125527d3841a9ba14236b91d7b2dbda24993e37a063593420fa2"
+        "f5f38234f2e6955ae5dc8868c4e1f2c3c8a6dad626192864f0b8e199db31f1e4"
     ],
     [
         [
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "77c89a888d80cb15e8f7497dca2e9070c2bcc2bc167ad8823537117bf6995646"
+        "4da3a72edc3cf3f967aa7148ab59b690cde5931a0f15b5106137d0d49bea3f12"
     ],
     [
         [
             "file",
             "sdk/wasp/types/index.ts"
         ],
-        "0edc8cb5f3980c49a2bdc1a1e0a02ad2dda877e1bba1533198d9168b24527555"
+        "ac77b944feeb257d8764e38501dbfcf0f1f0724788f10e9c4acf29a4b92b45fe"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/api/events.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/api/events.ts
@@ -1,4 +1,5 @@
-import mitt, { Emitter } from 'mitt';
+import mitt from 'mitt';
+import type { Emitter } from 'mitt';
 
 type ApiEvents = {
   // key: Event name

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/email/actions/signup.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/email/actions/signup.ts
@@ -1,6 +1,6 @@
 import { api, handleApiError } from '../../../api/index.js';
 import { SuccessResponseSchema } from '../../responseSchemas';
-import { type UserEmailSignupFields } from '../../providers'
+import type { UserEmailSignupFields } from '../../providers'
 
 type EmailSignupData = {
   email: string

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/Auth.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/Auth.tsx
@@ -4,10 +4,10 @@ import styles from './Auth.module.css'
 import './internal/auth-styles.css'
 import { tokenObjToCSSVars } from "./internal/util"
 
-import {
-  type State,
-  type CustomizationOptions,
-  type AdditionalSignupFields,
+import type {
+  State,
+  CustomizationOptions,
+  AdditionalSignupFields,
 } from './types'
 import { LoginSignupForm } from './internal/common/LoginSignupForm'
 import { MessageError, MessageSuccess } from './internal/Message'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/Form.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/Form.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from "react";
 import styles from "./Form.module.css";
 import "./auth-styles.css";
 import { clsx } from "./util";

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/Message.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/Message.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from "react";
 import styles from "./Message.module.css";
 import "./auth-styles.css";
 import { clsx } from "./util";

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/common/LoginSignupForm.tsx
@@ -1,4 +1,4 @@
-import { useForm, UseFormReturn } from 'react-hook-form'
+import { useForm, type UseFormReturn } from 'react-hook-form'
 import styles from './LoginSignupForm.module.css'
 import '../auth-styles.css'
 import { config } from '../../../../client/index.js'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/social/SocialButton.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/social/SocialButton.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ComponentRef, forwardRef } from "react";
+import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from "react";
 import "../auth-styles.css";
 import { clsx } from "../util";
 import styles from "./SocialButton.module.css";

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/util.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/internal/util.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from "react"
+import type { CSSProperties } from "react"
 
 export const clsx = (...classes: (string | undefined)[]) => {
   return classes.filter(Boolean).join(" ");

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/forms/types.ts
@@ -1,4 +1,4 @@
-import { UseFormReturn, RegisterOptions } from 'react-hook-form'
+import type { UseFormReturn, RegisterOptions } from 'react-hook-form'
 import type { LoginSignupFormFields } from './internal/common/LoginSignupForm'
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/index.ts
@@ -6,4 +6,4 @@ export {
 } from './user.js'
 
 // PUBLIC API
-export { type AuthUser } from './user.js'
+export type { AuthUser } from './user.js'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/useAuth.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/useAuth.ts
@@ -5,7 +5,7 @@ import { api, handleApiError } from '../api/index.js'
 import { HttpMethod } from '../client/index.js'
 import type { AuthUser, AuthUserData } from './user.js'
 import { makeAuthUserIfPossible } from './user.js'
-import { UseQueryResult } from '@tanstack/react-query'
+import type { UseQueryResult } from '@tanstack/react-query'
 
 // PUBLIC API
 export const getMe: Query<void, AuthUser | null> = createUserGetter()

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/user.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/auth/user.ts
@@ -1,14 +1,14 @@
-import {
-  type User,
-  type Auth,
-  type AuthIdentity,
+import type {
+  User,
+  Auth,
+  AuthIdentity,
 } from '../entities/index.js'
 import {
   type PossibleProviderData,
   type ProviderName,
   getProviderData,
 } from './providerData.js'
-import { Expand } from '../universal/types.js'
+import type { Expand } from '../universal/types.js'
 import { isNotNull } from '../universal/predicates.js'
 
 // PUBLIC API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/crud/operationsHelpers.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/crud/operationsHelpers.ts
@@ -1,9 +1,9 @@
-import { _Awaited, _ReturnType } from "../../universal/types";
+import type { _Awaited, _ReturnType } from "../../universal/types";
 import { useAction, useQuery } from "../operations";
 import type { ActionFor } from "../operations/actions/core";
 import type { ActionOptions } from "../operations/hooks";
 import type { QueryFor } from "../operations/queries/core";
-import { GenericBackendOperation } from "../operations/rpc";
+import type { GenericBackendOperation } from "../operations/rpc";
 
 // PRIVATE API
 export type UseQueryFor<Operation extends GenericBackendOperation> = (

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/env.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/env.ts
@@ -1,6 +1,6 @@
 import type * as z from "zod";
 import { ensureEnvSchema } from "../env/validation";
-import { CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
+import { type CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
 
 // PUBLIC API
 export const env: z.infer<CompleteClientEnvSchema> = ensureEnvSchema(

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/env/schema.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/env/schema.ts
@@ -1,5 +1,5 @@
 import * as z from "zod"
-import { FromRegister } from "../../types/register";
+import type { FromRegister } from "../../types/register";
 import { clientEnvValidationSchema as clientEnvValidationSchema_ext } from 'virtual:wasp/user/env'
 
 export type RegisteredClientEnvValidationSchema = FromRegister<"clientEnvValidationSchema", z.ZodObject<{}>>;

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
@@ -1,14 +1,14 @@
 import {
-  QueryClient,
-  QueryKey,
+  type QueryClient,
+  type QueryKey,
   useQuery as rqUseQuery,
   useMutation,
-  UseMutationOptions,
+  type UseMutationOptions,
   useQueryClient,
-  UseQueryResult,
+  type UseQueryResult,
 } from "@tanstack/react-query";
 import { makeQueryCacheKey } from "./queries/core";
-import { Action, Query } from "./rpc";
+import type { Action, Query } from "./rpc";
 export { configureQueryClient } from "./queryClient";
 
 // PUBLIC API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -21,7 +21,7 @@ export {
     queryClientInitialized
 } from './queryClient'
 
-export {
+export type {
     // PUBLIC API
-    type QueryMetadata,
+    QueryMetadata,
 } from './rpc'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
@@ -1,4 +1,4 @@
-import { Route } from '../../index.js'
+import type { Route } from '../../index.js'
 import type { _Awaited, _ReturnType } from '../../../universal/types.js'
 import type {
   GenericBackendOperation,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient, type QueryClientConfig } from '@tanstack/react-query'
 
 const defaultQueryClientConfig = {};
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
@@ -3,7 +3,7 @@ import type {
   _Awaited,
   _ReturnType
 } from "../../universal/types";
-import { type Route } from "../index";
+import type { Route } from "../index";
 
 // PRIVATE API (for SDK, should maybe be public, users define values of this
 // type).

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Link as RouterLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterLinkProps = Parameters<typeof RouterLink>[0]
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/router/NavLink.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/router/NavLink.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { NavLink as RouterNavLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterNavLinkProps = Parameters<typeof RouterNavLink>[0]
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/test/vitest/helpers.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/test/vitest/helpers.tsx
@@ -1,12 +1,12 @@
-import { ReactElement, ReactNode } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { http, type HttpResponseResolver, type RequestHandler } from 'msw'
 import { setupServer, type SetupServer } from 'msw/node'
 import { BrowserRouter as Router } from 'react-router'
-import { render, RenderResult, cleanup } from '@testing-library/react'
+import { render, type RenderResult, cleanup } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeAll, afterEach, afterAll } from 'vitest'
-import { Query } from '../../operations/rpc.js'
-import { config, HttpMethod, Route } from '../../index.js'
+import type { Query } from '../../operations/rpc.js'
+import { config, HttpMethod, type Route } from '../../index.js'
 import { serialize } from '../../../core/serialization/index.js'
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import path from 'path'
 
 export function detectServerImports(): Plugin {

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
@@ -1,4 +1,4 @@
-import { type Plugin, type UserConfig } from 'vite'
+import type { Plugin, UserConfig } from 'vite'
 import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 import {
   getClientEntryTsxContent,
   getRoutesTsxContent,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -1,5 +1,6 @@
-import { type PluginOption } from "vite";
-import react, { type Options as ReactOptions } from "@vitejs/plugin-react";
+import type { PluginOption } from "vite";
+import react from "@vitejs/plugin-react";
+import type { Options as ReactOptions } from "@vitejs/plugin-react";
 import ssr from "@wasp.sh/lib-vite-ssr";
 import { validateEnv } from "./validateEnv.js";
 import { envFile } from "./envFile.js";

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import type { PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/webSocket/WebSocketProvider.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/webSocket/WebSocketProvider.tsx
@@ -1,5 +1,5 @@
-import { createContext, useState, useEffect, Context, ReactNode } from 'react'
-import { io, Socket } from 'socket.io-client'
+import { createContext, useState, useEffect, type Context, type ReactNode } from 'react'
+import { io, type Socket } from 'socket.io-client'
 
 import { getSessionId } from '../../api/index.js'
 import { apiEventsEmitter } from '../../api/events.js'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/webSocket/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/client/webSocket/index.ts
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react'
-import { WebSocketContext, WebSocketContextValue } from './WebSocketProvider'
+import { WebSocketContext, type WebSocketContextValue } from './WebSocketProvider'
 import type {
   ClientToServerEvents,
   ServerToClientEvents,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -1,5 +1,5 @@
 import { deserialize, serialize } from "superjson"
-import { CustomSerializableJSONValue } from "./custom-register"
+import type { CustomSerializableJSONValue } from "./custom-register"
 
 import "./prisma"
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/entities/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/entities/index.ts
@@ -1,17 +1,17 @@
-import {
-  type User,
-  type Task,
-  type TaskVote,
-  type UppercaseTextRequest,
+import type {
+  User,
+  Task,
+  TaskVote,
+  UppercaseTextRequest,
 } from "@prisma/client"
 
-export {
-  type User,
-  type Task,
-  type TaskVote,
-  type UppercaseTextRequest,
-  type Auth,
-  type AuthIdentity,
+export type {
+  User,
+  Task,
+  TaskVote,
+  UppercaseTextRequest,
+  Auth,
+  AuthIdentity,
 } from "@prisma/client"
 
 export type Entity = 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
@@ -1,13 +1,13 @@
-import { type Expand } from '../../universal/types.js'
-import { type Request, type Response } from 'express'
-import {
-  type ParamsDictionary as ExpressParams,
-  type Query as ExpressQuery,
+import type { Expand } from '../../universal/types.js'
+import type { Request, Response } from 'express'
+import type {
+  ParamsDictionary as ExpressParams,
+  Query as ExpressQuery,
 } from 'express-serve-static-core'
 import { prisma } from '../index.js'
-import { type AuthUser } from '../../auth/user.js'
-import { type _Entity } from './taggedEntities'
-import { type Payload } from '../../core/serialization/index.js'
+import type { AuthUser } from '../../auth/user.js'
+import type { _Entity } from './taggedEntities'
+import type { Payload } from '../../core/serialization/index.js'
 
 export * from "./taggedEntities"
 export * from "../../core/serialization/index.js"

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
@@ -3,13 +3,13 @@
 //
 // We must explicitly tag all entities with their name to avoid issues with
 // structural typing. See https://github.com/wasp-lang/wasp/pull/982 for details.
-import { 
-  type Entity, 
-  type EntityName,
-  type User,
-  type Task,
-  type TaskVote,
-  type UppercaseTextRequest,
+import type { 
+  Entity, 
+  EntityName,
+  User,
+  Task,
+  TaskVote,
+  UppercaseTextRequest,
 } from '../../entities/index.js'
 
 export type _User = WithName<User, "User">

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/api/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/api/index.ts
@@ -1,10 +1,10 @@
 
-import { type ParamsDictionary as ExpressParams, type Query as ExpressQuery } from 'express-serve-static-core'
+import type { ParamsDictionary as ExpressParams, Query as ExpressQuery } from 'express-serve-static-core'
 
-import {
-  type _Task,
-  type Api,
-  type AuthenticatedApi,
+import type {
+  _Task,
+  Api,
+  AuthenticatedApi,
 } from '../_types'
 
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/email/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/email/utils.ts
@@ -1,6 +1,6 @@
 import { createJWT, TimeSpan } from '../jwt.js'
 import { emailSender } from '../../email/index.js';
-import { Email } from '../../email/core/types.js';
+import type { Email } from '../../email/core/types.js';
 import {
   createProviderId,
   updateAuthIdentityProviderData,
@@ -9,7 +9,7 @@ import {
   type EmailProviderData,
 } from '../utils.js';
 import { config as waspServerConfig } from '../../index.js';
-import { type User, type Auth } from '../../../entities/index.js'
+import type { User, Auth } from '../../../entities/index.js'
 
 // PUBLIC API
 export async function createEmailVerificationLink(

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/hooks.ts
@@ -1,7 +1,7 @@
 import type { Request as ExpressRequest } from 'express'
-import { type ProviderId, type CreateUserResult, type FindAuthWithUserResult } from './utils.js'
+import type { ProviderId, CreateUserResult, FindAuthWithUserResult } from './utils.js'
 import { prisma } from '../index.js'
-import { Expand } from '../../universal/types.js'
+import type { Expand } from '../../universal/types.js'
 
 // PUBLIC API
 export type OnBeforeSignupHook = (

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/lucia.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/lucia.ts
@@ -1,7 +1,7 @@
 import { Lucia } from "lucia";
 import { PrismaAdapter } from "@lucia-auth/adapter-prisma";
 import { prisma } from '../index.js'
-import { type User } from "../../entities/index.js"
+import type { User } from "../../entities/index.js"
 
 const prismaAdapter = new PrismaAdapter(
   prisma.session,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/oauth/provider.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/oauth/provider.ts
@@ -1,4 +1,4 @@
-import { OAuth2Provider, OAuth2ProviderWithPKCE } from "arctic";
+import type { OAuth2Provider, OAuth2ProviderWithPKCE } from "arctic";
 
 export function defineProvider<
   OAuthClient extends OAuth2Provider | OAuth2ProviderWithPKCE,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/session.ts
@@ -1,7 +1,7 @@
-import { Request as ExpressRequest } from "express";
+import type { Request as ExpressRequest } from "express";
 
-import { type User } from '../../entities/index.js';
-import { type AuthUserData } from '../../auth/user.js';
+import type { User } from '../../entities/index.js';
+import type { AuthUserData } from '../../auth/user.js';
 
 import { auth } from "./lucia.js";
 import type { Session } from "lucia";

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/auth/utils.ts
@@ -1,10 +1,10 @@
 import { hashPassword } from './password.js'
 import { prisma, HttpError } from '../index.js'
 import { sleep } from '../utils.js'
-import {
-  type User,
-  type Auth,
-  type AuthIdentity,
+import type {
+  User,
+  Auth,
+  AuthIdentity,
 } from '../../entities/index.js'
 import { Prisma } from '@prisma/client';
 
@@ -17,7 +17,7 @@ import {
   providerDataHasPasswordField,
 } from '../../auth/providerData.js'
 
-import { type UserSignupFields, type PossibleUserFields } from '../../auth/providers/types.js'
+import type { UserSignupFields, PossibleUserFields } from '../../auth/providers/types.js'
 
 // Runtime-agnostic provider data code, re-exported here because it's part of
 // the server-side auth API surface (e.g. through `wasp/server/auth`).

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/email/core/helpers.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/email/core/helpers.ts
@@ -1,4 +1,4 @@
-import { EmailFromField } from "./types";
+import type { EmailFromField } from "./types";
 
 // PRIVATE API
 // Formats an email address and an optional name into a string that can be used

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/email/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/email/index.ts
@@ -1,6 +1,6 @@
 import { env } from '../env.js';
 import { initEmailSender } from "./core/index.js";
-import { EmailSender } from "./core/types.js";
+import type { EmailSender } from "./core/types.js";
 
 const emailProvider = { 
     type: "smtp",

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/env.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/env.ts
@@ -1,6 +1,6 @@
 import * as z from "zod"
 import { ensureEnvSchema } from "../env/validation"
-import { FromRegister } from "../types/register";
+import type { FromRegister } from "../types/register";
 import { serverEnvValidationSchema as serverEnvValidationSchema_ext } from 'virtual:wasp/user/env'
 
 export type RegisteredServerEnvValidationSchema = FromRegister<"serverEnvValidationSchema", z.ZodObject<{}>>;

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
@@ -5,11 +5,11 @@ export { default as config } from './config.js'
 // PUBLIC API
 export { default as prisma, type PrismaClient } from './dbClient.js'
 // PUBLIC API
-export { type ServerSetupFn } from './types/index.js'
+export type { ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { type MiddlewareConfigFn } from './middleware/index.js'
+export type { MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/index.ts
@@ -1,3 +1,3 @@
-export { type JobFn } from './types'
+export type { JobFn } from './types'
 export { registerJob, createJobDefinition } from './pgBossJob.js'
 export { startPgBoss } from './pgBoss.js'

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/pgBossJob.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/pgBossJob.ts
@@ -2,7 +2,7 @@ import PgBoss from 'pg-boss'
 import { pgBossStarted } from './pgBoss.js'
 import { Job, SubmittedJob } from '../job.js'
 import type { JSONValue, JSONObject } from '../../../../core/serialization/index.js'
-import { PrismaDelegate } from '../../../_types/index.js'
+import type { PrismaDelegate } from '../../../_types/index.js'
 import type { JobFn } from './types.js'
 
 export const PG_BOSS_EXECUTOR_NAME = Symbol('PgBoss')

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/jobs/core/pgBoss/types.ts
@@ -1,4 +1,4 @@
-import { PrismaDelegate } from '../../../_types/index.js'
+import type { PrismaDelegate } from '../../../_types/index.js'
 import type { JSONValue, JSONObject } from '../../../../core/serialization/index.js'
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/middleware/globalMiddleware.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/middleware/globalMiddleware.ts
@@ -1,4 +1,4 @@
-import { type RequestHandler } from 'express'
+import type { RequestHandler } from 'express'
 
 // PUBLIC API
 export type MiddlewareConfigFn = (middlewareConfig: MiddlewareConfig) => MiddlewareConfig

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/actions/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/actions/types.ts
@@ -1,9 +1,9 @@
-import {
-  type _Task,
-  type _UppercaseTextRequest,
-  type UnauthenticatedActionDefinition,
-  type AuthenticatedActionDefinition,
-  type Payload,
+import type {
+  _Task,
+  _UppercaseTextRequest,
+  UnauthenticatedActionDefinition,
+  AuthenticatedActionDefinition,
+  Payload,
 } from '../../_types/index.js'
 
 // PUBLIC API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/queries/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/queries/types.ts
@@ -1,10 +1,10 @@
 
-import {
-  type _Task,
-  type _UppercaseTextRequest,
-  type UnauthenticatedQueryDefinition,
-  type AuthenticatedQueryDefinition,
-  type Payload,
+import type {
+  _Task,
+  _UppercaseTextRequest,
+  UnauthenticatedQueryDefinition,
+  AuthenticatedQueryDefinition,
+  Payload,
 } from '../../_types/index.js'
 
 // PUBLIC API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
@@ -1,7 +1,7 @@
-import { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
+import type { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
 
-import { type AuthUser } from '../../auth/user.js'
-import {
+import type { AuthUser } from '../../auth/user.js'
+import type {
   _Entity,
   AuthenticatedOperationDefinition,
   UnauthenticatedOperationDefinition,

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
@@ -1,5 +1,5 @@
-import { type Application } from 'express'
-import { Server } from 'http'
+import type { Application } from 'express'
+import type { Server } from 'http'
 
 // PUBLIC API
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/utils.ts
@@ -1,6 +1,6 @@
-import { Response, RequestHandler } from 'express'
+import type { Response, RequestHandler } from 'express'
 
-import { type AuthUserData } from '../auth/user.js'
+import type { AuthUserData } from '../auth/user.js'
 
 // This is explicitly how Express expects extensions to their
 // Request and Response objects to be done.

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/webSocket/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/server/webSocket/index.ts
@@ -1,10 +1,10 @@
 
-import { Server } from 'socket.io'
-import { EventsMap, DefaultEventsMap } from '@socket.io/component-emitter'
+import type { Server } from 'socket.io'
+import type { EventsMap, DefaultEventsMap } from '@socket.io/component-emitter'
 
-import { prisma } from '../index'
+import type { prisma } from '../index'
 import type { FromRegister } from '../../types/register'
-import { type AuthUser } from '../../auth/user.js'
+import type { AuthUser } from '../../auth/user.js'
 
 
 // Public API

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -39,8 +39,9 @@
     // `isolatedModules` rejects code that single-file transpilers (like esbuild)
     // can't handle. The SDK gets bundled, so it must not rely on such code.
     "isolatedModules": true,
-    // We haven't adopted `verbatimModuleSyntax` yet.
-    "verbatimModuleSyntax": false,
+    // `verbatimModuleSyntax` makes type-only imports explicit, so single-file
+    // transpilers can drop them without having to know what they refer to.
+    "verbatimModuleSyntax": true,
     "moduleDetection": "force", // Assume all files are modules
     /*
       The SDK code uses extensionless relative imports and imports its own

--- a/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/kitchen-sink-golden/wasp-app/.wasp/out/sdk/wasp/types/index.ts
@@ -1,1 +1,1 @@
-export { type Register } from "./register";
+export type { Register } from "./register";

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/.waspchecksums
@@ -39,7 +39,7 @@
             "file",
             "sdk/wasp/api/events.ts"
         ],
-        "91ec1889f649b608ca81cab8f048538b9dcc70f49444430b1e5b572af2a4970a"
+        "a49e9e7d605b95e741720fd26bfc264e5930ff148a6b5d0739019b32dc441935"
     ],
     [
         [
@@ -123,14 +123,14 @@
             "file",
             "sdk/wasp/client/env.ts"
         ],
-        "376a0376f927458a3052eee04d5ac0f4c6ace0daaa4f4016900df382839fdf59"
+        "a802c9a4d7cf15d376de7e7dbb8fd54094f946e822105f1d09c202f85f2049ab"
     ],
     [
         [
             "file",
             "sdk/wasp/client/env/schema.ts"
         ],
-        "ca6939a151338eaa6b83524f0fdcbf663ef28ed74c66ef17be8292512e4b492c"
+        "4c3a840544086dfbd9cdfaa29e40f7e6de938258c48e6761e9e288d897b97341"
     ],
     [
         [
@@ -165,14 +165,14 @@
             "file",
             "sdk/wasp/client/operations/hooks.ts"
         ],
-        "d2016f949fb6915b1b05e96020f4aba285f5e48bbcd6a4b26462b1f93302c8d2"
+        "9c22f453fb7abaeca08f48c7fdf7650b23610cfa16038b86851d4117bb6f46ad"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "c96965e460ada3ad0369ed17a0dc8ebce623781ba02ab8059e61856024d12df2"
+        "751e3c6788618cc77c412b3b0f2fb6f4f856d6d2d297484a75c95abf4a9cffd2"
     ],
     [
         [
@@ -200,7 +200,7 @@
             "file",
             "sdk/wasp/client/operations/queries/core.ts"
         ],
-        "63e324b622637513d40c0e3404c42cfbee665d7804a8f459036efeaa376f21d6"
+        "cf0cbee66bea7789d5eeac5798495c7f22f15868400bf0b6bab9c95d31bfe2ff"
     ],
     [
         [
@@ -214,28 +214,28 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "c32437fb349592ee41ab8d85aa0a92174e6eb7bf831cc63a0c3719c9cecd6343"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/rpc.ts"
         ],
-        "3b2c5f4ed90150f21da899cccc23c0aef42030db2f0171e56f28f0f016e25bc9"
+        "746c76905061b5d066cd3909a6cf7699cd57aa8ee17d04e3bad3d67e8c57483a"
     ],
     [
         [
             "file",
             "sdk/wasp/client/router/Link.tsx"
         ],
-        "d1a6f48d96f50b2900324f221f1fafa70a04bc9b5bba7d1dc78ffebfb7d2704b"
+        "504c73de9596bcf394d91b5bf3fc9078af5e461713b716a3155a918c9da03069"
     ],
     [
         [
             "file",
             "sdk/wasp/client/router/NavLink.tsx"
         ],
-        "22f7b0a0000fc53091f7a281feb025ea80f8a279bf2d21a2be3531d0c5b202ab"
+        "bcedb44395e0dced4009e5e4a8dffa18660b4bb81dec106a33407c454dedb991"
     ],
     [
         [
@@ -277,7 +277,7 @@
             "file",
             "sdk/wasp/client/test/vitest/helpers.tsx"
         ],
-        "f13f830a28370dc6038a5f69ce61b371530f776a407210b513daccb327bb8257"
+        "aafd398af585df12a06cb8f5ec5eb09a2f5db2deed01b257177566d43a42f704"
     ],
     [
         [
@@ -291,21 +291,21 @@
             "file",
             "sdk/wasp/client/vite/plugins/detectServerImports.ts"
         ],
-        "93885302fbb1758384e990fb6a7eac52fa03459f4df66a2b59eb8ac7b3e5c14a"
+        "af2157c5a71b7409055dd53094bdf33646ba2284fd3aaffad830489fecb06d79"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/envFile.ts"
         ],
-        "0fafefac0b8c9ecfa0cac06f13e084ac8e1661d8fbead6e2d8b2bc7a08c9b035"
+        "3bb6ae4f102a9fd9638669bac42e3c01d69bf9a6a26685d2debd9c4f19ce1af3"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
+        "1a144dffe58e7eab72b88edb64dd44220b63b09b902d51f1b6f92331fe3089e7"
     ],
     [
         [
@@ -319,28 +319,28 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "db4acaf6e01de4ad53a9c7fb75bff5da1809b99f88b4296a5a180ac3a9ef844f"
+        "aa97c9367c45f1aef790e98deea870c58413f5abf68696a20faa2d68f4857b4c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualWaspModules.ts"
         ],
-        "4aede5b77417f38713a8f8b72b119d8a060e1ef1984945ceca249119b528b38a"
+        "7988c7fa950d788a355cd82ad1a4577d43853aef7b302e81341e83e01d83c6ef"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "0e57fda79b9a03182c4d08788ea390f6af0604b4a59f107f778a23a2878d4e5b"
+        "97049725c4328c73207bea61937906188b95d8cab3ea9f06bb7ae38928a06b54"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "e8fb2bdec48dc07ca7d01dd800adef26b6caee924dd0600662aa191f7f3e24ef"
+        "7e63f5649c418c88d69204313b0a31d40dce6a6037394dde01cf806d2b672eab"
     ],
     [
         [
@@ -389,7 +389,7 @@
             "file",
             "sdk/wasp/core/serialization/index.ts"
         ],
-        "cb3b769a74f5cadab1582df4e6e36cdeeebfe9f926faa2c9f40e2ddf46ddf75b"
+        "10d36622eb490ffcbcf366d55c0a7a429aa92e8184b1a668118b766db04eb101"
     ],
     [
         [
@@ -403,7 +403,7 @@
             "file",
             "sdk/wasp/entities/index.ts"
         ],
-        "c59b97b122b977b5171686c92ee5ff2d80d397c2e83cc0915affb6ee136406fb"
+        "074286ce53a23dbe50b2f393afb2c99a08ec36e0de33bfab1934ecdec95f119f"
     ],
     [
         [
@@ -459,14 +459,14 @@
             "file",
             "sdk/wasp/server/_types/index.ts"
         ],
-        "1cfc989acb1bbd62c677d57fae0af75fa11b9d5fa17a47bd25534bca06bc168c"
+        "3c074cb8a8e0dc380c7bb9c7f769736d783f33c4a514d6da1352e7ee17ea929f"
     ],
     [
         [
             "file",
             "sdk/wasp/server/_types/taggedEntities.ts"
         ],
-        "3f56911846ce4c382bc4dfe16e847f475f504ef78e98dfa47ad704094a2fa0cc"
+        "bd901b832c0ed2297395b62d5fc0708fbab1f0709e9dd9cf57afb410504d7f8a"
     ],
     [
         [
@@ -487,21 +487,21 @@
             "file",
             "sdk/wasp/server/env.ts"
         ],
-        "10c3a06f2726fd3b247cf8fc138bce0237a9832151e107e92a041c3b8c2c6d7f"
+        "f3ef4efbc08161e36b6374937c0c11ea57c3591f79470495158b92a13a54196b"
     ],
     [
         [
             "file",
             "sdk/wasp/server/index.ts"
         ],
-        "a0d0ff1c97a4bc52f78d0fac37d1470690984b5dc2284f37b65244e633608cd8"
+        "1436713aa5119623c6384d8b399da9ee19c29a2441974cf5c6f9d674446581de"
     ],
     [
         [
             "file",
             "sdk/wasp/server/middleware/globalMiddleware.ts"
         ],
-        "53f258be83ca6de653b6b645253ce573e3c177e88017eb2adb17f5d3cebb36c3"
+        "ab20883dd155b8a66f8535a4ad1f532c2d89702fa750b3cd91ad79bc76a780c7"
     ],
     [
         [
@@ -522,7 +522,7 @@
             "file",
             "sdk/wasp/server/operations/actions/types.ts"
         ],
-        "30d5f5faeb3ae0e83a18a7a91d8928293855eda76f2ebb9a659f54cbdd565b83"
+        "8d77096d98e5ab9a544645a9a42efb844c0bff9bdbec0ec91014387a3eddc4aa"
     ],
     [
         [
@@ -543,42 +543,42 @@
             "file",
             "sdk/wasp/server/operations/queries/types.ts"
         ],
-        "dd1eb9d2fc6651128358bc73190f8e0cf1a1e5093c821bde0a3acfe51afadc9e"
+        "df7454a57eae3ee97a29f90e3f40892389fb2b5e37c43b332d1fef809424b84e"
     ],
     [
         [
             "file",
             "sdk/wasp/server/operations/wrappers.ts"
         ],
-        "352e7f555fb4cdc65556b215a072fd6ed1908cce606adffdf5906fa007b47dd6"
+        "342e3f17b028f7f01bf11e4425b027bce9f66a1a1d8e04a71a3049fc3ae101db"
     ],
     [
         [
             "file",
             "sdk/wasp/server/types/index.ts"
         ],
-        "0f2ffdfdd76c92084bd0ba270b674628ec907da0d047de6c8a9912e415462d97"
+        "0999c392608eb58a61adff654975e6b930f55bcf1f94a1c66618c2376f6fc23e"
     ],
     [
         [
             "file",
             "sdk/wasp/server/utils.ts"
         ],
-        "d7d15ef5f24220e7a71302f9c5a9e088688e99abf0609a2094f7fe87add4c099"
+        "7035b28021866e837e192e924d50fa7862d425d477d5209a215dd5aa20b9ad61"
     ],
     [
         [
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "77c89a888d80cb15e8f7497dca2e9070c2bcc2bc167ad8823537117bf6995646"
+        "4da3a72edc3cf3f967aa7148ab59b690cde5931a0f15b5106137d0d49bea3f12"
     ],
     [
         [
             "file",
             "sdk/wasp/types/index.ts"
         ],
-        "0edc8cb5f3980c49a2bdc1a1e0a02ad2dda877e1bba1533198d9168b24527555"
+        "ac77b944feeb257d8764e38501dbfcf0f1f0724788f10e9c4acf29a4b92b45fe"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/api/events.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/api/events.ts
@@ -1,4 +1,5 @@
-import mitt, { Emitter } from 'mitt';
+import mitt from 'mitt';
+import type { Emitter } from 'mitt';
 
 type ApiEvents = {
   // key: Event name

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/env.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/env.ts
@@ -1,6 +1,6 @@
 import type * as z from "zod";
 import { ensureEnvSchema } from "../env/validation";
-import { CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
+import { type CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
 
 // PUBLIC API
 export const env: z.infer<CompleteClientEnvSchema> = ensureEnvSchema(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/env/schema.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/env/schema.ts
@@ -1,5 +1,5 @@
 import * as z from "zod"
-import { FromRegister } from "../../types/register";
+import type { FromRegister } from "../../types/register";
 
 export type RegisteredClientEnvValidationSchema = FromRegister<"clientEnvValidationSchema", z.ZodObject<{}>>;
 type UserClientEnvSchema = RegisteredClientEnvValidationSchema;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
@@ -1,14 +1,14 @@
 import {
-  QueryClient,
-  QueryKey,
+  type QueryClient,
+  type QueryKey,
   useQuery as rqUseQuery,
   useMutation,
-  UseMutationOptions,
+  type UseMutationOptions,
   useQueryClient,
-  UseQueryResult,
+  type UseQueryResult,
 } from "@tanstack/react-query";
 import { makeQueryCacheKey } from "./queries/core";
-import { Action, Query } from "./rpc";
+import type { Action, Query } from "./rpc";
 export { configureQueryClient } from "./queryClient";
 
 // PUBLIC API

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -21,7 +21,7 @@ export {
     queryClientInitialized
 } from './queryClient'
 
-export {
+export type {
     // PUBLIC API
-    type QueryMetadata,
+    QueryMetadata,
 } from './rpc'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
@@ -1,4 +1,4 @@
-import { Route } from '../../index.js'
+import type { Route } from '../../index.js'
 import type { _Awaited, _ReturnType } from '../../../universal/types.js'
 import type {
   GenericBackendOperation,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient, type QueryClientConfig } from '@tanstack/react-query'
 
 const defaultQueryClientConfig = {};
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
@@ -3,7 +3,7 @@ import type {
   _Awaited,
   _ReturnType
 } from "../../universal/types";
-import { type Route } from "../index";
+import type { Route } from "../index";
 
 // PRIVATE API (for SDK, should maybe be public, users define values of this
 // type).

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Link as RouterLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterLinkProps = Parameters<typeof RouterLink>[0]
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/router/NavLink.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/router/NavLink.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { NavLink as RouterNavLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterNavLinkProps = Parameters<typeof RouterNavLink>[0]
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/test/vitest/helpers.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/test/vitest/helpers.tsx
@@ -1,12 +1,12 @@
-import { ReactElement, ReactNode } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { http, type HttpResponseResolver, type RequestHandler } from 'msw'
 import { setupServer, type SetupServer } from 'msw/node'
 import { BrowserRouter as Router } from 'react-router'
-import { render, RenderResult, cleanup } from '@testing-library/react'
+import { render, type RenderResult, cleanup } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeAll, afterEach, afterAll } from 'vitest'
-import { Query } from '../../operations/rpc.js'
-import { config, HttpMethod, Route } from '../../index.js'
+import type { Query } from '../../operations/rpc.js'
+import { config, HttpMethod, type Route } from '../../index.js'
 import { serialize } from '../../../core/serialization/index.js'
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import path from 'path'
 
 export function detectServerImports(): Plugin {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
@@ -1,4 +1,4 @@
-import { type Plugin, type UserConfig } from 'vite'
+import type { Plugin, UserConfig } from 'vite'
 import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 import {
   getClientEntryTsxContent,
   getRoutesTsxContent,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -1,5 +1,6 @@
-import { type PluginOption } from "vite";
-import react, { type Options as ReactOptions } from "@vitejs/plugin-react";
+import type { PluginOption } from "vite";
+import react from "@vitejs/plugin-react";
+import type { Options as ReactOptions } from "@vitejs/plugin-react";
 import ssr from "@wasp.sh/lib-vite-ssr";
 import { validateEnv } from "./validateEnv.js";
 import { envFile } from "./envFile.js";

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import type { PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -1,5 +1,5 @@
 import { deserialize, serialize } from "superjson"
-import { CustomSerializableJSONValue } from "./custom-register"
+import type { CustomSerializableJSONValue } from "./custom-register"
 
 
 export type Payload = void | SuperJSONValue;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/entities/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/entities/index.ts
@@ -1,7 +1,7 @@
-import {
+import type {
 } from "@prisma/client"
 
-export {
+export type {
 } from "@prisma/client"
 
 export type Entity = 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
@@ -1,12 +1,12 @@
-import { type Expand } from '../../universal/types.js'
-import { type Request, type Response } from 'express'
-import {
-  type ParamsDictionary as ExpressParams,
-  type Query as ExpressQuery,
+import type { Expand } from '../../universal/types.js'
+import type { Request, Response } from 'express'
+import type {
+  ParamsDictionary as ExpressParams,
+  Query as ExpressQuery,
 } from 'express-serve-static-core'
 import { prisma } from '../index.js'
-import { type _Entity } from './taggedEntities'
-import { type Payload } from '../../core/serialization/index.js'
+import type { _Entity } from './taggedEntities'
+import type { Payload } from '../../core/serialization/index.js'
 
 export * from "./taggedEntities"
 export * from "../../core/serialization/index.js"

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
@@ -3,9 +3,9 @@
 //
 // We must explicitly tag all entities with their name to avoid issues with
 // structural typing. See https://github.com/wasp-lang/wasp/pull/982 for details.
-import { 
-  type Entity, 
-  type EntityName,
+import type { 
+  Entity, 
+  EntityName,
 } from '../../entities/index.js'
 
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/env.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/env.ts
@@ -1,6 +1,6 @@
 import * as z from "zod"
 import { ensureEnvSchema } from "../env/validation"
-import { FromRegister } from "../types/register";
+import type { FromRegister } from "../types/register";
 
 export type RegisteredServerEnvValidationSchema = FromRegister<"serverEnvValidationSchema", z.ZodObject<{}>>;
 type UserServerEnvSchema = RegisteredServerEnvValidationSchema;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
@@ -5,11 +5,11 @@ export { default as config } from './config.js'
 // PUBLIC API
 export { default as prisma, type PrismaClient } from './dbClient.js'
 // PUBLIC API
-export { type ServerSetupFn } from './types/index.js'
+export type { ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { type MiddlewareConfigFn } from './middleware/index.js'
+export type { MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/middleware/globalMiddleware.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/middleware/globalMiddleware.ts
@@ -1,4 +1,4 @@
-import { type RequestHandler } from 'express'
+import type { RequestHandler } from 'express'
 
 // PUBLIC API
 export type MiddlewareConfigFn = (middlewareConfig: MiddlewareConfig) => MiddlewareConfig

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/actions/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/actions/types.ts
@@ -1,4 +1,4 @@
-import {
-  type Payload,
+import type {
+  Payload,
 } from '../../_types/index.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/queries/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/queries/types.ts
@@ -1,5 +1,5 @@
 
-import {
-  type Payload,
+import type {
+  Payload,
 } from '../../_types/index.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
@@ -1,6 +1,6 @@
-import { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
+import type { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
 
-import {
+import type {
   _Entity,
   UnauthenticatedOperationDefinition,
   Payload,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
@@ -1,5 +1,5 @@
-import { type Application } from 'express'
-import { Server } from 'http'
+import type { Application } from 'express'
+import type { Server } from 'http'
 
 // PUBLIC API
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/server/utils.ts
@@ -1,4 +1,4 @@
-import { Response, RequestHandler } from 'express'
+import type { Response, RequestHandler } from 'express'
 
 
 // This is explicitly how Express expects extensions to their

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -39,8 +39,9 @@
     // `isolatedModules` rejects code that single-file transpilers (like esbuild)
     // can't handle. The SDK gets bundled, so it must not rely on such code.
     "isolatedModules": true,
-    // We haven't adopted `verbatimModuleSyntax` yet.
-    "verbatimModuleSyntax": false,
+    // `verbatimModuleSyntax` makes type-only imports explicit, so single-file
+    // transpilers can drop them without having to know what they refer to.
+    "verbatimModuleSyntax": true,
     "moduleDetection": "force", // Assume all files are modules
     /*
       The SDK code uses extensionless relative imports and imports its own

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-build-golden/wasp-app/.wasp/out/sdk/wasp/types/index.ts
@@ -1,1 +1,1 @@
-export { type Register } from "./register";
+export type { Register } from "./register";

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/.waspchecksums
@@ -39,7 +39,7 @@
             "file",
             "sdk/wasp/api/events.ts"
         ],
-        "91ec1889f649b608ca81cab8f048538b9dcc70f49444430b1e5b572af2a4970a"
+        "a49e9e7d605b95e741720fd26bfc264e5930ff148a6b5d0739019b32dc441935"
     ],
     [
         [
@@ -123,14 +123,14 @@
             "file",
             "sdk/wasp/client/env.ts"
         ],
-        "376a0376f927458a3052eee04d5ac0f4c6ace0daaa4f4016900df382839fdf59"
+        "a802c9a4d7cf15d376de7e7dbb8fd54094f946e822105f1d09c202f85f2049ab"
     ],
     [
         [
             "file",
             "sdk/wasp/client/env/schema.ts"
         ],
-        "ca6939a151338eaa6b83524f0fdcbf663ef28ed74c66ef17be8292512e4b492c"
+        "4c3a840544086dfbd9cdfaa29e40f7e6de938258c48e6761e9e288d897b97341"
     ],
     [
         [
@@ -165,14 +165,14 @@
             "file",
             "sdk/wasp/client/operations/hooks.ts"
         ],
-        "d2016f949fb6915b1b05e96020f4aba285f5e48bbcd6a4b26462b1f93302c8d2"
+        "9c22f453fb7abaeca08f48c7fdf7650b23610cfa16038b86851d4117bb6f46ad"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "c96965e460ada3ad0369ed17a0dc8ebce623781ba02ab8059e61856024d12df2"
+        "751e3c6788618cc77c412b3b0f2fb6f4f856d6d2d297484a75c95abf4a9cffd2"
     ],
     [
         [
@@ -200,7 +200,7 @@
             "file",
             "sdk/wasp/client/operations/queries/core.ts"
         ],
-        "63e324b622637513d40c0e3404c42cfbee665d7804a8f459036efeaa376f21d6"
+        "cf0cbee66bea7789d5eeac5798495c7f22f15868400bf0b6bab9c95d31bfe2ff"
     ],
     [
         [
@@ -214,28 +214,28 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "c32437fb349592ee41ab8d85aa0a92174e6eb7bf831cc63a0c3719c9cecd6343"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/rpc.ts"
         ],
-        "3b2c5f4ed90150f21da899cccc23c0aef42030db2f0171e56f28f0f016e25bc9"
+        "746c76905061b5d066cd3909a6cf7699cd57aa8ee17d04e3bad3d67e8c57483a"
     ],
     [
         [
             "file",
             "sdk/wasp/client/router/Link.tsx"
         ],
-        "d1a6f48d96f50b2900324f221f1fafa70a04bc9b5bba7d1dc78ffebfb7d2704b"
+        "504c73de9596bcf394d91b5bf3fc9078af5e461713b716a3155a918c9da03069"
     ],
     [
         [
             "file",
             "sdk/wasp/client/router/NavLink.tsx"
         ],
-        "22f7b0a0000fc53091f7a281feb025ea80f8a279bf2d21a2be3531d0c5b202ab"
+        "bcedb44395e0dced4009e5e4a8dffa18660b4bb81dec106a33407c454dedb991"
     ],
     [
         [
@@ -277,7 +277,7 @@
             "file",
             "sdk/wasp/client/test/vitest/helpers.tsx"
         ],
-        "f13f830a28370dc6038a5f69ce61b371530f776a407210b513daccb327bb8257"
+        "aafd398af585df12a06cb8f5ec5eb09a2f5db2deed01b257177566d43a42f704"
     ],
     [
         [
@@ -291,21 +291,21 @@
             "file",
             "sdk/wasp/client/vite/plugins/detectServerImports.ts"
         ],
-        "93885302fbb1758384e990fb6a7eac52fa03459f4df66a2b59eb8ac7b3e5c14a"
+        "af2157c5a71b7409055dd53094bdf33646ba2284fd3aaffad830489fecb06d79"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/envFile.ts"
         ],
-        "0fafefac0b8c9ecfa0cac06f13e084ac8e1661d8fbead6e2d8b2bc7a08c9b035"
+        "3bb6ae4f102a9fd9638669bac42e3c01d69bf9a6a26685d2debd9c4f19ce1af3"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
+        "1a144dffe58e7eab72b88edb64dd44220b63b09b902d51f1b6f92331fe3089e7"
     ],
     [
         [
@@ -319,28 +319,28 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "db4acaf6e01de4ad53a9c7fb75bff5da1809b99f88b4296a5a180ac3a9ef844f"
+        "aa97c9367c45f1aef790e98deea870c58413f5abf68696a20faa2d68f4857b4c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualWaspModules.ts"
         ],
-        "4aede5b77417f38713a8f8b72b119d8a060e1ef1984945ceca249119b528b38a"
+        "7988c7fa950d788a355cd82ad1a4577d43853aef7b302e81341e83e01d83c6ef"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "0e57fda79b9a03182c4d08788ea390f6af0604b4a59f107f778a23a2878d4e5b"
+        "97049725c4328c73207bea61937906188b95d8cab3ea9f06bb7ae38928a06b54"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "e8fb2bdec48dc07ca7d01dd800adef26b6caee924dd0600662aa191f7f3e24ef"
+        "7e63f5649c418c88d69204313b0a31d40dce6a6037394dde01cf806d2b672eab"
     ],
     [
         [
@@ -389,7 +389,7 @@
             "file",
             "sdk/wasp/core/serialization/index.ts"
         ],
-        "cb3b769a74f5cadab1582df4e6e36cdeeebfe9f926faa2c9f40e2ddf46ddf75b"
+        "10d36622eb490ffcbcf366d55c0a7a429aa92e8184b1a668118b766db04eb101"
     ],
     [
         [
@@ -403,7 +403,7 @@
             "file",
             "sdk/wasp/entities/index.ts"
         ],
-        "c59b97b122b977b5171686c92ee5ff2d80d397c2e83cc0915affb6ee136406fb"
+        "074286ce53a23dbe50b2f393afb2c99a08ec36e0de33bfab1934ecdec95f119f"
     ],
     [
         [
@@ -459,14 +459,14 @@
             "file",
             "sdk/wasp/server/_types/index.ts"
         ],
-        "1cfc989acb1bbd62c677d57fae0af75fa11b9d5fa17a47bd25534bca06bc168c"
+        "3c074cb8a8e0dc380c7bb9c7f769736d783f33c4a514d6da1352e7ee17ea929f"
     ],
     [
         [
             "file",
             "sdk/wasp/server/_types/taggedEntities.ts"
         ],
-        "3f56911846ce4c382bc4dfe16e847f475f504ef78e98dfa47ad704094a2fa0cc"
+        "bd901b832c0ed2297395b62d5fc0708fbab1f0709e9dd9cf57afb410504d7f8a"
     ],
     [
         [
@@ -487,21 +487,21 @@
             "file",
             "sdk/wasp/server/env.ts"
         ],
-        "10c3a06f2726fd3b247cf8fc138bce0237a9832151e107e92a041c3b8c2c6d7f"
+        "f3ef4efbc08161e36b6374937c0c11ea57c3591f79470495158b92a13a54196b"
     ],
     [
         [
             "file",
             "sdk/wasp/server/index.ts"
         ],
-        "a0d0ff1c97a4bc52f78d0fac37d1470690984b5dc2284f37b65244e633608cd8"
+        "1436713aa5119623c6384d8b399da9ee19c29a2441974cf5c6f9d674446581de"
     ],
     [
         [
             "file",
             "sdk/wasp/server/middleware/globalMiddleware.ts"
         ],
-        "53f258be83ca6de653b6b645253ce573e3c177e88017eb2adb17f5d3cebb36c3"
+        "ab20883dd155b8a66f8535a4ad1f532c2d89702fa750b3cd91ad79bc76a780c7"
     ],
     [
         [
@@ -522,7 +522,7 @@
             "file",
             "sdk/wasp/server/operations/actions/types.ts"
         ],
-        "30d5f5faeb3ae0e83a18a7a91d8928293855eda76f2ebb9a659f54cbdd565b83"
+        "8d77096d98e5ab9a544645a9a42efb844c0bff9bdbec0ec91014387a3eddc4aa"
     ],
     [
         [
@@ -543,42 +543,42 @@
             "file",
             "sdk/wasp/server/operations/queries/types.ts"
         ],
-        "dd1eb9d2fc6651128358bc73190f8e0cf1a1e5093c821bde0a3acfe51afadc9e"
+        "df7454a57eae3ee97a29f90e3f40892389fb2b5e37c43b332d1fef809424b84e"
     ],
     [
         [
             "file",
             "sdk/wasp/server/operations/wrappers.ts"
         ],
-        "352e7f555fb4cdc65556b215a072fd6ed1908cce606adffdf5906fa007b47dd6"
+        "342e3f17b028f7f01bf11e4425b027bce9f66a1a1d8e04a71a3049fc3ae101db"
     ],
     [
         [
             "file",
             "sdk/wasp/server/types/index.ts"
         ],
-        "0f2ffdfdd76c92084bd0ba270b674628ec907da0d047de6c8a9912e415462d97"
+        "0999c392608eb58a61adff654975e6b930f55bcf1f94a1c66618c2376f6fc23e"
     ],
     [
         [
             "file",
             "sdk/wasp/server/utils.ts"
         ],
-        "d7d15ef5f24220e7a71302f9c5a9e088688e99abf0609a2094f7fe87add4c099"
+        "7035b28021866e837e192e924d50fa7862d425d477d5209a215dd5aa20b9ad61"
     ],
     [
         [
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "77c89a888d80cb15e8f7497dca2e9070c2bcc2bc167ad8823537117bf6995646"
+        "4da3a72edc3cf3f967aa7148ab59b690cde5931a0f15b5106137d0d49bea3f12"
     ],
     [
         [
             "file",
             "sdk/wasp/types/index.ts"
         ],
-        "0edc8cb5f3980c49a2bdc1a1e0a02ad2dda877e1bba1533198d9168b24527555"
+        "ac77b944feeb257d8764e38501dbfcf0f1f0724788f10e9c4acf29a4b92b45fe"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/api/events.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/api/events.ts
@@ -1,4 +1,5 @@
-import mitt, { Emitter } from 'mitt';
+import mitt from 'mitt';
+import type { Emitter } from 'mitt';
 
 type ApiEvents = {
   // key: Event name

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/env.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/env.ts
@@ -1,6 +1,6 @@
 import type * as z from "zod";
 import { ensureEnvSchema } from "../env/validation";
-import { CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
+import { type CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
 
 // PUBLIC API
 export const env: z.infer<CompleteClientEnvSchema> = ensureEnvSchema(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/env/schema.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/env/schema.ts
@@ -1,5 +1,5 @@
 import * as z from "zod"
-import { FromRegister } from "../../types/register";
+import type { FromRegister } from "../../types/register";
 
 export type RegisteredClientEnvValidationSchema = FromRegister<"clientEnvValidationSchema", z.ZodObject<{}>>;
 type UserClientEnvSchema = RegisteredClientEnvValidationSchema;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
@@ -1,14 +1,14 @@
 import {
-  QueryClient,
-  QueryKey,
+  type QueryClient,
+  type QueryKey,
   useQuery as rqUseQuery,
   useMutation,
-  UseMutationOptions,
+  type UseMutationOptions,
   useQueryClient,
-  UseQueryResult,
+  type UseQueryResult,
 } from "@tanstack/react-query";
 import { makeQueryCacheKey } from "./queries/core";
-import { Action, Query } from "./rpc";
+import type { Action, Query } from "./rpc";
 export { configureQueryClient } from "./queryClient";
 
 // PUBLIC API

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -21,7 +21,7 @@ export {
     queryClientInitialized
 } from './queryClient'
 
-export {
+export type {
     // PUBLIC API
-    type QueryMetadata,
+    QueryMetadata,
 } from './rpc'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
@@ -1,4 +1,4 @@
-import { Route } from '../../index.js'
+import type { Route } from '../../index.js'
 import type { _Awaited, _ReturnType } from '../../../universal/types.js'
 import type {
   GenericBackendOperation,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient, type QueryClientConfig } from '@tanstack/react-query'
 
 const defaultQueryClientConfig = {};
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
@@ -3,7 +3,7 @@ import type {
   _Awaited,
   _ReturnType
 } from "../../universal/types";
-import { type Route } from "../index";
+import type { Route } from "../index";
 
 // PRIVATE API (for SDK, should maybe be public, users define values of this
 // type).

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Link as RouterLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterLinkProps = Parameters<typeof RouterLink>[0]
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/router/NavLink.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/router/NavLink.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { NavLink as RouterNavLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterNavLinkProps = Parameters<typeof RouterNavLink>[0]
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/test/vitest/helpers.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/test/vitest/helpers.tsx
@@ -1,12 +1,12 @@
-import { ReactElement, ReactNode } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { http, type HttpResponseResolver, type RequestHandler } from 'msw'
 import { setupServer, type SetupServer } from 'msw/node'
 import { BrowserRouter as Router } from 'react-router'
-import { render, RenderResult, cleanup } from '@testing-library/react'
+import { render, type RenderResult, cleanup } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeAll, afterEach, afterAll } from 'vitest'
-import { Query } from '../../operations/rpc.js'
-import { config, HttpMethod, Route } from '../../index.js'
+import type { Query } from '../../operations/rpc.js'
+import { config, HttpMethod, type Route } from '../../index.js'
 import { serialize } from '../../../core/serialization/index.js'
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import path from 'path'
 
 export function detectServerImports(): Plugin {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
@@ -1,4 +1,4 @@
-import { type Plugin, type UserConfig } from 'vite'
+import type { Plugin, UserConfig } from 'vite'
 import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 import {
   getClientEntryTsxContent,
   getRoutesTsxContent,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -1,5 +1,6 @@
-import { type PluginOption } from "vite";
-import react, { type Options as ReactOptions } from "@vitejs/plugin-react";
+import type { PluginOption } from "vite";
+import react from "@vitejs/plugin-react";
+import type { Options as ReactOptions } from "@vitejs/plugin-react";
 import ssr from "@wasp.sh/lib-vite-ssr";
 import { validateEnv } from "./validateEnv.js";
 import { envFile } from "./envFile.js";

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import type { PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -1,5 +1,5 @@
 import { deserialize, serialize } from "superjson"
-import { CustomSerializableJSONValue } from "./custom-register"
+import type { CustomSerializableJSONValue } from "./custom-register"
 
 
 export type Payload = void | SuperJSONValue;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/entities/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/entities/index.ts
@@ -1,7 +1,7 @@
-import {
+import type {
 } from "@prisma/client"
 
-export {
+export type {
 } from "@prisma/client"
 
 export type Entity = 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
@@ -1,12 +1,12 @@
-import { type Expand } from '../../universal/types.js'
-import { type Request, type Response } from 'express'
-import {
-  type ParamsDictionary as ExpressParams,
-  type Query as ExpressQuery,
+import type { Expand } from '../../universal/types.js'
+import type { Request, Response } from 'express'
+import type {
+  ParamsDictionary as ExpressParams,
+  Query as ExpressQuery,
 } from 'express-serve-static-core'
 import { prisma } from '../index.js'
-import { type _Entity } from './taggedEntities'
-import { type Payload } from '../../core/serialization/index.js'
+import type { _Entity } from './taggedEntities'
+import type { Payload } from '../../core/serialization/index.js'
 
 export * from "./taggedEntities"
 export * from "../../core/serialization/index.js"

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
@@ -3,9 +3,9 @@
 //
 // We must explicitly tag all entities with their name to avoid issues with
 // structural typing. See https://github.com/wasp-lang/wasp/pull/982 for details.
-import { 
-  type Entity, 
-  type EntityName,
+import type { 
+  Entity, 
+  EntityName,
 } from '../../entities/index.js'
 
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/env.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/env.ts
@@ -1,6 +1,6 @@
 import * as z from "zod"
 import { ensureEnvSchema } from "../env/validation"
-import { FromRegister } from "../types/register";
+import type { FromRegister } from "../types/register";
 
 export type RegisteredServerEnvValidationSchema = FromRegister<"serverEnvValidationSchema", z.ZodObject<{}>>;
 type UserServerEnvSchema = RegisteredServerEnvValidationSchema;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
@@ -5,11 +5,11 @@ export { default as config } from './config.js'
 // PUBLIC API
 export { default as prisma, type PrismaClient } from './dbClient.js'
 // PUBLIC API
-export { type ServerSetupFn } from './types/index.js'
+export type { ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { type MiddlewareConfigFn } from './middleware/index.js'
+export type { MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/middleware/globalMiddleware.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/middleware/globalMiddleware.ts
@@ -1,4 +1,4 @@
-import { type RequestHandler } from 'express'
+import type { RequestHandler } from 'express'
 
 // PUBLIC API
 export type MiddlewareConfigFn = (middlewareConfig: MiddlewareConfig) => MiddlewareConfig

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/actions/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/actions/types.ts
@@ -1,4 +1,4 @@
-import {
-  type Payload,
+import type {
+  Payload,
 } from '../../_types/index.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/queries/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/queries/types.ts
@@ -1,5 +1,5 @@
 
-import {
-  type Payload,
+import type {
+  Payload,
 } from '../../_types/index.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
@@ -1,6 +1,6 @@
-import { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
+import type { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
 
-import {
+import type {
   _Entity,
   UnauthenticatedOperationDefinition,
   Payload,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
@@ -1,5 +1,5 @@
-import { type Application } from 'express'
-import { Server } from 'http'
+import type { Application } from 'express'
+import type { Server } from 'http'
 
 // PUBLIC API
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/server/utils.ts
@@ -1,4 +1,4 @@
-import { Response, RequestHandler } from 'express'
+import type { Response, RequestHandler } from 'express'
 
 
 // This is explicitly how Express expects extensions to their

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -39,8 +39,9 @@
     // `isolatedModules` rejects code that single-file transpilers (like esbuild)
     // can't handle. The SDK gets bundled, so it must not rely on such code.
     "isolatedModules": true,
-    // We haven't adopted `verbatimModuleSyntax` yet.
-    "verbatimModuleSyntax": false,
+    // `verbatimModuleSyntax` makes type-only imports explicit, so single-file
+    // transpilers can drop them without having to know what they refer to.
+    "verbatimModuleSyntax": true,
     "moduleDetection": "force", // Assume all files are modules
     /*
       The SDK code uses extensionless relative imports and imports its own

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-compile-golden/wasp-app/.wasp/out/sdk/wasp/types/index.ts
@@ -1,1 +1,1 @@
-export { type Register } from "./register";
+export type { Register } from "./register";

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/.waspchecksums
@@ -39,7 +39,7 @@
             "file",
             "sdk/wasp/api/events.ts"
         ],
-        "91ec1889f649b608ca81cab8f048538b9dcc70f49444430b1e5b572af2a4970a"
+        "a49e9e7d605b95e741720fd26bfc264e5930ff148a6b5d0739019b32dc441935"
     ],
     [
         [
@@ -123,14 +123,14 @@
             "file",
             "sdk/wasp/client/env.ts"
         ],
-        "376a0376f927458a3052eee04d5ac0f4c6ace0daaa4f4016900df382839fdf59"
+        "a802c9a4d7cf15d376de7e7dbb8fd54094f946e822105f1d09c202f85f2049ab"
     ],
     [
         [
             "file",
             "sdk/wasp/client/env/schema.ts"
         ],
-        "ca6939a151338eaa6b83524f0fdcbf663ef28ed74c66ef17be8292512e4b492c"
+        "4c3a840544086dfbd9cdfaa29e40f7e6de938258c48e6761e9e288d897b97341"
     ],
     [
         [
@@ -165,14 +165,14 @@
             "file",
             "sdk/wasp/client/operations/hooks.ts"
         ],
-        "d2016f949fb6915b1b05e96020f4aba285f5e48bbcd6a4b26462b1f93302c8d2"
+        "9c22f453fb7abaeca08f48c7fdf7650b23610cfa16038b86851d4117bb6f46ad"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/index.ts"
         ],
-        "c96965e460ada3ad0369ed17a0dc8ebce623781ba02ab8059e61856024d12df2"
+        "751e3c6788618cc77c412b3b0f2fb6f4f856d6d2d297484a75c95abf4a9cffd2"
     ],
     [
         [
@@ -200,7 +200,7 @@
             "file",
             "sdk/wasp/client/operations/queries/core.ts"
         ],
-        "63e324b622637513d40c0e3404c42cfbee665d7804a8f459036efeaa376f21d6"
+        "cf0cbee66bea7789d5eeac5798495c7f22f15868400bf0b6bab9c95d31bfe2ff"
     ],
     [
         [
@@ -214,28 +214,28 @@
             "file",
             "sdk/wasp/client/operations/queryClient.ts"
         ],
-        "5c1d87ac10513788bcde7ebc7c10601b9ad0854cddff355e8fb7e2d4685ecdef"
+        "c32437fb349592ee41ab8d85aa0a92174e6eb7bf831cc63a0c3719c9cecd6343"
     ],
     [
         [
             "file",
             "sdk/wasp/client/operations/rpc.ts"
         ],
-        "3b2c5f4ed90150f21da899cccc23c0aef42030db2f0171e56f28f0f016e25bc9"
+        "746c76905061b5d066cd3909a6cf7699cd57aa8ee17d04e3bad3d67e8c57483a"
     ],
     [
         [
             "file",
             "sdk/wasp/client/router/Link.tsx"
         ],
-        "d1a6f48d96f50b2900324f221f1fafa70a04bc9b5bba7d1dc78ffebfb7d2704b"
+        "504c73de9596bcf394d91b5bf3fc9078af5e461713b716a3155a918c9da03069"
     ],
     [
         [
             "file",
             "sdk/wasp/client/router/NavLink.tsx"
         ],
-        "22f7b0a0000fc53091f7a281feb025ea80f8a279bf2d21a2be3531d0c5b202ab"
+        "bcedb44395e0dced4009e5e4a8dffa18660b4bb81dec106a33407c454dedb991"
     ],
     [
         [
@@ -277,7 +277,7 @@
             "file",
             "sdk/wasp/client/test/vitest/helpers.tsx"
         ],
-        "f13f830a28370dc6038a5f69ce61b371530f776a407210b513daccb327bb8257"
+        "aafd398af585df12a06cb8f5ec5eb09a2f5db2deed01b257177566d43a42f704"
     ],
     [
         [
@@ -291,21 +291,21 @@
             "file",
             "sdk/wasp/client/vite/plugins/detectServerImports.ts"
         ],
-        "93885302fbb1758384e990fb6a7eac52fa03459f4df66a2b59eb8ac7b3e5c14a"
+        "af2157c5a71b7409055dd53094bdf33646ba2284fd3aaffad830489fecb06d79"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/envFile.ts"
         ],
-        "0fafefac0b8c9ecfa0cac06f13e084ac8e1661d8fbead6e2d8b2bc7a08c9b035"
+        "3bb6ae4f102a9fd9638669bac42e3c01d69bf9a6a26685d2debd9c4f19ce1af3"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/typescriptCheck.ts"
         ],
-        "d039097bc563e8f51831f01b9f73549e7eda752d21480cf2cbe545520c0f8aea"
+        "1a144dffe58e7eab72b88edb64dd44220b63b09b902d51f1b6f92331fe3089e7"
     ],
     [
         [
@@ -319,28 +319,28 @@
             "file",
             "sdk/wasp/client/vite/plugins/virtualUserModules.ts"
         ],
-        "db4acaf6e01de4ad53a9c7fb75bff5da1809b99f88b4296a5a180ac3a9ef844f"
+        "aa97c9367c45f1aef790e98deea870c58413f5abf68696a20faa2d68f4857b4c"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/virtualWaspModules.ts"
         ],
-        "4aede5b77417f38713a8f8b72b119d8a060e1ef1984945ceca249119b528b38a"
+        "7988c7fa950d788a355cd82ad1a4577d43853aef7b302e81341e83e01d83c6ef"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/wasp.ts"
         ],
-        "0e57fda79b9a03182c4d08788ea390f6af0604b4a59f107f778a23a2878d4e5b"
+        "97049725c4328c73207bea61937906188b95d8cab3ea9f06bb7ae38928a06b54"
     ],
     [
         [
             "file",
             "sdk/wasp/client/vite/plugins/waspConfig.ts"
         ],
-        "e8fb2bdec48dc07ca7d01dd800adef26b6caee924dd0600662aa191f7f3e24ef"
+        "7e63f5649c418c88d69204313b0a31d40dce6a6037394dde01cf806d2b672eab"
     ],
     [
         [
@@ -389,7 +389,7 @@
             "file",
             "sdk/wasp/core/serialization/index.ts"
         ],
-        "daaf6d88944b11969bcf278b84409b3ca81dc2f3cc97037df3ebc7f293381a74"
+        "329b29145a4e13a1278295fccc2f0c293b4b9975a10e2fb00423d288c9e89984"
     ],
     [
         [
@@ -410,7 +410,7 @@
             "file",
             "sdk/wasp/entities/index.ts"
         ],
-        "c5077f0d9a9224986a1c42b54de449e48af1f2b9ecc8778eb44cd55ebd9d23a7"
+        "eff58379f58bec1aaa3515dc81e8f945e8c0a247a51fbe4de0fcc78ad083b095"
     ],
     [
         [
@@ -466,14 +466,14 @@
             "file",
             "sdk/wasp/server/_types/index.ts"
         ],
-        "5fbfa58d566c5243c85698098a4d189196538437ff4715d630d61d37df06f42d"
+        "51d9c924b587941ed6514613e437f6f642bbd92d829c40b8f002def9e1c7b118"
     ],
     [
         [
             "file",
             "sdk/wasp/server/_types/taggedEntities.ts"
         ],
-        "2334c6c90cdf0e509cd4a7443035f884e5e942025a87d839800789e04c300b3e"
+        "7cc92031a066cfd5891eca4dd3ff7e06782d7ea3b70bce5c0c9fc4cd7750f20d"
     ],
     [
         [
@@ -494,21 +494,21 @@
             "file",
             "sdk/wasp/server/env.ts"
         ],
-        "10c3a06f2726fd3b247cf8fc138bce0237a9832151e107e92a041c3b8c2c6d7f"
+        "f3ef4efbc08161e36b6374937c0c11ea57c3591f79470495158b92a13a54196b"
     ],
     [
         [
             "file",
             "sdk/wasp/server/index.ts"
         ],
-        "a0d0ff1c97a4bc52f78d0fac37d1470690984b5dc2284f37b65244e633608cd8"
+        "1436713aa5119623c6384d8b399da9ee19c29a2441974cf5c6f9d674446581de"
     ],
     [
         [
             "file",
             "sdk/wasp/server/middleware/globalMiddleware.ts"
         ],
-        "53f258be83ca6de653b6b645253ce573e3c177e88017eb2adb17f5d3cebb36c3"
+        "ab20883dd155b8a66f8535a4ad1f532c2d89702fa750b3cd91ad79bc76a780c7"
     ],
     [
         [
@@ -529,7 +529,7 @@
             "file",
             "sdk/wasp/server/operations/actions/types.ts"
         ],
-        "30d5f5faeb3ae0e83a18a7a91d8928293855eda76f2ebb9a659f54cbdd565b83"
+        "8d77096d98e5ab9a544645a9a42efb844c0bff9bdbec0ec91014387a3eddc4aa"
     ],
     [
         [
@@ -550,42 +550,42 @@
             "file",
             "sdk/wasp/server/operations/queries/types.ts"
         ],
-        "dd1eb9d2fc6651128358bc73190f8e0cf1a1e5093c821bde0a3acfe51afadc9e"
+        "df7454a57eae3ee97a29f90e3f40892389fb2b5e37c43b332d1fef809424b84e"
     ],
     [
         [
             "file",
             "sdk/wasp/server/operations/wrappers.ts"
         ],
-        "352e7f555fb4cdc65556b215a072fd6ed1908cce606adffdf5906fa007b47dd6"
+        "342e3f17b028f7f01bf11e4425b027bce9f66a1a1d8e04a71a3049fc3ae101db"
     ],
     [
         [
             "file",
             "sdk/wasp/server/types/index.ts"
         ],
-        "0f2ffdfdd76c92084bd0ba270b674628ec907da0d047de6c8a9912e415462d97"
+        "0999c392608eb58a61adff654975e6b930f55bcf1f94a1c66618c2376f6fc23e"
     ],
     [
         [
             "file",
             "sdk/wasp/server/utils.ts"
         ],
-        "d7d15ef5f24220e7a71302f9c5a9e088688e99abf0609a2094f7fe87add4c099"
+        "7035b28021866e837e192e924d50fa7862d425d477d5209a215dd5aa20b9ad61"
     ],
     [
         [
             "file",
             "sdk/wasp/tsconfig.json"
         ],
-        "77c89a888d80cb15e8f7497dca2e9070c2bcc2bc167ad8823537117bf6995646"
+        "4da3a72edc3cf3f967aa7148ab59b690cde5931a0f15b5106137d0d49bea3f12"
     ],
     [
         [
             "file",
             "sdk/wasp/types/index.ts"
         ],
-        "0edc8cb5f3980c49a2bdc1a1e0a02ad2dda877e1bba1533198d9168b24527555"
+        "ac77b944feeb257d8764e38501dbfcf0f1f0724788f10e9c4acf29a4b92b45fe"
     ],
     [
         [

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/api/events.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/api/events.ts
@@ -1,4 +1,5 @@
-import mitt, { Emitter } from 'mitt';
+import mitt from 'mitt';
+import type { Emitter } from 'mitt';
 
 type ApiEvents = {
   // key: Event name

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/env.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/env.ts
@@ -1,6 +1,6 @@
 import type * as z from "zod";
 import { ensureEnvSchema } from "../env/validation";
-import { CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
+import { type CompleteClientEnvSchema, clientEnvSchema } from "./env/schema";
 
 // PUBLIC API
 export const env: z.infer<CompleteClientEnvSchema> = ensureEnvSchema(

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/env/schema.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/env/schema.ts
@@ -1,5 +1,5 @@
 import * as z from "zod"
-import { FromRegister } from "../../types/register";
+import type { FromRegister } from "../../types/register";
 
 export type RegisteredClientEnvValidationSchema = FromRegister<"clientEnvValidationSchema", z.ZodObject<{}>>;
 type UserClientEnvSchema = RegisteredClientEnvValidationSchema;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/hooks.ts
@@ -1,14 +1,14 @@
 import {
-  QueryClient,
-  QueryKey,
+  type QueryClient,
+  type QueryKey,
   useQuery as rqUseQuery,
   useMutation,
-  UseMutationOptions,
+  type UseMutationOptions,
   useQueryClient,
-  UseQueryResult,
+  type UseQueryResult,
 } from "@tanstack/react-query";
 import { makeQueryCacheKey } from "./queries/core";
-import { Action, Query } from "./rpc";
+import type { Action, Query } from "./rpc";
 export { configureQueryClient } from "./queryClient";
 
 // PUBLIC API

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/index.ts
@@ -21,7 +21,7 @@ export {
     queryClientInitialized
 } from './queryClient'
 
-export {
+export type {
     // PUBLIC API
-    type QueryMetadata,
+    QueryMetadata,
 } from './rpc'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queries/core.ts
@@ -1,4 +1,4 @@
-import { Route } from '../../index.js'
+import type { Route } from '../../index.js'
 import type { _Awaited, _ReturnType } from '../../../universal/types.js'
 import type {
   GenericBackendOperation,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query'
+import { QueryClient, type QueryClientConfig } from '@tanstack/react-query'
 
 const defaultQueryClientConfig = {};
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/operations/rpc.ts
@@ -3,7 +3,7 @@ import type {
   _Awaited,
   _ReturnType
 } from "../../universal/types";
-import { type Route } from "../index";
+import type { Route } from "../index";
 
 // PRIVATE API (for SDK, should maybe be public, users define values of this
 // type).

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/router/Link.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { Link as RouterLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterLinkProps = Parameters<typeof RouterLink>[0]
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/router/NavLink.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/router/NavLink.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { NavLink as RouterNavLink } from 'react-router'
 import { interpolatePath } from './linkHelpers'
-import { type Routes } from './index'
+import type { Routes } from './index'
 
 type RouterNavLinkProps = Parameters<typeof RouterNavLink>[0]
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/test/vitest/helpers.tsx
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/test/vitest/helpers.tsx
@@ -1,12 +1,12 @@
-import { ReactElement, ReactNode } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { http, type HttpResponseResolver, type RequestHandler } from 'msw'
 import { setupServer, type SetupServer } from 'msw/node'
 import { BrowserRouter as Router } from 'react-router'
-import { render, RenderResult, cleanup } from '@testing-library/react'
+import { render, type RenderResult, cleanup } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeAll, afterEach, afterAll } from 'vitest'
-import { Query } from '../../operations/rpc.js'
-import { config, HttpMethod, Route } from '../../index.js'
+import type { Query } from '../../operations/rpc.js'
+import { config, HttpMethod, type Route } from '../../index.js'
 import { serialize } from '../../../core/serialization/index.js'
 
 // PRIVATE API

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/detectServerImports.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import path from 'path'
 
 export function detectServerImports(): Plugin {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/envFile.ts
@@ -1,4 +1,4 @@
-import { type Plugin, type UserConfig } from 'vite'
+import type { Plugin, UserConfig } from 'vite'
 import { resolve } from 'node:path'
 import { readFile, access, constants } from 'node:fs/promises'
 import { parse as parseDotenv } from 'dotenv'

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/typescriptCheck.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import { spawn } from 'node:child_process'
 
 interface TypeScriptCheckOptions {

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualUserModules.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 
 /**
  * Maps virtual module IDs (pointing to user's client modules)

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/virtualWaspModules.ts
@@ -1,4 +1,4 @@
-import { type Plugin } from "vite";
+import type { Plugin } from "vite";
 import {
   getClientEntryTsxContent,
   getRoutesTsxContent,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/wasp.ts
@@ -1,5 +1,6 @@
-import { type PluginOption } from "vite";
-import react, { type Options as ReactOptions } from "@vitejs/plugin-react";
+import type { PluginOption } from "vite";
+import react from "@vitejs/plugin-react";
+import type { Options as ReactOptions } from "@vitejs/plugin-react";
 import ssr from "@wasp.sh/lib-vite-ssr";
 import { validateEnv } from "./validateEnv.js";
 import { envFile } from "./envFile.js";

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/client/vite/plugins/waspConfig.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest/config" />
-import { type PluginOption } from "vite";
+import type { PluginOption } from "vite";
 import { defaultExclude } from "vitest/config";
 
 // Vite merges `userConfig` and our `waspConfig` returned from the plugin.

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/core/serialization/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/core/serialization/index.ts
@@ -1,5 +1,5 @@
 import { deserialize, serialize } from "superjson"
-import { CustomSerializableJSONValue } from "./custom-register"
+import type { CustomSerializableJSONValue } from "./custom-register"
 
 import "./prisma"
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/entities/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/entities/index.ts
@@ -1,9 +1,9 @@
-import {
-  type Task,
+import type {
+  Task,
 } from "@prisma/client"
 
-export {
-  type Task,
+export type {
+  Task,
 } from "@prisma/client"
 
 export type Entity = 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/index.ts
@@ -1,12 +1,12 @@
-import { type Expand } from '../../universal/types.js'
-import { type Request, type Response } from 'express'
-import {
-  type ParamsDictionary as ExpressParams,
-  type Query as ExpressQuery,
+import type { Expand } from '../../universal/types.js'
+import type { Request, Response } from 'express'
+import type {
+  ParamsDictionary as ExpressParams,
+  Query as ExpressQuery,
 } from 'express-serve-static-core'
 import { prisma } from '../index.js'
-import { type _Entity } from './taggedEntities'
-import { type Payload } from '../../core/serialization/index.js'
+import type { _Entity } from './taggedEntities'
+import type { Payload } from '../../core/serialization/index.js'
 
 export * from "./taggedEntities"
 export * from "../../core/serialization/index.js"

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/_types/taggedEntities.ts
@@ -3,10 +3,10 @@
 //
 // We must explicitly tag all entities with their name to avoid issues with
 // structural typing. See https://github.com/wasp-lang/wasp/pull/982 for details.
-import { 
-  type Entity, 
-  type EntityName,
-  type Task,
+import type { 
+  Entity, 
+  EntityName,
+  Task,
 } from '../../entities/index.js'
 
 export type _Task = WithName<Task, "Task">

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/env.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/env.ts
@@ -1,6 +1,6 @@
 import * as z from "zod"
 import { ensureEnvSchema } from "../env/validation"
-import { FromRegister } from "../types/register";
+import type { FromRegister } from "../types/register";
 
 export type RegisteredServerEnvValidationSchema = FromRegister<"serverEnvValidationSchema", z.ZodObject<{}>>;
 type UserServerEnvSchema = RegisteredServerEnvValidationSchema;

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/index.ts
@@ -5,11 +5,11 @@ export { default as config } from './config.js'
 // PUBLIC API
 export { default as prisma, type PrismaClient } from './dbClient.js'
 // PUBLIC API
-export { type ServerSetupFn } from './types/index.js'
+export type { ServerSetupFn } from './types/index.js'
 // PUBLIC API
 export { HttpError } from './HttpError.js'
 // PUBLIC API
-export { type MiddlewareConfigFn } from './middleware/index.js'
+export type { MiddlewareConfigFn } from './middleware/index.js'
 // PUBLIC API
 export { env } from './env.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/middleware/globalMiddleware.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/middleware/globalMiddleware.ts
@@ -1,4 +1,4 @@
-import { type RequestHandler } from 'express'
+import type { RequestHandler } from 'express'
 
 // PUBLIC API
 export type MiddlewareConfigFn = (middlewareConfig: MiddlewareConfig) => MiddlewareConfig

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/actions/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/actions/types.ts
@@ -1,4 +1,4 @@
-import {
-  type Payload,
+import type {
+  Payload,
 } from '../../_types/index.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/queries/types.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/queries/types.ts
@@ -1,5 +1,5 @@
 
-import {
-  type Payload,
+import type {
+  Payload,
 } from '../../_types/index.js'
 

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/operations/wrappers.ts
@@ -1,6 +1,6 @@
-import { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
+import type { IfAny, _Awaited, _ReturnType, _Parameters } from '../../universal/types'
 
-import {
+import type {
   _Entity,
   UnauthenticatedOperationDefinition,
   Payload,

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/types/index.ts
@@ -1,5 +1,5 @@
-import { type Application } from 'express'
-import { Server } from 'http'
+import type { Application } from 'express'
+import type { Server } from 'http'
 
 // PUBLIC API
 export type ServerSetupFn = (context: ServerSetupFnContext) => Promise<void>

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/utils.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/server/utils.ts
@@ -1,4 +1,4 @@
-import { Response, RequestHandler } from 'express'
+import type { Response, RequestHandler } from 'express'
 
 
 // This is explicitly how Express expects extensions to their

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/tsconfig.json
@@ -39,8 +39,9 @@
     // `isolatedModules` rejects code that single-file transpilers (like esbuild)
     // can't handle. The SDK gets bundled, so it must not rely on such code.
     "isolatedModules": true,
-    // We haven't adopted `verbatimModuleSyntax` yet.
-    "verbatimModuleSyntax": false,
+    // `verbatimModuleSyntax` makes type-only imports explicit, so single-file
+    // transpilers can drop them without having to know what they refer to.
+    "verbatimModuleSyntax": true,
     "moduleDetection": "force", // Assume all files are modules
     /*
       The SDK code uses extensionless relative imports and imports its own

--- a/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/types/index.ts
+++ b/waspc/e2e-tests/test-outputs/snapshots/wasp-migrate-golden/wasp-app/.wasp/out/sdk/wasp/types/index.ts
@@ -1,1 +1,1 @@
-export { type Register } from "./register";
+export type { Register } from "./register";


### PR DESCRIPTION
## Description

Follow-up to #4808. Turns on `verbatimModuleSyntax` in the generated SDK `tsconfig.json`.

The SDK ends up in esbuild and Vite, which transpile file by file and can't tell whether an import refers to a type or a value. This flag makes type-only imports explicit, so the bundler can drop them safely without having to know what they refer to.

Three kinds of changes were needed:

- Imports that TypeScript flagged as type-only now use `type` (36 statements).
- Imports where every specifier was already `type`-marked inline (`import { type A } from`) now use `import type { A } from`. With the flag on, the inline form is emitted as `import {} from '...'`, which keeps a runtime import of the module. Notably `entities/index.ts` would otherwise have kept a client-side import of `@prisma/client`.
- A few imports of values that are only used in type positions (`Server` from `socket.io` and `http`, `Socket` from `socket.io-client`, `prisma` in the web socket types, `QueryClient` in hooks) became type imports so they still get dropped from the output.

CI also caught `server/email/core/providers/dummy.ts`, which kitchen-sink never generates because it uses SMTP. It imported two types as values and now uses `import type`. I audited every named relative import across all SDK templates with a small script that checks whether the imported name is a type-only export in the target module, and that was the only remaining case. Verified by compiling the `basic` starter, which uses the Dummy provider.

One real runtime issue turned up: `api/events.ts` imported `Emitter` from `mitt` as a value. TypeScript didn't complain because `mitt` ships no `types` entry in its `exports` map, so under `moduleResolution: bundler` it resolves to the untyped `.mjs` file and `Emitter` is `any`. With the flag on the import was kept and Vite failed with a missing export. It's now an explicit type import.

Verified by building `examples/kitchen-sink` with the dev CLI plus `npx vite build`, by diffing the emitted import statements in the SDK `dist` against a build without the flag (they match, except one server-only Prisma import that's a real value import in other configurations), and by regenerating the e2e snapshots.

## Agreement

<!-- Select just one with [x] -->

- [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
- [x] A maintainer agreed on the approach beforehand: authored by a maintainer, follow-up to #4808

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [x] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- Config and import syntax change, covered by the e2e snapshots. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
