### PR TITLE
Fix localtunnel domain typo in Slack auth docs

### DIFF
--- a/web/docs/auth/social-auth/slack.md
+++ b/web/docs/auth/social-auth/slack.md
@@ -88,7 +88,7 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
 4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -3065,7 +3065,7 @@ wasp start db
 wasp start db --db-image postgres:18
 
 # Use PostgreSQL with PostGIS extension for geographic data:
-wasp start db --db-image postgis/postgis:18-3.6
+wasp start db --db-image postgis/postgis:18-3.6 
 
 # Use PostgreSQL with pgvector extension for AI embeddings:
 wasp start db --db-image pgvector/pgvector:pg18
@@ -9954,7 +9954,7 @@ export const mySetupFunction: ServerSetupFn = async () => {
   // Let's pretend functions setUpSomeResource and startSomeCronJob
   // are implemented below or imported from another file.
   someResource = await setUpSomeResource()
-  startSomeCronJob()
+  startSomeCronJob()  
 }
 
 export const getSomeResource = () => someResource

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -3065,7 +3065,7 @@ wasp start db
 wasp start db --db-image postgres:18
 
 # Use PostgreSQL with PostGIS extension for geographic data:
-wasp start db --db-image postgis/postgis:18-3.6 
+wasp start db --db-image postgis/postgis:18-3.6
 
 # Use PostgreSQL with pgvector extension for AI embeddings:
 wasp start db --db-image pgvector/pgvector:pg18
@@ -7066,7 +7066,7 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 
 4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
 
-   - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+   - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
    - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 5. Hit **Save URLs**.
@@ -9954,7 +9954,7 @@ export const mySetupFunction: ServerSetupFn = async () => {
   // Let's pretend functions setUpSomeResource and startSomeCronJob
   // are implemented below or imported from another file.
   someResource = await setUpSomeResource()
-  startSomeCronJob()  
+  startSomeCronJob()
 }
 
 export const getSomeResource = () => someResource

--- a/web/versioned_docs/version-0.17/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.17/auth/social-auth/slack.md
@@ -84,8 +84,8 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
-4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**. 
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.
@@ -182,7 +182,7 @@ but free tier is limited).
 
 <Collapse title="Using localtunnel">
 
-Install localtunnel globally with `npm install -g localtunnel`. 
+Install localtunnel globally with `npm install -g localtunnel`.
 
 Start a tunnel with `lt --port 3001 -s <subdomain>`, where `<subdomain>` is a unique subdomain you would like to have.
 

--- a/web/versioned_docs/version-0.18/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.18/auth/social-auth/slack.md
@@ -84,8 +84,8 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
-4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**. 
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.
@@ -182,7 +182,7 @@ but free tier is limited).
 
 <Collapse title="Using localtunnel">
 
-Install localtunnel globally with `npm install -g localtunnel`. 
+Install localtunnel globally with `npm install -g localtunnel`.
 
 Start a tunnel with `lt --port 3001 -s <subdomain>`, where `<subdomain>` is a unique subdomain you would like to have.
 

--- a/web/versioned_docs/version-0.19/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.19/auth/social-auth/slack.md
@@ -84,8 +84,8 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
-4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**. 
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.
@@ -182,7 +182,7 @@ but free tier is limited).
 
 <Collapse title="Using localtunnel">
 
-Install localtunnel globally with `npm install -g localtunnel`. 
+Install localtunnel globally with `npm install -g localtunnel`.
 
 Start a tunnel with `lt --port 3001 -s <subdomain>`, where `<subdomain>` is a unique subdomain you would like to have.
 

--- a/web/versioned_docs/version-0.20/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.20/auth/social-auth/slack.md
@@ -84,8 +84,8 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
-4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**. 
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.
@@ -182,7 +182,7 @@ but free tier is limited).
 
 <Collapse title="Using localtunnel">
 
-Install localtunnel globally with `npm install -g localtunnel`. 
+Install localtunnel globally with `npm install -g localtunnel`.
 
 Start a tunnel with `lt --port 3001 -s <subdomain>`, where `<subdomain>` is a unique subdomain you would like to have.
 

--- a/web/versioned_docs/version-0.21/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.21/auth/social-auth/slack.md
@@ -86,7 +86,7 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
 4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.

--- a/web/versioned_docs/version-0.22/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.22/auth/social-auth/slack.md
@@ -86,7 +86,7 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
 4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.

--- a/web/versioned_docs/version-0.23/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.23/auth/social-auth/slack.md
@@ -86,7 +86,7 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
 4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.

--- a/web/versioned_docs/version-0.24/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.24/auth/social-auth/slack.md
@@ -88,7 +88,7 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
 4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.

--- a/web/versioned_docs/version-0.25/auth/social-auth/slack.md
+++ b/web/versioned_docs/version-0.25/auth/social-auth/slack.md
@@ -88,7 +88,7 @@ To use Slack as an authentication method, you'll first need to create a Slack Ap
 <img alt="Slack Applications Screenshot" src={useBaseUrl('img/integrations-slack-1.png')} width="400px" />
 
 4. Go to the **OAuth & Permissions** tab on the sidebar and click **Add New Redirect URL**.
-    - Enter the value `https://<subdomain>.local.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
+    - Enter the value `https://<subdomain>.loca.lt/auth/slack/callback`, where `<subdomain>` is your selected localtunnel subdomain.
     - Slack requires us to use HTTPS even when developing, [read below](#slack-https) how to set it up.
 
 4. Hit **Save URLs**.


### PR DESCRIPTION
## Description

The Slack social auth docs told users to register `https://<subdomain>.local.lt/auth/slack/callback` as the OAuth redirect URL, but localtunnel's domain is `loca.lt`, so following the instructions produced a callback URL that never resolves. This fixes the typo in `web/docs/` and in every versioned copy (0.17 through 0.25), plus the generated `web/markdown-snapshots/llms-full.txt`. The versioned docs are touched intentionally here: they are what users on older releases actually read, so leaving the broken domain there would keep the instructions unusable for them. A few incidental trailing-whitespace removals came along from formatting.

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
