### PR TITLE
Improve Supabase warning in Vercel deployment guide

### DIFF
--- a/web/docs/guides/deployment/cloud-providers/vercel.md
+++ b/web/docs/guides/deployment/cloud-providers/vercel.md
@@ -79,11 +79,11 @@ npx vercel env add --no-sensitive DATABASE_URL production
 
 Prisma migrations can't run through the transaction-mode pooler, so the build command in the next section runs them against `POSTGRES_URL_NON_POOLING` (Supabase's session-mode pooler) instead.
 
-:::warning
-The Supabase database is linked to your Vercel account. If you remove the integration or delete your Vercel account, the database will be deleted along with it.
-:::
-
 You can also use the Supabase dashboard to manage your database, run queries, and view logs. You can access it from the **Storage** tab of your Vercel project: click the database, then the **Open in Supabase** button.
+
+:::warning
+The Supabase database is linked to your Vercel account. If you remove the integration or delete your Vercel account, the database will be deleted along with it. If you're moving out of Vercel but want to keep your data in Supabase, [transfer the project](https://supabase.com/docs/guides/platform/project-transfer) to a standalone Supabase organization first.
+:::
 
 ### Deploying the server
 

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -20798,7 +20798,9 @@ If your app relies on any of these, deploy the server to a different provider (s
 
 #### Pricing
 
-Check [Vercel's pricing page](https://vercel.com/pricing#:~\:text=Vercel%20Functions) to see if the free plan is sufficient for your app, and what benefits paid plans bring. In our experience, the free plan is enough for testing most apps as you're starting out, but if you get a lot of traffic, you may want to upgrade to a paid plan.
+We estimate that Vercel's free plan is sufficient as a testing ground for most apps, or as production deployment for small-scale, non-commercial apps. For a large-scale app or a commercial one, you may need to consider a paid plan to handle increased traffic.
+
+Please check Vercel's [pricing page](https://vercel.com/pricing#:~\:text=Vercel%20Functions) for the most up-to-date information on their plans and their allowances; as well as their [Fair Usage guidelines](https://vercel.com/docs/limits/fair-use-guidelines#commercial-usage) on what constitutes commercial use.
 
 #### Prerequisites
 
@@ -20831,15 +20833,15 @@ npx vercel env add --no-sensitive DATABASE_URL production
 
 Prisma migrations can't run through the transaction-mode pooler, so the build command in the next section runs them against `POSTGRES_URL_NON_POOLING` (Supabase's session-mode pooler) instead.
 
-:::warning
-The Supabase database is linked to your Vercel account. If you remove the integration or delete your Vercel account, the database will be deleted along with it.
-:::
-
 You can also use the Supabase dashboard to manage your database, run queries, and view logs. You can access it from the **Storage** tab of your Vercel project: click the database, then the **Open in Supabase** button.
+
+:::warning
+The Supabase database is linked to your Vercel account. If you remove the integration or delete your Vercel account, the database will be deleted along with it. If you're moving out of Vercel but want to keep your data in Supabase, [transfer the project](https://supabase.com/docs/guides/platform/project-transfer) to a standalone Supabase organization first.
+:::
 
 #### Deploying the server
 
-1. Create a `vercel.json` that tells Vercel to treat the built server as an Express app:
+1. Create a `vercel.json` in your project root that tells Vercel to treat the built server as an Express app:
 
    ```json title="vercel.json"
    {


### PR DESCRIPTION
## Description

Moves the Supabase data-loss warning in the Vercel deployment guide below the dashboard paragraph and adds a link to Supabase's project transfer docs for users leaving Vercel who want to keep their data.

Also regenerates the markdown snapshots, which were stale after #4814.

## Agreement

<!-- Select just one with [x] -->

- [x] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
- [ ] A maintainer agreed on the approach beforehand: <!-- link to the GitHub issue or Discord thread -->

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [x] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.