### PR TITLE
Add the single deployment mode to the spec, make it the default

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -12,6 +12,7 @@
 - Wasp now manages your app's ports in development, so setting them yourself (e.g. `server.port` in `vite.config.ts`) is now an error. ([#4591](https://github.com/wasp-lang/wasp/pull/4591))
 - In deployed Wasp server apps, the `PORT` environment variable is now compulsory. ([#4591](https://github.com/wasp-lang/wasp/pull/4591))
 - Removed the `wasp info` command, in favor of the new `wasp show` family of commands. ([#4622](https://github.com/wasp-lang/wasp/pull/4622))
+- Wasp apps can now deploy as one app (server serves the client), which allows simple single origin deployment. Wasp will default to the new single app deployment. ([#4834](https://github.com/wasp-lang/wasp/pull/4834))
 
 ### 🎉 New Features
 

--- a/waspc/data/packages/spec/__tests__/spec/mapApp.unit.test.ts
+++ b/waspc/data/packages/spec/__tests__/spec/mapApp.unit.test.ts
@@ -105,7 +105,7 @@ describe("convertWaspSpecToAppSpec", () => {
     const db = Fixtures.getDbConfig("full");
     const emailSender = Fixtures.getEmailSenderConfig("full");
     const webSocket = Fixtures.getWebSocketConfig("full");
-    const deployment = {};
+    const deployment = Fixtures.getDeploymentConfig("full");
     const entityNames = Fixtures.getEntities("full");
 
     const inputApp = app({
@@ -149,7 +149,7 @@ describe("convertWaspSpecToAppSpec", () => {
         declValue: {
           wasp: inputApp.wasp,
           title: inputApp.title,
-          deployment: { mode: undefined },
+          deployment: AppSpecMapper.mapDeployment(deployment),
           head: inputApp.head,
           auth: AppSpecMapper.mapAuth(authConfig, ctx),
           server: AppSpecMapper.mapServer(server, ctx),

--- a/waspc/data/packages/spec/__tests__/spec/testFixtures.ts
+++ b/waspc/data/packages/spec/__tests__/spec/testFixtures.ts
@@ -37,6 +37,7 @@ export function getApp(scope: ConfigScope): WaspSpec.App {
         name: "FullApp",
         wasp: { version: "^0.16.3" },
         title: "Mock App",
+        deployment: getDeploymentConfig("full"),
         head: ['<link rel="icon" href="/favicon.ico" />'],
         auth: getAuthConfig("full"),
         server: getServerConfig("full"),
@@ -343,6 +344,24 @@ export function getDbConfig(scope: ConfigScope): Config<WaspSpec.Db> {
         seeds: [getRefObject("full", "named"), getRefObject("full", "default")],
         prismaSetupFn: getRefObject("full", "named"),
       } satisfies FullConfig<WaspSpec.Db>;
+    default:
+      assertUnreachable(scope);
+  }
+}
+
+export function getDeploymentConfig<Scope extends ConfigScope>(
+  scope: Scope,
+): ConfigFor<Scope, WaspSpec.Deployment>;
+export function getDeploymentConfig(
+  scope: ConfigScope,
+): Config<WaspSpec.Deployment> {
+  switch (scope) {
+    case "minimal":
+      return {} satisfies MinimalConfig<WaspSpec.Deployment>;
+    case "full":
+      return {
+        mode: "split",
+      } satisfies FullConfig<WaspSpec.Deployment>;
     default:
       assertUnreachable(scope);
   }

--- a/waspc/data/packages/spec/__tests__/spec/tsAppSpec.test-d.ts
+++ b/waspc/data/packages/spec/__tests__/spec/tsAppSpec.test-d.ts
@@ -6,8 +6,9 @@ import { describe, expectTypeOf, test } from "vitest";
 import type * as WaspSpec from "../../src/spec/publicApi/waspSpec.js";
 
 describe("Deployment", () => {
-  test("allows an omitted mode or split mode", () => {
+  test("allows an omitted, single or split mode", () => {
     expectTypeOf<{}>().toExtend<WaspSpec.Deployment>();
+    expectTypeOf<{ mode: "single" }>().toExtend<WaspSpec.Deployment>();
     expectTypeOf<{ mode: "split" }>().toExtend<WaspSpec.Deployment>();
   });
 });

--- a/waspc/data/packages/spec/src/appSpec.ts
+++ b/waspc/data/packages/spec/src/appSpec.ts
@@ -112,7 +112,7 @@ export type Deployment = {
   mode: Optional<DeploymentMode>;
 };
 
-export type DeploymentMode = "split";
+export type DeploymentMode = "single" | "split";
 
 export type ExtImport = NamedExtImport | DefaultExtImport;
 export type ExtImportKind = ExtImport["kind"];

--- a/waspc/data/packages/spec/src/spec/publicApi/waspSpec.ts
+++ b/waspc/data/packages/spec/src/spec/publicApi/waspSpec.ts
@@ -88,7 +88,12 @@ export interface Deployment {
   /**
    * How the client and server are deployed.
    *
-   * @default "split"
+   * - `"single"`: one deployable app that serves both the client and the
+   *   server.
+   * - `"split"`: the client and the server are deployed separately, each with
+   *   its own URL.
+   *
+   * @default "single"
    */
   mode?: DeploymentMode;
 }
@@ -96,7 +101,7 @@ export interface Deployment {
 /**
  * Supported app deployment modes.
  */
-export type DeploymentMode = "split";
+export type DeploymentMode = "single" | "split";
 
 /**
  * Wasp compiler metadata used by the app.

--- a/waspc/src/Wasp/AppSpec/App.hs
+++ b/waspc/src/Wasp/AppSpec/App.hs
@@ -41,7 +41,7 @@ instance IsDecl App
 
 getDeploymentMode :: App -> Deployment.DeploymentMode
 getDeploymentMode app =
-  fromMaybe Deployment.Split $ deployment app >>= Deployment.mode
+  fromMaybe Deployment.defaultMode $ deployment app >>= Deployment.mode
 
 instance Inspectable App where
   inspect app =

--- a/waspc/src/Wasp/AppSpec/App/Deployment.hs
+++ b/waspc/src/Wasp/AppSpec/App/Deployment.hs
@@ -6,11 +6,15 @@
 module Wasp.AppSpec.App.Deployment
   ( Deployment (..),
     DeploymentMode (..),
+    defaultMode,
+    deploymentModeName,
   )
 where
 
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (String), withText)
 import Data.Data (Data)
+import Data.List (find)
+import qualified Data.Text as T
 import GHC.Generics (Generic)
 
 data Deployment = Deployment
@@ -18,14 +22,26 @@ data Deployment = Deployment
   }
   deriving (Show, Eq, Data, Generic, FromJSON, ToJSON)
 
-data DeploymentMode = Split
-  deriving (Show, Eq, Data, Generic)
+-- | How the client and the server of a Wasp app are deployed.
+data DeploymentMode
+  = -- | One deployable app that serves both the client and the server.
+    Single
+  | -- | The client and the server are deployed separately, each with its own URL.
+    Split
+  deriving (Show, Eq, Data, Generic, Enum, Bounded)
+
+defaultMode :: DeploymentMode
+defaultMode = Single
+
+deploymentModeName :: DeploymentMode -> String
+deploymentModeName Single = "single"
+deploymentModeName Split = "split"
 
 instance FromJSON DeploymentMode where
-  parseJSON = withText "DeploymentMode" $ \deploymentMode ->
-    case deploymentMode of
-      "split" -> pure Split
-      _ -> fail $ "Unknown deployment mode: " ++ show deploymentMode
+  parseJSON = withText "DeploymentMode" $ \name ->
+    case find ((== T.unpack name) . deploymentModeName) [minBound .. maxBound] of
+      Just mode -> pure mode
+      Nothing -> fail $ "Unknown deployment mode: " ++ show name
 
 instance ToJSON DeploymentMode where
-  toJSON Split = String "split"
+  toJSON = String . T.pack . deploymentModeName

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -4,6 +4,7 @@ module Wasp.AppSpec.Valid
   ( validateAppSpec,
     getApp,
     isAuthEnabled,
+    getDeploymentMode,
     doesUserEntityContainField,
     getIdFieldFromCrudEntity,
     getLowestNodeVersionUserAllows,
@@ -27,6 +28,7 @@ import qualified Wasp.AppSpec.App as App
 import qualified Wasp.AppSpec.App.Auth as Auth
 import qualified Wasp.AppSpec.App.Client as Client
 import qualified Wasp.AppSpec.App.Db as AS.Db
+import Wasp.AppSpec.App.Deployment (DeploymentMode)
 import qualified Wasp.AppSpec.App.EmailSender as AS.EmailSender
 import qualified Wasp.AppSpec.App.Wasp as Wasp
 import Wasp.AppSpec.Core.Decl (getDeclName, takeDecls)
@@ -516,6 +518,10 @@ getApp spec = case takeDecls @App (AS.decls spec) of
 -- | This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).
 isAuthEnabled :: AppSpec -> Bool
 isAuthEnabled spec = isJust (App.auth $ snd $ getApp spec)
+
+-- | This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).
+getDeploymentMode :: AppSpec -> DeploymentMode
+getDeploymentMode = App.getDeploymentMode . snd . getApp
 
 getValidDbSystem :: AppSpec -> AS.Db.DbSystem
 getValidDbSystem = getValidDbSystemFromPrismaSchema . AS.prismaSchema

--- a/waspc/src/Wasp/Generator.hs
+++ b/waspc/src/Wasp/Generator.hs
@@ -11,6 +11,7 @@ import Data.List.NonEmpty (toList)
 import StrongPath (Abs, Dir, Path')
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
+import Wasp.AppSpec.Valid (getDeploymentMode)
 import qualified Wasp.ExternalConfig.Npm.Dependency as D
 import qualified Wasp.ExternalConfig.Npm.PackageJson as PJ
 import Wasp.Generator.Common (GeneratedAppDir)
@@ -56,7 +57,7 @@ writeWebAppCode spec dstDir sendMessage = do
         Left generatorErrors -> return (generatorWarnings, toList generatorErrors)
         Right fileDrafts -> do
           synchronizeFileDraftsWithDisk dstDir fileDrafts
-          WaspInfo.persist dstDir $ AS.buildType spec
+          WaspInfo.persist dstDir (AS.buildType spec) (getDeploymentMode spec)
           (setupGeneratorWarnings, setupGeneratorErrors) <- runSetup spec dstDir sendMessage
           return (generatorWarnings ++ setupGeneratorWarnings, setupGeneratorErrors)
 

--- a/waspc/src/Wasp/Generator/WaspInfo.hs
+++ b/waspc/src/Wasp/Generator/WaspInfo.hs
@@ -17,6 +17,7 @@ import Data.Version (showVersion)
 import GHC.Generics (Generic)
 import qualified Paths_waspc
 import StrongPath (Abs, Dir, File, Path', Rel, relfile, toFilePath, (</>))
+import Wasp.AppSpec.App.Deployment (DeploymentMode, deploymentModeName)
 import Wasp.Generator.Common (GeneratedAppDir)
 import Wasp.Inspectable (Inspectable (inspect), InspectionEntry (InspectionEntry))
 import Wasp.Project.BuildType (BuildType)
@@ -25,7 +26,8 @@ import Wasp.Util.IO (doesFileExist)
 data WaspInfo = WaspInfo
   { waspVersion :: String,
     generatedAt :: UTCTime,
-    buildType :: BuildType
+    buildType :: BuildType,
+    deploymentMode :: DeploymentMode
   }
   deriving (Eq, Show, Generic)
 
@@ -34,12 +36,13 @@ instance FromJSON WaspInfo
 instance ToJSON WaspInfo
 
 instance Inspectable WaspInfo where
-  inspect WaspInfo {waspVersion, generatedAt, buildType} =
+  inspect WaspInfo {waspVersion, generatedAt, buildType, deploymentMode} =
     [ InspectionEntry
         "Build"
         [ ("Wasp version", waspVersion),
           ("Generated at", show generatedAt),
-          ("Build type", show buildType)
+          ("Build type", show buildType),
+          ("Deployment mode", deploymentModeName deploymentMode)
         ]
     ]
 
@@ -48,15 +51,16 @@ data WaspInfoFile
 waspInfoInGeneratedAppDir :: Path' (Rel GeneratedAppDir) (File WaspInfoFile)
 waspInfoInGeneratedAppDir = [relfile|.waspinfo|]
 
-persist :: Path' Abs (Dir GeneratedAppDir) -> BuildType -> IO ()
-persist generatedAppDir currentBuildType = do
+persist :: Path' Abs (Dir GeneratedAppDir) -> BuildType -> DeploymentMode -> IO ()
+persist generatedAppDir currentBuildType currentDeploymentMode = do
   encodeFile (toFilePath waspInfoFile) . generateWaspInfo =<< getCurrentTime
   where
     generateWaspInfo currentTime =
       WaspInfo
         { waspVersion = currentVersion,
           generatedAt = currentTime,
-          buildType = currentBuildType
+          buildType = currentBuildType,
+          deploymentMode = currentDeploymentMode
         }
 
     waspInfoFile = generatedAppDir </> waspInfoInGeneratedAppDir

--- a/waspc/tests/AppSpec/FromJSONTest.hs
+++ b/waspc/tests/AppSpec/FromJSONTest.hs
@@ -26,6 +26,17 @@ import qualified Wasp.AppSpec.Route as Route
 spec_AppSpecFromJSON :: Spec
 spec_AppSpecFromJSON = do
   describe "Deployment" $ do
+    it "parses the single deployment mode" $ do
+      [trimming|
+          {
+            "mode": "single"
+          }
+        |]
+        `shouldDecodeTo` Just
+          ( Deployment.Deployment
+              { Deployment.mode = Just Deployment.Single
+              }
+          )
     it "parses the split deployment mode" $ do
       [trimming|
           {

--- a/waspc/tests/Generator/WaspInfoTest.hs
+++ b/waspc/tests/Generator/WaspInfoTest.hs
@@ -1,0 +1,28 @@
+module Generator.WaspInfoTest where
+
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (parseMaybe, (.:))
+import Data.Time (UTCTime (UTCTime), fromGregorian)
+import Test.Hspec
+import qualified Wasp.AppSpec.App.Deployment as Deployment
+import Wasp.Generator.WaspInfo (WaspInfo (..))
+import qualified Wasp.Project.BuildType as BuildType
+
+spec_WaspInfo :: Spec
+spec_WaspInfo = do
+  describe "WaspInfo JSON" $ do
+    it "writes the deployment mode by name" $ do
+      let json = Aeson.toJSON waspInfo
+      parseMaybe (Aeson.withObject "WaspInfo" (.: "deploymentMode")) json
+        `shouldBe` Just ("single" :: String)
+
+    it "reads back what it wrote" $ do
+      Aeson.decode (Aeson.encode waspInfo) `shouldBe` Just waspInfo
+  where
+    waspInfo =
+      WaspInfo
+        { waspVersion = "0.26.0",
+          generatedAt = UTCTime (fromGregorian 2026 1 1) 0,
+          buildType = BuildType.Production,
+          deploymentMode = Deployment.Single
+        }

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -627,6 +627,7 @@ test-suite waspc-tests
     Generator.JsImportTest
     Generator.MockWriteableMonad
     Generator.ServerGeneratorTest
+    Generator.WaspInfoTest
     Generator.WriteFileDraftsTest
     JsImportTest
     Node.InternalTest


### PR DESCRIPTION
## Description

- `deployment.mode` gains a `"single"` value next to the existing `"split"`, and `"single"` becomes the default.
- `.waspinfo` records the mode so `wasp deploy` can read it without re-analyzing the project.

**Nothing reads the mode yet**.

## Agreement

<!-- Select just one with [x] -->

- [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
- [x] A maintainer agreed on the approach beforehand: [#4784](https://github.com/wasp-lang/wasp/issues/4784), and the "[RFC] Single server" doc (status Accepted, decisions written up by @infomiho)

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [x] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

<!-- Marked breaking because this PR flips the default. On its own it changes no behaviour, since nothing reads the mode yet, but the decision lands here and so does its ChangeLog entry. -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended. <!-- Nothing user-visible to try yet. The only generated output that changes is `.waspinfo`. Covered by unit tests. -->

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- `FromJSONTest` for the new mode, `WaspInfoTest` for the recorded field, plus spec package tests. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Not a bug fix. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- Nothing observable to test yet. -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- Not needed. `single` is the default, so starters say nothing. -->
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- Not needed for this PR. -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- The docs for both modes are written in one piece, separately, rather than in fragments. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [x] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`. <!-- With the rest of the docs. -->
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Already at 0.26.0 on `main` since the last release. -->


