### PR TITLE
Use version numbers instead of dates in self-hosted deployment notices

### DIFF
--- a/web/docs/guides/deployment/self-hosted/caprover.md
+++ b/web/docs/guides/deployment/self-hosted/caprover.md
@@ -7,7 +7,7 @@ import { SecretGeneratorBlock } from "../../../project/SecretGeneratorBlock";
 
 # Caprover
 
-<LastCheckedWithVersionsNotice versions={{ Wasp: "0.24", Caprover: new Date("2026-01-30") }} />
+<LastCheckedWithVersionsNotice versions={{ Wasp: "0.24", Caprover: "1.14.1" }} />
 
 ## Deploy Wasp with Caprover
 

--- a/web/docs/guides/deployment/self-hosted/coolify.md
+++ b/web/docs/guides/deployment/self-hosted/coolify.md
@@ -7,7 +7,7 @@ import { SecretGeneratorBlock } from "../../../project/SecretGeneratorBlock";
 
 # Coolify
 
-<LastCheckedWithVersionsNotice versions={{ Wasp: "0.24", Coolify: new Date("2026-01-30") }} />
+<LastCheckedWithVersionsNotice versions={{ Wasp: "0.24", Coolify: "4.0.0-beta.462" }} />
 
 ## Deploy Wasp with Coolify
 

--- a/web/docs/guides/deployment/self-hosted/vps.md
+++ b/web/docs/guides/deployment/self-hosted/vps.md
@@ -7,7 +7,7 @@ import { SecretGeneratorBlock } from "../../../project/SecretGeneratorBlock";
 
 # Simple VPS
 
-<LastCheckedWithVersionsNotice versions={{ Wasp: "0.24", Caddy: new Date("2026-01-30"), Ubuntu: new Date("2026-01-30") }} />
+<LastCheckedWithVersionsNotice versions={{ Wasp: "0.24", Caddy: "2.10.2", "Ubuntu LTS": "24.04" }} />
 
 ## Deploy Wasp to a VPS
 

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -20962,7 +20962,7 @@ When you make updates and need to redeploy:
 ## Deployment / Self-Hosted / Caprover
 
 :::note
-Last checked with Wasp 0.24 and Caprover (as of Jan 30, 2026).
+Last checked with Wasp 0.24 and Caprover 1.14.1.
 
 This guide depends on external libraries or services, so it may become outdated over time. We do our best to keep it up to date, but make sure to check their documentation for any changes.
 :::
@@ -21212,7 +21212,7 @@ Push to the `main` branch and the GitHub Action will:
 ## Deployment / Self-Hosted / Coolify
 
 :::note
-Last checked with Wasp 0.24 and Coolify (as of Jan 30, 2026).
+Last checked with Wasp 0.24 and Coolify 4.0.0-beta.462.
 
 This guide depends on external libraries or services, so it may become outdated over time. We do our best to keep it up to date, but make sure to check their documentation for any changes.
 :::
@@ -21447,7 +21447,7 @@ Push to the `main` branch and the GitHub Action will:
 ## Deployment / Self-Hosted / Simple VPS
 
 :::note
-Last checked with Wasp 0.24, Caddy (as of Jan 30, 2026), and Ubuntu (as of Jan 30, 2026).
+Last checked with Wasp 0.24, Caddy 2.10.2, and Ubuntu LTS 24.04.
 
 This guide depends on external libraries or services, so it may become outdated over time. We do our best to keep it up to date, but make sure to check their documentation for any changes.
 :::


### PR DESCRIPTION
## Description

The "Last checked with" notices in the three self-hosted deployment guides listed Caddy, Ubuntu, Coolify and CapRover with only a date (Jan 30, 2026), which tells the reader less than a version number does. Each date is replaced with the version that was current on that date: Caddy 2.10.2 and Ubuntu LTS 24.04 in `vps.md`, Coolify 4.0.0-beta.462 in `coolify.md`, and CapRover 1.14.1 in `caprover.md`. Coolify's number looks odd but is correct: `versions.json` on their stable v4 install channel served `4.0.0-beta.462` at the time, so that is what a first-time installer got. The `llms-full.txt` markdown snapshot is regenerated to match.

## Agreement

<!-- Select just one with [x] -->

- [x] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
- [ ] A maintainer agreed on the approach beforehand: <!-- link to the GitHub issue or Discord thread -->

## Type of change

<!-- Select just one with [x] -->

- [x] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.
