### PR TITLE
Serve the built client from the server in production and build it in wasp build

### DIFF
--- a/examples/ask-the-documents/e2e-tests/playwright.config.ts
+++ b/examples/ask-the-documents/e2e-tests/playwright.config.ts
@@ -5,6 +5,15 @@ const WASP_APP_RUNNER_CLI_CMD =
 const WASP_RUN_MODE = process.env.WASP_RUN_MODE ?? "dev";
 const WASP_CLI_CMD = process.env.WASP_CLI_CMD ?? "wasp-cli";
 
+const isBuildMode = WASP_RUN_MODE === "build";
+
+const WASP_SERVER_PORT = 3001;
+const WASP_CLIENT_DEV_PORT = 3000;
+
+// In dev mode Vite serves the app and proxies API requests to the server.
+// In build mode a single container serves both the app and the API on the server port.
+const WASP_APP_URL = `http://localhost:${isBuildMode ? WASP_SERVER_PORT : WASP_CLIENT_DEV_PORT}`;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -29,7 +38,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: WASP_APP_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -52,7 +61,7 @@ export default defineConfig({
     command: `${WASP_APP_RUNNER_CLI_CMD} ${WASP_RUN_MODE} --path-to-app=../ --wasp-cli-cmd=${WASP_CLI_CMD} --db-image pgvector/pgvector:pg17`,
 
     // Wait for the server to start.
-    url: "http://localhost:3001/health",
+    url: `http://localhost:${WASP_SERVER_PORT}/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 180 * 1000,
     gracefulShutdown: { signal: "SIGTERM", timeout: 500 },

--- a/examples/kitchen-sink/e2e-tests/playwright.config.ts
+++ b/examples/kitchen-sink/e2e-tests/playwright.config.ts
@@ -6,24 +6,25 @@ const WASP_RUN_MODE = process.env.WASP_RUN_MODE ?? "dev";
 const WASP_CLI_CMD = process.env.WASP_CLI_CMD ?? "wasp-cli";
 
 const isDeployedMode = WASP_RUN_MODE === "deployed";
-const isDevMode = WASP_RUN_MODE === "dev";
+const isBuildMode = WASP_RUN_MODE === "build";
 
 const WASP_SERVER_PORT = 3001;
-const WASP_CLIENT_PORT = 3000;
+const WASP_CLIENT_DEV_PORT = 3000;
 
 // In dev mode Vite serves the app and proxies API requests to the server.
-// TODO: In build mode a single container serves both the app and the API on the server port.
+// In build mode a single container serves both the app and the API on the server port.
 export const WASP_APP_URL =
-  process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${WASP_CLIENT_PORT}`;
+  process.env.PLAYWRIGHT_BASE_URL ??
+  `http://localhost:${isBuildMode ? WASP_SERVER_PORT : WASP_CLIENT_DEV_PORT}`;
 
 const WASP_SERVER_URL =
   process.env.PLAYWRIGHT_SERVER_URL ?? `http://localhost:${WASP_SERVER_PORT}`;
 
-// The origin the client sends its API requests to. In dev mode the client dev server
-// proxies Wasp's routes to the server, so it is the app's own origin.
-// TODO: In build and deployed modes the client is still served separately, so it is the
-// server's own URL.
-export const WASP_API_URL = isDevMode ? WASP_APP_URL : WASP_SERVER_URL;
+// The origin the client sends its API requests to. The server serves the client, and in
+// dev mode the client dev server proxies Wasp's routes to it, so it is the app's own origin.
+// TODO: In deployed mode the client is still deployed separately, so it is the server's
+// own URL. It becomes the app URL once `wasp deploy` creates a single app.
+export const WASP_API_URL = isDeployedMode ? WASP_SERVER_URL : WASP_APP_URL;
 
 /**
  * Read environment variables from file.

--- a/examples/tutorials/TodoApp/e2e-tests/playwright.config.ts
+++ b/examples/tutorials/TodoApp/e2e-tests/playwright.config.ts
@@ -5,6 +5,15 @@ const WASP_APP_RUNNER_CLI_CMD =
 const WASP_RUN_MODE = process.env.WASP_RUN_MODE ?? "dev";
 const WASP_CLI_CMD = process.env.WASP_CLI_CMD ?? "wasp-cli";
 
+const isBuildMode = WASP_RUN_MODE === "build";
+
+const WASP_SERVER_PORT = 3001;
+const WASP_CLIENT_DEV_PORT = 3000;
+
+// In dev mode Vite serves the app and proxies API requests to the server.
+// In build mode a single container serves both the app and the API on the server port.
+const WASP_APP_URL = `http://localhost:${isBuildMode ? WASP_SERVER_PORT : WASP_CLIENT_DEV_PORT}`;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -29,7 +38,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: WASP_APP_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -52,7 +61,7 @@ export default defineConfig({
     command: `${WASP_APP_RUNNER_CLI_CMD} ${WASP_RUN_MODE} --path-to-app=../ --wasp-cli-cmd=${WASP_CLI_CMD}`,
 
     // Wait for the server to start.
-    url: "http://localhost:3001/health",
+    url: `http://localhost:${WASP_SERVER_PORT}/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 180 * 1000,
     gracefulShutdown: { signal: "SIGTERM", timeout: 500 },

--- a/examples/tutorials/TodoAppTs/e2e-tests/playwright.config.ts
+++ b/examples/tutorials/TodoAppTs/e2e-tests/playwright.config.ts
@@ -5,6 +5,15 @@ const WASP_APP_RUNNER_CLI_CMD =
 const WASP_RUN_MODE = process.env.WASP_RUN_MODE ?? "dev";
 const WASP_CLI_CMD = process.env.WASP_CLI_CMD ?? "wasp-cli";
 
+const isBuildMode = WASP_RUN_MODE === "build";
+
+const WASP_SERVER_PORT = 3001;
+const WASP_CLIENT_DEV_PORT = 3000;
+
+// In dev mode Vite serves the app and proxies API requests to the server.
+// In build mode a single container serves both the app and the API on the server port.
+const WASP_APP_URL = `http://localhost:${isBuildMode ? WASP_SERVER_PORT : WASP_CLIENT_DEV_PORT}`;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -29,7 +38,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: WASP_APP_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -52,7 +61,7 @@ export default defineConfig({
     command: `${WASP_APP_RUNNER_CLI_CMD} ${WASP_RUN_MODE} --path-to-app=../ --wasp-cli-cmd=${WASP_CLI_CMD}`,
 
     // Wait for the server to start.
-    url: "http://localhost:3001/health",
+    url: `http://localhost:${WASP_SERVER_PORT}/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 180 * 1000,
     gracefulShutdown: { signal: "SIGTERM", timeout: 500 },

--- a/examples/waspello/e2e-tests/playwright.config.ts
+++ b/examples/waspello/e2e-tests/playwright.config.ts
@@ -5,6 +5,15 @@ const WASP_APP_RUNNER_CLI_CMD =
 const WASP_RUN_MODE = process.env.WASP_RUN_MODE ?? "dev";
 const WASP_CLI_CMD = process.env.WASP_CLI_CMD ?? "wasp-cli";
 
+const isBuildMode = WASP_RUN_MODE === "build";
+
+const WASP_SERVER_PORT = 3001;
+const WASP_CLIENT_DEV_PORT = 3000;
+
+// In dev mode Vite serves the app and proxies API requests to the server.
+// In build mode a single container serves both the app and the API on the server port.
+const WASP_APP_URL = `http://localhost:${isBuildMode ? WASP_SERVER_PORT : WASP_CLIENT_DEV_PORT}`;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -29,7 +38,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: WASP_APP_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -52,7 +61,7 @@ export default defineConfig({
     command: `${WASP_APP_RUNNER_CLI_CMD} ${WASP_RUN_MODE} --path-to-app=../ --wasp-cli-cmd=${WASP_CLI_CMD}`,
 
     // Wait for the server to start.
-    url: "http://localhost:3001/health",
+    url: `http://localhost:${WASP_SERVER_PORT}/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 180 * 1000,
     gracefulShutdown: { signal: "SIGTERM", timeout: 500 },

--- a/examples/waspleau/e2e-tests/playwright.config.ts
+++ b/examples/waspleau/e2e-tests/playwright.config.ts
@@ -5,6 +5,15 @@ const WASP_APP_RUNNER_CLI_CMD =
 const WASP_RUN_MODE = process.env.WASP_RUN_MODE ?? "dev";
 const WASP_CLI_CMD = process.env.WASP_CLI_CMD ?? "wasp-cli";
 
+const isBuildMode = WASP_RUN_MODE === "build";
+
+const WASP_SERVER_PORT = 3001;
+const WASP_CLIENT_DEV_PORT = 3000;
+
+// In dev mode Vite serves the app and proxies API requests to the server.
+// In build mode a single container serves both the app and the API on the server port.
+const WASP_APP_URL = `http://localhost:${isBuildMode ? WASP_SERVER_PORT : WASP_CLIENT_DEV_PORT}`;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -29,7 +38,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: WASP_APP_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -52,7 +61,7 @@ export default defineConfig({
     command: `${WASP_APP_RUNNER_CLI_CMD} ${WASP_RUN_MODE} --path-to-app=../ --wasp-cli-cmd=${WASP_CLI_CMD}`,
 
     // Wait for the server to start.
-    url: "http://localhost:3001/health",
+    url: `http://localhost:${WASP_SERVER_PORT}/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 180 * 1000,
     gracefulShutdown: { signal: "SIGTERM", timeout: 500 },

--- a/examples/websockets-realtime-voting/e2e-tests/playwright.config.ts
+++ b/examples/websockets-realtime-voting/e2e-tests/playwright.config.ts
@@ -5,6 +5,15 @@ const WASP_APP_RUNNER_CLI_CMD =
 const WASP_RUN_MODE = process.env.WASP_RUN_MODE ?? "dev";
 const WASP_CLI_CMD = process.env.WASP_CLI_CMD ?? "wasp-cli";
 
+const isBuildMode = WASP_RUN_MODE === "build";
+
+const WASP_SERVER_PORT = 3001;
+const WASP_CLIENT_DEV_PORT = 3000;
+
+// In dev mode Vite serves the app and proxies API requests to the server.
+// In build mode a single container serves both the app and the API on the server port.
+const WASP_APP_URL = `http://localhost:${isBuildMode ? WASP_SERVER_PORT : WASP_CLIENT_DEV_PORT}`;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -29,7 +38,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: WASP_APP_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -52,7 +61,7 @@ export default defineConfig({
     command: `${WASP_APP_RUNNER_CLI_CMD} ${WASP_RUN_MODE} --path-to-app=../ --wasp-cli-cmd=${WASP_CLI_CMD}`,
 
     // Wait for the server to start.
-    url: "http://localhost:3001/health",
+    url: `http://localhost:${WASP_SERVER_PORT}/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 180 * 1000,
     gracefulShutdown: { signal: "SIGTERM", timeout: 500 },

--- a/waspc/cli/src/Wasp/Cli/Command/Build.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build.hs
@@ -6,7 +6,7 @@ module Wasp.Cli.Command.Build
 where
 
 import Control.Lens (at, (%~), (&), (.~))
-import Control.Monad (unless, when)
+import Control.Monad (when)
 import Control.Monad.Except (ExceptT (ExceptT), runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (Value)
@@ -14,7 +14,12 @@ import qualified Data.Aeson.Key as Key
 import Data.Aeson.Lens (key, _Object)
 import Data.Either (fromLeft)
 import StrongPath (Abs, Dir, Path', castRel, fromRelDir, (</>))
+import Wasp.AppSpec (AppSpec)
+import Wasp.AppSpec.App.Deployment (DeploymentMode (..))
+import Wasp.AppSpec.Valid (getDeploymentMode)
 import Wasp.Cli.Command (Command, CommandError (..), require)
+import Wasp.Cli.Command.Build.Client (buildClient)
+import Wasp.Cli.Command.Common (runAndPrintJob)
 import Wasp.Cli.Command.Compile (compileIOWithOptions, printCompilationResult)
 import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.Require.InWaspProject (InWaspProject (InWaspProject))
@@ -69,16 +74,27 @@ build = withProjectLock $ do
 
   cliSendMessageC $ Msg.Start "Building wasp project..."
 
-  (warnings, errors) <- liftIO $ buildIO waspProjectDir buildDir
-  liftIO $ printCompilationResult (warnings, errors)
-  unless (null errors) $
-    throwError $
-      CommandError "Building of wasp project failed" $
-        show (length errors) ++ " errors found."
+  (warnings, appSpecOrErrors) <- liftIO $ buildIO waspProjectDir buildDir
+  liftIO $ printCompilationResult (warnings, fromLeft [] appSpecOrErrors)
+  appSpec <- case appSpecOrErrors of
+    Left errors ->
+      throwError $
+        CommandError "Building of wasp project failed" $
+          show (length errors) ++ " errors found."
+    Right appSpec -> return appSpec
 
   liftIO (prepareFilesNecessaryForDockerBuild waspProjectDir buildDir) >>= \case
     Left err -> throwError $ CommandError "Failed to prepare files necessary for docker build" err
     Right () -> return ()
+
+  -- In single deployment mode the server serves the built client, so the client
+  -- has to be built before the Docker image is.
+  case getDeploymentMode appSpec of
+    Single -> do
+      cliSendMessageC $ Msg.Start "Building the client..."
+      runAndPrintJob "Building the client failed." $ buildClient [] waspProjectDir
+      cliSendMessageC $ Msg.Success "Client built."
+    Split -> return ()
 
   cliSendMessageC $
     Msg.Success $
@@ -151,10 +167,8 @@ build = withProjectLock $ do
 buildIO ::
   Path' Abs (Dir WaspProjectDir) ->
   Path' Abs (Dir GeneratedAppDir) ->
-  IO ([CompileWarning], [CompileError])
-buildIO waspProjectDir buildDir =
-  fmap (fromLeft [])
-    <$> compileIOWithOptions options waspProjectDir buildDir
+  IO ([CompileWarning], Either [CompileError] AppSpec)
+buildIO waspProjectDir buildDir = compileIOWithOptions options waspProjectDir buildDir
   where
     options =
       CompileOptions

--- a/waspc/cli/src/Wasp/Cli/Command/Build/Client.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Build/Client.hs
@@ -1,0 +1,19 @@
+module Wasp.Cli.Command.Build.Client
+  ( buildClient,
+  )
+where
+
+import Data.Function ((&))
+import StrongPath (Abs, Dir, Path')
+import Wasp.Env (EnvVar)
+import qualified Wasp.Job as J
+import Wasp.Job.Except (ExceptJob, toExceptJob)
+import Wasp.Job.Process (runNodeCommandAsJobWithExtraEnv)
+import Wasp.Project.Common (WaspProjectDir)
+
+-- | Builds the client with Vite into the generated web-app dir. The client reads its
+-- `REACT_APP_*` env vars at build time, from the given env vars and the current environment.
+buildClient :: [EnvVar] -> Path' Abs (Dir WaspProjectDir) -> ExceptJob
+buildClient envVars waspProjectDir =
+  runNodeCommandAsJobWithExtraEnv envVars waspProjectDir "npx" ["vite", "build"] J.WebApp
+    & toExceptJob (("Building the client failed with exit code: " <>) . show)

--- a/waspc/cli/src/Wasp/Cli/Command/BuildStart.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BuildStart.hs
@@ -3,17 +3,15 @@ module Wasp.Cli.Command.BuildStart
   )
 where
 
-import Control.Concurrent.Async (concurrently)
-import Control.Concurrent.Chan (newChan)
-import Control.Monad.Except (MonadError (throwError), runExceptT)
-import Control.Monad.IO.Class (liftIO)
 import Wasp.AppSpec.App.Deployment (DeploymentMode (..))
-import Wasp.Cli.Command (Command, CommandError (CommandError), require)
+import Wasp.Cli.Command (Command, require)
+import Wasp.Cli.Command.Build.Client (buildClient)
 import Wasp.Cli.Command.BuildStart.ArgumentsParser (buildStartArgsParser)
-import Wasp.Cli.Command.BuildStart.Client (buildClient, startClient)
+import Wasp.Cli.Command.BuildStart.Client (startClient)
 import Wasp.Cli.Command.BuildStart.Config (BuildStartConfig (..), makeBuildStartConfig)
 import Wasp.Cli.Command.BuildStart.Server (buildServer, startServer)
 import Wasp.Cli.Command.Call (Arguments)
+import Wasp.Cli.Command.Common (runAndPrintJob)
 import Wasp.Cli.Command.Compile (analyze)
 import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.Command.Require.GeneratedApp (GeneratedAppIsProduction (GeneratedAppIsProduction))
@@ -22,10 +20,10 @@ import Wasp.Cli.Command.Require.ValidNodeAndNpm (ValidNodeAndNpm (ValidNodeAndNp
 import Wasp.Cli.Command.Require.WaspSpecAvailable (WaspSpecAvailable (WaspSpecAvailable))
 import Wasp.Cli.RunConfigs (showRunConfigUrls)
 import Wasp.Cli.Util.Parser (withArguments)
-import Wasp.Job.Except (ExceptJob)
+import Wasp.Env (getEnvVars)
 import qualified Wasp.Job.Except as ExceptJob
-import Wasp.Job.IO (readJobMessagesAndPrintThemPrefixed)
 import qualified Wasp.Message as Msg
+import Wasp.Project.BuildType (BuildType (Production))
 
 buildStart :: Arguments -> Command ()
 buildStart = withArguments "wasp build start" buildStartArgsParser $ \args -> do
@@ -49,9 +47,10 @@ buildStart = withArguments "wasp build start" buildStartArgsParser $ \args -> do
 
 buildAndStartServerAndClient :: BuildStartConfig -> Command ()
 buildAndStartServerAndClient config = do
+  -- `wasp build` already built the client, but we build it again here so the `--client-env` vars apply.
   cliSendMessageC $ Msg.Start "Building client..."
   runAndPrintJob "Building client failed." $
-    buildClient config
+    buildClient (getEnvVars config.clientRunConfig) config.projectDir
   cliSendMessageC $ Msg.Success "Client built."
 
   cliSendMessageC $ Msg.Start "Building server..."
@@ -59,26 +58,24 @@ buildAndStartServerAndClient config = do
     buildServer config
   cliSendMessageC $ Msg.Success "Server built."
 
-  cliSendMessageC $ Msg.Start "Starting client and server..."
-  cliSendMessageC $
-    Msg.Info $
-      showRunConfigUrls Split (config.clientRunConfig, config.serverRunConfig)
-
-  runAndPrintJob "Starting Wasp app failed." $
-    ExceptJob.race_
-      (startClient config)
-      (startServer config)
+  case config.deploymentMode of
+    Single -> do
+      cliSendMessageC $ Msg.Start "Starting the app..."
+      cliSendMessageC $ Msg.Info $ showUrls config
+      -- The server container serves the built client, so there is no
+      -- separate client to start.
+      runAndPrintJob "Starting Wasp app failed." $
+        startServer config
+    Split -> do
+      cliSendMessageC $ Msg.Start "Starting client and server..."
+      cliSendMessageC $ Msg.Info $ showUrls config
+      runAndPrintJob "Starting Wasp app failed." $
+        ExceptJob.race_
+          (startClient config)
+          (startServer config)
   where
-    runAndPrintJob :: String -> ExceptJob -> Command ()
-    runAndPrintJob errorMessage job = do
-      liftIO (runAndPrintJobIO job)
-        >>= either (throwError . CommandError errorMessage) return
-
-    runAndPrintJobIO :: ExceptJob -> IO (Either String ())
-    runAndPrintJobIO job = do
-      chan <- newChan
-      (result, _) <-
-        concurrently
-          (runExceptT $ job chan)
-          (readJobMessagesAndPrintThemPrefixed chan)
-      return result
+    showUrls buildStartConfig =
+      showRunConfigUrls
+        Production
+        buildStartConfig.deploymentMode
+        (buildStartConfig.clientRunConfig, buildStartConfig.serverRunConfig)

--- a/waspc/cli/src/Wasp/Cli/Command/BuildStart/ArgumentsParser.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BuildStart/ArgumentsParser.hs
@@ -12,7 +12,8 @@ import Wasp.Cli.Util.EnvVarArgument (EnvVarArgument, envVarArgumentFileParser, e
 import Wasp.Cli.Util.PortArgument (portOption)
 
 data BuildStartArgs = BuildStartArgs
-  { clientPort :: PortNumber,
+  { -- | Kept optional so we can tell the user it is ignored in single deployment mode.
+    clientPort :: Maybe PortNumber,
     serverPort :: PortNumber,
     clientEnvVars :: [EnvVarArgument],
     serverEnvVars :: [EnvVarArgument]
@@ -22,15 +23,14 @@ buildStartArgsParser :: Opt.Parser BuildStartArgs
 buildStartArgsParser =
   BuildStartArgs
     <$> portParserForComponent "client" defaultDevClientPort
-    <*> portParserForComponent "server" defaultDevServerPort
+    <*> (fromMaybe defaultDevServerPort <$> portParserForComponent "server" defaultDevServerPort)
     <*> environmentVariableParsersForComponent 'c' "client"
     <*> environmentVariableParsersForComponent 's' "server"
   where
     portParserForComponent name defaultPort =
-      fromMaybe defaultPort
-        <$> portOption
-          (name ++ "-port")
-          ("Port to run the " ++ name ++ " on (default: " ++ show defaultPort ++ ")")
+      portOption
+        (name ++ "-port") -- e.g. "--client-port"
+        ("Port to run the " ++ name ++ " on (default: " ++ show defaultPort ++ ")")
 
     environmentVariableParsersForComponent shortOptionName name =
       liftA2

--- a/waspc/cli/src/Wasp/Cli/Command/BuildStart/Client.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BuildStart/Client.hs
@@ -1,6 +1,5 @@
 module Wasp.Cli.Command.BuildStart.Client
-  ( buildClient,
-    startClient,
+  ( startClient,
   )
 where
 
@@ -10,19 +9,6 @@ import Wasp.Env (getEnvVars)
 import qualified Wasp.Job as J
 import Wasp.Job.Except (ExceptJob, toExceptJob)
 import Wasp.Job.Process (runNodeCommandAsJobWithExtraEnv)
-
-buildClient :: BuildStartConfig -> ExceptJob
-buildClient config =
-  runNodeCommandAsJobWithExtraEnv
-    envVars
-    projectDir
-    "npx"
-    ["vite", "build"]
-    J.WebApp
-    & toExceptJob (("Building the client failed with exit code: " <>) . show)
-  where
-    envVars = getEnvVars config.clientRunConfig
-    projectDir = config.projectDir
 
 startClient :: BuildStartConfig -> ExceptJob
 startClient config =

--- a/waspc/cli/src/Wasp/Cli/Command/BuildStart/Config.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/BuildStart/Config.hs
@@ -11,15 +11,19 @@ import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.Extra (concatMapM)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Char (toLower)
+import Data.Maybe (fromMaybe, isJust)
 import StrongPath ((</>))
 import qualified StrongPath as SP
+import Wasp.AppComponentUrl (AppComponentUrl)
 import qualified Wasp.AppComponentUrl as AppComponentUrl
 import Wasp.AppSpec (AppSpec)
 import Wasp.AppSpec.App.Deployment (DeploymentMode (..))
 import qualified Wasp.AppSpec.Valid as ASV
+import Wasp.Cli.AppComponentPorts (defaultDevClientPort)
 import Wasp.Cli.AppComponentUrls (defaultDevServerUrl, makeDefaultDevClientUrl)
 import Wasp.Cli.Command (Command, CommandError (CommandError))
 import Wasp.Cli.Command.BuildStart.ArgumentsParser (BuildStartArgs (..), buildStartArgsParser)
+import Wasp.Cli.Command.Message (cliSendMessageC)
 import Wasp.Cli.EnvVarWithCtx (addEnvVarsUniqueC)
 import qualified Wasp.Cli.EnvVarWithCtx as EnvVarWithCtx
 import Wasp.Cli.RunConfigs (makeRunConfigs)
@@ -27,11 +31,14 @@ import Wasp.Cli.Util.Parser (getParserHelpMessage)
 import Wasp.Generator.Common (GeneratedAppDir)
 import Wasp.Generator.ServerGenerator.RunConfig (ServerRunConfig)
 import Wasp.Generator.WebAppGenerator.RunConfig (WebAppRunConfig)
+import qualified Wasp.Message as Msg
 import Wasp.Project.Common (WaspProjectDir, generatedAppDirInWaspProjectDir, makeAppUniqueId)
 import Wasp.Util.Terminal (styleCode)
 
 data BuildStartConfig = BuildStartConfig
   { appUniqueId :: String,
+    deploymentMode :: DeploymentMode,
+    -- | In single deployment mode this is the app URL, on the server port.
     clientRunConfig :: WebAppRunConfig,
     serverRunConfig :: ServerRunConfig,
     buildDir :: SP.Path' SP.Abs (SP.Dir GeneratedAppDir),
@@ -50,14 +57,11 @@ makeBuildStartConfig appSpec args projectDir' = do
   userServerEnvVars <- liftIO $ concatMapM EnvVarWithCtx.readEnvVarArgument args.serverEnvVars
   userClientEnvVars <- liftIO $ concatMapM EnvVarWithCtx.readEnvVarArgument args.clientEnvVars
 
-  let clientUrl = (makeDefaultDevClientUrl appSpec) {AppComponentUrl.port = args.clientPort}
-      serverUrl = defaultDevServerUrl {AppComponentUrl.port = args.serverPort}
+  when (deploymentMode' == Single && isJust args.clientPort) $
+    cliSendMessageC clientPortIgnoredWarning
 
-      -- TODO: The server does not serve the built client yet, so `wasp build start`
-      -- still runs them as two separate apps, which need the split run configs no
-      -- matter what the project's deployment mode says. This follows the deployment
-      -- mode once the server serves the client.
-      (baseClientRunConfig, baseServerRunConfig) = makeRunConfigs Split (clientUrl, serverUrl)
+  let (baseClientRunConfig, baseServerRunConfig) =
+        makeRunConfigs deploymentMode' (makeAppComponentUrls deploymentMode' appSpec args)
 
   clientRunConfig' <- baseClientRunConfig `addEnvVarsUniqueC` userClientEnvVars
   serverRunConfig' <- baseServerRunConfig `addEnvVarsUniqueC` userServerEnvVars
@@ -65,6 +69,7 @@ makeBuildStartConfig appSpec args projectDir' = do
   return $
     BuildStartConfig
       { appUniqueId = appUniqueId',
+        deploymentMode = deploymentMode',
         buildDir = buildDir',
         projectDir = projectDir',
         serverRunConfig = serverRunConfig',
@@ -73,6 +78,7 @@ makeBuildStartConfig appSpec args projectDir' = do
   where
     appUniqueId' = makeAppUniqueId projectDir' appName
     (appName, _) = ASV.getApp appSpec
+    deploymentMode' = ASV.getDeploymentMode appSpec
 
     buildDir' = projectDir' </> generatedAppDirInWaspProjectDir
 
@@ -88,6 +94,22 @@ makeBuildStartConfig appSpec args projectDir' = do
           ++ styleCode ".env"
           ++ " files unless you explicitly tell it. "
           ++ getParserHelpMessage buildStartArgsParser
+
+    clientPortIgnoredWarning =
+      Msg.Warning
+        "Ignoring --client-port"
+        "In single deployment mode the server serves the client, so the whole app runs on the server port."
+
+-- | In single deployment mode the server serves the client, so the app is reached on
+-- the server port and the client URL only adds the client base dir to it.
+makeAppComponentUrls :: DeploymentMode -> AppSpec -> BuildStartArgs -> (AppComponentUrl, AppComponentUrl)
+makeAppComponentUrls deploymentMode appSpec args = (clientUrl, serverUrl)
+  where
+    clientUrl = (makeDefaultDevClientUrl appSpec) {AppComponentUrl.port = clientPort}
+    serverUrl = defaultDevServerUrl {AppComponentUrl.port = args.serverPort}
+    clientPort = case deploymentMode of
+      Single -> args.serverPort
+      Split -> fromMaybe defaultDevClientPort args.clientPort
 
 dockerImageName :: BuildStartConfig -> String
 dockerImageName config =

--- a/waspc/cli/src/Wasp/Cli/Command/Common.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Common.hs
@@ -1,9 +1,13 @@
 module Wasp.Cli.Command.Common
   ( throwIfExeIsNotAvailable,
     deleteDirectoryIfExistsVerbosely,
+    runAndPrintJob,
   )
 where
 
+import Control.Concurrent.Async (concurrently)
+import Control.Concurrent.Chan (newChan)
+import Control.Monad.Except (runExceptT)
 import qualified Control.Monad.Except as E
 import Control.Monad.IO.Class (liftIO)
 import StrongPath (Abs, Dir, Path')
@@ -12,6 +16,8 @@ import StrongPath.Operations
 import System.Directory (findExecutable)
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Message (cliSendMessageC)
+import Wasp.Job.Except (ExceptJob)
+import Wasp.Job.IO (readJobMessagesAndPrintThemPrefixed)
 import qualified Wasp.Message as Msg
 import qualified Wasp.Util.IO as IOUtil
 
@@ -35,3 +41,12 @@ deleteDirectoryIfExistsVerbosely dir = do
       cliSendMessageC $ Msg.Success $ "Nothing to delete: The " ++ dirName ++ " directory does not exist."
   where
     dirName = SP.toFilePath $ basename dir
+
+-- | Runs the job while printing its output, and fails the command with the given message if the
+-- job fails.
+runAndPrintJob :: String -> ExceptJob -> Command ()
+runAndPrintJob errorMessage job = do
+  result <- liftIO $ do
+    chan <- newChan
+    fst <$> concurrently (runExceptT $ job chan) (readJobMessagesAndPrintThemPrefixed chan)
+  either (E.throwError . CommandError errorMessage) return result

--- a/waspc/cli/src/Wasp/Cli/Command/Start.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Start.hs
@@ -32,6 +32,7 @@ import Wasp.Generator.ServerGenerator.RunConfig (ServerRunConfig (..))
 import Wasp.Generator.WebAppGenerator.RunConfig (WebAppRunConfig)
 import qualified Wasp.Message as Msg
 import Wasp.Project (CompileError, CompileWarning)
+import Wasp.Project.BuildType (BuildType (Development))
 import Wasp.Project.Common (WaspProjectDir, findFileInWaspProjectDir, generatedAppDirInWaspProjectDir)
 import qualified Wasp.Project.Env as Env
 
@@ -69,7 +70,7 @@ start = withArguments "wasp start" startArgsParser $ \args -> withProjectLock $ 
 
   cliSendMessageC $ Msg.Start "Listening for file changes..."
   cliSendMessageC $ Msg.Start "Starting up generated project..."
-  cliSendMessageC $ Msg.Info $ showRunConfigUrls (getDeploymentMode appSpec) runConfigs
+  cliSendMessageC $ Msg.Info $ showRunConfigUrls Development (getDeploymentMode appSpec) runConfigs
 
   watchOrStartResult <- liftIO $ do
     -- This MVar is used to exchange information between the two processes below running in

--- a/waspc/cli/src/Wasp/Cli/RunConfigs.hs
+++ b/waspc/cli/src/Wasp/Cli/RunConfigs.hs
@@ -15,6 +15,7 @@ import Wasp.Generator.ServerGenerator.RunConfig (ServerRunConfig, makeServerRunC
 import qualified Wasp.Generator.ServerGenerator.RunConfig as ServerRunConfig
 import Wasp.Generator.WebAppGenerator.RunConfig (WebAppRunConfig, makeWebAppRunConfig)
 import qualified Wasp.Generator.WebAppGenerator.RunConfig as WebAppRunConfig
+import Wasp.Project.BuildType (BuildType (..))
 
 makeDefaultDevRunConfigs :: AppSpec -> (WebAppRunConfig, ServerRunConfig)
 makeDefaultDevRunConfigs appSpec = makeRunConfigs (getDeploymentMode appSpec) (makeDefaultUrls appSpec)
@@ -25,19 +26,24 @@ makeRunConfigs deploymentMode (clientUrl, serverUrl) = (clientRunConfig, serverR
     clientRunConfig = makeWebAppRunConfig deploymentMode clientUrl serverUrl
     serverRunConfig = makeServerRunConfig deploymentMode serverUrl clientUrl
 
--- | Shows the URLs of the running app components in development.
-showRunConfigUrls :: DeploymentMode -> (WebAppRunConfig, ServerRunConfig) -> String
-showRunConfigUrls deploymentMode (clientRunConfig, serverRunConfig) =
-  unlines $ case deploymentMode of
-    Single ->
-      [ " ℹ App:    " ++ showUrl (WebAppRunConfig.url clientRunConfig),
+-- | Shows the URLs the user reaches the running app on.
+showRunConfigUrls :: BuildType -> DeploymentMode -> (WebAppRunConfig, ServerRunConfig) -> String
+showRunConfigUrls buildType deploymentMode (clientRunConfig, serverRunConfig) =
+  unlines $ case (deploymentMode, buildType) of
+    -- The client dev server proxies to the server, so the app lives on the client's URL and
+    -- the server's own URL is only useful for debugging.
+    (Single, Development) ->
+      [ appUrlLine,
         "   For debugging purposes, you can reach the server directly here:",
-        " ℹ Server: " ++ showUrl (ServerRunConfig.url serverRunConfig)
+        serverUrlLine
       ]
-    Split ->
-      [ " ℹ Client: " ++ showUrl (WebAppRunConfig.url clientRunConfig),
-        " ℹ Server: " ++ showUrl (ServerRunConfig.url serverRunConfig)
-      ]
+    -- The server serves the built client, so there is nothing but the app's URL.
+    (Single, Production) -> [appUrlLine]
+    (Split, _) -> [clientUrlLine, serverUrlLine]
+  where
+    appUrlLine = " ℹ App:    " ++ showUrl (WebAppRunConfig.url clientRunConfig)
+    clientUrlLine = " ℹ Client: " ++ showUrl (WebAppRunConfig.url clientRunConfig)
+    serverUrlLine = " ℹ Server: " ++ showUrl (ServerRunConfig.url serverRunConfig)
 
 -- The server and client URLs have different expectations for trailing
 -- slashes, so for display consistency we just ensure they both have it.

--- a/waspc/cli/tests/Wasp/Cli/RunConfigsTest.hs
+++ b/waspc/cli/tests/Wasp/Cli/RunConfigsTest.hs
@@ -5,11 +5,12 @@ import Test.Hspec
 import Wasp.AppComponentUrl (AppComponentUrl (..))
 import Wasp.AppSpec.App.Deployment (DeploymentMode (..))
 import Wasp.Cli.RunConfigs (makeRunConfigs, showRunConfigUrls)
+import Wasp.Project.BuildType (BuildType (..))
 
 spec_showRunConfigUrls :: Spec
 spec_showRunConfigUrls = do
   it "in single deployment mode shows the app URL and the server URL for debugging" $ do
-    showRunConfigUrls Single (makeRunConfigs Single urls)
+    showRunConfigUrls Development Single (makeRunConfigs Single urls)
       `shouldBe` unlines
         [ " ℹ App:    http://localhost:3000/app/",
           "   For debugging purposes, you can reach the server directly here:",
@@ -17,10 +18,16 @@ spec_showRunConfigUrls = do
         ]
 
   it "in split mode shows the client and the server" $ do
-    showRunConfigUrls Split (makeRunConfigs Split urls)
+    showRunConfigUrls Development Split (makeRunConfigs Split urls)
       `shouldBe` unlines
         [ " ℹ Client: http://localhost:3000/app/",
           " ℹ Server: http://localhost:3001/"
+        ]
+
+  it "in single deployment mode in production shows only the app URL" $ do
+    showRunConfigUrls Production Single (makeRunConfigs Single urls)
+      `shouldBe` unlines
+        [ " ℹ App:    http://localhost:3000/app/"
         ]
   where
     urls = (Local {port = 3000, path = Just [absdirP|/app/|]}, Local {port = 3001, path = Nothing})

--- a/waspc/data/Generator/templates/Dockerfile
+++ b/waspc/data/Generator/templates/Dockerfile
@@ -72,6 +72,10 @@ COPY --from=server-builder /app/node_modules ./node_modules
 COPY --from=server-builder /app/.wasp/out/server/node_modules .wasp/out/server/node_modules
 COPY --from=server-builder /app/.wasp/out/server/bundle .wasp/out/server/bundle
 COPY --from=server-builder /app/.wasp/out/server/package*.json .wasp/out/server/
+{=# isClientServedByServer =}
+# The server serves the client built by `wasp build` from this directory.
+COPY web-app/build .wasp/out/web-app/build
+{=/ isClientServedByServer =}
 COPY db/ .wasp/out/db/
 EXPOSE ${PORT}
 WORKDIR /app/.wasp/out/server

--- a/waspc/data/Generator/templates/sdk/wasp/client/config.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/config.ts
@@ -4,8 +4,6 @@ import { env } from './env.js'
 
 
 {=!
-  TODO: In production the server does not serve the client yet, so for now the
-  shared origin below only exists in development.
   The client and the server share one origin, so in the browser the API is
   reached through the page's own origin. Outside the browser (e.g. SSR or
   prerendering inside the Vite process) there is no `window`, so we fall back

--- a/waspc/data/Generator/templates/sdk/wasp/client/env/schema.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/env/schema.ts
@@ -16,8 +16,6 @@ const userClientEnvSchema: UserClientEnvSchema = z.object({});
 {=/ envValidationSchema.isDefined =}
 
 {=!
-  TODO: This only applies in development for now, since the server does not
-  serve the client in production yet.
   In single deployment mode the client talks to the server through its own origin,
   so the server URL is optional (it is only used outside the browser).
 =}

--- a/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/client/vite/plugins/waspConfig/index.ts
@@ -57,6 +57,7 @@ export function waspConfig(): PluginOption {
         envPrefix: forcedOptions["envPrefix"],
         build: {
           outDir: forcedOptions["build.outDir"],
+          assetsDir: forcedOptions["build.assetsDir"],
         },
         resolve: {
           // These packages rely on a single instance per page. Not deduping them
@@ -98,6 +99,8 @@ const forcedOptions = {
   base: "{= baseDir =}",
   envPrefix: "REACT_APP_",
   "build.outDir": "{= clientBuildDirPath =}",
+  // The server tells fingerprinted files from client routes by this dir when it serves the client.
+  "build.assetsDir": "{= assetsDir =}",
   // Heads up! The env referred to by `clientPortEnvVarName` is empty during
   // `build`, so it's not persisted in the final output.
   "server.port": envVarAsNumber("{= clientPortEnvVarName =}"),

--- a/waspc/data/Generator/templates/sdk/wasp/client/webSocket/WebSocketProvider.tsx
+++ b/waspc/data/Generator/templates/sdk/wasp/client/webSocket/WebSocketProvider.tsx
@@ -26,8 +26,6 @@ export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
 
 function getWebSocketUrl(): string {
 {=!
-  TODO: In production the server does not serve the client yet, so for now the
-  shared origin below only exists in development.
   The client and the server share one origin, so the socket connects to the
   page's own origin. During SSR and prerendering there is no `window`, and
   `autoConnect` is off there anyway, so we just fall back to the API URL.

--- a/waspc/data/Generator/templates/sdk/wasp/server/config.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/config.ts
@@ -4,13 +4,19 @@ import { stripTrailingSlash, getOrigin } from '../universal/url.js'
 
 type NodeEnv = typeof env.NODE_ENV
 
-type Config = {
+// PUBLIC API
+export type Config = {
   env: NodeEnv;
   isDevelopment: boolean;
   port: number;
   databaseUrl: string;
   frontendUrl: string;
   serverUrl: string;
+  /**
+   * The client's base dir (`app.client.baseDir`) as a path prefix: `""` when the client lives
+   * at the root, otherwise without a trailing slash (e.g. `"/my-app"`).
+   */
+  clientBaseDir: string;
   allowedCORSOrigins: (string | RegExp)[];
   {=# isAuthEnabled =}
   auth: {
@@ -19,8 +25,16 @@ type Config = {
   {=/ isAuthEnabled =}
 }
 
-const frontendUrl = stripTrailingSlash(env['{= clientUrlEnvVarName =}'])
+const clientBaseDir: string = '{=& clientBaseDir =}'
+
 const serverUrl = stripTrailingSlash(env['{= serverUrlEnvVarName =}'])
+{=# isSingleDeployment =}
+// In single deployment mode the server serves the client, so the client URL defaults to the server URL.
+const frontendUrl = getOrigin(env['{= clientUrlEnvVarName =}'] ?? env['{= serverUrlEnvVarName =}']) + clientBaseDir
+{=/ isSingleDeployment =}
+{=^ isSingleDeployment =}
+const frontendUrl = stripTrailingSlash(env['{= clientUrlEnvVarName =}'])
+{=/ isSingleDeployment =}
 
 const allowedCORSOriginsPerEnv: Record<NodeEnv, Config['allowedCORSOrigins']> = {
   development: [/.*/],
@@ -31,6 +45,7 @@ const allowedCORSOrigins = allowedCORSOriginsPerEnv[env.NODE_ENV]
 const config: Config = {
   frontendUrl,
   serverUrl,
+  clientBaseDir,
   allowedCORSOrigins,
   env: env.NODE_ENV,
   isDevelopment: env.NODE_ENV === 'development',

--- a/waspc/data/Generator/templates/sdk/wasp/server/env.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/env.ts
@@ -148,6 +148,10 @@ const clientUrlSchema =
       error: '{= clientUrlEnvVarName =} must be a valid URL',
     })
   )
+{=# isSingleDeployment =}
+  // In single deployment mode the server serves the client, so the client URL defaults to {= serverUrlEnvVarName =}.
+  .optional()
+{=/ isSingleDeployment =}
 
 {=# isAuthEnabled =}
 const jwtTokenSchema = z

--- a/waspc/data/Generator/templates/sdk/wasp/server/index.ts
+++ b/waspc/data/Generator/templates/sdk/wasp/server/index.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from './dbClient.js'
 
 // PUBLIC API
-export { default as config } from './config.js'
+export { default as config, type Config } from './config.js'
 // PUBLIC API
 export { default as prisma, type PrismaClient } from './dbClient.js'
 // PUBLIC API

--- a/waspc/data/Generator/templates/server/src/clientAssets.ts
+++ b/waspc/data/Generator/templates/server/src/clientAssets.ts
@@ -1,0 +1,139 @@
+{{={= =}=}}
+import path from "node:path";
+import { existsSync } from "node:fs";
+import express from "express";
+import type { Express,  NextFunction,  Request,  Response } from "express";
+import type { Config } from "wasp/server";
+
+// The client is built into the generated web-app dir, next to the server bundle.
+const clientBuildDir = path.resolve(import.meta.dirname, "{=& clientBuildDirFromServerBundleDir =}");
+const assetsDirInClientBuildDir = "{= assetsDir =}";
+
+/**
+ * Serves the built client as static assets from the server.
+ */
+export function serveClientAssets(app: Express, config: Config): void {
+  // "" when the client lives at the root, otherwise e.g. "/my-app".
+  const clientBaseDir = config.clientBaseDir
+  const clientMountPath = clientBaseDir === "" ? "/" : clientBaseDir
+
+  app.use(
+    clientMountPath,
+    express.static(clientBuildDir, {
+      index: false,
+      redirect: false,
+      setHeaders: setCacheHeaders,
+    })
+  )
+
+  if (clientBaseDir !== "") {
+    app.get("/", (_req, res) => {
+      res.redirect(clientBaseDir)
+    })
+  }
+
+  app.use(clientMountPath, serveClientPage)
+}
+
+function setCacheHeaders(res: Response, filePath: string): void {
+  if (isFileInAssetsDir(filePath)) {
+    // Vite's assets can be cached forever.
+    // See `isFileInAssetsDir` for more details.
+    res.setHeader("Cache-Control", "public, max-age=31536000, immutable")
+  } else if (filePath.endsWith(".html")) {
+    // Always revalidated HTML files.
+    res.setHeader("Cache-Control", "no-cache")
+  }
+}
+
+/**
+ * Whether the file lives in the Vite's assets dir.
+ * 
+ * Vite suffixes every file it puts there with the file's hash,
+ * so any change to data creates a new file name (and new URL),
+ * which is why they are safe to cache forever.
+ *
+ * TODO: See if `public/assets/` dir would pose any trouble for users.
+ *       If yes, agree on how to deal with it.
+ */
+function isFileInAssetsDir(filePath: string): boolean {
+  const filePathInBuildDir = path.relative(clientBuildDir, filePath)
+  return filePathInBuildDir.startsWith(`${assetsDirInClientBuildDir}${path.sep}`)
+}
+
+/**
+ * Serves the page for a client route.
+ * Serves the prerendered `index.html` if there is one, otherwise the SPA fallback page.
+ */
+function serveClientPage(req: Request, res: Response, next: NextFunction): void {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    return next()
+  }
+  if (isServerRequest(req)) {
+    return next()
+  }
+  // A missing file under the assets dir is a broken link,
+  // so it gets a 404 instead of the SPA fallback page.
+  if (isInAssetsDir(req.path)) {
+    return next()
+  }
+
+  const pageFile = findPrerenderedPageFile(req.path) ?? spaFallbackPageFile;
+  setCacheHeaders(res, pageFile)
+  // `root` is required. Without it `sendFile` applies its dotfile check to the whole
+  // absolute path and rejects the `.wasp` directory the build lives in.
+  const sendFileOptions = { root: clientBuildDir, cacheControl: false };
+  res.sendFile(path.relative(clientBuildDir, pageFile), sendFileOptions, (err) => {
+    if (err) next(err)
+  })
+}
+const spaFallbackPageFile = path.join(clientBuildDir, "200.html");
+
+/**
+ * Whether the request should be handled by the server.
+ */
+function isServerRequest(req: Request): boolean {
+  const pathname = req.originalUrl.split('?')[0];
+  // Express routes are case insensitive.
+  const normalizedRequestPath = pathname.toLowerCase();
+  return (
+    serverGetExactPaths.some(
+      (path) => stripTrailingSlashes(path.toLowerCase()) === stripTrailingSlashes(normalizedRequestPath)
+    ) ||
+    serverGetSubtreePaths.some((path) => isPathSegmentPrefixOf(path.toLowerCase(), normalizedRequestPath))
+  )
+}
+// Only the paths the server answers `GET` on: this decides between the server and a page,
+// and a page is only ever asked for with `GET` (or `HEAD`, which Express serves with `GET`).
+const serverGetExactPaths: string[] = {=& serverGetExactPaths =}
+const serverGetSubtreePaths: string[] = {=& serverGetSubtreePaths =}
+
+function stripTrailingSlashes(path: string): string {
+  const stripped = path.replace(/\/+$/, "")
+  return stripped === "" ? "/" : stripped
+}
+
+function isPathSegmentPrefixOf(prefix: string, pathname: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`)
+}
+
+function isInAssetsDir(requestPath: string): boolean {
+  return requestPath.startsWith(`/${assetsDirInClientBuildDir}/`)
+}
+
+function findPrerenderedPageFile(requestPath: string): string | undefined {
+  const pageFile = path.join(clientBuildDir, decodePath(requestPath), "index.html")
+  const isInsideBuildDir = pageFile.startsWith(`${clientBuildDir}${path.sep}`)
+  if (isInsideBuildDir && existsSync(pageFile)) {
+    return pageFile
+  }
+  return undefined
+}
+
+function decodePath(requestPath: string): string {
+  try {
+    return decodeURIComponent(requestPath)
+  } catch {
+    return requestPath
+  }
+}

--- a/waspc/data/Generator/templates/server/src/server.ts
+++ b/waspc/data/Generator/templates/server/src/server.ts
@@ -1,5 +1,6 @@
 {{={= =}=}}
 import http from 'http'
+import express from 'express'
 
 import app from './app.js'
 import { config } from 'wasp/server'
@@ -19,6 +20,21 @@ import './jobs/core/allJobs.js'
 import { init as initWebSocket } from './webSocket/initialization.js'
 {=/ userWebSocketFn.isDefined =}
 
+{=# isClientServedByServer =}
+import { serveClientAssets } from './clientAssets.js'
+{=/ isClientServedByServer =}
+
+// The server's routes (Wasp's own, the user's apis and anything added in `setupFn`) live on
+// `app`. A root app mounts it, and serves the client around it.
+const rootApp = express()
+rootApp.use(app)
+
+{=# isClientServedByServer =}
+// The client is served after the server's routes so those (and the ones added in
+// `setupFn`) take precedence. Its errors go to Express's default error handler.
+serveClientAssets(rootApp, config)
+{=/ isClientServedByServer =}
+
 const startServer = async () => {
   {=# isPgBossJobExecutorUsed =}
   await startPgBoss()
@@ -27,7 +43,7 @@ const startServer = async () => {
   const port = normalizePort(config.port)
   app.set('port', port)
 
-  const server = http.createServer(app)
+  const server = http.createServer(rootApp)
 
   {=# setupFn.isDefined =}
   const serverSetupFnContext: ServerSetupFnContext = { app, server }

--- a/waspc/e2e-tests/Tests/ViteBuildTest.hs
+++ b/waspc/e2e-tests/Tests/ViteBuildTest.hs
@@ -11,6 +11,7 @@ import ShellCommands
     appendToFile,
     createTestWaspProject,
     inTestWaspProjectDir,
+    replaceMainWaspTsFile,
     setWaspDbToPSQL,
     waspCliBuild,
     writeToFile,
@@ -21,12 +22,16 @@ import Test (Test (..), TestCase (..))
 import Wasp.Cli.Command.CreateNewProject.AvailableTemplates (minimalStarterTemplate)
 import Wasp.Generator.WebAppGenerator (viteBuildDirPath)
 import Wasp.Project.Env (dotEnvClient)
+import Wasp.Version (waspVersion)
 
 viteBuildTest :: Test
 viteBuildTest =
   Test
     "vite-build"
     [ TestCase
+        "wasp-build-builds-client-in-single-deployment-mode"
+        (createSingleDeploymentBuildTestCase [assertClientBuildExists]),
+      TestCase
         "fail-on-missing-required-env-vars"
         (createViteBuildTestCase [expectCommandFailure <$> viteBuild]),
       TestCase
@@ -86,18 +91,53 @@ viteBuildTest =
         )
     ]
   where
-    createViteBuildTestCase :: [ShellCommandBuilder WaspProjectContext ShellCommand] -> ShellCommandBuilder TestContext [ShellCommand]
-    createViteBuildTestCase commands =
+    -- In single deployment mode `wasp build` builds the client itself.
+    createSingleDeploymentBuildTestCase :: [ShellCommandBuilder WaspProjectContext ShellCommand] -> ShellCommandBuilder TestContext [ShellCommand]
+    createSingleDeploymentBuildTestCase commands =
       sequence
         [ createTestWaspProject minimalStarterTemplate,
           inTestWaspProjectDir $ [setWaspDbToPSQL, writeMainPageTsx, waspCliBuild] ++ commands
         ]
+
+    -- In split mode `wasp build` doesn't build the client, so the test cases run `npx vite build` themselves.
+    createViteBuildTestCase :: [ShellCommandBuilder WaspProjectContext ShellCommand] -> ShellCommandBuilder TestContext [ShellCommand]
+    createViteBuildTestCase commands =
+      sequence
+        [ createTestWaspProject minimalStarterTemplate,
+          inTestWaspProjectDir $ [setWaspDbToPSQL, writeMainPageTsx, setSplitDeploymentMode, waspCliBuild] ++ commands
+        ]
+
+    setSplitDeploymentMode :: ShellCommandBuilder WaspProjectContext ShellCommand
+    setSplitDeploymentMode = replaceMainWaspTsFile mainWaspTsWithSplitDeployment
+
+    mainWaspTsWithSplitDeployment :: T.Text
+    mainWaspTsWithSplitDeployment =
+      [trimming|
+        import { app, page, route } from "@wasp.sh/spec";
+        import { MainPage } from "./src/MainPage" with { type: "ref" };
+
+        export default app({
+          name: "viteBuildTest",
+          title: "viteBuildTest",
+          wasp: { version: "$textWaspVersion" },
+          head: ["<link rel='icon' href='/favicon.ico' />"],
+          deployment: { mode: "split" },
+          spec: [
+            route("RootRoute", "/", page(MainPage)),
+          ],
+        });
+      |]
+      where
+        textWaspVersion = T.pack $ show waspVersion
 
     viteBuild :: ShellCommandBuilder WaspProjectContext ShellCommand
     viteBuild = return "npx vite build"
 
     viteBuildWithApiUrl :: ShellCommandBuilder WaspProjectContext ShellCommand
     viteBuildWithApiUrl = appendInlineEnvVars [apiUrlEnvVar] <$> viteBuild
+
+    assertClientBuildExists :: ShellCommandBuilder WaspProjectContext ShellCommand
+    assertClientBuildExists = return $ "test -f " ++ SP.fromRelFile (viteBuildDirPath </> [relfile|200.html|])
 
     assertBuildOutputContains :: String -> ShellCommandBuilder WaspProjectContext ShellCommand
     assertBuildOutputContains value = return $ "grep -r '" ++ value ++ "' " ++ SP.fromRelDir viteBuildDirPath

--- a/waspc/src/Wasp/AppSpec/Valid.hs
+++ b/waspc/src/Wasp/AppSpec/Valid.hs
@@ -10,12 +10,14 @@ module Wasp.AppSpec.Valid
     getLowestNodeVersionUserAllows,
     getValidDbSystem,
     isSingleDeploymentAndDevelopment,
+    isClientServedByServer,
     areWebSocketsUsed,
     ServerPath (..),
     ClaimedHttpMethods (..),
     getServerPaths,
     serverPathClaimedPath,
     serverPathClaimedHttpMethods,
+    claimedHttpMethodsInclude,
   )
 where
 
@@ -598,6 +600,11 @@ getDeploymentMode = App.getDeploymentMode . snd . getApp
 isSingleDeploymentAndDevelopment :: AppSpec -> Bool
 isSingleDeploymentAndDevelopment spec = getDeploymentMode spec == Single && AS.isDevelopment spec
 
+-- | Single deployment mode in a production build, where the server serves the built client itself.
+-- This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).
+isClientServedByServer :: AppSpec -> Bool
+isClientServedByServer spec = getDeploymentMode spec == Single && AS.isProduction spec
+
 -- | This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).
 -- TODO: This is here only because defining it in `Wasp.Generator.WebSocket` would give
 -- us cyclic imports. The whole `Valid` module needs a cleanup.
@@ -641,10 +648,12 @@ serverPathClaims (SubtreePath serverPath _) path = serverPath `isPathSegmentPref
 -- `GET` is the client's, so a `GET` on a `POST`-only path renders the page rather than 404ing.
 serverPathClaimsHttpMethod :: ServerPath -> AS.Api.HttpMethod -> String -> Bool
 serverPathClaimsHttpMethod serverPath httpMethod path =
-  serverPath `serverPathClaims` path && claimsMethod (serverPathClaimedHttpMethods serverPath)
-  where
-    claimsMethod AllHttpMethods = True
-    claimsMethod (OnlyHttpMethods httpMethods) = httpMethod `Set.member` httpMethods
+  serverPath `serverPathClaims` path && claimedHttpMethodsInclude httpMethod (serverPathClaimedHttpMethods serverPath)
+
+-- | Whether the claimed methods include the given one.
+claimedHttpMethodsInclude :: AS.Api.HttpMethod -> ClaimedHttpMethods -> Bool
+claimedHttpMethodsInclude _ AllHttpMethods = True
+claimedHttpMethodsInclude httpMethod (OnlyHttpMethods httpMethods) = httpMethod `Set.member` httpMethods
 
 -- | Every path the server answers on: Wasp's own routes and the user's apis.
 -- This function assumes that @AppSpec@ it operates on was validated beforehand (with @validateAppSpec@ function).

--- a/waspc/src/Wasp/Generator/DockerGenerator.hs
+++ b/waspc/src/Wasp/Generator/DockerGenerator.hs
@@ -16,7 +16,7 @@ import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import Wasp.AppSpec.Util (hasEntities)
-import Wasp.AppSpec.Valid (getLowestNodeVersionUserAllows)
+import Wasp.AppSpec.Valid (getLowestNodeVersionUserAllows, isClientServedByServer)
 import Wasp.Generator.Common
   ( GeneratedAppDir,
     ServerRootDir,
@@ -46,7 +46,8 @@ genDockerfile spec = do
             [ "usingPrisma" .= hasEntities spec,
               "dbSchemaFileFromServerDir" .= SP.fromRelFile dbSchemaFileFromServerDir,
               "nodeVersion" .= show (getLowestNodeVersionUserAllows spec),
-              "userDockerfile" .= fromMaybe "" (AS.userDockerfileContents spec)
+              "userDockerfile" .= fromMaybe "" (AS.userDockerfileContents spec),
+              "isClientServedByServer" .= isClientServedByServer spec
             ]
       )
 

--- a/waspc/src/Wasp/Generator/SdkGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator.hs
@@ -19,8 +19,9 @@ import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Auth as AS.App.Auth
 import qualified Wasp.AppSpec.App.Db as AS.Db
+import Wasp.AppSpec.App.Deployment (DeploymentMode (Single))
 import Wasp.AppSpec.Util (hasEntities)
-import Wasp.AppSpec.Valid (getApp, isAuthEnabled, isSingleDeploymentAndDevelopment)
+import Wasp.AppSpec.Valid (getApp, getDeploymentMode, isAuthEnabled)
 import qualified Wasp.AppSpec.Valid as AS.Valid
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
 import Wasp.Generator.Common
@@ -261,10 +262,7 @@ genClientConfigFile spec =
     tmplData =
       object
         [ "serverUrlEnvVarName" .= WebApp.serverUrlEnvVarName,
-          -- TODO: Wired to `isSingleDeploymentAndDevelopment` for now, since the
-          -- server only serves the client in development. It becomes a plain
-          -- `Single` mode check once it serves it in production too.
-          "isSingleDeployment" .= isSingleDeploymentAndDevelopment spec
+          "isSingleDeployment" .= (getDeploymentMode spec == Single)
         ]
 
 genCoreSerializationDir :: AppSpec -> Generator [FileDraft]
@@ -295,7 +293,9 @@ genServerConfigFile spec = return $ C.mkTmplFdWithData [relfile|server/config.ts
           "clientUrlEnvVarName" .= Server.clientUrlEnvVarName,
           "serverUrlEnvVarName" .= Server.serverUrlEnvVarName,
           "jwtSecretEnvVarName" .= AuthG.jwtSecretEnvVarName,
-          "databaseUrlEnvVarName" .= Db.databaseUrlEnvVarName
+          "databaseUrlEnvVarName" .= Db.databaseUrlEnvVarName,
+          "clientBaseDir" .= WebApp.getBaseDirPathPrefix spec,
+          "isSingleDeployment" .= (getDeploymentMode spec == Single)
         ]
 
 -- todo(filip): remove this duplication, we have almost the same thing in the

--- a/waspc/src/Wasp/Generator/SdkGenerator/Client/VitePluginG.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/Client/VitePluginG.hs
@@ -79,6 +79,7 @@ genWaspConfigPlugin spec = return $ C.mkTmplFdWithData tmplPath tmplData
           "clientPortEnvVarName" .= WebApp.clientPortEnvVarName,
           "isSingleDeploymentAndDevelopment" .= isSingleDeploymentAndDevelopment spec,
           "clientBuildDirPath" .= SP.fromRelDir viteBuildDirPath,
+          "assetsDir" .= WebApp.viteAssetsDirName,
           "depsExcludedFromOptimization" .= makeJsArrayFromHaskellList depsExcludedFromOptimization,
           "vitest"
             .= object

--- a/waspc/src/Wasp/Generator/SdkGenerator/EnvValidation.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/EnvValidation.hs
@@ -10,8 +10,9 @@ import StrongPath (relfile)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Client as AS.App.Client
+import Wasp.AppSpec.App.Deployment (DeploymentMode (Single))
 import qualified Wasp.AppSpec.App.Server as AS.App.Server
-import Wasp.AppSpec.Valid (getApp, isSingleDeploymentAndDevelopment)
+import Wasp.AppSpec.Valid (getApp, getDeploymentMode)
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
 import qualified Wasp.Generator.AuthProviders as AuthProviders
 import qualified Wasp.Generator.EmailSenders as EmailSenders
@@ -62,7 +63,8 @@ genServerEnv spec = return $ mkTmplFdWithData [relfile|server/env.ts|] tmplData
           "enabledAuthProviders" .= (AuthProviders.getEnabledAuthProvidersJson <$> maybeAuth),
           "isEmailSenderEnabled" .= isJust maybeEmailSender,
           "enabledEmailSenders" .= (EmailSenders.getEnabledEmailProvidersJson <$> maybeEmailSender),
-          "envValidationSchema" .= extImportToImportJson maybeEnvValidationSchema
+          "envValidationSchema" .= extImportToImportJson maybeEnvValidationSchema,
+          "isSingleDeployment" .= (getDeploymentMode spec == Single)
         ]
     maybeAuth = AS.App.auth app
     maybeEmailSender = AS.App.emailSender app
@@ -77,10 +79,7 @@ genClientEnvSchema spec = return $ mkTmplFdWithData tmplPath tmplData
       object
         [ "serverUrlEnvVarName" .= WebApp.serverUrlEnvVarName,
           "envValidationSchema" .= extImportToImportJson maybeEnvValidationSchema,
-          -- TODO: Wired to `isSingleDeploymentAndDevelopment` for now, since the
-          -- server only serves the client in development. It becomes a plain
-          -- `Single` mode check once it serves it in production too.
-          "isSingleDeployment" .= isSingleDeploymentAndDevelopment spec
+          "isSingleDeployment" .= (getDeploymentMode spec == Single)
         ]
     maybeEnvValidationSchema = AS.App.client app >>= AS.App.Client.envValidationSchema
     app = snd $ getApp spec

--- a/waspc/src/Wasp/Generator/SdkGenerator/WebSocketGenerator.hs
+++ b/waspc/src/Wasp/Generator/SdkGenerator/WebSocketGenerator.hs
@@ -10,8 +10,9 @@ import StrongPath (relfile)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
 import qualified Wasp.AppSpec.App as AS.App
+import Wasp.AppSpec.App.Deployment (DeploymentMode (Single))
 import qualified Wasp.AppSpec.App.WebSocket as AS.App.WS
-import Wasp.AppSpec.Valid (getApp, isAuthEnabled, isSingleDeploymentAndDevelopment)
+import Wasp.AppSpec.Valid (getApp, getDeploymentMode, isAuthEnabled)
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
 import Wasp.Generator.Common (makeJsonWithEntityData)
 import Wasp.Generator.FileDraft (FileDraft)
@@ -49,10 +50,7 @@ genClientWebSocketProvider spec =
     tmplData =
       object
         [ "autoConnect" .= map toLower (show shouldAutoConnect),
-          -- TODO: Wired to `isSingleDeploymentAndDevelopment` for now, since the
-          -- server only serves the client in development. It becomes a plain
-          -- `Single` mode check once it serves it in production too.
-          "isSingleDeployment" .= isSingleDeploymentAndDevelopment spec
+          "isSingleDeployment" .= (getDeploymentMode spec == Single)
         ]
     shouldAutoConnect = (AS.App.WS.autoConnect <$> maybeWebSocket) /= Just (Just False)
     maybeWebSocket = AS.App.webSocket $ snd $ getApp spec

--- a/waspc/src/Wasp/Generator/ServerGenerator.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator.hs
@@ -33,18 +33,20 @@ import StrongPath
     (</>),
   )
 import qualified StrongPath as SP
+import qualified System.FilePath as FP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec as AS
+import qualified Wasp.AppSpec.Api as AS.Api
 import qualified Wasp.AppSpec.App as AS.App
 import Wasp.AppSpec.App.Deployment (deploymentModeName)
 import qualified Wasp.AppSpec.App.Server as AS.App.Server
 import Wasp.AppSpec.ExternalFiles (SourceExternalCodeDir)
 import Wasp.AppSpec.Util (isPgBossJobExecutorUsed)
 import qualified Wasp.AppSpec.Util as AS.Util
-import Wasp.AppSpec.Valid (getApp, getDeploymentMode, getLowestNodeVersionUserAllows, isAuthEnabled)
+import Wasp.AppSpec.Valid (ServerPath (..), claimedHttpMethodsInclude, getApp, getDeploymentMode, getLowestNodeVersionUserAllows, getServerPaths, isAuthEnabled, isClientServedByServer)
 import Wasp.Env (envVarsToDotEnvContent)
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
-import Wasp.Generator.Common (ServerRootDir)
+import Wasp.Generator.Common (ServerRootDir, makeJsArrayFromHaskellList)
 import Wasp.Generator.DepVersions
   ( dotenvVersionRange,
     expressTypesVersionRange,
@@ -70,6 +72,7 @@ import Wasp.Generator.ServerGenerator.VirtualUserModulesPluginG (genVirtualUserM
 import Wasp.Generator.ServerGenerator.WebSocketG (depsRequiredByWebSockets, genWebSockets, mkWebSocketFnImport)
 import Wasp.Generator.WaspLibs.AvailableLibs (waspLibs)
 import qualified Wasp.Generator.WaspLibs.WaspLib as WaspLib
+import qualified Wasp.Generator.WebAppGenerator.Common as WebApp
 import qualified Wasp.Node.Version as NodeVersion
 import Wasp.Project.Common (SrcTsConfigFile, srcDirInWaspProjectDir, waspProjectDirFromGeneratedAppComponentDir)
 import Wasp.Project.Db (databaseUrlEnvVarName)
@@ -245,6 +248,7 @@ genSrcDir spec =
     [ genFileCopy [relfile|app.js|],
       genServerJs spec
     ]
+    <++> genClientAssets spec
     <++> genRoutesDir spec
     <++> genViewsDir spec
     <++> genOperationsRoutes spec
@@ -256,6 +260,30 @@ genSrcDir spec =
   where
     genFileCopy = return . C.mkSrcTmplFd
 
+-- | See `serveClientAssets` in the template.
+genClientAssets :: AppSpec -> Generator [FileDraft]
+genClientAssets spec
+  | isClientServedByServer spec =
+      return
+        [ C.mkTmplFdWithDstAndData
+            (C.asTmplFile [relfile|src/clientAssets.ts|])
+            (C.asServerFile [relfile|src/clientAssets.ts|])
+            ( Just $
+                object
+                  [ "clientBuildDirFromServerBundleDir" .= FP.dropTrailingPathSeparator (fromRelDir C.clientBuildDirFromServerBundleDir),
+                    "serverGetExactPaths" .= makeJsArrayFromHaskellList [path | ExactPath path httpMethods <- getServerPaths spec, claimsGet httpMethods],
+                    "serverGetSubtreePaths" .= makeJsArrayFromHaskellList [path | SubtreePath path httpMethods <- getServerPaths spec, claimsGet httpMethods],
+                    "assetsDir" .= WebApp.viteAssetsDirName
+                  ]
+            )
+        ]
+  | otherwise = return []
+  where
+    -- The client only ever serves a page, which the browser asks for with GET (or HEAD, which
+    -- Express answers with the GET route). Paths the server claims for other httpMethods cannot
+    -- take a page away from it, so they are none of its business.
+    claimsGet = claimedHttpMethodsInclude AS.Api.GET
+
 genServerJs :: AppSpec -> Generator FileDraft
 genServerJs spec =
   return $
@@ -266,7 +294,8 @@ genServerJs spec =
           object
             [ "setupFn" .= extImportToImportJson relPathToServerSrcDir maybeSetupJsFunction,
               "isPgBossJobExecutorUsed" .= isPgBossJobExecutorUsed spec,
-              "userWebSocketFn" .= mkWebSocketFnImport maybeWebSocket [reldirP|./|]
+              "userWebSocketFn" .= mkWebSocketFnImport maybeWebSocket [reldirP|./|],
+              "isClientServedByServer" .= isClientServedByServer spec
             ]
       )
   where

--- a/waspc/src/Wasp/Generator/ServerGenerator/Common.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/Common.hs
@@ -19,6 +19,9 @@ module Wasp.Generator.ServerGenerator.Common
     serverUrlEnvVarName,
     serverPortEnvVarName,
     libsRootDirFromServerDir,
+    ServerBundleDir,
+    bundleDirInServerRootDir,
+    clientBuildDirFromServerBundleDir,
   )
 where
 
@@ -34,9 +37,13 @@ import Wasp.Generator.Common
 import Wasp.Generator.FileDraft (FileDraft, createTemplateFileDraft)
 import Wasp.Generator.Templates (TemplatesDir)
 import qualified Wasp.Generator.WaspLibs.Common as WaspLibsC
+import Wasp.Generator.WebAppGenerator.Common (WebAppViteBuildDir, viteBuildDirInWebAppDir, webAppRootDirInGeneratedAppDir)
 import Wasp.Util.StrongPath (invertRelDir)
 
 data ServerSrcDir
+
+-- | The dir inside the generated server dir where the rollup output lives.
+data ServerBundleDir
 
 data ServerTemplatesDir
 
@@ -126,3 +133,14 @@ serverPortEnvVarName =
 
 libsRootDirFromServerDir :: Path' (Rel ServerRootDir) (Dir WaspLibsC.LibsRootDir)
 libsRootDirFromServerDir = invertRelDir serverRootDirInGeneratedAppDir </> WaspLibsC.libsRootDirInGeneratedAppDir
+
+bundleDirInServerRootDir :: Path' (Rel ServerRootDir) (Dir ServerBundleDir)
+bundleDirInServerRootDir = [reldir|bundle|]
+
+-- | Where the built client lives, relative to the server bundle. The server uses it to serve the
+-- client when it is the one serving it.
+clientBuildDirFromServerBundleDir :: Path' (Rel ServerBundleDir) (Dir WebAppViteBuildDir)
+clientBuildDirFromServerBundleDir =
+  invertRelDir (serverRootDirInGeneratedAppDir </> bundleDirInServerRootDir)
+    </> webAppRootDirInGeneratedAppDir
+    </> viteBuildDirInWebAppDir

--- a/waspc/src/Wasp/Generator/ServerGenerator/RunConfig.hs
+++ b/waspc/src/Wasp/Generator/ServerGenerator/RunConfig.hs
@@ -29,15 +29,15 @@ makeServerRunConfig :: DeploymentMode -> AppComponentUrl -> AppComponentUrl -> S
 makeServerRunConfig deploymentMode expectedUrl clientUrl =
   ServerRunConfig
     expectedUrl
-    [ (Common.clientUrlEnvVarName, AppComponentUrl.url clientUrl),
+    [ (Common.clientUrlEnvVarName, publicClientUrl),
       (Common.serverUrlEnvVarName, publicServerUrl),
       (Common.serverPortEnvVarName, show $ AppComponentUrl.port expectedUrl)
     ]
   where
-    publicServerUrl = case deploymentMode of
+    (publicClientUrl, publicServerUrl) = case deploymentMode of
       -- The server is reached through the client's origin, in dev via the
       -- Vite proxy and in production because the server serves the client.
-      -- TODO: production does not serve the client from the server yet, and
-      -- the client URL will need the client base dir appended once it does.
-      Single -> AppComponentUrl.origin clientUrl
-      Split -> AppComponentUrl.url expectedUrl
+      -- It only needs the client's origin, since it appends the client base
+      -- dir itself in this mode.
+      Single -> (AppComponentUrl.origin clientUrl, AppComponentUrl.origin clientUrl)
+      Split -> (AppComponentUrl.url clientUrl, AppComponentUrl.url expectedUrl)

--- a/waspc/src/Wasp/Generator/WebAppGenerator.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator.hs
@@ -6,25 +6,20 @@ module Wasp.Generator.WebAppGenerator
   )
 where
 
-import StrongPath (Abs, Dir, Path', Rel, reldir, (</>))
+import StrongPath (Abs, Dir, Path', Rel, (</>))
 import qualified StrongPath as SP
 import System.Directory (createDirectoryIfMissing)
 import Wasp.Generator.Common (GeneratedAppDir)
+import Wasp.Generator.WebAppGenerator.Common
+  ( WebAppViteBuildDir,
+    viteBuildDirInWebAppDir,
+    webAppRootDirInGeneratedAppDir,
+  )
 import Wasp.Project.Common
   ( WaspProjectDir,
     dotWaspDirInWaspProjectDir,
     generatedAppDirInDotWaspDir,
   )
-
-data WebAppRootDir
-
-data WebAppViteBuildDir
-
--- We require the `web-app` dir to be generated for deployment purposes.
--- Our deployment tooling expects to have a folder outside of the user project
--- dir where e.g. Dockerfile for static server or Staticfile can be created.
-webAppRootDirInGeneratedAppDir :: Path' (Rel GeneratedAppDir) (Dir WebAppRootDir)
-webAppRootDirInGeneratedAppDir = [reldir|web-app|]
 
 viteBuildDirPath :: Path' (Rel WaspProjectDir) (Dir WebAppViteBuildDir)
 viteBuildDirPath =
@@ -32,9 +27,6 @@ viteBuildDirPath =
     </> generatedAppDirInDotWaspDir
     </> webAppRootDirInGeneratedAppDir
     </> viteBuildDirInWebAppDir
-
-viteBuildDirInWebAppDir :: Path' (Rel WebAppRootDir) (Dir WebAppViteBuildDir)
-viteBuildDirInWebAppDir = [reldir|build|]
 
 createWebAppRootDir :: Path' Abs (Dir GeneratedAppDir) -> IO ()
 createWebAppRootDir generatedAppDir = createDirectoryIfMissing True webAppRootDir

--- a/waspc/src/Wasp/Generator/WebAppGenerator/Common.hs
+++ b/waspc/src/Wasp/Generator/WebAppGenerator/Common.hs
@@ -1,23 +1,53 @@
 module Wasp.Generator.WebAppGenerator.Common
-  ( getBaseDir,
+  ( WebAppRootDir,
+    WebAppViteBuildDir,
+    webAppRootDirInGeneratedAppDir,
+    viteBuildDirInWebAppDir,
+    viteAssetsDirName,
+    getBaseDir,
+    getBaseDirPathPrefix,
     serverUrlEnvVarName,
     devProxyTargetEnvVarName,
     clientPortEnvVarName,
   )
 where
 
+import Data.List (dropWhileEnd)
 import Data.Maybe (fromMaybe)
-import StrongPath (Abs, Dir, Path, Posix, absdirP)
+import StrongPath (Abs, Dir, Path, Path', Posix, Rel, absdirP, reldir)
 import qualified StrongPath as SP
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App as AS.App
 import qualified Wasp.AppSpec.App.Client as AS.App.Client
 import Wasp.AppSpec.Valid (getApp)
+import Wasp.Generator.Common (GeneratedAppDir)
+
+data WebAppRootDir
+
+data WebAppViteBuildDir
+
+-- We require the `web-app` dir to be generated for deployment purposes.
+-- Our deployment tooling expects to have a folder outside of the user project
+-- dir where e.g. Dockerfile for static server or Staticfile can be created.
+webAppRootDirInGeneratedAppDir :: Path' (Rel GeneratedAppDir) (Dir WebAppRootDir)
+webAppRootDirInGeneratedAppDir = [reldir|web-app|]
+
+viteBuildDirInWebAppDir :: Path' (Rel WebAppRootDir) (Dir WebAppViteBuildDir)
+viteBuildDirInWebAppDir = [reldir|build|]
+
+-- | The dir inside the Vite build where Vite puts the files it fingerprints (`build.assetsDir`).
+viteAssetsDirName :: String
+viteAssetsDirName = "assets"
 
 getBaseDir :: AppSpec -> Path Posix Abs (Dir ())
 getBaseDir spec = fromMaybe [absdirP|/|] maybeBaseDir
   where
     maybeBaseDir = SP.parseAbsDirP =<< (AS.App.Client.baseDir =<< AS.App.client (snd $ getApp spec))
+
+-- | The client base dir as a path prefix: "" for the root, otherwise without a trailing slash
+-- (e.g. "/my-app"), so it can go in front of a path or after an origin as it is.
+getBaseDirPathPrefix :: AppSpec -> String
+getBaseDirPathPrefix = dropWhileEnd (== '/') . SP.fromAbsDirP . getBaseDir
 
 serverUrlEnvVarName :: String
 serverUrlEnvVarName = "REACT_APP_API_URL"

--- a/waspc/tests/Generator/ServerGenerator/RunConfigTest.hs
+++ b/waspc/tests/Generator/ServerGenerator/RunConfigTest.hs
@@ -8,9 +8,9 @@ import Wasp.Generator.ServerGenerator.RunConfig (ServerRunConfig (..), makeServe
 
 spec_makeServerRunConfig :: Spec
 spec_makeServerRunConfig = do
-  it "in single deployment mode is reached on the client origin" $ do
+  it "in single deployment mode is reached on the client origin and gets the client origin without the base dir" $ do
     envVars (makeServerRunConfig Single serverUrl clientUrl)
-      `shouldBe` [ ("WASP_WEB_CLIENT_URL", "http://localhost:3000/app/"),
+      `shouldBe` [ ("WASP_WEB_CLIENT_URL", "http://localhost:3000"),
                    ("WASP_SERVER_URL", "http://localhost:3000"),
                    ("PORT", "3001")
                  ]

--- a/waspc/waspc.cabal
+++ b/waspc/waspc.cabal
@@ -489,6 +489,7 @@ library cli-lib
     Wasp.Cli.Command
     Wasp.Cli.Command.BashCompletion
     Wasp.Cli.Command.Build
+    Wasp.Cli.Command.Build.Client
     Wasp.Cli.Command.BuildStart
     Wasp.Cli.Command.BuildStart.ArgumentsParser
     Wasp.Cli.Command.BuildStart.Client


### PR DESCRIPTION
> [!WARNING]
> Still WIP. Was only partially human reviewed.

## Description

The server now serves the built client in production, so a deployed app runs on one origin. This is the production half of single deployment mode; the previous PR did the development half.

### What changes

- **`serveClientAssets`.** A new `clientAssets.ts` in the server template serves the Vite build. It mounts `express.static` at the client's `baseDir`, then a page handler that returns a prerendered `index.html` when one exists and the `200.html` SPA fallback otherwise. It takes the server config as an argument rather than importing it, so the module has nothing global in it.
- **Which requests the client may answer.** A `GET` for a path the server claims `GET` on gets a 404 rather than the fallback page, so a mistyped api path or a webhook probe fails visibly instead of returning HTML. Paths the server claims only for other methods are not in that list at all, so a `GET` on an operation's path renders the page, matching what the dev proxy does.
- **Caching.** Files in the Vite assets dir get `immutable`, HTML gets `no-cache`. See the open question below.
- **A root Express app.** `server.ts` mounts the existing `app` (Wasp's routes, user apis, anything from `setupFn`) on a new `rootApp`, and serves the client around it. Server routes are registered first, so they always win.
- **`wasp build` builds the client.** In single mode the client has to exist before the Docker image is built, so `build` now runs Vite itself and the Dockerfile copies `web-app/build` into the image. `buildClient` moved to its own module, shared with `wasp build start`.
- **`wasp build start` runs one app.** In single mode it starts only the server and prints one URL. `--client-port` became optional and warns that it is ignored in that mode.
- **Client origin.** `config.apiUrl`, the WebSocket URL and the client env schema now use the page's own origin in single mode, in production as well as development. The server's `frontendUrl` falls back to its own URL plus the client's `baseDir`.

- **`Config` is public.** `wasp/server` now exports the type next to the value, so anything receiving the config can name it.

Split mode is unchanged: `wasp build` does not build the client, and `wasp build start` still runs two processes.

## Open question: what may be cached forever

`immutable` caching is safe only for files whose name changes with their content, and Vite does that for everything it writes into `build.assetsDir`. So the rule here is "in the assets dir", which is what Next.js does with `/_next/static` and what Netlify and Vercel express as a path rule.

Wasp does not fully own that directory, though. Vite copies the user's `public` dir into the build root as is, so a `public/assets/logo.png` of their own lands next to Vite's output and would be cached for a year while keeping its name across builds. There is a `TODO` on the function.

Ways out, if reviewers would rather close it than document it:

- give the dir a name a user is unlikely to create, the way `_next` does
- warn at build time when `public/` contains a folder of that name
- set `build.manifest` and treat exactly the files Vite lists as immutable, which is what Django's `ManifestStaticFilesStorage` does and is the only option that is exact

## Agreement

<!-- Select just one with [x] -->

- [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
- [x] A maintainer agreed on the approach beforehand: [#4784](https://github.com/wasp-lang/wasp/issues/4784), and the "[RFC] Single server" doc (status Accepted, decisions written up by @infomiho)

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [x] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

<!-- Breaking: a built app is now one app instead of two, and `wasp build start` no longer starts a separate client in single mode. Covered by the ChangeLog entry that lands with the deployment mode itself. -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended. <!-- Verified through the kitchen-sink e2e suite in build mode and the vite-build e2e tests, not a hand-run deploy. Worth a manual `wasp build start` pass before this leaves draft. -->

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- `ServerGenerator/RunConfigTest` and `RunConfigsTest` for the single-mode run configs. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Not a bug fix. -->
  - [x] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- The Playwright config now points at the server port in build mode, so the existing specs run against the single app. `ViteBuildTest` gained a case asserting `wasp build` produces the client build. -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- Not needed: nothing in the starters depends on who serves the client. -->
  - [x] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- Every example's Playwright config follows the app URL instead of a fixed client port. -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa). <!-- Only the tutorials' Playwright configs changed, which the docs tutorial does not cover. -->

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- The docs for both modes are written in one piece, separately, rather than in fragments. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- The single deployment entry lands with the deployment mode itself, so this PR adds nothing new for users to read about. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`. <!-- With the rest of the docs. -->
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Already at 0.26.0 on `main` since the last release. -->

