### PR TITLE
Telemetry debouncing is now robust to slow or failed send attempts.

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Telemetry.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Telemetry.hs
@@ -42,15 +42,15 @@ telemetry = do
     for_ maybeProjectHash $ \projectHash -> do
       maybeProjectCache <- liftIO $ TlmProject.readProjectTelemetryCacheFile telemetryCacheDirPath projectHash
       for_ maybeProjectCache $ \projectCache -> do
-        let maybeTimeOfLastSending = TlmProject.getTimeOfLastTelemetryDataSent projectCache
-        for_ maybeTimeOfLastSending $ \timeOfLastSending -> do
-          cliSendMessageC $ Msg.Info $ "Last time telemetry data was sent for this project: " ++ show timeOfLastSending
+        let maybeTimeOfLastSendAttempt = TlmProject.getTimeOfLastTelemetryDataSendAttempt projectCache
+        for_ maybeTimeOfLastSendAttempt $ \timeOfLastSendAttempt -> do
+          cliSendMessageC $ Msg.Info $ "Last time we attempted to send telemetry data for this project: " ++ show timeOfLastSendAttempt
 
   cliSendMessageC $ Msg.Info "Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details."
 
 -- | Sends telemetry data about the current Wasp project, if conditions are met.
 -- If we are not in the Wasp project at the moment, nothing happens.
--- If telemetry data was already sent for this project in the last 12 hours, nothing happens.
+-- If we already attempted to send telemetry data for this project in the last 12 hours, nothing happens.
 -- If env var WASP_TELEMETRY_DISABLE is set, nothing happens.
 considerSendingData :: Command.Call.Call -> Command ()
 considerSendingData cmdCall = (`catchError` const (return ())) $ do

--- a/waspc/cli/src/Wasp/Cli/Command/Telemetry/Project.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Telemetry/Project.hs
@@ -4,7 +4,7 @@ module Wasp.Cli.Command.Telemetry.Project
   ( getWaspProjectPathHash,
     considerSendingData,
     readProjectTelemetryCacheFile,
-    getTimeOfLastTelemetryDataSent,
+    getTimeOfLastTelemetryDataSendAttempt,
   )
 where
 
@@ -40,30 +40,37 @@ considerSendingData :: Path' Abs (Dir TelemetryCacheDir) -> UserSignature -> Pro
 considerSendingData telemetryCacheDirPath userSignature projectHash cmdCall = do
   projectCache <- readOrCreateProjectTelemetryFile telemetryCacheDirPath projectHash
 
-  let relevantLastCheckIn = case cmdCall of
-        Command.Call.Build -> _lastCheckInBuild projectCache
-        Command.Call.Deploy _ -> _lastCheckInDeploy projectCache
-        _ -> _lastCheckIn projectCache
+  let relevantLastSendAttempt = case cmdCall of
+        Command.Call.Build -> _lastSendAttemptBuild projectCache
+        Command.Call.Deploy _ -> _lastSendAttemptDeploy projectCache
+        _ -> _lastSendAttempt projectCache
 
-  shouldSendData <- case relevantLastCheckIn of
+  shouldSendData <- case relevantLastSendAttempt of
     Nothing -> return True
-    Just lastCheckIn -> isOlderThanNHours 12 lastCheckIn
+    Just lastSendAttempt -> isOlderThanNHours 12 lastSendAttempt
 
   when shouldSendData $ do
-    telemetryContext <- getTelemetryContext
-    sendTelemetryData $ getProjectTelemetryData userSignature projectHash cmdCall telemetryContext
+    -- NOTE: We record the send attempt on disk *before* actually sending the data.
+    --   If we did it after, a slow or failed request (e.g. PostHog being down, or the CLI
+    --   aborting the telemetry thread because the main command finished) would leave the
+    --   cache unchanged, and we would keep attempting to send on every invocation.
     projectCache' <- newProjectCache projectCache
     writeProjectTelemetryFile telemetryCacheDirPath projectHash projectCache'
+    telemetryContext <- getTelemetryContext
+    sendTelemetryData $ getProjectTelemetryData userSignature projectHash cmdCall telemetryContext
   where
     newProjectCache :: ProjectTelemetryCache -> IO ProjectTelemetryCache
     newProjectCache currentProjectCache = do
       now <- T.getCurrentTime
       return
         currentProjectCache
-          { _lastCheckIn = Just now,
-            _lastCheckInBuild = case cmdCall of
+          { _lastSendAttempt = Just now,
+            _lastSendAttemptBuild = case cmdCall of
               Command.Call.Build -> Just now
-              _ -> _lastCheckInBuild currentProjectCache
+              _ -> _lastSendAttemptBuild currentProjectCache,
+            _lastSendAttemptDeploy = case cmdCall of
+              Command.Call.Deploy _ -> Just now
+              _ -> _lastSendAttemptDeploy currentProjectCache
           }
 
 getTelemetryContext :: IO String
@@ -94,9 +101,12 @@ getWaspProjectPathHash = do
 -- * Project telemetry cache.
 
 data ProjectTelemetryCache = ProjectTelemetryCache
-  { _lastCheckIn :: Maybe T.UTCTime, -- Last time when CLI was called for this project, any command.
-    _lastCheckInBuild :: Maybe T.UTCTime, -- Last time when CLI was called for this project, with Build command.
-    _lastCheckInDeploy :: Maybe T.UTCTime -- Last time when CLI was called for this project, with Deploy command.
+  { -- Last time we attempted to send telemetry data for this project, for any command.
+    _lastSendAttempt :: Maybe T.UTCTime,
+    -- Last time we attempted to send telemetry data for this project, for the Build command.
+    _lastSendAttemptBuild :: Maybe T.UTCTime,
+    -- Last time we attempted to send telemetry data for this project, for the Deploy command.
+    _lastSendAttemptDeploy :: Maybe T.UTCTime
   }
   deriving (Generic, Show)
 
@@ -105,12 +115,13 @@ instance Aeson.ToJSON ProjectTelemetryCache
 instance Aeson.FromJSON ProjectTelemetryCache
 
 initialCache :: ProjectTelemetryCache
-initialCache = ProjectTelemetryCache {_lastCheckIn = Nothing, _lastCheckInBuild = Nothing, _lastCheckInDeploy = Nothing}
+initialCache = ProjectTelemetryCache {_lastSendAttempt = Nothing, _lastSendAttemptBuild = Nothing, _lastSendAttemptDeploy = Nothing}
 
 -- * Project telemetry cache file.
 
-getTimeOfLastTelemetryDataSent :: ProjectTelemetryCache -> Maybe T.UTCTime
-getTimeOfLastTelemetryDataSent cache = max (_lastCheckIn cache) (_lastCheckInBuild cache)
+getTimeOfLastTelemetryDataSendAttempt :: ProjectTelemetryCache -> Maybe T.UTCTime
+getTimeOfLastTelemetryDataSendAttempt cache =
+  maximum [_lastSendAttempt cache, _lastSendAttemptBuild cache, _lastSendAttemptDeploy cache]
 
 readProjectTelemetryCacheFile :: Path' Abs (Dir TelemetryCacheDir) -> ProjectHash -> IO (Maybe ProjectTelemetryCache)
 readProjectTelemetryCacheFile telemetryCacheDirPath projectHash =

--- a/web/docs/general/cli.md
+++ b/web/docs/general/cli.md
@@ -146,7 +146,7 @@ $ wasp telemetry
 
 Telemetry is currently: ENABLED
 Telemetry cache directory: /home/user/.cache/wasp/telemetry/
-Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
+Last time we attempted to send telemetry data for this project: 2021-05-27 09:21:16.79537226 UTC
 Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 
 ```

--- a/web/docs/telemetry.md
+++ b/web/docs/telemetry.md
@@ -14,7 +14,7 @@ Our telemetry implementation is anonymized and very limited in its scope, focuse
 ## When and what is sent?
 
 - Information is sent via HTTPS request when `wasp` CLI command is invoked.
-  Information is sent no more than twice in a period of 12 hours (sending is paused for 12 hours after last invocation, separately for `wasp build` command and for all other commands). Exact information as it is sent:
+  Information is sent no more than three times in a period of 12 hours (sending is paused for 12 hours after the last attempt to send it, separately for `wasp build` command, for `wasp deploy` command, and for all other commands). Exact information as it is sent:
 
   ```json
   {

--- a/web/markdown-snapshots/llms-full.txt
+++ b/web/markdown-snapshots/llms-full.txt
@@ -15083,7 +15083,7 @@ $ wasp telemetry
 
 Telemetry is currently: ENABLED
 Telemetry cache directory: /home/user/.cache/wasp/telemetry/
-Last time telemetry data was sent for this project: 2021-05-27 09:21:16.79537226 UTC
+Last time we attempted to send telemetry data for this project: 2021-05-27 09:21:16.79537226 UTC
 Our telemetry is anonymized and very limited in its scope: check https://wasp.sh/docs/telemetry for more details.
 ```
 


### PR DESCRIPTION
<!--
  Thanks for contributing to Wasp!
  Make sure to follow this PR template, so that we can speed up the review process.
  It will also help you not forget important steps when making a change.
  If you don't know how to fill any of the sections below, it's okay to leave
  them blank and ask for help.
-->

## Description

Simple fix where we first record on the disk that we are bout to send telemetry data, then we send it, instead of vice versa where we wait for he sending to successfully finish, which would on slower connection result (>1s) in not recording the sending on the disk (even though event ends up being sent successfuly) therefore making our debouncing (send only every 12 hours, the events) not working. We had that happen sometimes, and this takes care of it.

## Agreement

<!-- Select just one with [x] -->

- [X] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
- [ ] A maintainer agreed on the approach beforehand: <!-- link to the GitHub issue or Discord thread -->

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [X] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [ ] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [X] I tested my change in a Wasp app to verify that it works as intended.

- 🧪 Tests and apps:

  - [ ] I added **unit tests** for my change. <!-- If not, explain why. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- If not, explain why. -->
  - [ ] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`.
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed.
  - [ ] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed.
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa).

- 📜 Documentation:

  - [X] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`.

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change.
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`.
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced.

<!--
  Bumping the version on `waspc/waspc.cabal`:

  We still haven't reached 1.0, so the version bumping follows these rules:
    - Bug fix:            0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - New feature:        0.X.+1    (e.g. 0.16.3 bumps to 0.16.4)
    - Breaking change:    0.+1.0    (e.g. 0.16.3 bumps to 0.17.0)

  If the version has already been bumped on `main` since the last release, skip this.
-->
