### PR TITLE
Deploy one app on Fly and Railway in single deployment mode

### DIFF
--- a/.github/workflows/ci-deploy-test.yaml
+++ b/.github/workflows/ci-deploy-test.yaml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ${{ env.APP_TO_DEPLOY }}
         run: |
           # `fly launch` fails if Fly toml files already exist.
-          rm -f fly-server.toml fly-client.toml
+          rm -f fly-server.toml
 
           echo "Deploying with prefix: $APP_PREFIX"
           mapfile -d $'\0' -t ENV_VAR_ARGUMENTS < <(node ../../scripts/deploy-test/prepare-deploy-secrets.mjs .env.server.example)
@@ -71,17 +71,15 @@ jobs:
             config_file="$1"
             flyctl status -j -c "$config_file" | jq -r '.Hostname'
           }
+          # The server app also serves the client, so it is the only app URL.
           SERVER_HOSTNAME=$(get_fly_app_hostname fly-server.toml)
-          CLIENT_HOSTNAME=$(get_fly_app_hostname fly-client.toml)
           echo "server=$SERVER_HOSTNAME" >> "$GITHUB_OUTPUT"
-          echo "client=$CLIENT_HOSTNAME" >> "$GITHUB_OUTPUT"
 
       - name: Run E2E tests against deployed app
         working-directory: ${{ env.APP_TO_DEPLOY }}
         env:
           WASP_RUN_MODE: deployed
-          PLAYWRIGHT_BASE_URL: "https://${{ steps.get-hostnames.outputs.client }}"
-          PLAYWRIGHT_SERVER_URL: "https://${{ steps.get-hostnames.outputs.server }}"
+          PLAYWRIGHT_BASE_URL: "https://${{ steps.get-hostnames.outputs.server }}"
         run: npm test
 
   cleanup_fly_deploy_test:
@@ -104,7 +102,6 @@ jobs:
         run: |
           # NOTE: We are relying on Wasp's naming conventions here
           flyctl apps destroy -y $APP_PREFIX-server || true
-          flyctl apps destroy -y $APP_PREFIX-client || true
           flyctl apps destroy -y $APP_PREFIX-db || true
 
   test_railway_deployment:
@@ -147,12 +144,10 @@ jobs:
             service_name="$1"
             railway status --json | jq -r --arg NAME "$service_name" '.environments.edges[].node.serviceInstances.edges[].node | select(.serviceName == $NAME) | .domains.serviceDomains[0].domain'
           }
+          # The server service also serves the client, so it is the only app URL.
           server_service_name="${APP_PREFIX}-server"
-          client_service_name="${APP_PREFIX}-client"
           SERVER_HOSTNAME=$(get_railway_service_hostname "$server_service_name")
-          CLIENT_HOSTNAME=$(get_railway_service_hostname "$client_service_name")
           echo "server=$SERVER_HOSTNAME" >> "$GITHUB_OUTPUT"
-          echo "client=$CLIENT_HOSTNAME" >> "$GITHUB_OUTPUT"
 
       # NOTE: `railway up --ci` (used by `wasp-cli deploy railway launch`)
       # returns when the build finishes, not when the deployment serves
@@ -162,7 +157,6 @@ jobs:
       - name: Wait for deployed app to be reachable
         env:
           SERVER_HOSTNAME: ${{ steps.get-hostnames.outputs.server }}
-          CLIENT_HOSTNAME: ${{ steps.get-hostnames.outputs.client }}
         run: |
           function wait_for_url() {
             url="$1"
@@ -178,14 +172,12 @@ jobs:
             return 1
           }
           wait_for_url "https://${SERVER_HOSTNAME}"
-          wait_for_url "https://${CLIENT_HOSTNAME}"
 
       - name: Run E2E tests against deployed app
         working-directory: ${{ env.APP_TO_DEPLOY }}
         env:
           WASP_RUN_MODE: deployed
-          PLAYWRIGHT_BASE_URL: "https://${{ steps.get-hostnames.outputs.client }}"
-          PLAYWRIGHT_SERVER_URL: "https://${{ steps.get-hostnames.outputs.server }}"
+          PLAYWRIGHT_BASE_URL: "https://${{ steps.get-hostnames.outputs.server }}"
         run: npm test
 
   cleanup_railway_deploy_test:

--- a/examples/kitchen-sink/e2e-tests/playwright.config.ts
+++ b/examples/kitchen-sink/e2e-tests/playwright.config.ts
@@ -17,15 +17,6 @@ export const WASP_APP_URL =
   process.env.PLAYWRIGHT_BASE_URL ??
   `http://localhost:${isBuildMode ? WASP_SERVER_PORT : WASP_CLIENT_DEV_PORT}`;
 
-const WASP_SERVER_URL =
-  process.env.PLAYWRIGHT_SERVER_URL ?? `http://localhost:${WASP_SERVER_PORT}`;
-
-// The origin the client sends its API requests to. The server serves the client, and in
-// dev mode the client dev server proxies Wasp's routes to it, so it is the app's own origin.
-// TODO: In deployed mode the client is still deployed separately, so it is the server's
-// own URL. It becomes the app URL once `wasp deploy` creates a single app.
-export const WASP_API_URL = isDeployedMode ? WASP_SERVER_URL : WASP_APP_URL;
-
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv

--- a/examples/kitchen-sink/e2e-tests/tests/auth.spec.ts
+++ b/examples/kitchen-sink/e2e-tests/tests/auth.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { WASP_API_URL } from "../playwright.config";
+import { WASP_APP_URL } from "../playwright.config";
 import { performEmailVerification, performLogin, performSignup } from "./auth";
 import {
   generateRandomEmail,
@@ -13,7 +13,7 @@ test.describe("auth", () => {
     await page.goto("/signup");
 
     await expect(
-      page.locator(`a[href='${WASP_API_URL}/auth/google/login']`),
+      page.locator(`a[href='${WASP_APP_URL}/auth/google/login']`),
     ).toBeVisible();
   });
 

--- a/examples/kitchen-sink/e2e-tests/tests/custom-route.spec.ts
+++ b/examples/kitchen-sink/e2e-tests/tests/custom-route.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { WASP_API_URL } from "../playwright.config";
+import { WASP_APP_URL } from "../playwright.config";
 
 test.describe("custom route", () => {
   test("custom route from the server setup is reachable", async ({
     request,
   }) => {
-    const response = await request.get(`${WASP_API_URL}/customRoute`);
+    const response = await request.get(`${WASP_APP_URL}/customRoute`);
 
     expect(response.ok()).toBe(true);
     expect(await response.text()).toBe("I am a custom route");

--- a/waspc/data/packages/deploy/src/common/waspBuild.ts
+++ b/waspc/data/packages/deploy/src/common/waspBuild.ts
@@ -1,6 +1,10 @@
-import { type ProcessOutput } from "zx";
 import { WaspCliExe, WaspProjectDir } from "./brandedTypes.js";
 import { waspSays } from "./terminal.js";
+import {
+  DeploymentMode,
+  getWaspInfoPath,
+  readWaspInfo,
+} from "./waspProject.js";
 import { createCommandWithCwd } from "./zx.js";
 
 export const ensureWaspProjectIsBuilt = createEnsureWaspProjectIsBuilt();
@@ -12,10 +16,11 @@ function createEnsureWaspProjectIsBuilt() {
   }: {
     waspProjectDir: WaspProjectDir;
     waspExe: WaspCliExe;
-  }): Promise<ProcessOutput> {
+  }): Promise<{ deploymentMode: DeploymentMode }> {
     waspSays("Building your Wasp app...");
     const waspCli = createCommandWithCwd(waspExe, waspProjectDir);
-    return waspCli(["build"]);
+    await waspCli(["build"]);
+    return { deploymentMode: getDeploymentMode(waspProjectDir) };
   }
 
   type BuildWaspApp = typeof buildWaspApp;
@@ -30,4 +35,19 @@ function createEnsureWaspProjectIsBuilt() {
     }
     return cachedWaspBuildResult;
   };
+}
+
+// `wasp build` records the mode in `.wasp/out/.waspinfo`.
+function getDeploymentMode(waspProjectDir: WaspProjectDir): DeploymentMode {
+  const { deploymentMode } = readWaspInfo(waspProjectDir);
+
+  if (deploymentMode === undefined) {
+    waspSays(
+      `Warning: ${getWaspInfoPath(waspProjectDir)} has no "deploymentMode" field. ` +
+        "The project was probably built with an older Wasp CLI. Assuming split mode.",
+    );
+    return "split";
+  }
+
+  return deploymentMode;
 }

--- a/waspc/data/packages/deploy/src/common/waspProject.ts
+++ b/waspc/data/packages/deploy/src/common/waspProject.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "node:path";
+import * as z from "zod";
 
 import { WaspCliExe, WaspProjectDir } from "./brandedTypes.js";
 import { assertDirExists, assertDirPathIsAbsolute } from "./validation.js";
@@ -50,6 +51,51 @@ export function getClientBuildArtefactsDir(
 
 function getWaspBuildDir(waspProjectDir: WaspProjectDir): string {
   return path.join(waspProjectDir, ".wasp", "out");
+}
+
+export function getWaspInfoPath(waspProjectDir: WaspProjectDir): string {
+  return path.join(getWaspBuildDir(waspProjectDir), ".waspinfo");
+}
+
+const waspInfoSchema = z.object({
+  // "single": the server serves the web client, one app/service to deploy.
+  // "split": the client is a separate static app/service, the server is CORS'd.
+  deploymentMode: z.enum(["single", "split"]).optional(),
+});
+
+export type WaspInfo = z.infer<typeof waspInfoSchema>;
+
+export type DeploymentMode = NonNullable<WaspInfo["deploymentMode"]>;
+
+// `wasp build` writes `.wasp/out/.waspinfo`, so call this only after the
+// project has been built.
+export function readWaspInfo(waspProjectDir: WaspProjectDir): WaspInfo {
+  const waspInfoPath = getWaspInfoPath(waspProjectDir);
+
+  let contents: string;
+  try {
+    contents = fs.readFileSync(waspInfoPath, "utf8");
+  } catch {
+    throw new Error(
+      `Could not read ${waspInfoPath}. Run \`wasp build\` and retry.`,
+    );
+  }
+
+  try {
+    return waspInfoSchema.parse(JSON.parse(contents));
+  } catch (error) {
+    throw new Error(
+      `${waspInfoPath} is not a valid .waspinfo file (${describeError(error)}). ` +
+        "Run `wasp build` with the current Wasp CLI and retry.",
+    );
+  }
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    return z.prettifyError(error);
+  }
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function getServerDeploymentDir(waspProjectDir: WaspProjectDir): string {

--- a/waspc/data/packages/deploy/src/providers/fly/commands/deploy/deploy.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/commands/deploy/deploy.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../common/terminal.js";
 import { ensureWaspProjectIsBuilt } from "../../../../common/waspBuild.js";
 import {
+  DeploymentMode,
   getClientDeploymentDir,
   getServerDeploymentDir,
 } from "../../../../common/waspProject.js";
@@ -34,7 +35,7 @@ import { DeployCmdOptions } from "./DeployCmdOptions.js";
 export async function deploy(cmdOptions: DeployCmdOptions): Promise<void> {
   waspSays("Deploying your Wasp app to Fly.io!");
 
-  await ensureWaspProjectIsBuilt(cmdOptions);
+  const { deploymentMode } = await ensureWaspProjectIsBuilt(cmdOptions);
 
   const tomlFilePaths = getTomlFilePaths(cmdOptions);
 
@@ -57,10 +58,24 @@ export async function deploy(cmdOptions: DeployCmdOptions): Promise<void> {
       cmdOptions,
       tomlFilePaths,
     });
-    await deployServer(deploymentInstructions, cmdOptions);
+    await deployServer(deploymentInstructions, cmdOptions, deploymentMode);
   }
 
-  if (!clientTomlExistsInProject(tomlFilePaths)) {
+  if (deploymentMode === "single") {
+    waspSays(
+      "Single deployment mode: the server app also serves the web client. Skipping client deploy.",
+    );
+    if (cmdOptions.skipClient) {
+      waspSays(
+        "The --skip-client option has no effect in single deployment mode.",
+      );
+    }
+    if (cmdOptions.customServerUrl) {
+      waspSays(
+        "The --custom-server-url option has no effect in single deployment mode, the client always uses its own origin.",
+      );
+    }
+  } else if (!clientTomlExistsInProject(tomlFilePaths)) {
     waspSays(
       `${
         tomlFilePaths.clientTomlPath
@@ -84,6 +99,7 @@ export async function deploy(cmdOptions: DeployCmdOptions): Promise<void> {
 async function deployServer(
   deploymentInstructions: DeploymentInstructions<DeployCmdOptions>,
   { buildLocally }: DeployCmdOptions,
+  deploymentMode: DeploymentMode,
 ) {
   waspSays("Deploying your server now...");
 
@@ -106,7 +122,14 @@ async function deployServer(
   // TOOD: Consider how to best handle this situation across all operations.
   copyLocalServerTomlToProject(deploymentInstructions.tomlFilePaths);
 
-  waspSays("Server has been deployed!");
+  if (deploymentMode === "single") {
+    displayWaspRocketImage();
+    waspSays(
+      `Server has been deployed! Your Wasp app is accessible at: ${getFlyAppUrl(deploymentInstructions.serverFlyAppName)}`,
+    );
+  } else {
+    waspSays("Server has been deployed!");
+  }
 }
 
 async function deployClient(

--- a/waspc/data/packages/deploy/src/providers/fly/commands/setup/setup.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/commands/setup/setup.ts
@@ -5,6 +5,7 @@ import { generateRandomHexString } from "../../../../common/random.js";
 import { waspSays } from "../../../../common/terminal.js";
 import { ensureWaspProjectIsBuilt } from "../../../../common/waspBuild.js";
 import {
+  DeploymentMode,
   getClientDeploymentDir,
   getServerDeploymentDir,
 } from "../../../../common/waspProject.js";
@@ -37,7 +38,7 @@ export async function setup(
 ): Promise<void> {
   waspSays("Setting up your Wasp app with Fly.io!");
 
-  await ensureWaspProjectIsBuilt(cmdOptions);
+  const { deploymentMode } = await ensureWaspProjectIsBuilt(cmdOptions);
 
   const tomlFilePaths = getTomlFilePaths(cmdOptions);
   const deploymentInstructions = createDeploymentInstructions({
@@ -50,10 +51,19 @@ export async function setup(
   if (serverTomlExistsInProject(tomlFilePaths)) {
     waspSays(`${tomlFilePaths.serverTomlPath} exists. Skipping server setup.`);
   } else {
-    await setupServer(deploymentInstructions);
+    await setupServer(deploymentInstructions, deploymentMode);
   }
 
-  if (clientTomlExistsInProject(tomlFilePaths)) {
+  if (deploymentMode === "single") {
+    waspSays(
+      "Single deployment mode: the server app also serves the web client. Skipping client setup.",
+    );
+    if (cmdOptions.clientSecret.length > 0) {
+      waspSays(
+        "The --client-secret option has no effect in single deployment mode.",
+      );
+    }
+  } else if (clientTomlExistsInProject(tomlFilePaths)) {
     waspSays(`${tomlFilePaths.clientTomlPath} exists. Skipping client setup.`);
   } else {
     await setupClient(deploymentInstructions);
@@ -66,6 +76,7 @@ export async function setup(
 
 async function setupServer(
   deploymentInstructions: DeploymentInstructions<SetupCmdOptions>,
+  deploymentMode: DeploymentMode,
 ) {
   waspSays(
     `Setting up server app with name ${deploymentInstructions.serverFlyAppName}`,
@@ -133,13 +144,21 @@ Press any key to continue or Ctrl+C to cancel.`);
 
   const jwtSecret = generateRandomHexString();
 
+  const serverUrl = getFlyAppUrl(deploymentInstructions.serverFlyAppName);
+  // In single deployment mode the server app serves the web client, so the client
+  // lives on the server origin.
+  const clientUrl =
+    deploymentMode === "single"
+      ? serverUrl
+      : getFlyAppUrl(deploymentInstructions.clientFlyAppName);
+
   const secretsArgs = [
     `JWT_SECRET=${jwtSecret}`,
     // NOTE: Normally these would just be envars, but flyctl
     // doesn't provide a way to set envars that persist to fly.toml.
     `PORT=${serverAppPort}`,
-    `WASP_WEB_CLIENT_URL=${getFlyAppUrl(deploymentInstructions.clientFlyAppName)}`,
-    `WASP_SERVER_URL=${getFlyAppUrl(deploymentInstructions.serverFlyAppName)}`,
+    `WASP_WEB_CLIENT_URL=${clientUrl}`,
+    `WASP_SERVER_URL=${serverUrl}`,
   ];
 
   if (deploymentInstructions.cmdOptions.serverSecret.length > 0) {

--- a/waspc/data/packages/deploy/src/providers/fly/index.ts
+++ b/waspc/data/packages/deploy/src/providers/fly/index.ts
@@ -76,7 +76,7 @@ class FlyCommand extends Command {
       [],
     ).option(
       "--client-secret <clientSecret>",
-      "secret to set on the client app (of form FOO=BAR)",
+      "secret to set on the client app (of form FOO=BAR) (split deployment mode only)",
       collect,
       [],
     );
@@ -84,7 +84,7 @@ class FlyCommand extends Command {
   addCustomServerUrlOption(): this {
     return this.option(
       "--custom-server-url <url>",
-      "URL of the server that the client will connect to",
+      "URL of the server that the client will connect to (split deployment mode only)",
     );
   }
 }
@@ -193,7 +193,10 @@ function makeFlySetupCommand(): Command {
 function makeFlyDeployCommand(): Command {
   return new FlyCommand("deploy")
     .description("(Re-)Deploy existing app to Fly.io")
-    .option("--skip-client", "do not deploy the web client")
+    .option(
+      "--skip-client",
+      "do not deploy the web client (split deployment mode only)",
+    )
     .option("--skip-server", "do not deploy the server")
     .addLocalBuildOption()
     .addCustomServerUrlOption()

--- a/waspc/data/packages/deploy/src/providers/railway/commands/deploy/index.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/commands/deploy/index.ts
@@ -38,15 +38,29 @@ export async function deploy(
 
   waspSays("Deploying your Wasp app to Railway!");
 
-  await ensureWaspProjectIsBuilt(options);
+  const { deploymentMode } = await ensureWaspProjectIsBuilt(options);
 
   if (options.skipServer) {
     waspSays("Skipping server deploy due to CLI option.");
   } else {
-    await deployServer(deploymentInstructions);
+    await deployServer(deploymentInstructions, deploymentMode);
   }
 
-  if (options.skipClient) {
+  if (deploymentMode === "single") {
+    waspSays(
+      "Single deployment mode: the server service also serves the web client. Skipping client deploy.",
+    );
+    if (options.skipClient) {
+      waspSays(
+        "The --skip-client option has no effect in single deployment mode.",
+      );
+    }
+    if (options.customServerUrl) {
+      waspSays(
+        "The --custom-server-url option has no effect in single deployment mode, the client always uses its own origin.",
+      );
+    }
+  } else if (options.skipClient) {
     waspSays("Skipping client deploy due to CLI option.");
   } else {
     await deployClient(deploymentInstructions);

--- a/waspc/data/packages/deploy/src/providers/railway/commands/deploy/server.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/commands/deploy/server.ts
@@ -1,6 +1,15 @@
-import { waspSays } from "../../../../common/terminal.js";
-import { getServerBuildArtefactsDir } from "../../../../common/waspProject.js";
+import {
+  displayWaspRocketImage,
+  waspSays,
+} from "../../../../common/terminal.js";
+import {
+  DeploymentMode,
+  getServerBuildArtefactsDir,
+} from "../../../../common/waspProject.js";
+import { ServerServiceName } from "../../brandedTypes.js";
 import { DeploymentInstructions } from "../../DeploymentInstructions.js";
+import { serverAppPort } from "../../ports.js";
+import { generateServiceUrl } from "../../railwayService/url.js";
 
 import {
   deployServiceWithStreamingLogs,
@@ -8,10 +17,13 @@ import {
 } from "./common.js";
 import { DeployCmdOptions } from "./DeployCmdOptions.js";
 
-export async function deployServer({
-  cmdOptions: options,
-  serverServiceName,
-}: DeploymentInstructions<DeployCmdOptions>): Promise<void> {
+export async function deployServer(
+  {
+    cmdOptions: options,
+    serverServiceName,
+  }: DeploymentInstructions<DeployCmdOptions>,
+  deploymentMode: DeploymentMode,
+): Promise<void> {
   waspSays("Deploying your server now...");
 
   const serverBuildArtefactsDir = getServerBuildArtefactsDir(
@@ -26,11 +38,36 @@ export async function deployServer({
     options,
   );
 
+  const appUrlNote = await makeAppUrlNote(
+    deploymentMode,
+    serverServiceName,
+    options,
+  );
   const messages: Record<ServiceDeploymentStatus, string> = {
-    [ServiceDeploymentStatus.SUCCESS]: "Server has been deployed!",
-    [ServiceDeploymentStatus.FAILED_TO_STREAM_LOGS]:
-      "Server deployment started, but failed to stream build logs. Please check the Railway dashboard for build logs.",
+    [ServiceDeploymentStatus.SUCCESS]: `Server has been deployed!${appUrlNote}`,
+    [ServiceDeploymentStatus.FAILED_TO_STREAM_LOGS]: `Server deployment started, but failed to stream build logs. Please check the Railway dashboard for build logs.${appUrlNote}`,
   };
 
+  if (deploymentMode === "single") {
+    displayWaspRocketImage();
+  }
   waspSays(messages[deploymentStatus]);
+}
+
+// In single deployment mode the server service serves the web client too, so its
+// URL is the app URL.
+async function makeAppUrlNote(
+  deploymentMode: DeploymentMode,
+  serverServiceName: ServerServiceName,
+  options: DeployCmdOptions,
+): Promise<string> {
+  if (deploymentMode !== "single") {
+    return "";
+  }
+  const serverUrl = await generateServiceUrl(
+    serverServiceName,
+    serverAppPort,
+    options,
+  );
+  return ` Your Wasp app is accessible at: ${serverUrl}`;
 }

--- a/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/commands/setup/setup.ts
@@ -5,6 +5,7 @@ import { generateRandomHexString } from "../../../../common/random.js";
 import { waspSays } from "../../../../common/terminal.js";
 import { ensureWaspProjectIsBuilt } from "../../../../common/waspBuild.js";
 import {
+  DeploymentMode,
   getClientDeploymentDir,
   getServerDeploymentDir,
 } from "../../../../common/waspProject.js";
@@ -57,7 +58,7 @@ export async function setup(
     workspace: options.workspace,
   });
 
-  await ensureWaspProjectIsBuilt(options);
+  const { deploymentMode } = await ensureWaspProjectIsBuilt(options);
 
   const dbService = project.findService(deploymentInstructions.dbServiceName);
   if (dbService) {
@@ -71,7 +72,18 @@ export async function setup(
     await setupDb(deploymentInstructions);
   }
 
-  if (project.doesServiceExist(deploymentInstructions.clientServiceName)) {
+  if (deploymentMode === "single") {
+    waspSays(
+      "Single deployment mode: the server service also serves the web client. Skipping client setup.",
+    );
+    if (options.clientSecret.length > 0) {
+      waspSays(
+        "The --client-secret option has no effect in single deployment mode.",
+      );
+    }
+  } else if (
+    project.doesServiceExist(deploymentInstructions.clientServiceName)
+  ) {
     waspSays("Client service already exists. Skipping client setup.");
   } else {
     await setupClient(deploymentInstructions);
@@ -80,7 +92,7 @@ export async function setup(
   if (project.doesServiceExist(deploymentInstructions.serverServiceName)) {
     waspSays("Server service already exists. Skipping server setup.");
   } else {
-    await setupServer(deploymentInstructions);
+    await setupServer(deploymentInstructions, deploymentMode);
   }
 }
 
@@ -158,17 +170,22 @@ async function setupDb({
   await waitForServiceDeploymentSuccess(dbService, options);
 }
 
-async function setupServer({
-  cmdOptions: options,
-  serverServiceName,
-  clientServiceName,
-  dbServiceName,
-}: DeploymentInstructions<SetupCmdOptions>): Promise<void> {
+async function setupServer(
+  {
+    cmdOptions: options,
+    serverServiceName,
+    clientServiceName,
+    dbServiceName,
+  }: DeploymentInstructions<SetupCmdOptions>,
+  deploymentMode: DeploymentMode,
+): Promise<void> {
   waspSays(`Setting up server app with name ${serverServiceName}`);
 
-  // The client service needs a URL so it can be referenced in the
-  // server service env variables.
-  await generateServiceUrl(clientServiceName, clientAppPort, options);
+  if (deploymentMode === "split") {
+    // The client service needs a URL so it can be referenced in the
+    // server service env variables.
+    await generateServiceUrl(clientServiceName, clientAppPort, options);
+  }
 
   const serverDeploymentDir = getServerDeploymentDir(options.waspProjectDir);
   const railwayCli = createCommandWithCwd(
@@ -176,12 +193,14 @@ async function setupServer({
     serverDeploymentDir,
   );
 
-  const clientUrl = `https://${getRailwayEnvVarValueReference(
-    "RAILWAY_PUBLIC_DOMAIN",
-    { serviceName: clientServiceName },
-  )}`;
   // If we reference the service URL in its OWN env variables, we don't prefix it with the service name.
   const serverUrl = `https://${getRailwayEnvVarValueReference("RAILWAY_PUBLIC_DOMAIN")}`;
+  // In single deployment mode the server service serves the web client, so the
+  // client lives on the server origin.
+  const clientUrl =
+    deploymentMode === "single"
+      ? serverUrl
+      : `https://${getRailwayEnvVarValueReference("RAILWAY_PUBLIC_DOMAIN", { serviceName: clientServiceName })}`;
   const databaseUrl = getRailwayEnvVarValueReference("DATABASE_URL", {
     serviceName: dbServiceName,
   });

--- a/waspc/data/packages/deploy/src/providers/railway/index.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/index.ts
@@ -36,7 +36,7 @@ class RailwayCommand extends Command {
       [],
     ).option(
       "--client-secret <clientSecret>",
-      "secret to set on the client app (of form FOO=BAR)",
+      "secret to set on the client app (of form FOO=BAR) (split deployment mode only)",
       collect,
       [],
     );
@@ -44,7 +44,7 @@ class RailwayCommand extends Command {
   addCustomServerUrlOption(): this {
     return this.option(
       "--custom-server-url <url>",
-      "URL of the server that the client will connect to",
+      "URL of the server that the client will connect to (split deployment mode only)",
     );
   }
   addDbOptions(): this {
@@ -146,7 +146,10 @@ function makeRailwayDeployCommand(): Command {
   return new RailwayCommand("deploy")
     .description("Deploys the app to Railway")
     .addProjectNameArgument()
-    .option("--skip-client", "do not deploy the web client")
+    .option(
+      "--skip-client",
+      "do not deploy the web client (split deployment mode only)",
+    )
     .option("--skip-server", "do not deploy the server")
     .option(
       "--existing-project-id [projectId]",

--- a/waspc/data/packages/deploy/src/providers/railway/railwayService/url.ts
+++ b/waspc/data/packages/deploy/src/providers/railway/railwayService/url.ts
@@ -36,9 +36,6 @@ export async function generateServiceUrl(
 
   if (domains.length > 1) {
     waspInfo(`Multiple domains detected, using the first one: ${domain}.`);
-    waspInfo(
-      'If you want to use a custom domain for the server, you should add the "--custom-server-url <url>" flag.',
-    );
   }
 
   return domain;

--- a/waspc/data/packages/deploy/test/common/tempWaspProject.ts
+++ b/waspc/data/packages/deploy/test/common/tempWaspProject.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { WaspProjectDir } from "../../src/common/brandedTypes.js";
+
+const projectDirs: string[] = [];
+
+export function makeProjectWithWaspInfo(contents: string): WaspProjectDir {
+  const projectDir = makeProjectWithoutWaspInfo();
+  fs.writeFileSync(
+    path.join(projectDir, ".wasp", "out", ".waspinfo"),
+    contents,
+  );
+  return projectDir;
+}
+
+export function makeProjectWithoutWaspInfo(): WaspProjectDir {
+  const projectDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "wasp-deploy-test-"),
+  );
+  fs.mkdirSync(path.join(projectDir, ".wasp", "out"), { recursive: true });
+  projectDirs.push(projectDir);
+  return projectDir as WaspProjectDir;
+}
+
+export function removeTempProjects(): void {
+  for (const projectDir of projectDirs.splice(0)) {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+}

--- a/waspc/data/packages/deploy/test/common/waspBuild.test.ts
+++ b/waspc/data/packages/deploy/test/common/waspBuild.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type {
+  WaspCliExe,
+  WaspProjectDir,
+} from "../../src/common/brandedTypes.js";
+import {
+  makeProjectWithWaspInfo,
+  removeTempProjects,
+} from "./tempWaspProject.js";
+
+vi.mock("../../src/common/terminal.js", () => ({
+  waspSays: vi.fn(),
+}));
+
+// `ensureWaspProjectIsBuilt` runs `wasp build` through zx, which the tests
+// replace with a no-op.
+vi.mock("../../src/common/zx.js", () => ({
+  createCommandWithCwd: () => vi.fn().mockResolvedValue(undefined),
+}));
+
+import { waspSays } from "../../src/common/terminal.js";
+
+const waspExe = "wasp" as WaspCliExe;
+
+// The build result is cached per module instance, so every test gets a fresh one.
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  removeTempProjects();
+});
+
+describe("ensureWaspProjectIsBuilt", () => {
+  test.each(["single", "split"] as const)(
+    "returns the %s deployment mode of the build",
+    async (deploymentMode) => {
+      const waspProjectDir = makeProjectWithWaspInfo(
+        JSON.stringify({ deploymentMode }),
+      );
+      const ensureWaspProjectIsBuilt = await importEnsureWaspProjectIsBuilt();
+
+      const result = await ensureWaspProjectIsBuilt({
+        waspProjectDir,
+        waspExe,
+      });
+
+      expect(result).toEqual({ deploymentMode });
+      expect(waspSays).not.toHaveBeenCalledWith(
+        expect.stringContaining("Assuming split mode"),
+      );
+    },
+  );
+
+  test("assumes split mode with a warning when the build has no deployment mode", async () => {
+    const waspProjectDir = makeProjectWithWaspInfo(
+      JSON.stringify({ waspVersion: "0.25.0" }),
+    );
+    const ensureWaspProjectIsBuilt = await importEnsureWaspProjectIsBuilt();
+
+    const result = await ensureWaspProjectIsBuilt({ waspProjectDir, waspExe });
+
+    expect(result).toEqual({ deploymentMode: "split" });
+    expect(waspSays).toHaveBeenCalledWith(
+      expect.stringContaining("Assuming split mode"),
+    );
+  });
+
+  test("builds only once", async () => {
+    const waspProjectDir = makeProjectWithWaspInfo(
+      JSON.stringify({ deploymentMode: "single" }),
+    );
+    const ensureWaspProjectIsBuilt = await importEnsureWaspProjectIsBuilt();
+
+    await ensureWaspProjectIsBuilt({ waspProjectDir, waspExe });
+    await ensureWaspProjectIsBuilt({ waspProjectDir, waspExe });
+
+    expect(waspSays).toHaveBeenCalledTimes(1);
+  });
+});
+
+async function importEnsureWaspProjectIsBuilt(): Promise<
+  (options: {
+    waspProjectDir: WaspProjectDir;
+    waspExe: WaspCliExe;
+  }) => Promise<{ deploymentMode: "single" | "split" }>
+> {
+  const waspBuild = await import("../../src/common/waspBuild.js");
+  return waspBuild.ensureWaspProjectIsBuilt;
+}

--- a/waspc/data/packages/deploy/test/common/waspProject.test.ts
+++ b/waspc/data/packages/deploy/test/common/waspProject.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { readWaspInfo } from "../../src/common/waspProject.js";
+import {
+  makeProjectWithoutWaspInfo,
+  makeProjectWithWaspInfo,
+  removeTempProjects,
+} from "./tempWaspProject.js";
+
+afterEach(removeTempProjects);
+
+describe("readWaspInfo", () => {
+  test.each(["single", "split"] as const)(
+    "reads the %s deployment mode",
+    (deploymentMode) => {
+      const projectDir = makeProjectWithWaspInfo(
+        JSON.stringify({ deploymentMode }),
+      );
+
+      expect(readWaspInfo(projectDir).deploymentMode).toBe(deploymentMode);
+    },
+  );
+
+  test("reads no deployment mode when the field is missing", () => {
+    const projectDir = makeProjectWithWaspInfo(
+      JSON.stringify({ waspVersion: "0.25.0" }),
+    );
+
+    expect(readWaspInfo(projectDir).deploymentMode).toBeUndefined();
+  });
+
+  test("rejects a missing .waspinfo", () => {
+    const projectDir = makeProjectWithoutWaspInfo();
+
+    expect(() => readWaspInfo(projectDir)).toThrow("Could not read");
+  });
+
+  test.each([
+    ["malformed", "not-json"],
+    ["non-object", "[]"],
+    ["unknown deployment mode", JSON.stringify({ deploymentMode: "other" })],
+  ])("rejects a %s .waspinfo", (_caseName, contents) => {
+    const projectDir = makeProjectWithWaspInfo(contents);
+
+    expect(() => readWaspInfo(projectDir)).toThrow(
+      "is not a valid .waspinfo file",
+    );
+  });
+});


### PR DESCRIPTION
> [!WARNING]
> Still WIP. Wasn't human reviewed yet.

## Description

`wasp deploy` now deploys a single deployment mode app as one app: the server serves the client, so there is no separate client app to create, configure or deploy.

### What changes

- **The mode comes from the build.** `wasp build` records it in `.wasp/out/.waspinfo`, and the deploy package reads it back through a zod schema rather than re-analyzing the project. A build from an older CLI has no `deploymentMode` field, so it warns and assumes `split`.
- **Fly.** In single mode, `setup` and `deploy` skip the client app entirely. `--skip-client`, `--custom-server-url` and `--client-secret` have nothing to act on there, so each says so instead of silently doing nothing. The client URL the server is configured with becomes the server's own origin, and the final message points at the one URL the app is reachable on.
- **Railway.** The same shape: one service instead of two, the same options neutralised with a message, the same single URL at the end.
- **Tests.** `waspBuild.test.ts` and `waspProject.test.ts` cover reading the mode and the missing-field fallback, with a `tempWaspProject` helper for building fixtures.
- **CI.** `ci-deploy-test.yaml` follows the single app.

Split mode deploys exactly as before, two apps and all the existing options.

## Agreement

<!-- Select just one with [x] -->

- [ ] This is a small, obvious fix (typo, docs corrections, clear small bug with a test).
- [x] A maintainer agreed on the approach beforehand: [#4784](https://github.com/wasp-lang/wasp/issues/4784), and the "[RFC] Single server" doc (status Accepted, decisions written up by @infomiho)

## Type of change

<!-- Select just one with [x] -->

- [ ] **🔧 Just code/docs improvement** <!-- no functional change -->
- [ ] **🐞 Bug fix** <!-- non-breaking change which fixes an issue -->
- [ ] **🚀 New/improved feature** <!-- non-breaking change which adds functionality -->
- [x] **💥 Breaking change** <!-- fix or feature that would cause existing functionality to not work as expected -->

<!-- Breaking: a project on the default mode now deploys as one app, so an existing two-app deployment changes shape. Covered by the ChangeLog entry that lands with the deployment mode itself. -->

## Checklist

<!--
  Check all the applicable boxes with [x], and leave the rest empty.
  If you're unsure about any of them, don't hesitate to ask for help.
-->

- [ ] I tested my change in a Wasp app to verify that it works as intended. <!-- Not yet run against real Fly and Railway accounts. That pass is the main thing this PR is waiting on. -->

- 🧪 Tests and apps:

  - [x] I added **unit tests** for my change. <!-- `waspBuild.test.ts` and `waspProject.test.ts` in the deploy package. -->
  - [ ] _(if you fixed a bug)_ I added a **regression test** for the bug I fixed. <!-- Not a bug fix. -->
  - [x] _(if you added/updated a feature)_ I added/updated **e2e tests** in `examples/kitchen-sink/e2e-tests`. <!-- The auth and custom-route specs and the Playwright config follow the single app. -->
  - [ ] _(if you added/updated a feature)_ I updated the **starter templates** in `waspc/data/Cli/templates`, as needed. <!-- Not needed: the starters say nothing about deployment. -->
  - [x] _(if you added/updated a feature)_ I updated the **example apps** in `examples/`, as needed. <!-- kitchen-sink only. -->
    - [ ] _(if you updated `examples/tutorials`)_ I updated the tutorial in the docs (and vice versa). <!-- Tutorials untouched here. -->

- 📜 Documentation:

  - [ ] _(if you added/updated a feature)_ I **added/updated the documentation** in `web/docs/`. <!-- The docs for both modes are written in one piece, in the next PR. -->

- 🆕 Changelog: _(if change is more than just code/docs improvement)_
  - [ ] I updated `waspc/ChangeLog.md` with a **user-friendly** description of the change. <!-- The single deployment entry lands with the deployment mode itself, so this PR adds nothing new for users to read about. -->
  - [ ] _(if you did a breaking change)_ I added a step to the current **migration guide** in `web/docs/migration-guides/`. <!-- With the rest of the docs, in the next PR. -->
  - [ ] I **bumped the `version`** in `waspc/waspc.cabal` to reflect the changes I introduced. <!-- Already at 0.26.0 on `main` since the last release. -->
