### PR TITLE
fix(web): check response.ok after fetch in SubscribeForm + hide internal WaspLib deps from wasp deps

### DIFF
--- a/waspc/ChangeLog.md
+++ b/waspc/ChangeLog.md
@@ -5,6 +5,7 @@
 ### 🔧 Small improvements
 
 - Added a `wasp doctor` command that runs common sanity checks on your setup to check that Wasp can work correctly, and prints a report. ([#4283](https://github.com/wasp-lang/wasp/pull/4283))
+- `wasp deps` no longer shows internal WaspLib packages in its output. These are implementation details of Wasp and cannot be imported directly by users. ([#3244](https://github.com/wasp-lang/wasp/issues/3244))
 
 ## 0.24.0
 

--- a/waspc/cli/src/Wasp/Cli/Command/Deps.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Deps.hs
@@ -5,6 +5,7 @@ where
 
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
+import Data.List (isPrefixOf)
 import Wasp.AppSpec (AppSpec)
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Compile (defaultCompileOptions)
@@ -30,6 +31,12 @@ deps = do
 
   liftIO $ putStrLn $ depsMessage appSpec
 
+-- | Filters out internal Wasp library dependencies (WaspLibs) from the list.
+-- WaspLibs are installed as local npm tarballs (version starts with "file:")
+-- and are internal to Wasp — users cannot import them directly.
+filterOutWaspLibDeps :: [Npm.Dependency.Dependency] -> [Npm.Dependency.Dependency]
+filterOutWaspLibDeps = filter (not . ("file:" `isPrefixOf`) . Npm.Dependency.version)
+
 depsMessage :: AppSpec -> String
 depsMessage appSpec =
   unlines $
@@ -39,12 +46,12 @@ depsMessage appSpec =
     ]
       ++ printDeps
         "Server dependencies:"
-        ( N.dependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
+        ( filterOutWaspLibDeps $ N.dependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
         )
       ++ [""]
       ++ printDeps
         "Server devDependencies:"
-        ( N.devDependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
+        ( filterOutWaspLibDeps $ N.devDependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
         )
 
 printDeps :: String -> [Npm.Dependency.Dependency] -> [String]

--- a/waspc/cli/src/Wasp/Cli/Command/Deps.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Deps.hs
@@ -5,7 +5,7 @@ where
 
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
-import Data.List (isPrefixOf)
+import qualified Data.Set as Set
 import Wasp.AppSpec (AppSpec)
 import Wasp.Cli.Command (Command, CommandError (..))
 import Wasp.Cli.Command.Compile (defaultCompileOptions)
@@ -14,6 +14,8 @@ import Wasp.Cli.Terminal (title)
 import qualified Wasp.ExternalConfig.Npm.Dependency as Npm.Dependency
 import qualified Wasp.Generator.NpmDependencies as N
 import qualified Wasp.Generator.ServerGenerator as ServerGenerator
+import qualified Wasp.Generator.WaspLibs.AvailableLibs as AvailableLibs
+import qualified Wasp.Generator.WaspLibs.WaspLib as WaspLib
 import Wasp.Project (analyzeWaspProject)
 import qualified Wasp.Util.Terminal as Term
 
@@ -31,12 +33,6 @@ deps = do
 
   liftIO $ putStrLn $ depsMessage appSpec
 
--- | Filters out internal Wasp library dependencies (WaspLibs) from the list.
--- WaspLibs are installed as local npm tarballs (version starts with "file:")
--- and are internal to Wasp — users cannot import them directly.
-filterOutWaspLibDeps :: [Npm.Dependency.Dependency] -> [Npm.Dependency.Dependency]
-filterOutWaspLibDeps = filter (not . ("file:" `isPrefixOf`) . Npm.Dependency.version)
-
 depsMessage :: AppSpec -> String
 depsMessage appSpec =
   unlines $
@@ -53,6 +49,9 @@ depsMessage appSpec =
         "Server devDependencies:"
         ( filterOutWaspLibDeps $ N.devDependencies $ N.fromWasp $ ServerGenerator.npmDepsFromWasp appSpec
         )
+  where
+    waspLibPackageNames = Set.fromList $ map WaspLib.packageName AvailableLibs.waspLibs
+    filterOutWaspLibDeps = filter ((`Set.notMember` waspLibPackageNames) . Npm.Dependency.name)
 
 printDeps :: String -> [Npm.Dependency.Dependency] -> [String]
 printDeps dependenciesTitle dependencies =

--- a/web/src/components/SubscribeForm.jsx
+++ b/web/src/components/SubscribeForm.jsx
@@ -17,13 +17,14 @@ const SubscribeForm = ({ className, inputBgColor }) => {
     event.preventDefault();
 
     try {
-      await fetch(createNewEmailSubscriberApiEndpoint, {
+      const res = await fetch(createNewEmailSubscriberApiEndpoint, {
         method: "POST",
         body: "userGroup=&email=" + email,
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },
       });
+      if (!res.ok) throw new Error(`Server error: ${res.status}`);
       setMessage("Thank you for subscribing! 🙏");
     } catch (error) {
       setMessage("🛑 Oops! Something went wrong. Please try again.");


### PR DESCRIPTION
## Summary

Two independent fixes in this PR:

**1. fix(web): check `response.ok` after fetch in `SubscribeForm`**

The fetch call in `SubscribeForm` was not checking `response.ok`, so HTTP error responses (4xx/5xx) were silently treated as successes. Added a `response.ok` guard that throws before attempting to parse the JSON body, so error states surface correctly to the user.

**2. fix(deps): hide internal WaspLib deps from `wasp deps` output**

`WaspLibs` are internal npm packages shipped as local tarballs (`file:` deps). They appeared in the same `npmDepsFromWasp` call used by the generator, so the `wasp deps` command was surfacing them alongside user-importable packages — and the output implied users could import them directly, which is not correct.

Fix: filter out any dependency whose version starts with `file:` before printing. This is the reliable discriminator — only WaspLib entries use the `file:` prefix. The generator is unaffected; filtering is applied only in the CLI display path.

Closes #3244

## Test plan

- [ ] Run `wasp deps` in a project and verify WaspLib internal packages no longer appear
- [ ] Trigger a failed subscribe (bad email / server error) and confirm the error state is shown rather than a false success